### PR TITLE
Intercept calls to ClientOverrideConfiguration to apply our instrumen…

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsClientInstrumentation.java
@@ -15,7 +15,6 @@
  */
 package io.opentelemetry.auto.instrumentation.awssdk.v2_2;
 
-import static io.opentelemetry.auto.bootstrap.WeakMap.Provider.newWeakMap;
 import static io.opentelemetry.auto.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.auto.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -24,7 +23,6 @@ import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.auto.bootstrap.WeakMap;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,8 +36,6 @@ import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
 /** AWS SDK v2 instrumentation */
 @AutoService(Instrumenter.class)
 public final class AwsClientInstrumentation extends AbstractAwsClientInstrumentation {
-
-  public static final WeakMap<SdkClientBuilder, Boolean> OVERRIDDEN = newWeakMap();
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
@@ -75,7 +71,7 @@ public final class AwsClientInstrumentation extends AbstractAwsClientInstrumenta
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void methodEnter(@Advice.This final SdkClientBuilder thiz) {
-      OVERRIDDEN.put(thiz, true);
+      TracingExecutionInterceptor.OVERRIDDEN.put(thiz, true);
     }
   }
 
@@ -83,7 +79,7 @@ public final class AwsClientInstrumentation extends AbstractAwsClientInstrumenta
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void methodEnter(@Advice.This final SdkClientBuilder thiz) {
-      if (!Boolean.TRUE.equals(OVERRIDDEN.get(thiz))) {
+      if (!Boolean.TRUE.equals(TracingExecutionInterceptor.OVERRIDDEN.get(thiz))) {
         TracingExecutionInterceptor.overrideConfiguration(thiz);
       }
     }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsClientOverrideInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsClientOverrideInstrumentation.java
@@ -1,0 +1,52 @@
+package io.opentelemetry.auto.instrumentation.awssdk.v2_2;
+
+import static io.opentelemetry.auto.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.isStatic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.auto.tooling.Instrumenter;
+import java.util.Collections;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+
+/**
+ * Separate instrumentation to inject into user configuration overrides. Overrides aren't merged so
+ * we need to either inject into their override or create our own, but not both.
+ */
+@AutoService(Instrumenter.class)
+public final class AwsClientOverrideInstrumentation extends AbstractAwsClientInstrumentation {
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Optimization for expensive typeMatcher.
+    return hasClassesNamed("software.amazon.awssdk.core.client.config.ClientOverrideConfiguration");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("software.amazon.awssdk.core.client.config.ClientOverrideConfiguration");
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return Collections.singletonMap(
+        isMethod().and(isPublic()).and(isStatic()).and(named("builder")),
+        AwsClientOverrideInstrumentation.class.getName() + "$AwsSdkClientOverrideAdvice");
+  }
+
+  public static class AwsSdkClientOverrideAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void methodEnter(
+        @Advice.Return final ClientOverrideConfiguration.Builder builder) {
+      TracingExecutionInterceptor.overrideConfiguration(builder);
+    }
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsClientOverrideInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsClientOverrideInstrumentation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.opentelemetry.auto.instrumentation.awssdk.v2_2;
 
 import static io.opentelemetry.auto.tooling.ClassLoaderMatcher.hasClassesNamed;

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
@@ -15,8 +15,10 @@
  */
 package io.opentelemetry.auto.instrumentation.awssdk.v2_2;
 
+import static io.opentelemetry.auto.bootstrap.WeakMap.Provider.newWeakMap;
 import static io.opentelemetry.trace.TracingContextUtils.currentContextWith;
 
+import io.opentelemetry.auto.bootstrap.WeakMap;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdk;
 import io.opentelemetry.trace.Span;
@@ -56,6 +58,10 @@ import software.amazon.awssdk.http.SdkHttpResponse;
  * current context to allow downstream instrumentation like Netty to pick it up.
  */
 public class TracingExecutionInterceptor implements ExecutionInterceptor {
+
+  // Keeps track of SDK clients that have been overridden by the user and don't need to be
+  // overridden by us.
+  public static final WeakMap<SdkClientBuilder, Boolean> OVERRIDDEN = newWeakMap();
 
   public static class ScopeHolder {
     public static final ThreadLocal<Scope> CURRENT = new ThreadLocal<>();

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
@@ -81,7 +81,18 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
    * compiling this for instrumentation code that should load into Java7.
    */
   public static void overrideConfiguration(final SdkClientBuilder client) {
-    client.overrideConfiguration(OVERRIDE_CONFIGURATION_CONSUMER);
+    // We intercept calls to overrideConfiguration to make sure when a user overrides the
+    // configuration, we join their configuration. This means all we need to do is call the method
+    // here and we will intercept the builder and add our interceptor.
+    client.overrideConfiguration(builder -> {});
+  }
+
+  /**
+   * We keep this method here because it references Java8 classes and we would like to avoid
+   * compiling this for instrumentation code that should load into Java7.
+   */
+  public static void overrideConfiguration(final ClientOverrideConfiguration.Builder builder) {
+    OVERRIDE_CONFIGURATION_CONSUMER.accept(builder);
   }
 
   public static void muzzleCheck() {


### PR DESCRIPTION
…tation to user overriden clients too.

Only the last call to `overrideConfiguration` takes affect for an SDK client so currently it is impossible for a user to tweak their client when the agent is installed. I initially thought maybe this is incorrect semantics for the method, https://github.com/aws/aws-sdk-java-v2/issues/1850, but thinking about it, it seems ok to expect users to define a single configuration override. The agent doesn't work with this because it hackily works around the APIs so it's worth handling this issue in the agent as best as possible.

I have added interception of the creation of `ClientOverrideConfiguration` to make sure anytime it is created it has our interceptor included. In addition, now `overrideConfiguration` is only called by the agent if the user didn't call it themselves (if they did, it means they passed in a configuration of their own).

Now users can configure the client if they need to :)