### PR TITLE
add exporter configurations to springboot autoconfigure

### DIFF
--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -18,7 +18,8 @@ bootJar {
 }
 
 dependencies {
-  annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+  annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor"
+  implementation "org.springframework.boot:spring-boot-starter-validation"
   
   testImplementation('org.springframework.boot:spring-boot-starter-test') {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
@@ -32,7 +33,14 @@ dependencies {
   implementation project(':instrumentation-core:spring:spring-webflux-5.0')
   
   api deps.opentelemetryApi 
-  api "io.opentelemetry:opentelemetry-exporters-logging:0.5.0"
+  
+  compileOnly deps.opentelemetryJaeger
+  compileOnly deps.opentelemetryOtlp
+  implementation group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
+  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.24.0'
+  
+  compileOnly deps.opentelemetryZipkin
+  compileOnly "io.opentelemetry:opentelemetry-exporters-logging:0.5.0"
 }
 
 test {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -31,10 +31,12 @@ dependencies {
   
   api deps.opentelemetryApi 
 
-  compileOnly "io.opentelemetry:opentelemetry-exporters-logging:0.5.0"
+  compileOnly "io.opentelemetry:opentelemetry-exporters-logging:0.6.0"
   compileOnly deps.opentelemetryJaeger
   compileOnly deps.opentelemetryOtlp
   compileOnly deps.opentelemetryZipkin
+  
+  compileOnly group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
 }
 
 test {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -34,11 +34,7 @@ dependencies {
   compileOnly "io.opentelemetry:opentelemetry-exporters-logging:0.5.0"
   compileOnly deps.opentelemetryJaeger
   compileOnly deps.opentelemetryOtlp
-  compileOnly group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
-  compileOnly group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.24.0'
-  
   compileOnly deps.opentelemetryZipkin
-  compileOnly group: 'io.zipkin.reporter2', name: 'zipkin-sender-okhttp3', version: '2.12.2'
 }
 
 test {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -25,15 +25,13 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
   
-  implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation project(':instrumentation-core:spring:spring-webmvc-3.1')
   implementation project(':instrumentation-core:spring:spring-web-3.1')
-  
-  implementation 'org.springframework.boot:spring-boot-starter-webflux'
   implementation project(':instrumentation-core:spring:spring-webflux-5.0')
   
   api deps.opentelemetryApi 
 
+  compileOnly "io.opentelemetry:opentelemetry-exporters-logging:0.5.0"
   compileOnly deps.opentelemetryJaeger
   compileOnly deps.opentelemetryOtlp
   implementation group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
@@ -41,8 +39,6 @@ dependencies {
   
   compileOnly deps.opentelemetryZipkin
   implementation group: 'io.zipkin.reporter2', name: 'zipkin-sender-okhttp3', version: '2.12.2'
-  
-  compileOnly "io.opentelemetry:opentelemetry-exporters-logging:0.5.0"
 }
 
 test {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -34,11 +34,11 @@ dependencies {
   compileOnly "io.opentelemetry:opentelemetry-exporters-logging:0.5.0"
   compileOnly deps.opentelemetryJaeger
   compileOnly deps.opentelemetryOtlp
-  implementation group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
-  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.24.0'
+  compileOnly group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
+  compileOnly group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.24.0'
   
   compileOnly deps.opentelemetryZipkin
-  implementation group: 'io.zipkin.reporter2', name: 'zipkin-sender-okhttp3', version: '2.12.2'
+  compileOnly group: 'io.zipkin.reporter2', name: 'zipkin-sender-okhttp3', version: '2.12.2'
 }
 
 test {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -40,6 +40,8 @@ dependencies {
   implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.24.0'
   
   compileOnly deps.opentelemetryZipkin
+  implementation group: 'io.zipkin.reporter2', name: 'zipkin-sender-okhttp3', version: '2.12.2'
+  
   compileOnly "io.opentelemetry:opentelemetry-exporters-logging:0.5.0"
 }
 

--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -33,7 +33,7 @@ dependencies {
   implementation project(':instrumentation-core:spring:spring-webflux-5.0')
   
   api deps.opentelemetryApi 
-  
+
   compileOnly deps.opentelemetryJaeger
   compileOnly deps.opentelemetryOtlp
   implementation group: 'io.grpc', name: 'grpc-api', version: '1.24.0'

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
@@ -17,12 +17,17 @@
 package io.opentelemetry.instrumentation.spring.autoconfigure;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.exporters.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.MultiSpanProcessor;
+import io.opentelemetry.sdk.trace.Samplers;
 import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.trace.Tracer;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -31,29 +36,47 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Create an {@link io.opentelemetry.trace.Tracer}.
  *
- * <p>If {@code TracerProperties.loggingExporterIsEnabled=True}: Create a simple span processor
- * using the LoggingSpanExporter
+ * <p>Adds Open Telemetry SpanProcessors to the tracer provider using available exporter beans
+ *
+ * <p>Sets Sampler probability
  */
 @Configuration
 @EnableConfigurationProperties(TracerProperties.class)
 public class TracerAutoConfiguration {
 
-  @Autowired TracerProperties tracerProperties;
-
   @Bean
   @ConditionalOnMissingBean
-  public Tracer otelTracer() throws Exception {
+  public Tracer otelTracer(
+      TracerProperties tracerProperties, ObjectProvider<List<SpanExporter>> spanExportersProvider)
+      throws Exception {
     Tracer tracer = OpenTelemetry.getTracer(tracerProperties.getName());
-    setLoggingExporter();
+
+    List<SpanExporter> spanExporters = spanExportersProvider.getIfAvailable();
+    if (spanExporters == null || spanExporters.isEmpty()) {
+      return tracer;
+    }
+
+    addSpanProcessors(spanExporters);
+    setSampler(tracerProperties);
+
     return tracer;
   }
 
-  private void setLoggingExporter() {
-    if (!tracerProperties.isLoggingExporterEnabled()) {
-      return;
-    }
+  private void addSpanProcessors(List<SpanExporter> spanExporters) {
 
-    SpanProcessor logProcessor = SimpleSpanProcessor.newBuilder(new LoggingSpanExporter()).build();
-    OpenTelemetrySdk.getTracerProvider().addSpanProcessor(logProcessor);
+    List<SpanProcessor> spanProcessors =
+        spanExporters.stream()
+            .map(spanExporter -> SimpleSpanProcessor.newBuilder(spanExporter).build())
+            .collect(Collectors.toList());
+
+    OpenTelemetrySdk.getTracerProvider()
+        .addSpanProcessor(MultiSpanProcessor.create(spanProcessors));
+  }
+
+  private void setSampler(TracerProperties tracerProperties) {
+    TraceConfig.getDefault()
+        .toBuilder()
+        .setSampler(Samplers.probability(tracerProperties.getSamplerProbability()))
+        .build();
   }
 }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
@@ -64,7 +64,6 @@ public class TracerAutoConfiguration {
   }
 
   private void addSpanProcessors(List<SpanExporter> spanExporters) {
-
     List<SpanProcessor> spanProcessors =
         spanExporters.stream()
             .map(spanExporter -> SimpleSpanProcessor.newBuilder(spanExporter).build())

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.Configuration;
  * <p>Adds span exporter beans to the active tracer provider {@code
  * OpenTelemetrySdk.getTracerProvider()}
  *
- * <p>Sets {@link TraceConfig} sampler probability
+ * <p>Updates the sampler probability in the active {@link TraceConfig}
  */
 @Configuration
 @EnableConfigurationProperties(TracerProperties.class)
@@ -74,9 +74,13 @@ public class TracerAutoConfiguration {
   }
 
   private void setSampler(TracerProperties tracerProperties) {
-    TraceConfig.getDefault()
-        .toBuilder()
-        .setSampler(Samplers.probability(tracerProperties.getSamplerProbability()))
-        .build();
+    TraceConfig updatedTraceConfig =
+        OpenTelemetrySdk.getTracerProvider()
+            .getActiveTraceConfig()
+            .toBuilder()
+            .setSampler(Samplers.probability(tracerProperties.getSamplerProbability()))
+            .build();
+
+    OpenTelemetrySdk.getTracerProvider().updateActiveTraceConfig(updatedTraceConfig);
   }
 }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
@@ -34,11 +34,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Create an {@link io.opentelemetry.trace.Tracer}.
+ * Create {@link io.opentelemetry.trace.Tracer} bean if bean is missing.
  *
- * <p>Adds Open Telemetry SpanProcessors to the tracer provider using available exporter beans
+ * <p>Adds span exporter beans to the active tracer provider {@code
+ * OpenTelemetrySdk.getTracerProvider()}
  *
- * <p>Sets Sampler probability
+ * <p>Sets {@link TraceConfig} sampler probability
  */
 @Configuration
 @EnableConfigurationProperties(TracerProperties.class)

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
@@ -29,11 +29,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "opentelemetry.trace.tracer")
 public final class TracerProperties {
-  // TODO: Add support for Span Batch Processor
 
   private String name = "otel-spring-tracer";
 
-  /** If Sample probability == 1: always sample If Sample probability == 0: never sample */
+  /** 
+  * If Sample probability == 1: always sample
+  *
+  * <p> If Sample probability == 0: never sample 
+  */
   @DecimalMin("0.0")
   @DecimalMax("1.0")
   private double samplerProbability = 1.0;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
@@ -32,11 +32,11 @@ public final class TracerProperties {
 
   private String name = "otel-spring-tracer";
 
-  /** 
-  * If Sample probability == 1: always sample
-  *
-  * <p> If Sample probability == 0: never sample 
-  */
+  /**
+   * If Sample probability == 1: always sample
+   *
+   * <p>If Sample probability == 0: never sample
+   */
   @DecimalMin("0.0")
   @DecimalMax("1.0")
   private double samplerProbability = 1.0;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
@@ -33,6 +33,7 @@ public final class TracerProperties {
 
   private String name = "otel-spring-tracer";
 
+  /** If Sample probability == 1: always sample If Sample probability == 0: never sample */
   @DecimalMin("0.0")
   @DecimalMax("1.0")
   private double samplerProbability = 1.0;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
@@ -23,9 +23,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Configuration for OpenTelemetry Tracer
  *
- * <p>Get Tracer Name {@link getName()}
+ * <p>Get Tracer Name
  *
- * <p>Get Sampling Probability {@link getSamplerProbability()}
+ * <p>Get Sampling Probability
  */
 @ConfigurationProperties(prefix = "opentelemetry.trace.tracer")
 public final class TracerProperties {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
@@ -23,7 +23,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Configuration for OpenTelemetry Tracer
  *
- * <p>Sets default tracer name and sampler probability
+ * <p>Get Tracer Name {@link getName()}
+ *
+ * <p>Get Sampling Probability {@link getSamplerProbability()}
  */
 @ConfigurationProperties(prefix = "opentelemetry.trace.tracer")
 public final class TracerProperties {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerProperties.java
@@ -16,18 +16,24 @@
 
 package io.opentelemetry.instrumentation.spring.autoconfigure;
 
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Configuration for OpenTelemetry Tracer
  *
- * <p>Configures LoggingExporter and sets default tracer name
+ * <p>Sets default tracer name and sampler probability
  */
 @ConfigurationProperties(prefix = "opentelemetry.trace.tracer")
 public final class TracerProperties {
+  // TODO: Add support for Span Batch Processor
 
   private String name = "otel-spring-tracer";
-  private boolean loggingExporterEnabled = true;
+
+  @DecimalMin("0.0")
+  @DecimalMax("1.0")
+  private double samplerProbability = 1.0;
 
   public String getName() {
     return name;
@@ -37,11 +43,11 @@ public final class TracerProperties {
     this.name = name;
   }
 
-  public boolean isLoggingExporterEnabled() {
-    return loggingExporterEnabled;
+  public double getSamplerProbability() {
+    return samplerProbability;
   }
 
-  public void setLoggingExporterEnabled(boolean loggingExporterEnabled) {
-    this.loggingExporterEnabled = loggingExporterEnabled;
+  public void setSamplerProbability(double samplerProbability) {
+    this.samplerProbability = samplerProbability;
   }
 }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerExporterProperties.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.jaeger;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Configuration for JaegerExporter */
+@ConfigurationProperties(prefix = "opentelemetry.trace.exporter.jaeger")
+public class JaegerExporterProperties {
+
+  private boolean enabled = true;
+  private String serviceName = "otel-spring-boot-jaeger-exporter";
+  private String host = "localhost";
+  private int port = 14250;
+  private Duration deadline = Duration.ofMillis(1000L);
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  public void setServiceName(String serviceName) {
+    this.serviceName = serviceName;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  public Duration getDeadline() {
+    return deadline;
+  }
+
+  public void setDeadline(Duration deadline) {
+    this.deadline = deadline;
+  }
+}

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
@@ -28,7 +28,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Create JaegerExporter */
+/**
+ * Configures {@link JaegerGrpcSpanExporter} for tracing.
+ *
+ * <p>Initializes {@link JaegerGrpcSpanExporter} bean if bean is missing.
+ */
 @Configuration
 @AutoConfigureBefore(TracerAutoConfiguration.class)
 @EnableConfigurationProperties(JaegerSpanExporterProperties.class)

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.jaeger;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.opentelemetry.exporters.jaeger.JaegerGrpcSpanExporter;
+import io.opentelemetry.instrumentation.spring.autoconfigure.TracerAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Create JaegerExporter */
+@Configuration
+@AutoConfigureBefore(TracerAutoConfiguration.class)
+@EnableConfigurationProperties(JaegerExporterProperties.class)
+@ConditionalOnProperty(
+    prefix = "opentelemetry.trace.exporter.jaeger",
+    name = "enabled",
+    matchIfMissing = true)
+@ConditionalOnClass(JaegerGrpcSpanExporter.class)
+public class JaegerSpanExporterAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public JaegerGrpcSpanExporter otelJaegerSpanExporter(
+      JaegerExporterProperties jaegerExporterProperties) {
+
+    ManagedChannel channel =
+        ManagedChannelBuilder.forAddress(
+                jaegerExporterProperties.getHost(), jaegerExporterProperties.getPort())
+            .usePlaintext()
+            .build();
+
+    return JaegerGrpcSpanExporter.newBuilder()
+        .setServiceName(jaegerExporterProperties.getServiceName())
+        .setDeadlineMs(jaegerExporterProperties.getDeadline().toMillis())
+        .setChannel(channel)
+        .build();
+  }
+}

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Configuration;
 /** Create JaegerExporter */
 @Configuration
 @AutoConfigureBefore(TracerAutoConfiguration.class)
-@EnableConfigurationProperties(JaegerExporterProperties.class)
+@EnableConfigurationProperties(JaegerSpanExporterProperties.class)
 @ConditionalOnProperty(
     prefix = "opentelemetry.trace.exporter.jaeger",
     name = "enabled",
@@ -42,17 +42,17 @@ public class JaegerSpanExporterAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public JaegerGrpcSpanExporter otelJaegerSpanExporter(
-      JaegerExporterProperties jaegerExporterProperties) {
+      JaegerSpanExporterProperties jaegerSpanExporterProperties) {
 
     ManagedChannel channel =
         ManagedChannelBuilder.forAddress(
-                jaegerExporterProperties.getHost(), jaegerExporterProperties.getPort())
+                jaegerSpanExporterProperties.getHost(), jaegerSpanExporterProperties.getPort())
             .usePlaintext()
             .build();
 
     return JaegerGrpcSpanExporter.newBuilder()
-        .setServiceName(jaegerExporterProperties.getServiceName())
-        .setDeadlineMs(jaegerExporterProperties.getDeadline().toMillis())
+        .setServiceName(jaegerSpanExporterProperties.getServiceName())
+        .setDeadlineMs(jaegerSpanExporterProperties.getDeadline().toMillis())
         .setChannel(channel)
         .build();
   }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
@@ -49,8 +49,7 @@ public class JaegerSpanExporterAutoConfiguration {
       JaegerSpanExporterProperties jaegerSpanExporterProperties) {
 
     ManagedChannel channel =
-        ManagedChannelBuilder.forAddress(
-                jaegerSpanExporterProperties.getHost(), jaegerSpanExporterProperties.getPort())
+        ManagedChannelBuilder.forTarget(jaegerSpanExporterProperties.getEndpoint())
             .usePlaintext()
             .build();
 

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
@@ -40,7 +40,7 @@ import org.springframework.context.annotation.Configuration;
     prefix = "opentelemetry.trace.exporter.jaeger",
     name = "enabled",
     matchIfMissing = true)
-@ConditionalOnClass(JaegerGrpcSpanExporter.class)
+@ConditionalOnClass({JaegerGrpcSpanExporter.class, ManagedChannel.class})
 public class JaegerSpanExporterAutoConfiguration {
 
   @Bean

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
@@ -55,7 +55,7 @@ public class JaegerSpanExporterAutoConfiguration {
 
     return JaegerGrpcSpanExporter.newBuilder()
         .setServiceName(jaegerSpanExporterProperties.getServiceName())
-        .setDeadlineMs(jaegerSpanExporterProperties.getDeadline().toMillis())
+        .setDeadlineMs(jaegerSpanExporterProperties.getSpanTimeout().toMillis())
         .setChannel(channel)
         .build();
   }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
@@ -19,9 +19,19 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.jaeger;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Configuration for JaegerSpanExporter */
+/**
+ * Configuration for {@link JaegerSpanExporter}
+ *
+ * <p>Get Exporter Service Name {@link getServiceName()}
+ *
+ * <p>Get Exporter Host Name {@link getHost()}
+ *
+ * <p>Get Exporter Port {@link getPort()}
+ *
+ * <p>Get max wait time for Collector to process Span Batches {@link getDeadline()}
+ */
 @ConfigurationProperties(prefix = "opentelemetry.trace.exporter.jaeger")
-public class JaegerSpanExporterProperties {
+public final class JaegerSpanExporterProperties {
 
   private boolean enabled = true;
   private String serviceName = "otel-spring-boot-jaeger-exporter";

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
@@ -34,7 +34,7 @@ public final class JaegerSpanExporterProperties {
   private boolean enabled = true;
   private String serviceName = "unknown";
   private String endpoint = "localhost:14250";
-  private Duration deadline = Duration.ofSeconds(1);
+  private Duration spanTimeout = Duration.ofSeconds(1);
 
   public boolean isEnabled() {
     return enabled;
@@ -60,11 +60,11 @@ public final class JaegerSpanExporterProperties {
     this.endpoint = endpoint;
   }
 
-  public Duration getDeadline() {
-    return deadline;
+  public Duration getSpanTimeout() {
+    return spanTimeout;
   }
 
-  public void setDeadline(Duration deadline) {
-    this.deadline = deadline;
+  public void setSpanTimeout(Duration spanTimeout) {
+    this.spanTimeout = spanTimeout;
   }
 }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
@@ -35,9 +35,7 @@ public final class JaegerSpanExporterProperties {
 
   private boolean enabled = true;
   private String serviceName = "unknown";
-  private String host = "localhost";
-  /** Default port from {@link JaegerSpanExporter.DEFAULT_JAEGER_ENDPOINT} */
-  private int port = 14250;
+  private String endpoint = "localhost:14250";
 
   private Duration deadline = Duration.ofSeconds(1);
 

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
@@ -19,9 +19,9 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.jaeger;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Configuration for JaegerExporter */
+/** Configuration for JaegerSpanExporter */
 @ConfigurationProperties(prefix = "opentelemetry.trace.exporter.jaeger")
-public class JaegerExporterProperties {
+public class JaegerSpanExporterProperties {
 
   private boolean enabled = true;
   private String serviceName = "otel-spring-boot-jaeger-exporter";

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
@@ -34,7 +34,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public final class JaegerSpanExporterProperties {
 
   private boolean enabled = true;
-  private String serviceName = "otel-spring-boot-jaeger-exporter";
+  private String serviceName = "unknown";
   private String host = "localhost";
   /** Default port from {@link JaegerSpanExporter.DEFAULT_JAEGER_ENDPOINT} */
   private int port = 14250;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
@@ -24,9 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * <p>Get Exporter Service Name
  *
- * <p>Get Exporter Host Name
- *
- * <p>Get Exporter Port
+ * <p>Get Exporter Endpoint
  *
  * <p>Get max wait time for Collector to process Span Batches
  */

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
@@ -22,13 +22,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Configuration for {@link JaegerSpanExporter}
  *
- * <p>Get Exporter Service Name {@link getServiceName()}
+ * <p>Get Exporter Service Name
  *
- * <p>Get Exporter Host Name {@link getHost()}
+ * <p>Get Exporter Host Name
  *
- * <p>Get Exporter Port {@link getPort()}
+ * <p>Get Exporter Port
  *
- * <p>Get max wait time for Collector to process Span Batches {@link getDeadline()}
+ * <p>Get max wait time for Collector to process Span Batches
  */
 @ConfigurationProperties(prefix = "opentelemetry.trace.exporter.jaeger")
 public final class JaegerSpanExporterProperties {
@@ -36,8 +36,10 @@ public final class JaegerSpanExporterProperties {
   private boolean enabled = true;
   private String serviceName = "otel-spring-boot-jaeger-exporter";
   private String host = "localhost";
+  /** Default port from {@link JaegerSpanExporter.DEFAULT_JAEGER_ENDPOINT} */
   private int port = 14250;
-  private Duration deadline = Duration.ofMillis(1000L);
+
+  private Duration deadline = Duration.ofSeconds(1);
 
   public boolean isEnabled() {
     return enabled;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
@@ -36,7 +36,6 @@ public final class JaegerSpanExporterProperties {
   private boolean enabled = true;
   private String serviceName = "unknown";
   private String endpoint = "localhost:14250";
-
   private Duration deadline = Duration.ofSeconds(1);
 
   public boolean isEnabled() {
@@ -55,20 +54,12 @@ public final class JaegerSpanExporterProperties {
     this.serviceName = serviceName;
   }
 
-  public String getHost() {
-    return host;
+  public String getEndpoint() {
+    return endpoint;
   }
 
-  public void setHost(String host) {
-    this.host = host;
-  }
-
-  public int getPort() {
-    return port;
-  }
-
-  public void setPort(int port) {
-    this.port = port;
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
   }
 
   public Duration getDeadline() {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
@@ -14,35 +14,32 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.instrumentation.spring.autoconfigure.httpclients.resttemplate;
+package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.logging;
 
-import io.opentelemetry.instrumentation.spring.autoconfigure.httpclients.HttpClientsProperties;
-import io.opentelemetry.trace.Tracer;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.opentelemetry.exporters.logging.LoggingSpanExporter;
+import io.opentelemetry.instrumentation.spring.autoconfigure.TracerAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestTemplate;
 
-/**
- * Configures {@link RestTemplate} for tracing.
- *
- * <p>Adds Open Telemetry instrumentation to RestTemplate beans after initialization
- */
+/** Create LoggingSpanExporter */
 @Configuration
-@ConditionalOnClass(RestTemplate.class)
-@EnableConfigurationProperties(HttpClientsProperties.class)
+@EnableConfigurationProperties(LoggingSpanExporterProperties.class)
+@AutoConfigureBefore(TracerAutoConfiguration.class)
 @ConditionalOnProperty(
-    prefix = "opentelemetry.trace.httpclients",
+    prefix = "opentelemetry.trace.exporter.logging",
     name = "enabled",
     matchIfMissing = true)
-public class RestTemplateAutoConfiguration {
+@ConditionalOnClass(LoggingSpanExporter.class)
+public class LoggingSpanExporterAutoConfiguration {
 
   @Bean
-  @Autowired
-  public RestTemplateBeanPostProcessor otelRestTemplateBeanPostProcessor(final Tracer tracer) {
-    return new RestTemplateBeanPostProcessor(tracer);
+  @ConditionalOnMissingBean
+  public LoggingSpanExporter otelLoggingSpanExporter() {
+    return new LoggingSpanExporter();
   }
 }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Create LoggingSpanExporter */
+/** Create LoggingSpanExporter bean*/
 @Configuration
 @EnableConfigurationProperties(LoggingSpanExporterProperties.class)
 @AutoConfigureBefore(TracerAutoConfiguration.class)

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Create LoggingSpanExporter bean*/
+/** Create LoggingSpanExporter bean */
 @Configuration
 @EnableConfigurationProperties(LoggingSpanExporterProperties.class)
 @AutoConfigureBefore(TracerAutoConfiguration.class)

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Create LoggingSpanExporter bean */
+/** Configures {@link LoggingSpanExporter} bean for tracing. */
 @Configuration
 @EnableConfigurationProperties(LoggingSpanExporterProperties.class)
 @AutoConfigureBefore(TracerAutoConfiguration.class)

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterProperties.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.logging;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Configuration for LoggingSpanExporter */
+@ConfigurationProperties(prefix = "opentelemetry.trace.exporter.logging")
+public final class LoggingSpanExporterProperties {
+  private boolean enabled = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+}

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterProperties.java
@@ -18,7 +18,7 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.logging;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Configuration for LoggingSpanExporter */
+/** Configuration for {@link LoggingSpanExporter} */
 @ConfigurationProperties(prefix = "opentelemetry.trace.exporter.logging")
 public final class LoggingSpanExporterProperties {
   private boolean enabled = true;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
@@ -40,7 +40,7 @@ import org.springframework.context.annotation.Configuration;
     prefix = "opentelemetry.trace.exporter.otlp",
     name = "enabled",
     matchIfMissing = true)
-@ConditionalOnClass(OtlpGrpcSpanExporter.class)
+@ConditionalOnClass({OtlpGrpcSpanExporter.class, ManagedChannel.class})
 public class OtlpGrpcSpanExporterAutoConfiguration {
 
   @Bean

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
@@ -48,8 +48,7 @@ public class OtlpGrpcSpanExporterAutoConfiguration {
   public OtlpGrpcSpanExporter otelOtlpGrpcSpanExporter(
       OtlpGrpcSpanExporterProperties otlpGrpcSpanExporterProperties) {
     ManagedChannel channel =
-        ManagedChannelBuilder.forAddress(
-                otlpGrpcSpanExporterProperties.getHost(), otlpGrpcSpanExporterProperties.getPort())
+        ManagedChannelBuilder.forTarget(otlpGrpcSpanExporterProperties.getEndpoint())
             .usePlaintext()
             .build();
 

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Create JaegerExporter */
+/** Creates OTLP Exporter bean */
 @Configuration
 @AutoConfigureBefore(TracerAutoConfiguration.class)
 @EnableConfigurationProperties(OtlpGrpcSpanExporterProperties.class)

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
@@ -54,7 +54,7 @@ public class OtlpGrpcSpanExporterAutoConfiguration {
 
     return OtlpGrpcSpanExporter.newBuilder()
         .setChannel(channel)
-        .setDeadlineMs(otlpGrpcSpanExporterProperties.getDeadline().toMillis())
+        .setDeadlineMs(otlpGrpcSpanExporterProperties.getSpanTimeout().toMillis())
         .build();
   }
 }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.otlp;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.opentelemetry.exporters.otlp.OtlpGrpcSpanExporter;
+import io.opentelemetry.instrumentation.spring.autoconfigure.TracerAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Create JaegerExporter */
+@Configuration
+@AutoConfigureBefore(TracerAutoConfiguration.class)
+@EnableConfigurationProperties(OtlpGrpcSpanExporterProperties.class)
+@ConditionalOnProperty(
+    prefix = "opentelemetry.trace.exporter.otlp",
+    name = "enabled",
+    matchIfMissing = true)
+@ConditionalOnClass(OtlpGrpcSpanExporter.class)
+public class OtlpGrpcSpanExporterAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public OtlpGrpcSpanExporter otelOtlpGrpcSpanExporter(
+      OtlpGrpcSpanExporterProperties otlpGrpcSpanExporterProperties) {
+    ManagedChannel channel =
+        ManagedChannelBuilder.forAddress(
+                otlpGrpcSpanExporterProperties.getHost(), otlpGrpcSpanExporterProperties.getPort())
+            .usePlaintext()
+            .build();
+
+    return OtlpGrpcSpanExporter.newBuilder()
+        .setChannel(channel)
+        .setDeadlineMs(otlpGrpcSpanExporterProperties.getDeadline().toMillis())
+        .build();
+  }
+}

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
@@ -28,7 +28,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Creates OTLP Exporter bean */
+/**
+ * Configures {@link OtlpGrpcSpanExporter} for tracing.
+ *
+ * <p>Initializes {@link OtlpGrpcSpanExporter} bean if bean is missing.
+ */
 @Configuration
 @AutoConfigureBefore(TracerAutoConfiguration.class)
 @EnableConfigurationProperties(OtlpGrpcSpanExporterProperties.class)

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
@@ -34,7 +34,7 @@ public final class OtlpGrpcSpanExporterProperties {
   private boolean enabled = true;
   private String serviceName = "unknown";
   private String endpoint = "localhost:14250";
-  private Duration deadline = Duration.ofSeconds(1);
+  private Duration spanTimeout = Duration.ofSeconds(1);
 
   public boolean isEnabled() {
     return enabled;
@@ -60,11 +60,11 @@ public final class OtlpGrpcSpanExporterProperties {
     this.endpoint = endpoint;
   }
 
-  public Duration getDeadline() {
-    return deadline;
+  public Duration getSpanTimeout() {
+    return spanTimeout;
   }
 
-  public void setDeadline(Duration deadline) {
-    this.deadline = deadline;
+  public void setSpanTimeout(Duration spanTimeout) {
+    this.spanTimeout = spanTimeout;
   }
 }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
@@ -35,9 +35,7 @@ public final class OtlpGrpcSpanExporterProperties {
 
   private boolean enabled = true;
   private String serviceName = "unknown";
-  private String host = "localhost";
-  /** Default end point in {@link OTLPGrpcSpanExporter.OTEL_OTLP_ENDPOINT} */
-  private int port = 14250;
+  private String endpoint = "localhost:14250";
 
   private Duration deadline = Duration.ofSeconds(1);
 

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
@@ -19,7 +19,7 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.otlp;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Configuration for JaegerExporter */
+/** Configuration for OTLPGrpcSpanExporter */
 @ConfigurationProperties(prefix = "opentelemetry.trace.exporter.otlp")
 public class OtlpGrpcSpanExporterProperties {
 

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
@@ -24,9 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * <p>Get Exporter Service Name
  *
- * <p>Get Exporter Host Name
- *
- * <p>Get Exporter Port
+ * <p>Get Exporter Endpoint
  *
  * <p>Get max wait time for Collector to process Span Batches
  */

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
@@ -19,9 +19,19 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.otlp;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Configuration for OTLPGrpcSpanExporter */
+/**
+ * Configuration for {@link OTLPGrpcSpanExporter}
+ *
+ * <p>Get Exporter Service Name {@link getServiceName()}
+ *
+ * <p>Get Exporter Host Name {@link getHost()}
+ *
+ * <p>Get Exporter Port {@link getPort()}
+ *
+ * <p>Get max wait time for Collector to process Span Batches {@link getDeadline()}
+ */
 @ConfigurationProperties(prefix = "opentelemetry.trace.exporter.otlp")
-public class OtlpGrpcSpanExporterProperties {
+public final class OtlpGrpcSpanExporterProperties {
 
   private boolean enabled = true;
   private String serviceName = "otel-spring-boot-zipkin-otlp";

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
@@ -34,7 +34,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public final class OtlpGrpcSpanExporterProperties {
 
   private boolean enabled = true;
-  private String serviceName = "otel-spring-boot-zipkin-otlp";
+  private String serviceName = "unknown";
   private String host = "localhost";
   /** Default end point in {@link OTLPGrpcSpanExporter.OTEL_OTLP_ENDPOINT} */
   private int port = 14250;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
@@ -22,13 +22,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Configuration for {@link OTLPGrpcSpanExporter}
  *
- * <p>Get Exporter Service Name {@link getServiceName()}
+ * <p>Get Exporter Service Name
  *
- * <p>Get Exporter Host Name {@link getHost()}
+ * <p>Get Exporter Host Name
  *
- * <p>Get Exporter Port {@link getPort()}
+ * <p>Get Exporter Port
  *
- * <p>Get max wait time for Collector to process Span Batches {@link getDeadline()}
+ * <p>Get max wait time for Collector to process Span Batches
  */
 @ConfigurationProperties(prefix = "opentelemetry.trace.exporter.otlp")
 public final class OtlpGrpcSpanExporterProperties {
@@ -36,8 +36,10 @@ public final class OtlpGrpcSpanExporterProperties {
   private boolean enabled = true;
   private String serviceName = "otel-spring-boot-zipkin-otlp";
   private String host = "localhost";
+  /** Default end point in {@link OTLPGrpcSpanExporter.OTEL_OTLP_ENDPOINT} */
   private int port = 14250;
-  private Duration deadline = Duration.ofMillis(1000L);
+
+  private Duration deadline = Duration.ofSeconds(1);
 
   public boolean isEnabled() {
     return enabled;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
@@ -36,7 +36,6 @@ public final class OtlpGrpcSpanExporterProperties {
   private boolean enabled = true;
   private String serviceName = "unknown";
   private String endpoint = "localhost:14250";
-
   private Duration deadline = Duration.ofSeconds(1);
 
   public boolean isEnabled() {
@@ -55,20 +54,12 @@ public final class OtlpGrpcSpanExporterProperties {
     this.serviceName = serviceName;
   }
 
-  public String getHost() {
-    return host;
+  public String getEndpoint() {
+    return endpoint;
   }
 
-  public void setHost(String host) {
-    this.host = host;
-  }
-
-  public int getPort() {
-    return port;
-  }
-
-  public void setPort(int port) {
-    this.port = port;
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
   }
 
   public Duration getDeadline() {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.otlp;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Configuration for JaegerExporter */
+@ConfigurationProperties(prefix = "opentelemetry.trace.exporter.otlp")
+public class OtlpGrpcSpanExporterProperties {
+
+  private boolean enabled = true;
+  private String serviceName = "otel-spring-boot-zipkin-otlp";
+  private String host = "localhost";
+  private int port = 14250;
+  private Duration deadline = Duration.ofMillis(1000L);
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  public void setServiceName(String serviceName) {
+    this.serviceName = serviceName;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  public Duration getDeadline() {
+    return deadline;
+  }
+
+  public void setDeadline(Duration deadline) {
+    this.deadline = deadline;
+  }
+}

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Create ZipkinSpanExporter bean */
+/** Create ZipkinSpanExporter */
 @Configuration
 @AutoConfigureBefore(TracerAutoConfiguration.class)
 @EnableConfigurationProperties(ZipkinSpanExporterProperties.class)

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
@@ -48,11 +48,7 @@ public class ZipkinSpanExporterAutoConfiguration {
 
     return ZipkinSpanExporter.newBuilder()
         .setServiceName(zipkinSpanExporterProperties.getServiceName())
-        .setEndpoint(getEndpoint(zipkinSpanExporterProperties))
+        .setEndpoint(zipkinSpanExporterProperties.getEndpoint())
         .build();
-  }
-
-  private String getEndpoint(ZipkinSpanExporterProperties zipkinSpanExporterProperties) {
-    return zipkinSpanExporterProperties.getHost() + ":" + zipkinSpanExporterProperties.getPort();
   }
 }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.zipkin;
+
+import io.opentelemetry.exporters.zipkin.ZipkinSpanExporter;
+import io.opentelemetry.instrumentation.spring.autoconfigure.TracerAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Create JaegerExporter */
+@Configuration
+@AutoConfigureBefore(TracerAutoConfiguration.class)
+@EnableConfigurationProperties(ZipkinSpanExporterProperties.class)
+@ConditionalOnProperty(
+    prefix = "opentelemetry.trace.exporter.zipkin",
+    name = "enabled",
+    matchIfMissing = true)
+@ConditionalOnClass(ZipkinSpanExporter.class)
+public class ZipkinSpanExporterAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public ZipkinSpanExporter otelZipKinSpanExporter(
+      ZipkinSpanExporterProperties zipkinSpanExporterProperties) {
+
+    return ZipkinSpanExporter.newBuilder()
+        .setServiceName(zipkinSpanExporterProperties.getServiceName())
+        .setEndpoint(getEndpoint(zipkinSpanExporterProperties))
+        .build();
+  }
+
+  private String getEndpoint(ZipkinSpanExporterProperties zipkinSpanExporterProperties) {
+    return zipkinSpanExporterProperties.getHost() + ":" + zipkinSpanExporterProperties.getPort();
+  }
+}

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Create JaegerExporter */
+/** Create ZipkinSpanExporter bean */
 @Configuration
 @AutoConfigureBefore(TracerAutoConfiguration.class)
 @EnableConfigurationProperties(ZipkinSpanExporterProperties.class)

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
@@ -26,7 +26,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Create ZipkinSpanExporter */
+/**
+ * Configures {@link ZipkinSpanExporter} for tracing.
+ *
+ * <p>Initializes {@link ZipkinSpanExporter} bean if bean is missing.
+ */
 @Configuration
 @AutoConfigureBefore(TracerAutoConfiguration.class)
 @EnableConfigurationProperties(ZipkinSpanExporterProperties.class)

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
@@ -31,7 +31,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ZipkinSpanExporterProperties {
 
   private boolean enabled = true;
-  private String serviceName = "otel-spring-boot-zipkin-exporter";
+  private String serviceName = "unknown";
   private String endpoint = "http://localhost:14250";
 
   public boolean isEnabled() {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
@@ -23,9 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * <p>Get Exporter Service Name {@link getServiceName()}
  *
- * <p>Get Exporter Host Name {@link getHost()}
- *
- * <p>Get Exporter Port {@link getPort()}
+ * <p>Get Exporter Endpoint
  */
 @ConfigurationProperties(prefix = "opentelemetry.trace.exporter.zipkin")
 public class ZipkinSpanExporterProperties {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
@@ -18,7 +18,7 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.zipkin;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Configuration for JaegerExporter */
+/** Configuration for ZipkinSpanExporter */
 @ConfigurationProperties(prefix = "opentelemetry.trace.exporter.zipkin")
 public class ZipkinSpanExporterProperties {
 

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
@@ -50,19 +50,11 @@ public class ZipkinSpanExporterProperties {
     this.serviceName = serviceName;
   }
 
-  public String getHost() {
-    return host;
+  public String getEndpoint() {
+    return endpoint;
   }
 
-  public void setHost(String host) {
-    this.host = host;
-  }
-
-  public int getPort() {
-    return port;
-  }
-
-  public void setPort(int port) {
-    this.port = port;
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
   }
 }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
@@ -32,7 +32,7 @@ public class ZipkinSpanExporterProperties {
 
   private boolean enabled = true;
   private String serviceName = "otel-spring-boot-zipkin-exporter";
-  private String host = "localhost";
+  private String host = "http://localhost";
   /** Default end point in {@link ZipkinSpanExporter.OTEL_ZIPKIN_ENDPOINT} */
   private int port = 14250;
 

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
@@ -32,9 +32,7 @@ public class ZipkinSpanExporterProperties {
 
   private boolean enabled = true;
   private String serviceName = "otel-spring-boot-zipkin-exporter";
-  private String host = "http://localhost";
-  /** Default end point in {@link ZipkinSpanExporter.OTEL_ZIPKIN_ENDPOINT} */
-  private int port = 14250;
+  private String endpoint = "http://localhost:14250";
 
   public boolean isEnabled() {
     return enabled;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
@@ -18,7 +18,15 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.zipkin;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/** Configuration for ZipkinSpanExporter */
+/**
+ * Configuration for {@link ZipkinSpanExporter}
+ *
+ * <p>Get Exporter Service Name {@link getServiceName()}
+ *
+ * <p>Get Exporter Host Name {@link getHost()}
+ *
+ * <p>Get Exporter Port {@link getPort()}
+ */
 @ConfigurationProperties(prefix = "opentelemetry.trace.exporter.zipkin")
 public class ZipkinSpanExporterProperties {
 

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
@@ -33,6 +33,7 @@ public class ZipkinSpanExporterProperties {
   private boolean enabled = true;
   private String serviceName = "otel-spring-boot-zipkin-exporter";
   private String host = "localhost";
+  /** Default end point in {@link ZipkinSpanExporter.OTEL_ZIPKIN_ENDPOINT} */
   private int port = 14250;
 
   public boolean isEnabled() {

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.zipkin;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Configuration for JaegerExporter */
+@ConfigurationProperties(prefix = "opentelemetry.trace.exporter.zipkin")
+public class ZipkinSpanExporterProperties {
+
+  private boolean enabled = true;
+  private String serviceName = "otel-spring-boot-zipkin-exporter";
+  private String host = "localhost";
+  private int port = 14250;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  public void setServiceName(String serviceName) {
+    this.serviceName = serviceName;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+}

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,8 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.opentelemetry.instrumentation.spring.autoconfigure.exporters.jaeger.JaegerSpanExporterAutoConfiguration,\
+io.opentelemetry.instrumentation.spring.autoconfigure.exporters.otlp.OtlpGrpcSpanExporterAutoConfiguration,\
+io.opentelemetry.instrumentation.spring.autoconfigure.exporters.zipkin.ZipkinSpanExporterAutoConfiguration,\
+io.opentelemetry.instrumentation.spring.autoconfigure.exporters.logging.LoggingSpanExporterAutoConfiguration,\
 io.opentelemetry.instrumentation.spring.autoconfigure.TracerAutoConfiguration,\
 io.opentelemetry.instrumentation.spring.autoconfigure.httpclients.resttemplate.RestTemplateAutoConfiguration,\
 io.opentelemetry.instrumentation.spring.autoconfigure.httpclients.webclient.WebClientAutoConfiguration,\


### PR DESCRIPTION
Add Spring Boot auto configurations and configuration properties for OTLPGrpcSpanExporter, LoggingSpanExporter, JaegerSpanExporter, and ZipkinSpanExporter. 

My next pull request will add spring boot starters for these exporters. Here's a preview: https://github.com/mabdinur/opentelemetry-java-instrumentation/pull/6/files :)