### PR TITLE
Add jvmargs to gradle.properties to provide more RAM when building

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx1024m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.parallel=true
 org.gradle.caching=true
+
+org.gradle.jvmargs=-Xmx2048m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 
+# Gradle default is 256m which causes issues with our build - https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 
-org.gradle.jvmargs=-Xmx1024m
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
I got an out-of-heap space when working in the project in IntelliJ and it suggests raising the RAM like this. I have a feeling previously, the metaspace flag of 1G was implicitly causing Gradle to use more RAM while now it's the default, I think is just hundreds of MB.

I went with 2G arbitrarily since in other large projects I've had better experience with it than 1G and haven't needed more.