### PR TITLE
Fix response header capture

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v2_0/CommonsHttpClientDecorator.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v2_0/CommonsHttpClientDecorator.java
@@ -55,16 +55,13 @@ public class CommonsHttpClientDecorator extends HttpClientDecorator<HttpMethod, 
 
   @Override
   protected String requestHeader(HttpMethod httpMethod, String name) {
-    return header(httpMethod, name);
+    final Header header = httpMethod.getRequestHeader(name);
+    return header != null ? header.getValue() : null;
   }
 
   @Override
   protected String responseHeader(HttpMethod httpMethod, String name) {
-    return header(httpMethod, name);
-  }
-
-  private static String header(HttpMethod httpMethod, String name) {
-    final Header header = httpMethod.getRequestHeader(name);
+    final Header header = httpMethod.getResponseHeader(name);
     return header != null ? header.getValue() : null;
   }
 }


### PR DESCRIPTION
Randomly ran across this. Well not so randomly. I'm using it for a (soon to be retired) legacy context propagation scheme.