### PR TITLE
Trim down a P1 GA requirement and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,35 +275,4 @@ Debug logging negatively impacts the performance of your application.
 
 ## Roadmap to 1.0 (GA)
 
-It is our goal to release 1.0 (GA) of the auto-instrumentation agent during the first wave of
-OpenTelemetry 1.0 (GA) releases, along with as many manual instrumentation libraries as possible.
-
-High-level roadmap:
-
-* Conform with all OpenTelemetry specifications
-  * Implement all applicable semantic attributes
-    * Clearly document additional attributes not defined in specification
-  * Support standard configuration properties (e.g. exporters, propagators, samplers)
-  * Capture standard metrics (still TBD, e.g.
-      [opentelemetry-specification#522](https://github.com/open-telemetry/opentelemetry-specification/issues/522))
-  * See issues with label
-    [specification](https://github.com/open-telemetry/opentelemetry-java-instrumentation/labels/specification)
-* Great documentation
-  * See issues with label
-    [documentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/labels/documentation)
-* Build out manual instrumentation libraries for existing auto-instrumentation
-  * Share code and tests between manual and auto-instrumentation
-  * See issue
-    [#45](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/45)
-* Good support for vendors to extend the agent
-  * Including ability for any user to write their own auto-instrumentation
-  * See issues with label
-    [packaging](https://github.com/open-telemetry/opentelemetry-java-instrumentation/labels/packaging)
-* Better smoke test harness and more smoke tests
-  * See issue
-    [#298](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/298)
-* Benchmarking and tuning (both runtime and startup)
-* Address sporadic test failures
-  * See issues with label
-    [sporadic test failure](https://github.com/open-telemetry/opentelemetry-java-instrumentation/labels/sporadic%20test%20failure)
-* Speed up CI build feedback
+See [GA Requirements](docs/ga-requirements.md)

--- a/docs/ga-requirements.md
+++ b/docs/ga-requirements.md
@@ -19,9 +19,9 @@ P1 (e.g. cannot GA without these):
   * For each instrumentation
     * Document any instrumentation-specific configuration
   * How to troubleshoot (start documenting common issues somewhere)
-* Library (manual) instrumentations for libraries commonly used with Spring
-  * Spring WebMVC, Spring WebFlux, Spring RestTemplate, Spring Kafka, Spring AMQP,
-    Reactor, JDBC, java.util.concurrent
+* Library (manual) instrumentations for a few libraries commonly used with Spring:
+  Spring WebMVC, Spring WebFlux, Spring RestTemplate, JDBC
+  * (this requirement is to ensure that we have a good path forward for supporting both auto and manual instrumentation)
 
 P2:
 * Contributor experience (tag "contributor experience" plus tag "cleanup" plus tag "sporadic test failure")
@@ -37,6 +37,8 @@ P3:
 * Auto-collected metrics
   * System / JVM metrics (https://github.com/open-telemetry/opentelemetry-specification/issues/651)
   * Request metrics (https://github.com/open-telemetry/opentelemetry-specification/issues/522, https://github.com/open-telemetry/opentelemetry-specification/pull/657)
+* Library (manual) instrumentations for more libraries commonly used with Spring
+  * Spring Kafka, Spring AMQP, Reactor, java.util.concurrent
 * Library (manual) instrumentations for libraries commonly used with Android
   * OkHttp, gRPC
 * Document the basic configuration points


### PR DESCRIPTION
Trimmed down one of the P1 requirements based on https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/734#discussion_r459256991