### PR TITLE
[WIP] Add a (trait | rule) to encapsulate test agent bootstrap logic …

### DIFF
--- a/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/auto/instrumentation/lettuce/v5_1/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/auto/instrumentation/lettuce/v5_1/LettuceSyncClientTest.groovy
@@ -17,19 +17,22 @@
 package io.opentelemetry.auto.instrumentation.lettuce.v5_1
 
 import io.lettuce.core.ClientOptions
-
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisConnectionException
 import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.api.sync.RedisCommands
-import io.opentelemetry.auto.test.AgentTestRunner
+import io.opentelemetry.auto.test.AgentTestTrait
+import io.opentelemetry.auto.test.SpockRunner
 import io.opentelemetry.auto.test.utils.PortUtils
+import org.junit.runner.RunWith
 import redis.embedded.RedisServer
 import spock.lang.Shared
+import spock.lang.Specification
 
 import static io.opentelemetry.trace.Span.Kind.CLIENT
 
-class LettuceSyncClientTest extends AgentTestRunner {
+@RunWith(SpockRunner.class)
+class LettuceSyncClientTest extends Specification implements AgentTestTrait {
   public static final String HOST = "127.0.0.1"
   public static final int DB_INDEX = 0
   // Disable autoreconnect so we do not get stray traces popping up on server shutdown
@@ -64,7 +67,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
   StatefulConnection connection
   RedisCommands<String, ?> syncCommands
 
-  def setupSpec() {
+  def childSetupSpec() {
     port = PortUtils.randomOpenPort()
     incorrectPort = PortUtils.randomOpenPort()
     dbAddr = HOST + ":" + port + "/" + DB_INDEX
@@ -81,7 +84,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
       .port(port).build()
   }
 
-  def setup() {
+  def childSetup() {
     redisClient = RedisClient.create(embeddedDbUri)
 
     redisServer.start()

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/AgentClassRule.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/AgentClassRule.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.auto.test;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class AgentClassRule extends AgentTestRunner implements TestRule {
+
+  private static final ThreadLocal<AgentClassRule> CLASSRULES = new ThreadLocal<>();
+
+  public InMemoryExporter getTestWriter() {
+    return TEST_WRITER;
+  }
+
+  public static class AgentRule implements TestRule {
+    @Override
+    public Statement apply(final Statement base, Description description) {
+      return new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+          AgentClassRule classRule = CLASSRULES.get();
+          if (classRule != null) {
+            classRule.beforeTest();
+          }
+          base.evaluate();
+        }
+      };
+    }
+  }
+
+  @Override
+  public Statement apply(final Statement base, Description description) {
+    final AgentClassRule classRule = this;
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        agentSetup();
+        setupBeforeTests();
+        CLASSRULES.set(classRule);
+        try {
+          base.evaluate();
+        } finally{
+          CLASSRULES.remove();
+          cleanUpAfterTests();
+          agentCleanup();
+        }
+      }
+    };
+  }
+}

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
@@ -54,7 +54,6 @@ import net.bytebuddy.utility.JavaModule;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
 import org.slf4j.LoggerFactory;
 import org.spockframework.runtime.model.SpecMetadata;
 
@@ -73,7 +72,6 @@ import org.spockframework.runtime.model.SpecMetadata;
  *       in an initialized state.
  * </ul>
  */
-@RunWith(SpockRunner.class)
 @SpecMetadata(filename = "AgentTestRunner.java", line = 0)
 @Slf4j
 public abstract class AgentTestRunner extends AgentSpecification {
@@ -170,7 +168,7 @@ public abstract class AgentTestRunner extends AgentSpecification {
   public void beforeTest() {
     assert !getTestTracer().getCurrentSpan().getContext().isValid()
         : "Span is active before test has started: " + getTestTracer().getCurrentSpan();
-    log.debug("Starting test: '{}'", getSpecificationContext().getCurrentIteration().getName());
+    // log.debug("Starting test: '{}'", getSpecificationContext().getCurrentIteration().getName());
     TEST_WRITER.clear();
   }
 

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/AgentTestTrait.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/AgentTestTrait.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.auto.test
+
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
+import io.opentelemetry.auto.test.asserts.InMemoryExporterAssert
+
+trait AgentTestTrait {
+
+  static AgentTestRunner AGENT_TEST_RUNNER
+  static InMemoryExporter TEST_WRITER
+
+  def setupSpec() {
+    AGENT_TEST_RUNNER = new AgentClassRule()
+    TEST_WRITER = AgentTestRunner.TEST_WRITER
+
+    AgentTestRunner.agentSetup()
+    AGENT_TEST_RUNNER.setupBeforeTests()
+
+    childSetupSpec()
+  }
+
+  def childSetupSpec() {}
+
+  def setup() {
+    AGENT_TEST_RUNNER.beforeTest()
+
+    childSetup()
+  }
+
+  def childSetup() {}
+
+  def cleanupSpec() {
+    AGENT_TEST_RUNNER.cleanUpAfterTests()
+    AgentTestRunner.agentCleanup()
+  }
+
+  void assertTraces(final int size,
+                   @ClosureParams(
+                     value = SimpleType.class,
+                     options = "io.opentelemetry.auto.test.asserts.ListWriterAssert")
+                   @DelegatesTo(value = InMemoryExporterAssert.class, strategy = Closure.DELEGATE_FIRST)
+                   final Closure spec) {
+    AgentTestRunner.assertTraces(size, spec)
+  }
+}

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/InstrumentationTestTrait.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/InstrumentationTestTrait.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.auto.test
+
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
+import io.opentelemetry.auto.test.asserts.InMemoryExporterAssert
+
+trait InstrumentationTestTrait {
+
+  static InstrumentationTestRunner INSTRUMENTATION_TEST_RUNNER
+  static InMemoryExporter TEST_WRITER
+
+  def setupSpec() {
+    INSTRUMENTATION_TEST_RUNNER = new InstrumentationTestRunnerImpl()
+    TEST_WRITER = InstrumentationTestRunner.TEST_WRITER
+  }
+
+  def childSetupSpec() {
+  }
+
+  def setup() {
+    INSTRUMENTATION_TEST_RUNNER.beforeTest()
+  }
+
+  def childSetup() {
+  }
+
+  void assertTraces(final int size,
+                    @ClosureParams(
+                      value = SimpleType.class,
+                      options = "io.opentelemetry.auto.test.asserts.ListWriterAssert")
+                    @DelegatesTo(value = InMemoryExporterAssert.class, strategy = Closure.DELEGATE_FIRST)
+                    final Closure spec) {
+    INSTRUMENTATION_TEST_RUNNER.assertTraces(size, spec)
+  }
+
+  static class InstrumentationTestRunnerImpl extends InstrumentationTestRunner {}
+}


### PR DESCRIPTION
…to allow sharing test hierarchy between auto and non-auto instrumentation

I was examining sharing test code for auto and manual instrumentation (my first candidate is a WIP extraction of the lettuce-51 instrumentation where the test cases would be identical) and found the blocker is that spock will only find test methods (feature methods I guess is what spock calls them) in the class hierarchy. This makes some sense and reminds me of junit4 where it was strongly recommended to migrate from using base classes for behavior to rules to avoid constricting the test hierarchy.

So I tried adding a junit rule to use alternatively to `AgentTestRunner`. It's a big unwieldy though because we need both a classrule and a rule, and I don't think there's a way to do that in junit4 with a single class (jupiter has no problem but spock / sputnik doesn't work on jupiter.

So I tried a different pattern of using a Groovy trait, which spock does support for reading behavior (fixture methods). Unfortunately it has its own problem, where child classes can't define their own fixture methods using the normal names due to this.

https://stackoverflow.com/questions/56464191/public-groovy-method-must-be-public-says-the-compiler

The workaround of using a different method like `childSetup` works ok though.

The other change is with these approaches, `@RunWith` needs to be added to the test class. I'm ok with this since it's a very small amount of boilerplate and I've seen many codebases where they used a custom runner and had this on all tests, it's fairly idiomatic I guess.

Any thoughts? I lean towards the trait since codifying the groovy restrictions isn't that hard and it is a bit easier to use in the tests themselves. Not doing anything is ok too, but I don't know if we'd ever be able to share tests between auto / manual in that case.

https://github.com/spockframework/spock/issues/106

As an aside, I found several long-standing open issues in spock during my investigation of this, and including issues like that one we had with the weird closure / parent class mock, have a mostly negative impression. If using junit5 + assertj + mockito, since we're a Java project, is on the table I'm happy to explore it :) I'm also happy with not though, projects should use the framework they prefer.