### PR TITLE
Create instrumentation-core apache-httpclient-4.0

### DIFF
--- a/instrumentation-core/apache-httpclient-4.0/apache-httpclient-4.0.gradle
+++ b/instrumentation-core/apache-httpclient-4.0/apache-httpclient-4.0.gradle
@@ -1,0 +1,24 @@
+plugins {
+  id "com.github.johnrengelman.shadow"
+}
+
+ext {
+  noShadowPublish = true
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+group = 'io.opentelemetry.instrumentation'
+
+shadowJar {
+  archiveClassifier = 'agent'
+  configurations = []
+  relocate 'io.opentelemetry.instrumentation.apachehttpclient.v4_0', 'io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.shaded'
+}
+
+dependencies {
+  compileOnly project(':auto-bootstrap')
+  compileOnly deps.opentelemetryApi
+    
+  compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.0'
+}

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
@@ -19,18 +19,14 @@ package io.opentelemetry.instrumentation.apachehttpclient.v4_0;
 import io.grpc.Context;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator;
-import io.opentelemetry.trace.Tracer;
 import java.net.URI;
 import org.apache.http.Header;
 import org.apache.http.HttpMessage;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 
-class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriRequest, HttpResponse> {
+public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriRequest, HttpResponse> {
   public static final ApacheHttpClientDecorator DECORATE = new ApacheHttpClientDecorator();
-
-  public static final Tracer TRACER =
-      OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.apache-httpclient-4.0");
 
   public void inject(Context context, HttpUriRequest request) {
     OpenTelemetry.getPropagators()

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0;
+package io.opentelemetry.instrumentation.apachehttpclient.v4_0;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator;

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.instrumentation.apachehttpclient.v4_0;
 
+import io.grpc.Context;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import io.opentelemetry.trace.Tracer;
@@ -30,6 +31,12 @@ public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriReques
 
   public static final Tracer TRACER =
       OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.apache-httpclient-4.0");
+
+  public void inject(Context context, HttpUriRequest request) {
+    OpenTelemetry.getPropagators()
+        .getHttpTextFormat()
+        .inject(context, request, HttpHeadersInjectAdapter.SETTER);
+  }
 
   @Override
   protected String method(final HttpUriRequest httpRequest) {

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
@@ -25,7 +25,7 @@ import org.apache.http.HttpMessage;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 
-public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriRequest, HttpResponse> {
+class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriRequest, HttpResponse> {
   public static final ApacheHttpClientDecorator DECORATE = new ApacheHttpClientDecorator();
 
   public void inject(Context context, HttpUriRequest request) {

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
@@ -26,7 +26,7 @@ import org.apache.http.HttpMessage;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 
-public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriRequest, HttpResponse> {
+class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriRequest, HttpResponse> {
   public static final ApacheHttpClientDecorator DECORATE = new ApacheHttpClientDecorator();
 
   public static final Tracer TRACER =

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHelper.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHelper.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.context.ContextUtils.withScopedContext;
 import static io.opentelemetry.instrumentation.apachehttpclient.v4_0.ApacheHttpClientDecorator.DECORATE;
 
 import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.CallDepthThreadLocalMap;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.ClientDecorator;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
@@ -31,6 +32,14 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 
 public class ApacheHttpClientHelper {
+
+  public static final Tracer TRACER =
+      OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.spring-webflux-5.0");
+
+  public static SpanWithScope doMethodEnter(final HttpUriRequest request) {
+    return doMethodEnter(request, TRACER);
+  }
+
   public static SpanWithScope doMethodEnter(final HttpUriRequest request, final Tracer tracer) {
     final Span span = DECORATE.getOrCreateSpan(request, tracer);
 

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHelper.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHelper.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.apachehttpclient.v4_0;
+
+import static io.opentelemetry.context.ContextUtils.withScopedContext;
+
+import io.grpc.Context;
+import io.opentelemetry.auto.bootstrap.CallDepthThreadLocalMap;
+import io.opentelemetry.auto.bootstrap.instrumentation.decorator.ClientDecorator;
+import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+
+public class ApacheHttpClientHelper {
+  public static SpanWithScope doMethodEnter(
+      final HttpUriRequest request,
+      final Tracer tracer,
+      final ApacheHttpClientDecorator decorator) {
+    final Span span = decorator.getOrCreateSpan(request, tracer);
+
+    decorator.afterStart(span);
+    decorator.onRequest(span, request);
+
+    final Context context = ClientDecorator.currentContextWith(span);
+    if (span.getContext().isValid()) {
+      decorator.inject(context, request);
+    }
+    final Scope scope = withScopedContext(context);
+
+    return new SpanWithScope(span, scope);
+  }
+
+  public static void doResetCallDepthThread(final SpanWithScope spanWithScope) {
+    if (spanWithScope == null) {
+      return;
+    }
+    CallDepthThreadLocalMap.reset(HttpClient.class);
+  }
+
+  public static void doMethodExit(
+      final SpanWithScope spanWithScope,
+      final Object result,
+      final Throwable throwable,
+      final ApacheHttpClientDecorator decorator) {
+    if (spanWithScope == null) {
+      return;
+    }
+
+    try {
+      final Span span = spanWithScope.getSpan();
+
+      if (result instanceof HttpResponse) {
+        decorator.onResponse(span, (HttpResponse) result);
+      } // else they probably provided a ResponseHandler.
+
+      decorator.onError(span, throwable);
+      decorator.beforeFinish(span);
+      span.end();
+    } finally {
+      spanWithScope.closeScope();
+    }
+  }
+}

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/HostAndRequestAsHttpUriRequest.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/HostAndRequestAsHttpUriRequest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0;
+package io.opentelemetry.instrumentation.apachehttpclient.v4_0;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/HttpHeadersInjectAdapter.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/HttpHeadersInjectAdapter.java
@@ -19,7 +19,7 @@ package io.opentelemetry.instrumentation.apachehttpclient.v4_0;
 import io.opentelemetry.context.propagation.HttpTextFormat;
 import org.apache.http.client.methods.HttpUriRequest;
 
-public class HttpHeadersInjectAdapter implements HttpTextFormat.Setter<HttpUriRequest> {
+class HttpHeadersInjectAdapter implements HttpTextFormat.Setter<HttpUriRequest> {
 
   public static final HttpHeadersInjectAdapter SETTER = new HttpHeadersInjectAdapter();
 

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/HttpHeadersInjectAdapter.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/HttpHeadersInjectAdapter.java
@@ -19,7 +19,7 @@ package io.opentelemetry.instrumentation.apachehttpclient.v4_0;
 import io.opentelemetry.context.propagation.HttpTextFormat;
 import org.apache.http.client.methods.HttpUriRequest;
 
-class HttpHeadersInjectAdapter implements HttpTextFormat.Setter<HttpUriRequest> {
+public class HttpHeadersInjectAdapter implements HttpTextFormat.Setter<HttpUriRequest> {
 
   public static final HttpHeadersInjectAdapter SETTER = new HttpHeadersInjectAdapter();
 

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/HttpHeadersInjectAdapter.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/HttpHeadersInjectAdapter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0;
+package io.opentelemetry.instrumentation.apachehttpclient.v4_0;
 
 import io.opentelemetry.context.propagation.HttpTextFormat;
 import org.apache.http.client.methods.HttpUriRequest;

--- a/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/WrappingStatusSettingResponseHandler.java
+++ b/instrumentation-core/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_0/WrappingStatusSettingResponseHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.apachehttpclient.v4_0;
+
+import static io.opentelemetry.instrumentation.apachehttpclient.v4_0.ApacheHttpClientDecorator.DECORATE;
+
+import io.opentelemetry.trace.Span;
+import java.io.IOException;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+
+public class WrappingStatusSettingResponseHandler implements ResponseHandler {
+  final Span span;
+  final ResponseHandler handler;
+
+  public WrappingStatusSettingResponseHandler(final Span span, final ResponseHandler handler) {
+    this.span = span;
+    this.handler = handler;
+  }
+
+  @Override
+  public Object handleResponse(final HttpResponse response)
+      throws ClientProtocolException, IOException {
+    if (null != span) {
+      DECORATE.onResponse(span, response);
+    }
+    return handler.handleResponse(response);
+  }
+}

--- a/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
+++ b/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
@@ -1,4 +1,4 @@
-group = 'io.opentelemetry.instrumentation.spring'
+group = 'io.opentelemetry.instrumentation'
 
 apply plugin: 'java'
 apply from: "$rootDir/gradle/java.gradle"

--- a/instrumentation-core/spring/spring-webflux-5.0/spring-webflux-5.0.gradle
+++ b/instrumentation-core/spring/spring-webflux-5.0/spring-webflux-5.0.gradle
@@ -9,7 +9,7 @@ ext {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-group = 'io.opentelemetry.instrumentation.spring'
+group = 'io.opentelemetry.instrumentation'
 
 dependencies {
   compileOnly project(':auto-bootstrap')

--- a/instrumentation-core/spring/spring-webflux-5.0/spring-webflux-5.0.gradle
+++ b/instrumentation-core/spring/spring-webflux-5.0/spring-webflux-5.0.gradle
@@ -9,7 +9,7 @@ ext {
 
 apply from: "$rootDir/gradle/java.gradle"
 
-group = 'io.opentelemetry.instrumentation.spring.webflux'
+group = 'io.opentelemetry.instrumentation.spring'
 
 dependencies {
   compileOnly project(':auto-bootstrap')

--- a/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,4 +1,4 @@
-group = 'io.opentelemetry.instrumentation.spring'
+group = 'io.opentelemetry.instrumentation'
 
 apply from: "$rootDir/gradle/java.gradle"
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/apache-httpclient-4.0.gradle
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/apache-httpclient-4.0.gradle
@@ -30,6 +30,7 @@ testSets {
 }
 
 dependencies {
+  implementation project(path: ':instrumentation-core:apache-httpclient-4.0', configuration: 'shadow')
   compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.0'
 
   testImplementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.0'

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentation.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentation.java
@@ -16,9 +16,9 @@
 
 package io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0;
 
-import static io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.ApacheHttpClientDecorator.DECORATE;
-import static io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.ApacheHttpClientDecorator.TRACER;
-import static io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.HttpHeadersInjectAdapter.SETTER;
+import static io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.shaded.ApacheHttpClientDecorator.DECORATE;
+import static io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.shaded.ApacheHttpClientDecorator.TRACER;
+import static io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.shaded.HttpHeadersInjectAdapter.SETTER;
 import static io.opentelemetry.auto.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.auto.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
 import static io.opentelemetry.context.ContextUtils.withScopedContext;
@@ -34,6 +34,7 @@ import io.grpc.Context;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.CallDepthThreadLocalMap;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.ClientDecorator;
+import io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.shaded.HostAndRequestAsHttpUriRequest;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.context.Scope;
@@ -75,9 +76,9 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".ApacheHttpClientDecorator",
-      packageName + ".HttpHeadersInjectAdapter",
-      packageName + ".HostAndRequestAsHttpUriRequest",
+      packageName + ".shaded.ApacheHttpClientDecorator",
+      packageName + ".shaded.HttpHeadersInjectAdapter",
+      packageName + ".shaded.HostAndRequestAsHttpUriRequest",
       getClass().getName() + "$HelperMethods",
       getClass().getName() + "$WrappingStatusSettingResponseHandler",
     };

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentation.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentation.java
@@ -26,14 +26,12 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.CallDepthThreadLocalMap;
 import io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.shaded.ApacheHttpClientHelper;
 import io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.shaded.HostAndRequestAsHttpUriRequest;
 import io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.shaded.WrappingStatusSettingResponseHandler;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
-import io.opentelemetry.trace.Tracer;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -49,9 +47,6 @@ import org.apache.http.client.methods.HttpUriRequest;
 
 @AutoService(Instrumenter.class)
 public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
-
-  public static final Tracer TRACER =
-      OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.spring-webflux-5.0");
 
   public ApacheHttpClientInstrumentation() {
     super("httpclient", "apache-httpclient", "apache-http-client");
@@ -174,7 +169,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
         return null;
       }
 
-      return ApacheHttpClientHelper.doMethodEnter(request, TRACER);
+      return ApacheHttpClientHelper.doMethodEnter(request);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -202,7 +197,7 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
         return null;
       }
 
-      final SpanWithScope spanWithScope = ApacheHttpClientHelper.doMethodEnter(request, TRACER);
+      final SpanWithScope spanWithScope = ApacheHttpClientHelper.doMethodEnter(request);
 
       // Wrap the handler so we capture the status code
       if (handler instanceof ResponseHandler) {
@@ -232,10 +227,10 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
       }
 
       if (request instanceof HttpUriRequest) {
-        return ApacheHttpClientHelper.doMethodEnter((HttpUriRequest) request, TRACER);
+        return ApacheHttpClientHelper.doMethodEnter((HttpUriRequest) request);
       } else {
         return ApacheHttpClientHelper.doMethodEnter(
-            new HostAndRequestAsHttpUriRequest(host, request), TRACER);
+            new HostAndRequestAsHttpUriRequest(host, request));
       }
     }
 
@@ -268,11 +263,10 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
       final SpanWithScope spanWithScope;
 
       if (request instanceof HttpUriRequest) {
-        spanWithScope = ApacheHttpClientHelper.doMethodEnter((HttpUriRequest) request, TRACER);
+        spanWithScope = ApacheHttpClientHelper.doMethodEnter((HttpUriRequest) request);
       } else {
         spanWithScope =
-            ApacheHttpClientHelper.doMethodEnter(
-                new HostAndRequestAsHttpUriRequest(host, request), TRACER);
+            ApacheHttpClientHelper.doMethodEnter(new HostAndRequestAsHttpUriRequest(host, request));
       }
 
       // Wrap the handler so we capture the status code

--- a/settings.gradle
+++ b/settings.gradle
@@ -150,6 +150,7 @@ include ':instrumentation:twilio-6.6'
 include ':instrumentation:vertx-3.0'
 include ':instrumentation:vertx-reactive-3.5'
 
+include ':instrumentation-core:apache-httpclient-4.0'
 include ':instrumentation-core:aws-sdk:aws-sdk-2.2'
 include ':instrumentation-core:reactor-3.1'
 include ':instrumentation-core:servlet'


### PR DESCRIPTION
Extract code that can be used in manual instrumentation from instrumentation:apache-httpclient:apache-httpclient-4.0 to instrumentation-core.