### PR TITLE
Make Cassandra 3.0 instrumentation Java 7 compatible

### DIFF
--- a/instrumentation/cassandra/cassandra-3.0/cassandra-3.0.gradle
+++ b/instrumentation/cassandra/cassandra-3.0/cassandra-3.0.gradle
@@ -1,6 +1,8 @@
 // Set properties before any plugins get loaded
 ext {
-  // Test use Cassandra 3 which requires Java 8. (Currently incompatible with Java 9.)
+  // TODO switch to container-based tests (away from cassandraunit)
+  // Tests use cassandraunit, which runs embedded Cassandra 3, which requires Java 8
+  // (and is currently incompatible with Java 9.)
   minJavaVersionForTests = JavaVersion.VERSION_1_8
   maxJavaVersionForTests = JavaVersion.VERSION_1_8
   cassandraDriverTestVersions = "[3.0,4.0)"
@@ -8,6 +10,13 @@ ext {
 
 apply from: "$rootDir/gradle/instrumentation.gradle"
 apply plugin: 'org.unbroken-dome.test-sets'
+
+// TODO switch to container-based tests (away from cassandraunit)
+//   then we can run tests using Java 7 (see above) and won't need this override section
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_7
+  targetCompatibility = JavaVersion.VERSION_1_7
+}
 
 muzzle {
 


### PR DESCRIPTION
Cassandra 3.0 instrumentation stopped working on Java 7 after recent build changes b/c it's now compiled to Java 8 bytecode. See comments in the PR for more details.