### PR TITLE
Make sure that filter chain always runs

### DIFF
--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/HandlerMappingResourceNameFilter.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/HandlerMappingResourceNameFilter.java
@@ -60,9 +60,9 @@ public class HandlerMappingResourceNameFilter extends OncePerRequestFilter imple
       } catch (final Exception ignored) {
         // mapping.getHandler() threw exception.  Ignore
       }
-
-      filterChain.doFilter(request, response);
     }
+
+    filterChain.doFilter(request, response);
   }
 
   /**


### PR DESCRIPTION
`filterChain.doFilter(request, response)` was accidentally nested inside of a conditional.

cc: @tylerbenson, you may want this in dd-trace-java