### PR TITLE
Fix muzzle failure

### DIFF
--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyHandlerInstrumentation.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyHandlerInstrumentation.java
@@ -52,6 +52,8 @@ public final class JettyHandlerInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
+    // order matters here because subclasses (e.g. JettyHttpServerTracer) need to be injected into
+    // the class loader after their super classes (e.g. Servlet3HttpServerTracer)
     return new String[] {
       "io.opentelemetry.instrumentation.servlet.HttpServletRequestGetter",
       "io.opentelemetry.instrumentation.servlet.ServletHttpServerTracer",

--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyHandlerInstrumentation.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyHandlerInstrumentation.java
@@ -53,11 +53,11 @@ public final class JettyHandlerInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".JettyHttpServerTracer",
+      "io.opentelemetry.instrumentation.servlet.HttpServletRequestGetter",
+      "io.opentelemetry.instrumentation.servlet.ServletHttpServerTracer",
       "io.opentelemetry.auto.instrumentation.servlet.v3_0.Servlet3HttpServerTracer",
       "io.opentelemetry.auto.instrumentation.servlet.v3_0.TagSettingAsyncListener",
-      "io.opentelemetry.instrumentation.servlet.ServletHttpServerTracer",
-      "io.opentelemetry.instrumentation.servlet.HttpServletRequestGetter",
+      packageName + ".JettyHttpServerTracer",
     };
   }
 


### PR DESCRIPTION
No idea why `muzzle` only started failing, but it looks like the failure is because `JettyHttpServerTracer` extends `Servlet3HttpServerTracer`, but due to the ordering in `helperClassNames()`, `JettyHttpServerTracer` is added to the class loader first, before `Servlet3HttpServerTracer` (it's super class) has been added.