### PR TITLE
[3.3] Refactor instrumentation:spring:spring-webmvc-3.1

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpServerTracer.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpServerTracer.java
@@ -16,38 +16,14 @@
 
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator;
 
-import static io.opentelemetry.OpenTelemetry.getPropagators;
-import static io.opentelemetry.context.ContextUtils.withScopedContext;
-import static io.opentelemetry.trace.Span.Kind.SERVER;
-import static io.opentelemetry.trace.TracingContextUtils.getSpan;
-import static io.opentelemetry.trace.TracingContextUtils.withSpan;
-
-import io.grpc.Context;
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.auto.config.Config;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
-import io.opentelemetry.auto.instrumentation.api.Tags;
-import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.trace.Span;
-import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.Tracer;
-import io.opentelemetry.trace.attributes.SemanticAttributes;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.reflect.Method;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.concurrent.ExecutionException;
-import lombok.extern.slf4j.Slf4j;
 
 // TODO In search for a better home package
-@Slf4j
-public abstract class HttpServerTracer<REQUEST, CONNECTION, STORAGE> {
-  public static final String CONTEXT_ATTRIBUTE = "io.opentelemetry.instrumentation.context";
-  // Keeps track of the server span for the current trace.
-  private static final Context.Key<Span> CONTEXT_SERVER_SPAN_KEY =
-      Context.key("opentelemetry-trace-server-span-key");
+public abstract class HttpServerTracer<REQUEST, CONNECTION, STORAGE>
+    extends HttpServerTracerBase<REQUEST, CONNECTION, STORAGE> {
 
   protected final Tracer tracer;
 
@@ -60,205 +36,15 @@ public abstract class HttpServerTracer<REQUEST, CONNECTION, STORAGE> {
   protected abstract String getVersion();
 
   public Span startSpan(REQUEST request, CONNECTION connection, Method origin, String originType) {
-    String spanName = spanNameForMethod(origin);
-    return startSpan(request, connection, spanName, originType);
+    return startSpan(tracer, request, connection, origin, originType);
   }
 
   public Span startSpan(
       REQUEST request, CONNECTION connection, String spanName, String originType) {
-    final Span.Builder builder =
-        tracer
-            .spanBuilder(spanName)
-            .setSpanKind(SERVER)
-            .setParent(extract(request, getGetter()))
-            // TODO Where span.origin.type is defined?
-            .setAttribute("span.origin.type", originType);
-
-    Span span = builder.startSpan();
-    onConnection(span, connection);
-    onRequest(span, request);
-
-    return span;
-  }
-
-  protected void onConnection(Span span, CONNECTION connection) {
-    SemanticAttributes.NET_PEER_IP.set(span, peerHostIP(connection));
-    final Integer port = peerPort(connection);
-    // Negative or Zero ports might represent an unset/null value for an int type.  Skip setting.
-    if (port != null && port > 0) {
-      SemanticAttributes.NET_PEER_PORT.set(span, port);
-    }
-  }
-
-  // TODO use semantic attributes
-  protected void onRequest(final Span span, final REQUEST request) {
-    SemanticAttributes.HTTP_METHOD.set(span, method(request));
-
-    // Copy of HttpClientDecorator url handling
-    try {
-      final URI url = url(request);
-      if (url != null) {
-        final StringBuilder urlBuilder = new StringBuilder();
-        if (url.getScheme() != null) {
-          urlBuilder.append(url.getScheme());
-          urlBuilder.append("://");
-        }
-        if (url.getHost() != null) {
-          urlBuilder.append(url.getHost());
-          if (url.getPort() > 0 && url.getPort() != 80 && url.getPort() != 443) {
-            urlBuilder.append(":");
-            urlBuilder.append(url.getPort());
-          }
-        }
-        final String path = url.getPath();
-        if (path.isEmpty()) {
-          urlBuilder.append("/");
-        } else {
-          urlBuilder.append(path);
-        }
-        final String query = url.getQuery();
-        if (query != null) {
-          urlBuilder.append("?").append(query);
-        }
-        final String fragment = url.getFragment();
-        if (fragment != null) {
-          urlBuilder.append("#").append(fragment);
-        }
-
-        span.setAttribute(Tags.HTTP_URL, urlBuilder.toString());
-
-        if (Config.get().isHttpServerTagQueryString()) {
-          span.setAttribute(MoreTags.HTTP_QUERY, url.getQuery());
-          span.setAttribute(MoreTags.HTTP_FRAGMENT, url.getFragment());
-        }
-      }
-    } catch (final Exception e) {
-      log.debug("Error tagging url", e);
-    }
-    // TODO set resource name from URL.
-  }
-
-  /**
-   * This method is used to generate an acceptable span (operation) name based on a given method
-   * reference. Anonymous classes are named based on their parent.
-   */
-  private String spanNameForMethod(final Method method) {
-    return spanNameForClass(method.getDeclaringClass()) + "." + method.getName();
-  }
-
-  /**
-   * This method is used to generate an acceptable span (operation) name based on a given class
-   * reference. Anonymous classes are named based on their parent.
-   */
-  private String spanNameForClass(final Class clazz) {
-    if (!clazz.isAnonymousClass()) {
-      return clazz.getSimpleName();
-    }
-    String className = clazz.getName();
-    if (clazz.getPackage() != null) {
-      final String pkgName = clazz.getPackage().getName();
-      if (!pkgName.isEmpty()) {
-        className = clazz.getName().replace(pkgName, "").substring(1);
-      }
-    }
-    return className;
-  }
-
-  protected void onError(final Span span, final Throwable throwable) {
-    addThrowable(span, unwrapThrowable(throwable));
-  }
-
-  // TODO semantic attributes
-  public static void addThrowable(final Span span, final Throwable throwable) {
-    span.setAttribute(MoreTags.ERROR_MSG, throwable.getMessage());
-    span.setAttribute(MoreTags.ERROR_TYPE, throwable.getClass().getName());
-
-    final StringWriter errorString = new StringWriter();
-    throwable.printStackTrace(new PrintWriter(errorString));
-    span.setAttribute(MoreTags.ERROR_STACK, errorString.toString());
+    return startSpan(tracer, request, connection, spanName, originType);
   }
 
   public Span getCurrentSpan() {
     return tracer.getCurrentSpan();
   }
-
-  public Span getServerSpan(STORAGE storage) {
-    Context attachedContext = getServerContext(storage);
-    return attachedContext == null ? null : CONTEXT_SERVER_SPAN_KEY.get(attachedContext);
-  }
-
-  /**
-   * Creates new scoped context with the given span.
-   *
-   * <p>Attaches new context to the request to avoid creating duplicate server spans.
-   */
-  public Scope startScope(Span span, STORAGE storage) {
-    // TODO we could do this in one go, but TracingContextUtils.CONTEXT_SPAN_KEY is private
-    Context serverSpanContext = Context.current().withValue(CONTEXT_SERVER_SPAN_KEY, span);
-    Context newContext = withSpan(span, serverSpanContext);
-    attachServerContext(newContext, storage);
-    return withScopedContext(newContext);
-  }
-
-  // TODO should end methods remove SPAN attribute from request as well?
-  public void end(Span span, int responseStatus) {
-    setStatus(span, responseStatus);
-    span.end();
-  }
-
-  /** Ends given span exceptionally with default response status code 500. */
-  public void endExceptionally(Span span, Throwable throwable) {
-    endExceptionally(span, throwable, 500);
-  }
-
-  public void endExceptionally(Span span, Throwable throwable, int responseStatus) {
-    if (responseStatus == 200) {
-      // TODO I think this is wrong.
-      // We must report that response status that was actually sent to end user
-      // We may change span status, but not http_status attribute
-      responseStatus = 500;
-    }
-    onError(span, unwrapThrowable(throwable));
-    end(span, responseStatus);
-  }
-
-  protected Throwable unwrapThrowable(Throwable throwable) {
-    return throwable instanceof ExecutionException ? throwable.getCause() : throwable;
-  }
-
-  private <C> SpanContext extract(final C carrier, final HttpTextFormat.Getter<C> getter) {
-    final Context context =
-        getPropagators().getHttpTextFormat().extract(Context.current(), carrier, getter);
-    final Span span = getSpan(context);
-    return span.getContext();
-  }
-
-  private void setStatus(Span span, int status) {
-    SemanticAttributes.HTTP_STATUS_CODE.set(span, status);
-    // TODO status_message
-    span.setStatus(HttpStatusConverter.statusFromHttpStatus(status));
-  }
-
-  protected abstract Integer peerPort(CONNECTION connection);
-
-  protected abstract String peerHostIP(CONNECTION connection);
-
-  protected abstract HttpTextFormat.Getter<REQUEST> getGetter();
-
-  protected abstract URI url(REQUEST request) throws URISyntaxException;
-
-  protected abstract String method(REQUEST request);
-
-  /**
-   * Stores given context in the given request-response-loop storage in implementation specific way.
-   */
-  protected abstract void attachServerContext(Context context, STORAGE storage);
-
-  /**
-   * Returns context stored to the given request-response-loop storage by {@link
-   * #attachServerContext(Context, STORAGE)}.
-   *
-   * <p>May be null.
-   */
-  public abstract Context getServerContext(STORAGE storage);
 }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpServerTracerBase.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpServerTracerBase.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.auto.bootstrap.instrumentation.decorator;
+
+import static io.opentelemetry.OpenTelemetry.getPropagators;
+import static io.opentelemetry.context.ContextUtils.withScopedContext;
+import static io.opentelemetry.trace.Span.Kind.SERVER;
+import static io.opentelemetry.trace.TracingContextUtils.getSpan;
+import static io.opentelemetry.trace.TracingContextUtils.withSpan;
+
+import io.grpc.Context;
+import io.opentelemetry.auto.config.Config;
+import io.opentelemetry.auto.instrumentation.api.MoreTags;
+import io.opentelemetry.auto.instrumentation.api.Tags;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.HttpTextFormat;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.SpanContext;
+import io.opentelemetry.trace.Tracer;
+import io.opentelemetry.trace.attributes.SemanticAttributes;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+// TODO In search for a better home package
+public abstract class HttpServerTracerBase<REQUEST, CONNECTION, STORAGE> {
+  public static final String CONTEXT_ATTRIBUTE = "io.opentelemetry.instrumentation.context";
+  // Keeps track of the server span for the current trace.
+  private static final Context.Key<Span> CONTEXT_SERVER_SPAN_KEY =
+      Context.key("opentelemetry-trace-server-span-key");
+
+  public Span startSpan(
+      Tracer tracer, REQUEST request, CONNECTION connection, Method origin, String originType) {
+    String spanName = spanNameForMethod(origin);
+    return startSpan(tracer, request, connection, spanName, originType);
+  }
+
+  public Span startSpan(
+      Tracer tracer, REQUEST request, CONNECTION connection, String spanName, String originType) {
+    final Span.Builder builder =
+        tracer
+            .spanBuilder(spanName)
+            .setSpanKind(SERVER)
+            .setParent(extract(request, getGetter()))
+            // TODO Where span.origin.type is defined?
+            .setAttribute("span.origin.type", originType);
+
+    Span span = builder.startSpan();
+    onConnection(span, connection);
+    onRequest(span, request);
+
+    return span;
+  }
+
+  protected void onConnection(Span span, CONNECTION connection) {
+    SemanticAttributes.NET_PEER_IP.set(span, peerHostIP(connection));
+    final Integer port = peerPort(connection);
+    // Negative or Zero ports might represent an unset/null value for an int type. Skip setting.
+    if (port != null && port > 0) {
+      SemanticAttributes.NET_PEER_PORT.set(span, port);
+    }
+  }
+
+  // TODO use semantic attributes
+  protected void onRequest(final Span span, final REQUEST request) {
+    SemanticAttributes.HTTP_METHOD.set(span, method(request));
+
+    // Copy of HttpClientDecorator url handling
+    try {
+      final URI url = url(request);
+      if (url != null) {
+        final StringBuilder urlBuilder = new StringBuilder();
+        if (url.getScheme() != null) {
+          urlBuilder.append(url.getScheme());
+          urlBuilder.append("://");
+        }
+        if (url.getHost() != null) {
+          urlBuilder.append(url.getHost());
+          if (url.getPort() > 0 && url.getPort() != 80 && url.getPort() != 443) {
+            urlBuilder.append(":");
+            urlBuilder.append(url.getPort());
+          }
+        }
+        final String path = url.getPath();
+        if (path.isEmpty()) {
+          urlBuilder.append("/");
+        } else {
+          urlBuilder.append(path);
+        }
+        final String query = url.getQuery();
+        if (query != null) {
+          urlBuilder.append("?").append(query);
+        }
+        final String fragment = url.getFragment();
+        if (fragment != null) {
+          urlBuilder.append("#").append(fragment);
+        }
+
+        span.setAttribute(Tags.HTTP_URL, urlBuilder.toString());
+
+        if (Config.get().isHttpServerTagQueryString()) {
+          span.setAttribute(MoreTags.HTTP_QUERY, url.getQuery());
+          span.setAttribute(MoreTags.HTTP_FRAGMENT, url.getFragment());
+        }
+      }
+    } catch (final Exception e) {
+      log.debug("Error tagging url", e);
+    }
+    // TODO set resource name from URL.
+  }
+
+  /**
+   * This method is used to generate an acceptable span (operation) name based on a given method
+   * reference. Anonymous classes are named based on their parent.
+   */
+  private String spanNameForMethod(final Method method) {
+    return spanNameForClass(method.getDeclaringClass()) + "." + method.getName();
+  }
+
+  /**
+   * This method is used to generate an acceptable span (operation) name based on a given class
+   * reference. Anonymous classes are named based on their parent.
+   */
+  protected String spanNameForClass(final Class clazz) {
+    if (!clazz.isAnonymousClass()) {
+      return clazz.getSimpleName();
+    }
+    String className = clazz.getName();
+    if (clazz.getPackage() != null) {
+      final String pkgName = clazz.getPackage().getName();
+      if (!pkgName.isEmpty()) {
+        className = clazz.getName().replace(pkgName, "").substring(1);
+      }
+    }
+    return className;
+  }
+
+  protected void onError(final Span span, final Throwable throwable) {
+    addThrowable(span, unwrapThrowable(throwable));
+  }
+
+  // TODO semantic attributes
+  public static void addThrowable(final Span span, final Throwable throwable) {
+    span.setAttribute(MoreTags.ERROR_MSG, throwable.getMessage());
+    span.setAttribute(MoreTags.ERROR_TYPE, throwable.getClass().getName());
+
+    final StringWriter errorString = new StringWriter();
+    throwable.printStackTrace(new PrintWriter(errorString));
+    span.setAttribute(MoreTags.ERROR_STACK, errorString.toString());
+  }
+
+  public Span getCurrentSpan(Tracer tracer) {
+    return tracer.getCurrentSpan();
+  }
+
+  public Span getServerSpan(STORAGE storage) {
+    Context attachedContext = getServerContext(storage);
+    return attachedContext == null ? null : CONTEXT_SERVER_SPAN_KEY.get(attachedContext);
+  }
+
+  /**
+   * Creates new scoped context with the given span.
+   *
+   * <p>Attaches new context to the request to avoid creating duplicate server spans.
+   */
+  public Scope startScope(Span span, STORAGE storage) {
+    // TODO we could do this in one go, but TracingContextUtils.CONTEXT_SPAN_KEY is private
+    Context serverSpanContext = Context.current().withValue(CONTEXT_SERVER_SPAN_KEY, span);
+    Context newContext = withSpan(span, serverSpanContext);
+    attachServerContext(newContext, storage);
+    return withScopedContext(newContext);
+  }
+
+  // TODO should end methods remove SPAN attribute from request as well?
+  public void end(Span span, int responseStatus) {
+    setStatus(span, responseStatus);
+    span.end();
+  }
+
+  /** Ends given span exceptionally with default response status code 500. */
+  public void endExceptionally(Span span, Throwable throwable) {
+    endExceptionally(span, throwable, 500);
+  }
+
+  public void endExceptionally(Span span, Throwable throwable, int responseStatus) {
+    if (responseStatus == 200) {
+      // TODO I think this is wrong.
+      // We must report that response status that was actually sent to end user
+      // We may change span status, but not http_status attribute
+      responseStatus = 500;
+    }
+    onError(span, unwrapThrowable(throwable));
+    end(span, responseStatus);
+  }
+
+  protected Throwable unwrapThrowable(Throwable throwable) {
+    return throwable instanceof ExecutionException ? throwable.getCause() : throwable;
+  }
+
+  private <C> SpanContext extract(final C carrier, final HttpTextFormat.Getter<C> getter) {
+    final Context context =
+        getPropagators().getHttpTextFormat().extract(Context.current(), carrier, getter);
+    final Span span = getSpan(context);
+    return span.getContext();
+  }
+
+  private void setStatus(Span span, int status) {
+    SemanticAttributes.HTTP_STATUS_CODE.set(span, status);
+    // TODO status_message
+    span.setStatus(HttpStatusConverter.statusFromHttpStatus(status));
+  }
+
+  protected abstract Integer peerPort(CONNECTION connection);
+
+  protected abstract String peerHostIP(CONNECTION connection);
+
+  protected abstract HttpTextFormat.Getter<REQUEST> getGetter();
+
+  protected abstract URI url(REQUEST request) throws URISyntaxException;
+
+  protected abstract String method(REQUEST request);
+
+  /**
+   * Stores given context in the given request-response-loop storage in implementation specific way.
+   */
+  protected abstract void attachServerContext(Context context, STORAGE storage);
+
+  /**
+   * Returns context stored to the given request-response-loop storage by {@link
+   * #attachServerContext(Context, STORAGE)}.
+   *
+   * <p>May be null.
+   */
+  public abstract Context getServerContext(STORAGE storage);
+}

--- a/instrumentation-core/spring/spring-webmvc-3.1-core/spring-webmvc-3.1-core.gradle
+++ b/instrumentation-core/spring/spring-webmvc-3.1-core/spring-webmvc-3.1-core.gradle
@@ -1,0 +1,52 @@
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_1_7
+}
+
+group = 'io.opentelemetry.instrumentation'
+version = '0.0.1-SNAPSHOT'
+
+apply from: "$rootDir/gradle/java.gradle"
+apply plugin: 'muzzle'
+
+muzzle {
+  pass {
+    group = 'org.springframework'
+    module = 'spring-webmvc'
+    versions = "[3.1.0.RELEASE,]"
+    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4'] // broken releases... missing dependencies
+    skipVersions += '3.2.1.RELEASE' // missing a required class.  (bad release?)
+    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
+    assertInverse = true
+  }
+
+  // FIXME: webmvc depends on web, so we need a separate integration for spring-web specifically.
+  fail {
+    group = 'org.springframework'
+    module = 'spring-web'
+    versions = "[,]"
+    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4'] // broken releases... missing dependencies
+    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
+  }
+}
+
+sourceCompatibility = '7'
+
+dependencies {
+  // copy-paste from instrumentation-core-aws-sdk:aws-sdk-2.2-core:
+  // TODO(anuraaga): We currently include common instrumentation logic like decorators in the
+  // bootstrap, but we need to move it out so manual instrumentation does not depend on code from
+  // the agent, like Agent.
+  api project(':auto-bootstrap')
+
+  // TODO(mabdinur):
+  // Move servlet-common to instrumentation-core
+  compileOnly project(':instrumentation:servlet:servlet-common')
+
+  api deps.opentelemetryApi
+  api group: 'org.springframework', name: 'spring-webmvc', version: '3.1.0.RELEASE'
+  api group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
+}
+
+test {
+  useJUnitPlatform()
+}

--- a/instrumentation-core/spring/spring-webmvc-3.1-core/src/main/java/io/opentelemetry/instrumentation/springwebmvc/HandlerMappingResourceNameFilter.java
+++ b/instrumentation-core/spring/spring-webmvc-3.1-core/src/main/java/io/opentelemetry/instrumentation/springwebmvc/HandlerMappingResourceNameFilter.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.auto.instrumentation.springwebmvc;
+package io.opentelemetry.instrumentation.springwebmvc;
 
 import static io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpServerTracer.CONTEXT_ATTRIBUTE;
-import static io.opentelemetry.auto.instrumentation.springwebmvc.SpringWebMvcDecorator.DECORATE;
+import static io.opentelemetry.instrumentation.springwebmvc.SpringWebMvcDecorator.DECORATE;
 
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
@@ -55,7 +55,7 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
         if (findMapping(request)) {
           // Name the parent span based on the matching pattern
           // Let the parent span resource name be set with the attribute set in findMapping.
-          DECORATE.onRequest(parentSpan, request);
+          DECORATE.updateSpanNameUsingPattern(parentSpan, request);
         }
       } catch (final Exception ignored) {
         // mapping.getHandler() threw exception.  Ignore

--- a/instrumentation-core/spring/spring-webmvc-3.1-core/src/main/java/io/opentelemetry/instrumentation/springwebmvc/WebMVCTracingFilter.java
+++ b/instrumentation-core/spring/spring-webmvc-3.1-core/src/main/java/io/opentelemetry/instrumentation/springwebmvc/WebMVCTracingFilter.java
@@ -22,7 +22,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -32,7 +31,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 public class WebMVCTracingFilter extends OncePerRequestFilter implements Ordered {
 
-  private static final String CLASS_NAME = "WebMVCTracingFilter";
+  private static final String FILTER_CLASS = "WebMVCTracingFilter";
+  private static final String FILTER_METHOD = "doFilterInteral";
   private final Tracer tracer;
 
   public WebMVCTracingFilter(Tracer tracer) {
@@ -45,8 +45,7 @@ public class WebMVCTracingFilter extends OncePerRequestFilter implements Ordered
       throws ServletException, IOException {
     HttpServletRequest req = (HttpServletRequest) request;
 
-    Method doFilterInteral = this.getClass().getEnclosingMethod();
-    Span serverSpan = DECORATE.startSpan(tracer, request, doFilterInteral, CLASS_NAME);
+    Span serverSpan = DECORATE.startSpan(tracer, req, req, FILTER_METHOD, FILTER_CLASS);
 
     try (Scope scope = tracer.withSpan(serverSpan)) {
       filterChain.doFilter(req, response);

--- a/instrumentation-core/spring/spring-webmvc-3.1-core/src/main/java/io/opentelemetry/instrumentation/springwebmvc/WebMVCTracingFilter.java
+++ b/instrumentation-core/spring/spring-webmvc-3.1-core/src/main/java/io/opentelemetry/instrumentation/springwebmvc/WebMVCTracingFilter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.springwebmvc;
+
+import static io.opentelemetry.instrumentation.springwebmvc.SpringWebMvcDecorator.DECORATE;
+
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class WebMVCTracingFilter extends OncePerRequestFilter implements Ordered {
+
+  private static final String CLASS_NAME = "WebMVCTracingFilter";
+  private final Tracer tracer;
+
+  public WebMVCTracingFilter(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  @Override
+  public void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    HttpServletRequest req = (HttpServletRequest) request;
+
+    Method doFilterInteral = this.getClass().getEnclosingMethod();
+    Span serverSpan = DECORATE.startSpan(tracer, request, doFilterInteral, CLASS_NAME);
+
+    try (Scope scope = tracer.withSpan(serverSpan)) {
+      filterChain.doFilter(req, response);
+    } catch (Throwable t) {
+      DECORATE.onError(serverSpan, t);
+    } finally {
+      DECORATE.end(serverSpan, response.getStatus());
+    }
+  }
+
+  @Override
+  public void destroy() {}
+
+  @Override
+  public int getOrder() {
+    // Run after all HIGHEST_PRECEDENCE items
+    return Ordered.HIGHEST_PRECEDENCE + 1;
+  }
+}

--- a/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,7 +1,7 @@
 apply from: "$rootDir/gradle/instrumentation.gradle"
 
 dependencies {
-  compileOnly project(':instrumentation-core:spring:spring-webmvc-3.1-core')
+  implementation project(':instrumentation-core:spring:spring-webmvc-3.1-core')
 
   testImplementation(project(':testing')) {
     exclude(module: 'jetty-server') // incompatable servlet api

--- a/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,31 +1,7 @@
 apply from: "$rootDir/gradle/instrumentation.gradle"
 
-muzzle {
-  pass {
-    group = 'org.springframework'
-    module = 'spring-webmvc'
-    versions = "[3.1.0.RELEASE,]"
-    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4'] // broken releases... missing dependencies
-    skipVersions += '3.2.1.RELEASE' // missing a required class.  (bad release?)
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-    assertInverse = true
-  }
-
-  // FIXME: webmvc depends on web, so we need a separate integration for spring-web specifically.
-  fail {
-    group = 'org.springframework'
-    module = 'spring-web'
-    versions = "[,]"
-    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4'] // broken releases... missing dependencies
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-  }
-}
-
 dependencies {
-  compileOnly group: 'org.springframework', name: 'spring-webmvc', version: '3.1.0.RELEASE'
-  compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
-//  compileOnly group: 'org.springframework', name: 'spring-webmvc', version: '2.5.6'
-//  compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.4'
+  implementation project(':instrumentation-core:spring:spring-webmvc-3.1-core')
 
   testImplementation(project(':testing')) {
     exclude(module: 'jetty-server') // incompatable servlet api

--- a/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,7 +1,7 @@
 apply from: "$rootDir/gradle/instrumentation.gradle"
 
 dependencies {
-  implementation project(':instrumentation-core:spring:spring-webmvc-3.1-core')
+  compileOnly project(':instrumentation-core:spring:spring-webmvc-3.1-core')
 
   testImplementation(project(':testing')) {
     exclude(module: 'jetty-server') // incompatable servlet api

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
@@ -17,10 +17,11 @@
 package io.opentelemetry.auto.instrumentation.springwebmvc;
 
 import static io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpServerTracer.CONTEXT_ATTRIBUTE;
-import static io.opentelemetry.auto.instrumentation.springwebmvc.SpringWebMvcDecorator.DECORATE;
-import static io.opentelemetry.auto.instrumentation.springwebmvc.SpringWebMvcDecorator.TRACER;
+import static io.opentelemetry.auto.instrumentation.springwebmvc.InstrumentationHelper.CORE_INSTRUMENTATION_PACKAGE_NAME;
 import static io.opentelemetry.auto.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.auto.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
+import static io.opentelemetry.instrumentation.springwebmvc.SpringWebMvcDecorator.DECORATE;
+import static io.opentelemetry.instrumentation.springwebmvc.SpringWebMvcDecorator.TRACER;
 import static io.opentelemetry.trace.TracingContextUtils.currentContextWith;
 import static io.opentelemetry.trace.TracingContextUtils.getSpan;
 import static java.util.Collections.singletonMap;
@@ -63,7 +64,7 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".SpringWebMvcDecorator"};
+    return new String[] {CORE_INSTRUMENTATION_PACKAGE_NAME + ".SpringWebMvcDecorator"};
   }
 
   @Override
@@ -85,7 +86,7 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
       // Name the parent span based on the matching pattern
       final Object parentContext = request.getAttribute(CONTEXT_ATTRIBUTE);
       if (parentContext instanceof Context) {
-        DECORATE.onRequest(getSpan((Context) parentContext), request);
+        DECORATE.updateSpanNameUsingPattern(getSpan((Context) parentContext), request);
       }
 
       if (!TRACER.getCurrentSpan().getContext().isValid()) {

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/InstrumentationHelper.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/InstrumentationHelper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.auto.instrumentation.springwebmvc;
+
+public class InstrumentationHelper {
+
+  public static final String CORE_INSTRUMENTATION_PACKAGE_NAME =
+      "io.opentelemetry.instrumentation.springwebmvc";
+}

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/WebApplicationContextInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/WebApplicationContextInstrumentation.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.auto.instrumentation.springwebmvc;
 
+import static io.opentelemetry.auto.instrumentation.springwebmvc.InstrumentationHelper.CORE_INSTRUMENTATION_PACKAGE_NAME;
 import static io.opentelemetry.auto.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.auto.tooling.bytebuddy.matcher.AgentElementMatchers.extendsClass;
 import static io.opentelemetry.auto.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
@@ -26,6 +27,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.auto.tooling.Instrumenter;
+import io.opentelemetry.instrumentation.springwebmvc.HandlerMappingResourceNameFilter;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -36,6 +38,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 
 @AutoService(Instrumenter.class)
 public class WebApplicationContextInstrumentation extends Instrumenter.Default {
+
   public WebApplicationContextInstrumentation() {
     super("spring-web");
   }
@@ -57,9 +60,9 @@ public class WebApplicationContextInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".SpringWebMvcDecorator",
-      packageName + ".HandlerMappingResourceNameFilter",
-      packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",
+      CORE_INSTRUMENTATION_PACKAGE_NAME + ".SpringWebMvcDecorator",
+      CORE_INSTRUMENTATION_PACKAGE_NAME + ".HandlerMappingResourceNameFilter",
+      CORE_INSTRUMENTATION_PACKAGE_NAME + ".HandlerMappingResourceNameFilter$BeanDefinition",
     };
   }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -151,7 +151,8 @@ include ':instrumentation:vertx-3.0'
 include ':instrumentation:vertx-reactive-3.5'
 
 include ':instrumentation-core:aws-sdk:aws-sdk-2.2'
-include ':instrumentation-core:spring'
+
+include ':instrumentation-core:spring:spring-webmvc-3.1-core'
 
 // exporter adapters
 include ":auto-exporters"


### PR DESCRIPTION
I broke up this pull requests in to smaller changes that build on each other:
  1) [3.1] Create decorator https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/647
  2) [3.2] Create instrumentation-core:spring:spring-webmvc-3.1-core https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/648

This changes extracts code which can be used for manual instrumentation from instrumentation:spring-webmvc-3.1 to instrumentation-core:spring:spring-webmvc-3.1-core. This change includes:
- Moved HandlerMappingResourceNameFilter.java  to spring-webmvc-3.1-core
- Moved SpringWebMvcDecorator.java to spring-webmvc-3.1-core (this class will now extend the new decorator HttpServerTracingBase)
     - Override abstract methods in HttpServerTracingBase
- Update references to HandlerMappingResourceNameFilter and SpringWebMvcDecorator in instrumentation:spring-webmvc-3.1
   - Update package names in DispatcherServletInstrumentation, HandlerAdaptorInstrumentation, WebApplicationContextInstrumentation

**I am not blocked by this pull request. All this change does is move things around. I'm blocked by https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/640, https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/639, https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/647, and https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/648**


