### PR TITLE
Fix JerseyClient sporadic test failure

### DIFF
--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -57,6 +57,7 @@ abstract class JaxRsClientAsyncTest extends HttpClientTest {
         latch.countDown()
       }
     }).get()
+    response.close()
 
     // need to wait for callback to complete in case test is expecting span from it
     latch.await()


### PR DESCRIPTION
Closes #434, #447 (hopefully)

Looking over the log files from these failures, the problem is that there are two _server_ spans instead of one.

Searching for "jersey client duplicate request", seems to point to lack of closing the reponse.

https://www.google.com/search?q=jersey+client+duplicate+request

Worth a try...