### PR TITLE
Add missing AWS SDK helper.

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AbstractAwsClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AbstractAwsClientInstrumentation.java
@@ -29,6 +29,7 @@ public abstract class AbstractAwsClientInstrumentation extends Instrumenter.Defa
     return new String[] {
       "io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdk",
       "io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkClientDecorator",
+      "io.opentelemetry.instrumentation.awssdk.v2_2.TracingExecutionInterceptor",
       packageName + ".TracingExecutionInterceptor",
       packageName + ".TracingExecutionInterceptor$ScopeHolder",
     };


### PR DESCRIPTION
Given how much the muzzle was biting me (or technically causing the dog to bite? :) ), surprised it seems to have missed this. When trying out the snapshot, I get this right now

```
[opentelemetry.auto.trace 2020-06-09 18:35:45:346 +0900] [main] DEBUG io.opentelemetry.auto.bootstrap.ExceptionLogger - Failed to handle exception in instrumentation for software.amazon.awssdk.core.client.config.ClientOverrideConfiguration on jdk.internal.loader.ClassLoaders$AppClassLoader@3d4eac69
java.lang.NoClassDefFoundError: io/opentelemetry/instrumentation/awssdk/v2_2/TracingExecutionInterceptor
	at io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdk.newInterceptor(AwsSdk.java:67)
	at io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdk.newInterceptor(AwsSdk.java:58)
	at io.opentelemetry.auto.instrumentation.awssdk.v2_2.TracingExecutionInterceptor.lambda$static$0(TracingExecutionInterceptor.java:76)
	at io.opentelemetry.auto.instrumentation.awssdk.v2_2.TracingExecutionInterceptor.overrideConfiguration(TracingExecutionInterceptor.java:100)
	at software.amazon.awssdk.core.client.config.ClientOverrideConfiguration.builder(ClientOverrideConfiguration.java:89)
	at software.amazon.awssdk.core.client.builder.SdkClientBuilder.overrideConfiguration(SdkClientBuilder.java:46)
	at com.softwareaws.xray.examples.Application.dynamoDb(Application.java:48)
	at com.softwareaws.xray.examples.Application$$EnhancerBySpringCGLIB$$a309843a.CGLIB$dynamoDb$0(<generated>)
	at com.softwareaws.xray.examples.Application$$EnhancerBySpringCGLIB$$a309843a$$FastClassBySpringCGLIB$$dbcfe2dc.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:244)
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:331)
	at com.softwareaws.xray.examples.Application$$EnhancerBySpringCGLIB$$a309843a.dynamoDb(<generated>)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:154)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:651)
```