### PR TITLE
remove the restriction on instrumenting classes in com.newrelic

### DIFF
--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/matcher/GlobalIgnoresMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/matcher/GlobalIgnoresMatcher.java
@@ -68,7 +68,6 @@ public class GlobalIgnoresMatcher<T extends TypeDescription>
         || name.startsWith("org.aspectj.")
         || name.startsWith("com.intellij.rt.debugger.")
         || name.startsWith("com.p6spy.")
-        || name.startsWith("com.newrelic.")
         || name.startsWith("com.dynatrace.")
         || name.startsWith("com.jloadtrace.")
         || name.startsWith("com.appdynamics.")


### PR DESCRIPTION
This will enable internal New Relic users to use the OTel agent to instrument their code.