### PR TITLE
Bring back max-workers=6 for CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
             GRADLE_OPTS="-Dota.forkedMaxHeapSize=4G -Dota.forkedMinHeapSize=64M"
             ./gradlew <<# parameters.prefixTestTask>>testJava<</ parameters.prefixTestTask>><< parameters.testTask >>
             << pipeline.parameters.gradle_flags >>
-            --max-workers=3
+            --max-workers=6
 
       - run:
           name: Collect Reports


### PR DESCRIPTION
We reduced to max-workers=3 for CI tests in #725, just checking here to see if we can bring it back.