### PR TITLE
Fix references to old artifact name

### DIFF
--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/VersionLogger.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/VersionLogger.java
@@ -28,9 +28,10 @@ public class VersionLogger {
   /** Log version string for java-agent */
   public static void logAllVersions() {
     log.info(
-        "opentelemetry-auto - version: {}",
+        "opentelemetry-javaagent - version: {}",
         getVersionString(
-            ClassLoader.getSystemClassLoader().getResourceAsStream("opentelemetry-auto.version")));
+            ClassLoader.getSystemClassLoader()
+                .getResourceAsStream("opentelemetry-javaagent.version")));
     if (log.isDebugEnabled()) {
       log.debug(
           "Running on Java {}. JVM {} - {} - {}",

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/ClassRetransformingBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/ClassRetransformingBenchmark.java
@@ -44,11 +44,11 @@ public class ClassRetransformingBenchmark {
     state.inst.retransformClasses(TracedClass.class);
   }
 
-  @Fork(jvmArgsAppend = "-javaagent:/path/to/opentelemetry-auto-master.jar")
+  @Fork(jvmArgsAppend = "-javaagent:/path/to/opentelemetry-javaagent-master.jar")
   public static class WithAgentMaster extends ClassRetransformingBenchmark {}
 
   @Fork(
       jvmArgsAppend =
-          "-javaagent:/path/to/opentelemetry-java-instrumentation/java-agent/build/libs/opentelemetry-auto.jar")
+          "-javaagent:/path/to/opentelemetry-java-instrumentation/java-agent/build/libs/opentelemetry-javaagent.jar")
   public static class WithAgent extends ClassRetransformingBenchmark {}
 }

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
@@ -68,7 +68,7 @@ public class HttpBenchmark {
 
   @Fork(
       jvmArgsAppend = {
-        "-javaagent:/path/to/opentelemetry-java-instrumentation/java-agent/build/libs/opentelemetry-auto.jar",
+        "-javaagent:/path/to/opentelemetry-java-instrumentation/java-agent/build/libs/opentelemetry-javaagent.jar",
         "-Dota.exporter=logging"
       })
   public static class WithAgent extends ClassRetransformingBenchmark {}

--- a/opentelemetry-javaagent/src/main/java/io/opentelemetry/auto/bootstrap/AgentBootstrap.java
+++ b/opentelemetry-javaagent/src/main/java/io/opentelemetry/auto/bootstrap/AgentBootstrap.java
@@ -193,11 +193,11 @@ public class AgentBootstrap {
       }
     }
     throw new RuntimeException(
-        "opentelemetry-auto is not installed, because class '"
+        "opentelemetry-javaagent is not installed, because class '"
             + thisClass.getCanonicalName()
             + "' is located in '"
             + jarUrl
-            + "'. Make sure you don't have this .class file anywhere, besides opentelemetry-auto.jar");
+            + "'. Make sure you don't have this .class file anywhere, besides opentelemetry-javaagent.jar");
   }
 
   /**


### PR DESCRIPTION
This part resolves #655:

```
getResourceAsStream("opentelemetry-javaagent.version")
```