### PR TITLE
Add extension point for HTTP client decorators to return headers gene…

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -39,7 +39,9 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
 
   protected abstract Integer status(RESPONSE response);
 
-  protected abstract String userAgent(REQUEST request);
+  protected abstract String requestHeader(REQUEST request, String name);
+
+  protected abstract String responseHeader(RESPONSE response, String name);
 
   public Span getOrCreateSpan(REQUEST request, Tracer tracer) {
     return getOrCreateSpan(spanNameForRequest(request), tracer);
@@ -58,7 +60,7 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
     if (request != null) {
       span.setAttribute(Tags.HTTP_METHOD, method(request));
 
-      final String userAgent = userAgent(request);
+      final String userAgent = requestHeader(request, USER_AGENT);
       if (userAgent != null) {
         SemanticAttributes.HTTP_USER_AGENT.set(span, userAgent);
       }

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
@@ -46,14 +46,14 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
       1 * span.setAttribute(Tags.HTTP_URL, "$req.url")
       1 * span.setAttribute(MoreTags.NET_PEER_NAME, req.url.host)
       1 * span.setAttribute(MoreTags.NET_PEER_PORT, req.url.port)
-      1 * span.setAttribute(SemanticAttributes.HTTP_USER_AGENT.key(), req.userAgent)
+      1 * span.setAttribute(SemanticAttributes.HTTP_USER_AGENT.key(), req["User-Agent"])
     }
     0 * _
 
     where:
     req << [
       null,
-      [method: "test-method", url: testUrl, userAgent: testUserAgent]
+      [method: "test-method", url: testUrl, "User-Agent": testUserAgent]
     ]
   }
 
@@ -165,8 +165,13 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
       }
 
       @Override
-      protected String userAgent(Map m) {
-        return m.userAgent
+      protected String requestHeader(Map m, String name) {
+        return m[name]
+      }
+
+      @Override
+      protected String responseHeader(Map m, String name) {
+        return m[name]
       }
     }
   }

--- a/instrumentation-core/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkClientDecorator.java
+++ b/instrumentation-core/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkClientDecorator.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.http.SdkHttpHeaders;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 
@@ -77,7 +78,7 @@ final class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, Sd
 
   // Certain headers in the request like User-Agent are only available after execution.
   Span afterExecution(final Span span, final SdkHttpRequest request) {
-    SemanticAttributes.HTTP_USER_AGENT.set(span, userAgent(request));
+    SemanticAttributes.HTTP_USER_AGENT.set(span, requestHeader(request, USER_AGENT));
     return span;
   }
 
@@ -105,7 +106,16 @@ final class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, Sd
   }
 
   @Override
-  protected String userAgent(SdkHttpRequest sdkHttpRequest) {
-    return sdkHttpRequest.firstMatchingHeader(USER_AGENT).orElse(null);
+  protected String requestHeader(SdkHttpRequest sdkHttpRequest, String name) {
+    return header(sdkHttpRequest, name);
+  }
+
+  @Override
+  protected String responseHeader(SdkHttpResponse sdkHttpResponse, String name) {
+    return header(sdkHttpResponse, name);
+  }
+
+  private static String header(SdkHttpHeaders headers, String name) {
+    return headers.firstMatchingHeader(name).orElse(null);
   }
 }

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpClientDecorator.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpClientDecorator.java
@@ -47,7 +47,12 @@ public class AkkaHttpClientDecorator extends HttpClientDecorator<HttpRequest, Ht
   }
 
   @Override
-  protected String userAgent(HttpRequest httpRequest) {
-    return httpRequest.getHeader(USER_AGENT).map(HttpHeader::value).orElse(null);
+  protected String requestHeader(HttpRequest httpRequest, String name) {
+    return httpRequest.getHeader(name).map(HttpHeader::value).orElse(null);
+  }
+
+  @Override
+  protected String responseHeader(HttpResponse httpResponse, String name) {
+    return httpResponse.getHeader(name).map(HttpHeader::value).orElse(null);
   }
 }

--- a/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
+++ b/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
@@ -28,10 +28,8 @@ import org.apache.http.HttpResponse;
 import org.apache.http.RequestLine;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.HttpCoreContext;
 
