### PR TITLE
Fix duplicate log capture

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/logging/LoggerDepth.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/logging/LoggerDepth.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.opentelemetry.auto.bootstrap.instrumentation.logging;
+
+// this is a marker class that can be used across different logging instrumentations in order to
+// prevent nested log capture (this is especially a problem on JBoss)
+public class LoggerDepth {}

--- a/instrumentation/log4j/log4j-1.1/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v1_1/Log4jSpansInstrumentation.java
+++ b/instrumentation/log4j/log4j-1.1/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v1_1/Log4jSpansInstrumentation.java
@@ -23,6 +23,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.auto.bootstrap.CallDepthThreadLocalMap;
+import io.opentelemetry.auto.bootstrap.instrumentation.logging.LoggerDepth;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import java.util.HashMap;
 import java.util.Map;
@@ -75,8 +76,7 @@ public class Log4jSpansInstrumentation extends Instrumenter.Default {
         @Advice.Argument(3) final Throwable t) {
       // need to track call depth across all loggers to avoid double capture when one logging
       // framework delegates to another
-      final boolean topLevel =
-          CallDepthThreadLocalMap.incrementCallDepth(java.util.logging.Logger.class) == 0;
+      final boolean topLevel = CallDepthThreadLocalMap.incrementCallDepth(LoggerDepth.class) == 0;
       if (topLevel) {
         Log4jSpans.capture(logger, level, message, t);
       }
@@ -86,7 +86,7 @@ public class Log4jSpansInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void methodExit(@Advice.Enter final boolean topLevel) {
       if (topLevel) {
-        CallDepthThreadLocalMap.reset(java.util.logging.Logger.class);
+        CallDepthThreadLocalMap.reset(LoggerDepth.class);
       }
     }
   }

--- a/instrumentation/log4j/log4j-2.0/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v2_0/Log4jSpansInstrumentation.java
+++ b/instrumentation/log4j/log4j-2.0/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v2_0/Log4jSpansInstrumentation.java
@@ -25,6 +25,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.auto.bootstrap.CallDepthThreadLocalMap;
+import io.opentelemetry.auto.bootstrap.instrumentation.logging.LoggerDepth;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import java.util.HashMap;
 import java.util.Map;
@@ -92,8 +93,7 @@ public class Log4jSpansInstrumentation extends Instrumenter.Default {
         @Advice.Argument(4) final Throwable t) {
       // need to track call depth across all loggers in order to avoid double capture when one
       // logging framework delegates to another
-      final boolean topLevel =
-          CallDepthThreadLocalMap.incrementCallDepth(java.util.logging.Logger.class) == 0;
+      final boolean topLevel = CallDepthThreadLocalMap.incrementCallDepth(LoggerDepth.class) == 0;
       if (topLevel) {
         Log4jSpans.capture(logger, level, message, t);
       }
@@ -103,7 +103,7 @@ public class Log4jSpansInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void methodExit(@Advice.Enter final boolean topLevel) {
       if (topLevel) {
-        CallDepthThreadLocalMap.reset(java.util.logging.Logger.class);
+        CallDepthThreadLocalMap.reset(LoggerDepth.class);
       }
     }
   }
@@ -118,8 +118,7 @@ public class Log4jSpansInstrumentation extends Instrumenter.Default {
         @Advice.Argument(5) final Throwable t) {
       // need to track call depth across all loggers in order to avoid double capture when one
       // logging framework delegates to another
-      final boolean topLevel =
-          CallDepthThreadLocalMap.incrementCallDepth(java.util.logging.Logger.class) == 0;
+      final boolean topLevel = CallDepthThreadLocalMap.incrementCallDepth(LoggerDepth.class) == 0;
       if (topLevel) {
         Log4jSpans.capture(logger, level, message, t);
       }
@@ -129,7 +128,7 @@ public class Log4jSpansInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void methodExit(@Advice.Enter final boolean topLevel) {
       if (topLevel) {
-        CallDepthThreadLocalMap.reset(java.util.logging.Logger.class);
+        CallDepthThreadLocalMap.reset(LoggerDepth.class);
       }
     }
   }

--- a/instrumentation/logback-1.0/src/main/java/io/opentelemetry/auto/instrumentation/logback/LogbackSpansInstrumentation.java
+++ b/instrumentation/logback-1.0/src/main/java/io/opentelemetry/auto/instrumentation/logback/LogbackSpansInstrumentation.java
@@ -24,6 +24,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.auto.bootstrap.CallDepthThreadLocalMap;
+import io.opentelemetry.auto.bootstrap.instrumentation.logging.LoggerDepth;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import java.util.HashMap;
 import java.util.Map;
@@ -67,8 +68,7 @@ public class LogbackSpansInstrumentation extends Instrumenter.Default {
     public static boolean methodEnter(@Advice.Argument(0) final ILoggingEvent event) {
       // need to track call depth across all loggers in order to avoid double capture when one
       // logging framework delegates to another
-      final boolean topLevel =
-          CallDepthThreadLocalMap.incrementCallDepth(java.util.logging.Logger.class) == 0;
+      final boolean topLevel = CallDepthThreadLocalMap.incrementCallDepth(LoggerDepth.class) == 0;
       if (topLevel) {
         LogbackSpans.capture(event);
       }
@@ -78,7 +78,7 @@ public class LogbackSpansInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void methodExit(@Advice.Enter final boolean topLevel) {
       if (topLevel) {
-        CallDepthThreadLocalMap.reset(java.util.logging.Logger.class);
+        CallDepthThreadLocalMap.reset(LoggerDepth.class);
       }
     }
   }


### PR DESCRIPTION
This broke when `CallDepthThreadLocalMap` key was changed from `Object` to `Class`.

The string "logger" was used prior to that in order to prevent nesting across logging instrumentation.

But when the map was changed from `Object` to `Class`, I chose the unfortunate `java.util.logging.Logger` class as replacement for the string "logger", and that class gets shaded inconsistently (mostly to `PatchLogger` but in j.u.l. instrumentation itself it doesn't get shaded at all).