### PR TITLE
Remove tests on some Java versions to temporarily help control cost

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,16 +203,7 @@ workflows:
           name: test_<< matrix.testTask >>
           matrix:
             parameters:
-              testTask: ["7", "8"]
-          filters:
-            tags:
-              only: /.*/
-
-      - default_test_job:
-          requires:
-            - build
-          name: test_11
-          testTask: test jacocoTestReport jacocoTestCoverageVerification
+              testTask: ["8"]
           filters:
             tags:
               only: /.*/
@@ -235,9 +226,7 @@ workflows:
 
       - publish_master:
           requires:
-            - test_7
             - test_8
-            - test_11
             - test_latest
             - muzzle
           filters:
@@ -283,7 +272,7 @@ workflows:
           name: test_<< matrix.testTask >>
           matrix:
             parameters:
-              testTask: ["7", "8"]
+              testTask: ["7", "8", "14"]
           filters:
             branches:
               only: /\d+\.\d+\.x$/
@@ -318,6 +307,7 @@ workflows:
             - test_7
             - test_8
             - test_11
+            - test_14
             - test_latest
             - muzzle
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ workflows:
           name: test_<< matrix.testTask >>
           matrix:
             parameters:
-              testTask: ["7", "8", "14"]
+              testTask: ["7", "8"]
           filters:
             tags:
               only: /.*/
@@ -238,7 +238,6 @@ workflows:
             - test_7
             - test_8
             - test_11
-            - test_14
             - test_latest
             - muzzle
           filters:
@@ -284,7 +283,7 @@ workflows:
           name: test_<< matrix.testTask >>
           matrix:
             parameters:
-              testTask: ["7", "8", "14"]
+              testTask: ["7", "8"]
           filters:
             branches:
               only: /\d+\.\d+\.x$/
@@ -319,7 +318,6 @@ workflows:
             - test_7
             - test_8
             - test_11
-            - test_14
             - test_latest
             - muzzle
           filters:


### PR DESCRIPTION
CircleCI cost is exploding lately ☹️.

I've started working on migrating to Github Actions (see my initial comment about feasibility here https://github.com/open-telemetry/community/issues/398#issuecomment-651401954).

In the meantime, I'd like to remove the Java 14 tests, to make a small dent in cost. I don't recall anything fail only on Java 14, so I think we are fine without it for a short while.