### PR TITLE
Use gRPC Status for thrown exceptions too and remove redundant legacy…

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -59,7 +59,15 @@ public abstract class BaseDecorator {
   public Span onError(final Span span, final Throwable throwable) {
     assert span != null;
     if (throwable != null) {
-      span.setStatus(Status.UNKNOWN);
+      onComplete(span, Status.UNKNOWN, throwable);
+    }
+    return span;
+  }
+
+  public Span onComplete(Span span, Status status, Throwable throwable) {
+    assert span != null;
+    span.setStatus(status);
+    if (throwable != null) {
       addThrowable(
           span, throwable instanceof ExecutionException ? throwable.getCause() : throwable);
     }

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -105,6 +105,25 @@ class BaseDecoratorTest extends AgentSpecification {
     error << [new Exception(), null]
   }
 
+  def "test onComplete"() {
+    when:
+    decorator.onComplete(span, status, error)
+
+    then:
+    1 * span.setStatus(status)
+    if (error) {
+      1 * span.setAttribute(MoreTags.ERROR_TYPE, error.getClass().getName())
+      1 * span.setAttribute(MoreTags.ERROR_STACK, _)
+      1 * span.setAttribute(MoreTags.ERROR_MSG, null)
+    }
+    0 * _
+
+    where:
+    error           | status
+    new Exception() | Status.INTERNAL
+    null            | Status.OK
+  }
+
   def "test beforeFinish"() {
     when:
     decorator.beforeFinish(span)

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -29,21 +29,14 @@ public class GrpcClientDecorator extends ClientDecorator {
       OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.grpc-1.5");
 
   public Span onClose(final Span span, final io.grpc.Status status) {
-    if (status.getCause() != null) {
-      // We have a Status so only call super.onError to fill in common error tags.
-      super.onError(span, status.getCause());
-    }
-    span.setStatus(GrpcHelper.statusFromGrpcStatus(status));
+    onComplete(span, GrpcHelper.statusFromGrpcStatus(status), status.getCause());
     return span;
   }
 
   @Override
   public Span onError(Span span, Throwable throwable) {
     assert span != null;
-    if (throwable != null) {
-      super.onError(span, throwable);
-      span.setStatus(GrpcHelper.statusFromGrpcStatus(Status.fromThrowable(throwable)));
-    }
+    onClose(span, Status.fromThrowable(throwable));
     return span;
   }
 }

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -29,7 +29,10 @@ public class GrpcClientDecorator extends ClientDecorator {
       OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.grpc-1.5");
 
   public Span onClose(final Span span, final io.grpc.Status status) {
-    super.onError(span, status.getCause());
+    if (status.getCause() != null) {
+      // We have a Status so only call super.onError to fill in common error tags.
+      super.onError(span, status.getCause());
+    }
     span.setStatus(GrpcHelper.statusFromGrpcStatus(status));
     return span;
   }

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.auto.instrumentation.grpc.client;
 
+import io.grpc.Status;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.ClientDecorator;
 import io.opentelemetry.auto.instrumentation.grpc.common.GrpcHelper;
@@ -28,12 +29,18 @@ public class GrpcClientDecorator extends ClientDecorator {
       OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.grpc-1.5");
 
   public Span onClose(final Span span, final io.grpc.Status status) {
-
-    span.setAttribute("status.code", status.getCode().name());
-    span.setAttribute("status.description", status.getDescription());
-
-    onError(span, status.getCause());
+    super.onError(span, status.getCause());
     span.setStatus(GrpcHelper.statusFromGrpcStatus(status));
+    return span;
+  }
+
+  @Override
+  public Span onError(Span span, Throwable throwable) {
+    assert span != null;
+    if (throwable != null) {
+      super.onError(span, throwable);
+      span.setStatus(GrpcHelper.statusFromGrpcStatus(Status.fromThrowable(throwable)));
+    }
     return span;
   }
 }

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -29,21 +29,14 @@ public class GrpcServerDecorator extends ServerDecorator {
       OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.grpc-1.5");
 
   public Span onClose(final Span span, final Status status) {
-    if (status.getCause() != null) {
-      // We have a Status so only call super.onError to fill in common error tags.
-      super.onError(span, status.getCause());
-    }
-    span.setStatus(GrpcHelper.statusFromGrpcStatus(status));
+    onComplete(span, GrpcHelper.statusFromGrpcStatus(status), status.getCause());
     return span;
   }
 
   @Override
   public Span onError(Span span, Throwable throwable) {
     assert span != null;
-    if (throwable != null) {
-      super.onError(span, throwable);
-      span.setStatus(GrpcHelper.statusFromGrpcStatus(Status.fromThrowable(throwable)));
-    }
+    onClose(span, Status.fromThrowable(throwable));
     return span;
   }
 }

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -29,11 +29,18 @@ public class GrpcServerDecorator extends ServerDecorator {
       OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.grpc-1.5");
 
   public Span onClose(final Span span, final Status status) {
-
-    span.setAttribute("status.code", status.getCode().name());
-    span.setAttribute("status.description", status.getDescription());
-    onError(span, status.getCause());
+    super.onError(span, status.getCause());
     span.setStatus(GrpcHelper.statusFromGrpcStatus(status));
+    return span;
+  }
+
+  @Override
+  public Span onError(Span span, Throwable throwable) {
+    assert span != null;
+    if (throwable != null) {
+      super.onError(span, throwable);
+      span.setStatus(GrpcHelper.statusFromGrpcStatus(Status.fromThrowable(throwable)));
+    }
     return span;
   }
 }

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -29,7 +29,10 @@ public class GrpcServerDecorator extends ServerDecorator {
       OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.grpc-1.5");
 
   public Span onClose(final Span span, final Status status) {
-    super.onError(span, status.getCause());
+    if (status.getCause() != null) {
+      // We have a Status so only call super.onError to fill in common error tags.
+      super.onError(span, status.getCause());
+    }
     span.setStatus(GrpcHelper.statusFromGrpcStatus(status));
     return span;
   }

--- a/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -25,6 +25,7 @@ import io.grpc.stub.StreamObserver
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
+import io.opentelemetry.trace.Status
 
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
@@ -119,11 +120,11 @@ class GrpcStreamingTest extends AgentTestRunner {
           spanKind CLIENT
           parent()
           errored false
+          status(Status.OK)
           tags {
             "$MoreTags.RPC_SERVICE" "Greeter"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" port
-            "status.code" "OK"
           }
           (1..(clientMessageCount * serverMessageCount)).each {
             def messageId = it
@@ -141,11 +142,11 @@ class GrpcStreamingTest extends AgentTestRunner {
           spanKind SERVER
           childOf span(0)
           errored false
+          status(Status.OK)
           tags {
             "$MoreTags.RPC_SERVICE" "Greeter"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
-            "status.code" "OK"
           }
           clientRange.each {
             def messageId = it

--- a/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -273,7 +273,9 @@ class GrpcTest extends AgentTestRunner {
             "$MoreTags.RPC_SERVICE" "Greeter"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
-            errorTags error.class, error.message
+            if (grpcStatus.cause != null) {
+              errorTags grpcStatus.cause.class, grpcStatus.cause.message
+            }
           }
         }
       }


### PR DESCRIPTION
… status attributes.

I noticed that only exceptions explicitly returned by `ResponseObserver.onError` are passed through `onStatus`, but gRPC defines a mapping from throwable to status so we should use that for thrown exceptions. 

Also removed the now redundant `status.code` attributes and assert on status instead.