### PR TITLE
Fix CircleCI job name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ workflows:
                 - depends-on-otel-java-snapshot
     jobs:
       - default_test_job:
-          name: test_8
+          name: test_11
           testTask: test jacocoTestReport jacocoTestCoverageVerification
 
   release:


### PR DESCRIPTION
I noticed the `test_8` job is named `test_8-1` after #553, I think this might be why...

EDIT: it was!