### PR TITLE
OTLP exporetr: use standard exporter configuration from OpenTelemetry Java SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,14 @@ A simple wrapper for the Zipkin exporter of opentelemetry-java. It POSTs json in
 
 A simple wrapper for the OTLP exporter of opentelemetry-java.
 
-| System property                  | Environment variable             | Purpose                                                              |
-|----------------------------------|----------------------------------|----------------------------------------------------------------------|
-| ota.exporter=otlp (default)      | OTA_EXPORTER=otlp                | To select OpenTelemetry exporter (default)                           |
-| ota.exporter.jar                 | OTA_EXPORTER_JAR                 | Path to the exporter fat-jar that you want to use                    |
-| ota.exporter.otlp.endpoint       | OTA_EXPORTER_OTLP_ENDPOINT       | The OTLP endpoint to connect to.                                     |
+| System property                  | Environment variable             | Purpose                                                                 |
+|----------------------------------|----------------------------------|-------------------------------------------------------------------------|
+| ota.exporter=otlp (default)      | OTA_EXPORTER=otlp                | To select OpenTelemetry exporter (default)                              |
+| ota.exporter.jar                 | OTA_EXPORTER_JAR                 | Path to the exporter fat-jar that you want to use                       |
+| otel.otlp.endpoint               | OTEL_OTLP_ENDPOINT               | The OTLP endpoint to connect to.                                        |
+| otel.otlp.use.tls                | OTEL_OTLP_USE_TLS                | To use or not TLS, default is false.                                    |
+| otel.otlp.metadata               | OTEL_OTLP_METADATA               | The key-value pairs separated by semicolon to pass as request metadata. |
+| otel.otlp.span.timeout           | OTEL_OTLP_SPAN_TIMEOUT           | The max waiting time allowed to send each span batch, default is 1000.  |
 
 #### Logging Exporter
 

--- a/auto-exporters/otlp/src/main/java/io/opentelemetry/auto/exporters/otlp/OtlpSpanExporterFactory.java
+++ b/auto-exporters/otlp/src/main/java/io/opentelemetry/auto/exporters/otlp/OtlpSpanExporterFactory.java
@@ -16,23 +16,18 @@
 
 package io.opentelemetry.auto.exporters.otlp;
 
-import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.exporters.otlp.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.extensions.auto.config.Config;
 import io.opentelemetry.sdk.extensions.auto.config.SpanExporterFactory;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public class OtlpSpanExporterFactory implements SpanExporterFactory {
-  private static final String OTLP_ENDPOINT = "otlp.endpoint";
 
   @Override
   public SpanExporter fromConfig(final Config config) {
-    final String otlpEndpoint = config.getString(OTLP_ENDPOINT, "localhost:55680");
-    if (otlpEndpoint.isEmpty()) {
-      throw new IllegalStateException("ota.exporter.otlp.endpoint is required");
-    }
     return OtlpGrpcSpanExporter.newBuilder()
-        .setChannel(ManagedChannelBuilder.forTarget(otlpEndpoint).usePlaintext().build())
+        .readEnvironmentVariables()
+        .readSystemProperties()
         .build();
   }
 }


### PR DESCRIPTION
closes #564 
closes #531 