### PR TITLE
Update approvers list in CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,6 +198,7 @@ Suggested plugins and settings:
 
 Approvers:
 
+- [Anuraag Agrawal](https://github.com/anuraaga), AWS
 - [John Watson](https://github.com/jkwatson), New Relic
 
 Maintainers:


### PR DESCRIPTION
I forgot to do this in #585

@anuraaga I used AWS (instead of Amazon) based on your github profile, but no problem to change it if you have different preference