### PR TITLE
Map peer service in HttpClientDecorator.

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -200,7 +200,7 @@ public abstract class BaseDecorator {
     return span.getContext();
   }
 
-  private static String mapToPeer(String endpoint) {
+  protected static String mapToPeer(String endpoint) {
     if (endpoint == null) {
       return null;
     }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -75,6 +75,10 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
           if (url.getHost() != null) {
             urlBuilder.append(url.getHost());
             span.setAttribute(MoreTags.NET_PEER_NAME, url.getHost());
+            String peerService = mapToPeer(url.getHost());
+            if (peerService != null) {
+              span.setAttribute("peer.service", peerService);
+            }
             if (url.getPort() > 0) {
               span.setAttribute(MoreTags.NET_PEER_PORT, url.getPort());
               if (url.getPort() != 80 && url.getPort() != 443) {

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
@@ -19,10 +19,11 @@ package io.opentelemetry.auto.bootstrap.instrumentation.decorator
 import io.opentelemetry.auto.config.Config
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.test.utils.ConfigUtils
 import io.opentelemetry.trace.Span
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import spock.lang.Shared
+
+import static io.opentelemetry.auto.test.utils.ConfigUtils.withConfigOverride
 
 class HttpClientDecoratorTest extends ClientDecoratorTest {
 
@@ -62,7 +63,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     def req = [method: "test-method", url: testUrl, userAgent: testUserAgent]
 
     when:
-    ConfigUtils.withConfigOverride(
+    withConfigOverride(
       "endpoint.peer.service.mapping",
       "myhost=reservation-service") {
       decorator.onRequest(span, req)


### PR DESCRIPTION
Found that at least Apache client doesn't call `onPeerConnection` and only has the net.peer.name from this `HttpClientDecorator`.