-public class ApacheHttpAsyncClientDecorator extends HttpClientDecorator<HttpRequest, HttpContext> {
+public class ApacheHttpAsyncClientDecorator extends HttpClientDecorator<HttpRequest, HttpResponse> {
 
   public static final ApacheHttpAsyncClientDecorator DECORATE =
       new ApacheHttpAsyncClientDecorator();
@@ -65,15 +63,9 @@ public class ApacheHttpAsyncClientDecorator extends HttpClientDecorator<HttpRequ
   }
 
   @Override
-  protected Integer status(final HttpContext context) {
-    HttpResponse response = extractResponse(context);
-    if (response != null) {
-      final StatusLine statusLine = response.getStatusLine();
-      if (statusLine != null) {
-        return statusLine.getStatusCode();
-      }
-    }
-    return null;
+  protected Integer status(final HttpResponse response) {
+    final StatusLine statusLine = response.getStatusLine();
+    return statusLine != null ? statusLine.getStatusCode() : null;
   }
 
   @Override
@@ -82,21 +74,12 @@ public class ApacheHttpAsyncClientDecorator extends HttpClientDecorator<HttpRequ
   }
 
   @Override
-  protected String responseHeader(HttpContext context, String name) {
-    HttpResponse response = extractResponse(context);
-    if (response != null) {
-      return header(response, name);
-    }
-    return null;
+  protected String responseHeader(HttpResponse response, String name) {
+    return header(response, name);
   }
 
   private static String header(HttpMessage message, String name) {
     Header header = message.getFirstHeader(name);
     return header != null ? header.getValue() : null;
-  }
-
-  private static HttpResponse extractResponse(HttpContext context) {
-    Object responseObject = context.getAttribute(HttpCoreContext.HTTP_RESPONSE);
-    return responseObject instanceof HttpResponse ? (HttpResponse) responseObject : null;
   }
 }

--- a/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -46,11 +46,13 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.nio.ContentEncoder;
 import org.apache.http.nio.IOControl;
 import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
 
 @AutoService(Instrumenter.class)
 public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Default {
@@ -203,7 +205,7 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Default {
 
     @Override
     public void completed(final T result) {
-      DECORATE.onResponse(clientSpan, context);
+      DECORATE.onResponse(clientSpan, getResponse(context));
       DECORATE.beforeFinish(clientSpan);
       clientSpan.end(); // end span before calling delegate
 
@@ -218,7 +220,7 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Default {
 
     @Override
     public void failed(final Exception ex) {
-      DECORATE.onResponse(clientSpan, context);
+      DECORATE.onResponse(clientSpan, getResponse(context));
       DECORATE.onError(clientSpan, ex);
       DECORATE.beforeFinish(clientSpan);
       clientSpan.end(); // end span before calling delegate
@@ -234,7 +236,7 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Default {
 
     @Override
     public void cancelled() {
-      DECORATE.onResponse(clientSpan, context);
+      DECORATE.onResponse(clientSpan, getResponse(context));
       DECORATE.beforeFinish(clientSpan);
       clientSpan.end(); // end span before calling delegate
 
@@ -263,6 +265,10 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Default {
       if (delegate != null) {
         delegate.cancelled();
       }
+    }
+
+    private static HttpResponse getResponse(HttpContext context) {
+      return (HttpResponse) context.getAttribute(HttpCoreContext.HTTP_RESPONSE);
     }
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v2_0/CommonsHttpClientDecorator.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v2_0/CommonsHttpClientDecorator.java
@@ -54,8 +54,17 @@ public class CommonsHttpClientDecorator extends HttpClientDecorator<HttpMethod, 
   }
 
   @Override
-  protected String userAgent(HttpMethod httpMethod) {
-    final Header header = httpMethod.getRequestHeader(USER_AGENT);
+  protected String requestHeader(HttpMethod httpMethod, String name) {
+    return header(httpMethod, name);
+  }
+
+  @Override
+  protected String responseHeader(HttpMethod httpMethod, String name) {
+    return header(httpMethod, name);
+  }
+
+  private static String header(HttpMethod httpMethod, String name) {
+    final Header header = httpMethod.getRequestHeader(name);
     return header != null ? header.getValue() : null;
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
@@ -21,6 +21,7 @@ import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecor
 import io.opentelemetry.trace.Tracer;
 import java.net.URI;
 import org.apache.http.Header;
+import org.apache.http.HttpMessage;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 
@@ -46,8 +47,17 @@ public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriReques
   }
 
   @Override
-  protected String userAgent(HttpUriRequest httpUriRequest) {
-    final Header header = httpUriRequest.getFirstHeader(USER_AGENT);
+  protected String requestHeader(HttpUriRequest request, String name) {
+    return header(request, name);
+  }
+
+  @Override
+  protected String responseHeader(HttpResponse response, String name) {
+    return header(response, name);
+  }
+
+  private static String header(HttpMessage message, String name) {
+    Header header = message.getFirstHeader(name);
     return header != null ? header.getValue() : null;
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/AwsSdkClientDecorator.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/AwsSdkClientDecorator.java
@@ -117,7 +117,12 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String userAgent(Request request) {
-    return (String) request.getHeaders().get(USER_AGENT);
+  protected String requestHeader(Request request, String name) {
+    return (String) request.getHeaders().get(name);
+  }
+
+  @Override
+  protected String responseHeader(Response response, String name) {
+    return response.getHttpResponse().getHeaders().get(name);
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/AwsSdkClientDecorator.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/AwsSdkClientDecorator.java
@@ -27,7 +27,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response> {
+public class AwsSdkClientDecorator extends HttpClientDecorator<Request<?>, Response<?>> {
 
   static final String COMPONENT_NAME = "java-aws-sdk";
 
@@ -41,7 +41,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  public String spanNameForRequest(final Request request) {
+  public String spanNameForRequest(final Request<?> request) {
     if (request == null) {
       return DEFAULT_SPAN_NAME;
     }
@@ -51,7 +51,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  public Span onRequest(final Span span, final Request request) {
+  public Span onRequest(final Span span, final Request<?> request) {
     // Call super first because we override the span name below.
     super.onRequest(span, request);
 
@@ -79,7 +79,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  public Span onResponse(final Span span, final Response response) {
+  public Span onResponse(final Span span, final Response<?> response) {
     if (response.getAwsResponse() instanceof AmazonWebServiceResponse) {
       final AmazonWebServiceResponse awsResp = (AmazonWebServiceResponse) response.getAwsResponse();
       span.setAttribute("aws.requestId", awsResp.getRequestId());
@@ -102,27 +102,27 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String method(final Request request) {
+  protected String method(final Request<?> request) {
     return request.getHttpMethod().name();
   }
 
   @Override
-  protected URI url(final Request request) {
+  protected URI url(final Request<?> request) {
     return request.getEndpoint();
   }
 
   @Override
-  protected Integer status(final Response response) {
+  protected Integer status(final Response<?> response) {
     return response.getHttpResponse().getStatusCode();
   }
 
   @Override
-  protected String requestHeader(Request request, String name) {
-    return (String) request.getHeaders().get(name);
+  protected String requestHeader(Request<?> request, String name) {
+    return request.getHeaders().get(name);
   }
 
   @Override
-  protected String responseHeader(Response response, String name) {
+  protected String responseHeader(Response<?> response, String name) {
     return response.getHttpResponse().getHeaders().get(name);
   }
 }

--- a/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.auto.instrumentation.googlehttpclient;
 
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import io.opentelemetry.OpenTelemetry;
@@ -50,7 +51,16 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   }
 
   @Override
-  protected String userAgent(HttpRequest httpRequest) {
-    return httpRequest.getHeaders().getUserAgent();
+  protected String requestHeader(HttpRequest httpRequest, String name) {
+    return header(httpRequest.getHeaders(), name);
+  }
+
+  @Override
+  protected String responseHeader(HttpResponse httpResponse, String name) {
+    return header(httpResponse.getHeaders(), name);
+  }
+
+  private static String header(HttpHeaders headers, String name) {
+    return (String) headers.get(name);
   }
 }

--- a/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -61,6 +61,6 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   }
 
   private static String header(HttpHeaders headers, String name) {
-    return (String) headers.get(name);
+    return headers.getFirstHeaderStringValue(name);
   }
 }

--- a/instrumentation/grizzly-client-1.9/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/client/ClientDecorator.java
+++ b/instrumentation/grizzly-client-1.9/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/client/ClientDecorator.java
@@ -47,7 +47,12 @@ public class ClientDecorator extends HttpClientDecorator<Request, Response> {
   }
 
   @Override
-  protected String userAgent(Request request) {
-    return request.getHeaders().getFirstValue(USER_AGENT);
+  protected String requestHeader(Request request, String name) {
+    return request.getHeaders().getFirstValue(name);
+  }
+
+  @Override
+  protected String responseHeader(Response response, String name) {
+    return response.getHeaders().getFirstValue(name);
   }
 }

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/HttpUrlConnectionDecorator.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/HttpUrlConnectionDecorator.java
@@ -45,7 +45,12 @@ public class HttpUrlConnectionDecorator extends HttpClientDecorator<HttpURLConne
   }
 
   @Override
-  protected String userAgent(HttpURLConnection httpURLConnection) {
-    return httpURLConnection.getRequestProperty(USER_AGENT);
+  protected String requestHeader(HttpURLConnection httpURLConnection, String name) {
+    return httpURLConnection.getRequestProperty(name);
+  }
+
+  @Override
+  protected String responseHeader(Integer integer, String name) {
+    return null;
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Decorator.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Decorator.java
@@ -45,7 +45,12 @@ public class JaxRsClientV1Decorator extends HttpClientDecorator<ClientRequest, C
   }
 
   @Override
-  protected String userAgent(ClientRequest clientRequest) {
-    return (String) clientRequest.getHeaders().getFirst(USER_AGENT);
+  protected String requestHeader(ClientRequest clientRequest, String name) {
+    return (String) clientRequest.getHeaders().getFirst(name);
+  }
+
+  @Override
+  protected String responseHeader(ClientResponse clientResponse, String name) {
+    return clientResponse.getHeaders().getFirst(name);
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Decorator.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Decorator.java
@@ -46,7 +46,8 @@ public class JaxRsClientV1Decorator extends HttpClientDecorator<ClientRequest, C
 
   @Override
   protected String requestHeader(ClientRequest clientRequest, String name) {
-    return (String) clientRequest.getHeaders().getFirst(name);
+    Object header = clientRequest.getHeaders().getFirst(name);
+    return header != null ? header.toString() : null;
   }
 
   @Override

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JaxRsClientDecorator.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JaxRsClientDecorator.java
@@ -46,7 +46,12 @@ public class JaxRsClientDecorator
   }
 
   @Override
-  protected String userAgent(ClientRequestContext clientRequestContext) {
-    return clientRequestContext.getHeaderString(USER_AGENT);
+  protected String requestHeader(ClientRequestContext clientRequestContext, String name) {
+    return clientRequestContext.getHeaderString(name);
+  }
+
+  @Override
+  protected String responseHeader(ClientResponseContext clientResponseContext, String name) {
+    return clientResponseContext.getHeaderString(name);
   }
 }

--- a/instrumentation/khttp-0.1/src/main/java/io/opentelemetry/auto/instrumentation/khttp/KHttpDecorator.java
+++ b/instrumentation/khttp-0.1/src/main/java/io/opentelemetry/auto/instrumentation/khttp/KHttpDecorator.java
@@ -45,8 +45,13 @@ public class KHttpDecorator extends HttpClientDecorator<RequestWrapper, Response
   }
 
   @Override
-  protected String userAgent(RequestWrapper requestWrapper) {
-    // TODO: Find out how to get user agent.
+  protected String requestHeader(RequestWrapper requestWrapper, String name) {
+    // TODO: Find out how to get request header.
     return null;
+  }
+
+  @Override
+  protected String responseHeader(Response response, String name) {
+    return response.getHeaders().get(name);
   }
 }

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/NettyHttpClientDecorator.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/NettyHttpClientDecorator.java
@@ -55,7 +55,12 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   }
 
   @Override
-  protected String userAgent(HttpRequest httpRequest) {
-    return httpRequest.headers().get(USER_AGENT);
+  protected String requestHeader(HttpRequest httpRequest, String name) {
+    return httpRequest.headers().get(name);
+  }
+
+  @Override
+  protected String responseHeader(HttpResponse httpResponse, String name) {
+    return httpResponse.headers().get(name);
   }
 }

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/NettyHttpClientDecorator.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/NettyHttpClientDecorator.java
@@ -55,7 +55,12 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   }
 
   @Override
-  protected String userAgent(HttpRequest httpRequest) {
-    return httpRequest.headers().get(USER_AGENT);
+  protected String requestHeader(HttpRequest httpRequest, String name) {
+    return httpRequest.headers().get(name);
+  }
+
+  @Override
+  protected String responseHeader(HttpResponse httpResponse, String name) {
+    return httpResponse.headers().get(name);
   }
 }

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/NettyHttpClientDecorator.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/NettyHttpClientDecorator.java
@@ -55,7 +55,12 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   }
 
   @Override
-  protected String userAgent(HttpRequest httpRequest) {
-    return httpRequest.headers().get(USER_AGENT);
+  protected String requestHeader(HttpRequest httpRequest, String name) {
+    return httpRequest.headers().get(name);
+  }
+
+  @Override
+  protected String responseHeader(HttpResponse httpResponse, String name) {
+    return httpResponse.headers().get(name);
   }
 }

--- a/instrumentation/okhttp/okhttp-2.2/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/v2_2/OkHttpClientDecorator.java
+++ b/instrumentation/okhttp/okhttp-2.2/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/v2_2/OkHttpClientDecorator.java
@@ -46,7 +46,12 @@ public class OkHttpClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String userAgent(Request request) {
-    return request.header(USER_AGENT);
+  protected String requestHeader(Request request, String name) {
+    return request.header(name);
+  }
+
+  @Override
+  protected String responseHeader(Response response, String name) {
+    return response.header(name);
   }
 }

--- a/instrumentation/okhttp/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/v3_0/OkHttpClientDecorator.java
+++ b/instrumentation/okhttp/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/v3_0/OkHttpClientDecorator.java
@@ -45,7 +45,12 @@ public class OkHttpClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String userAgent(Request request) {
-    return request.header(USER_AGENT);
+  protected String requestHeader(Request request, String name) {
+    return request.header(name);
+  }
+
+  @Override
+  protected String responseHeader(Response response, String name) {
+    return response.header(name);
   }
 }

--- a/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/auto/instrumentation/playws/PlayWSClientDecorator.java
+++ b/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/auto/instrumentation/playws/PlayWSClientDecorator.java
@@ -46,7 +46,12 @@ public class PlayWSClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String userAgent(Request request) {
-    return request.getHeaders().get(USER_AGENT);
+  protected String requestHeader(Request request, String name) {
+    return request.getHeaders().get(name);
+  }
+
+  @Override
+  protected String responseHeader(Response response, String name) {
+    return response.getHeader(name);
   }
 }

--- a/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/auto/instrumentation/playws/PlayWSClientDecorator.java
+++ b/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/auto/instrumentation/playws/PlayWSClientDecorator.java
@@ -52,6 +52,6 @@ public class PlayWSClientDecorator extends HttpClientDecorator<Request, Response
 
   @Override
   protected String responseHeader(Response response, String name) {
-    return response.getHeader(name);
+    return response.getHeaders().get(name);
   }
 }

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
@@ -21,6 +21,7 @@ import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecor
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.net.URI;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
@@ -55,7 +56,13 @@ public class SpringWebfluxHttpClientDecorator
   }
 
   @Override
-  protected String userAgent(ClientRequest clientRequest) {
-    return clientRequest.headers().getFirst(USER_AGENT);
+  protected String requestHeader(ClientRequest clientRequest, String name) {
+    return clientRequest.headers().getFirst(name);
+  }
+
+  @Override
+  protected String responseHeader(ClientResponse clientResponse, String name) {
+    List<String> headers = clientResponse.headers().header(name);
+    return !headers.isEmpty() ? headers.get(0) : null;
   }
 }


### PR DESCRIPTION
…rically instead of only user agent.

When preparing to record content-length, I realized my previous change for user agents lacked foresight... By providing a generic header extension for HTTP decorators, we should be able to do everything in one place.

This should be added to HTTP server decorators too but for now doing client only to make sure it's not a terrible direction to go in.