### PR TITLE
Remove unnecessary shadow

### DIFF
--- a/agent-bootstrap/agent-bootstrap.gradle
+++ b/agent-bootstrap/agent-bootstrap.gradle
@@ -1,8 +1,3 @@
-// The shadowJar of this project will be injected into the JVM's bootstrap classloader
-plugins {
-  id "com.github.johnrengelman.shadow"
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 
 // FIXME: Improve test coverage.


### PR DESCRIPTION
It doesn't seem that we need to shadow (fat jar) the bootstrap module itself.