### PR TITLE
Update server span

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseTracer.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseTracer.java
@@ -17,10 +17,6 @@
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator;
 
 import io.grpc.Context;
-import io.opentelemetry.trace.Span;
-import io.opentelemetry.trace.Tracer;
-import java.lang.reflect.Method;
-import io.grpc.Context;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.instrumentation.api.MoreAttributes;
 import io.opentelemetry.trace.Span;
@@ -60,15 +56,9 @@ public abstract class BaseTracer {
   }
 
   /** Returns valid span of type SERVER from current context or <code>null</code> if not found. */
-  public Span getCurrentServerSpan() {
-    Span result = CONTEXT_SERVER_SPAN_KEY.get(Context.current());
-    System.out.println(
-        Thread.currentThread().getId()
-            + " getCurrentServerSpan = "
-            + Context.current()
-            + " server span = "
-            + result);
-    return result;
+  // TODO when all decorator are replaced with tracers, make this method instance
+  public static Span getCurrentServerSpan() {
+    return CONTEXT_SERVER_SPAN_KEY.get(Context.current());
   }
 
   protected abstract String getInstrumentationName();

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseTracer.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseTracer.java
@@ -16,11 +16,134 @@
 
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator;
 
+import io.grpc.Context;
 import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
+import java.lang.reflect.Method;
+import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.auto.instrumentation.api.MoreAttributes;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Status;
+import io.opentelemetry.trace.Tracer;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.concurrent.ExecutionException;
 
 public abstract class BaseTracer {
+  // Keeps track of the server span for the current trace.
+  public static final Context.Key<Span> CONTEXT_SERVER_SPAN_KEY =
+      Context.key("opentelemetry-trace-server-span-key");
 
-  protected BaseTracer() {}
+  protected final Tracer tracer;
+
+  public BaseTracer() {
+    tracer = OpenTelemetry.getTracerProvider().get(getInstrumentationName(), getVersion());
+  }
+
+  public BaseTracer(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  public Span startSpan(Class<?> clazz) {
+    String spanName = spanNameForClass(clazz);
+    return startSpan(spanName);
+  }
+
+  public Span startSpan(String spanName) {
+    return tracer.spanBuilder(spanName).startSpan();
+  }
+
+  public Span getCurrentSpan() {
+    return tracer.getCurrentSpan();
+  }
+
+  /** Returns valid span of type SERVER from current context or <code>null</code> if not found. */
+  public Span getCurrentServerSpan() {
+    Span result = CONTEXT_SERVER_SPAN_KEY.get(Context.current());
+    System.out.println(
+        Thread.currentThread().getId()
+            + " getCurrentServerSpan = "
+            + Context.current()
+            + " server span = "
+            + result);
+    return result;
+  }
+
+  protected abstract String getInstrumentationName();
+
+  protected String getVersion() {
+    return null;
+  }
+
+  /**
+   * This method is used to generate an acceptable span (operation) name based on a given method
+   * reference. Anonymous classes are named based on their parent.
+   */
+  protected String spanNameForMethod(final Method method) {
+    return spanNameForClass(method.getDeclaringClass()) + "." + method.getName();
+  }
+
+  /**
+   * This method is used to generate an acceptable span (operation) name based on a given method
+   * reference. Anonymous classes are named based on their parent.
+   *
+   * @param method the method to get the name from, nullable
+   * @return the span name from the class and method
+   */
+  protected String spanNameForMethod(final Class<?> clazz, final Method method) {
+    return spanNameForMethod(clazz, null == method ? null : method.getName());
+  }
+
+  protected String spanNameForMethod(Class<?> cl, String methodName) {
+    return spanNameForClass(cl) + "." + methodName;
+  }
+
+  /**
+   * This method is used to generate an acceptable span (operation) name based on a given class
+   * reference. Anonymous classes are named based on their parent.
+   */
+  protected String spanNameForClass(final Class<?> clazz) {
+    if (!clazz.isAnonymousClass()) {
+      return clazz.getSimpleName();
+    }
+    String className = clazz.getName();
+    if (clazz.getPackage() != null) {
+      String pkgName = clazz.getPackage().getName();
+      if (!pkgName.isEmpty()) {
+        className = clazz.getName().replace(pkgName, "").substring(1);
+      }
+    }
+    return className;
+  }
+
+  public void end(Span span) {
+    span.end();
+  }
+
+  public void endExceptionally(Span span, Throwable throwable) {
+    onError(span, unwrapThrowable(throwable));
+    span.setStatus(Status.INTERNAL);
+    end(span);
+  }
+
+  protected void onError(final Span span, final Throwable throwable) {
+    addThrowable(span, throwable);
+  }
+
+  protected Throwable unwrapThrowable(Throwable throwable) {
+    return throwable instanceof ExecutionException ? throwable.getCause() : throwable;
+  }
+
+  public void addThrowable(final Span span, final Throwable throwable) {
+    span.setAttribute(MoreAttributes.ERROR_MSG, throwable.getMessage());
+    span.setAttribute(MoreAttributes.ERROR_TYPE, throwable.getClass().getName());
+
+    StringWriter errorString = new StringWriter();
+    throwable.printStackTrace(new PrintWriter(errorString));
+    span.setAttribute(MoreAttributes.ERROR_STACK, errorString.toString());
+  }
 
   public static void setPeer(final Span span, String peerName, String peerIp) {
     BaseDecorator.setPeer(span, peerName, peerIp);

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpServerTracer.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpServerTracer.java
@@ -23,7 +23,6 @@ import static io.opentelemetry.trace.TracingContextUtils.getSpan;
 import static io.opentelemetry.trace.TracingContextUtils.withSpan;
 
 import io.grpc.Context;
-import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.config.Config;
 import io.opentelemetry.auto.instrumentation.api.MoreAttributes;
 import io.opentelemetry.context.Scope;
@@ -32,12 +31,9 @@ import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.Tracer;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,18 +43,13 @@ public abstract class HttpServerTracer<REQUEST, CONNECTION, STORAGE> extends Bas
   private static final Logger log = LoggerFactory.getLogger(HttpServerTracer.class);
 
   public static final String CONTEXT_ATTRIBUTE = "io.opentelemetry.instrumentation.context";
-  // Keeps track of the server span for the current trace.
-  private static final Context.Key<Span> CONTEXT_SERVER_SPAN_KEY =
-      Context.key("opentelemetry-trace-server-span-key");
-
-  protected final Tracer tracer;
 
   public HttpServerTracer() {
-    tracer = OpenTelemetry.getTracerProvider().get(getInstrumentationName(), getVersion());
+    super();
   }
 
   public HttpServerTracer(Tracer tracer) {
-    this.tracer = tracer;
+    super(tracer);
   }
 
   public Span startSpan(REQUEST request, CONNECTION connection, Method origin) {
@@ -84,8 +75,7 @@ public abstract class HttpServerTracer<REQUEST, CONNECTION, STORAGE> extends Bas
    */
   public Scope startScope(Span span, STORAGE storage) {
     // TODO we could do this in one go, but TracingContextUtils.CONTEXT_SPAN_KEY is private
-    Context serverSpanContext = Context.current().withValue(CONTEXT_SERVER_SPAN_KEY, span);
-    Context newContext = withSpan(span, serverSpanContext);
+    Context newContext = withSpan(span, Context.current().withValue(CONTEXT_SERVER_SPAN_KEY, span));
     attachServerContext(newContext, storage);
     return withScopedContext(newContext);
   }
@@ -112,14 +102,11 @@ public abstract class HttpServerTracer<REQUEST, CONNECTION, STORAGE> extends Bas
     end(span, responseStatus);
   }
 
-  public Span getCurrentSpan() {
-    return tracer.getCurrentSpan();
-  }
-
   public Span getServerSpan(STORAGE storage) {
     Context attachedContext = getServerContext(storage);
     return attachedContext == null ? null : CONTEXT_SERVER_SPAN_KEY.get(attachedContext);
   }
+
   /**
    * Returns context stored to the given request-response-loop storage by {@link
    * #attachServerContext(Context, STORAGE)}.
@@ -185,49 +172,6 @@ public abstract class HttpServerTracer<REQUEST, CONNECTION, STORAGE> extends Bas
     // TODO set resource name from URL.
   }
 
-  /**
-   * This method is used to generate an acceptable span (operation) name based on a given method
-   * reference. Anonymous classes are named based on their parent.
-   */
-  private String spanNameForMethod(final Method method) {
-    return spanNameForClass(method.getDeclaringClass()) + "." + method.getName();
-  }
-
-  /**
-   * This method is used to generate an acceptable span (operation) name based on a given class
-   * reference. Anonymous classes are named based on their parent.
-   */
-  private String spanNameForClass(final Class clazz) {
-    if (!clazz.isAnonymousClass()) {
-      return clazz.getSimpleName();
-    }
-    String className = clazz.getName();
-    if (clazz.getPackage() != null) {
-      String pkgName = clazz.getPackage().getName();
-      if (!pkgName.isEmpty()) {
-        className = clazz.getName().replace(pkgName, "").substring(1);
-      }
-    }
-    return className;
-  }
-
-  protected void onError(final Span span, final Throwable throwable) {
-    addThrowable(span, unwrapThrowable(throwable));
-  }
-
-  protected static void addThrowable(final Span span, final Throwable throwable) {
-    span.setAttribute(MoreAttributes.ERROR_MSG, throwable.getMessage());
-    span.setAttribute(MoreAttributes.ERROR_TYPE, throwable.getClass().getName());
-
-    StringWriter errorString = new StringWriter();
-    throwable.printStackTrace(new PrintWriter(errorString));
-    span.setAttribute(MoreAttributes.ERROR_STACK, errorString.toString());
-  }
-
-  protected Throwable unwrapThrowable(Throwable throwable) {
-    return throwable instanceof ExecutionException ? throwable.getCause() : throwable;
-  }
-
   private <C> SpanContext extract(final C carrier, final HttpTextFormat.Getter<C> getter) {
     // Using Context.ROOT here may be quite unexpected, but the reason is simple.
     // We want either span context extracted from the carrier or invalid one.
@@ -242,10 +186,6 @@ public abstract class HttpServerTracer<REQUEST, CONNECTION, STORAGE> extends Bas
     // TODO status_message
     span.setStatus(HttpStatusConverter.statusFromHttpStatus(status));
   }
-
-  protected abstract String getInstrumentationName();
-
-  protected abstract String getVersion();
 
   protected abstract Integer peerPort(CONNECTION connection);
 

--- a/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
+++ b/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
@@ -87,8 +87,6 @@ public class FinatraInstrumentation extends Instrumenter.Default {
       Span serverSpan = TRACER.getCurrentServerSpan();
       if (serverSpan != null) {
         serverSpan.updateName(routeInfo.path());
-      } else {
-        throw new IllegalStateException();
       }
 
       Span span = TRACER.startSpan(clazz);

--- a/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraTracer.java
+++ b/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraTracer.java
@@ -16,13 +16,13 @@
 
 package io.opentelemetry.auto.instrumentation.finatra;
 
-import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.trace.Tracer;
+import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseTracer;
 
-public class FinatraDecorator extends BaseDecorator {
-  public static final FinatraDecorator DECORATE = new FinatraDecorator();
+public class FinatraTracer extends BaseTracer {
+  public static final FinatraTracer TRACER = new FinatraTracer();
 
-  public static final Tracer TRACER =
-      OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.finatra-2.9");
+  @Override
+  protected String getInstrumentationName() {
+    return "io.opentelemetry.auto.finatra-2.9";
+  }
 }

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
@@ -19,7 +19,7 @@ import io.opentelemetry.auto.test.AgentTestRunner
 import org.junit.ClassRule
 import spock.lang.Shared
 
-import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderServerTrace
 import static io.opentelemetry.trace.Span.Kind.INTERNAL
 
 class JerseyTest extends AgentTestRunner {
@@ -35,7 +35,7 @@ class JerseyTest extends AgentTestRunner {
   def "test #resource"() {
     when:
     // start a trace because the test doesn't go through any servlet or other instrumentation.
-    def response = runUnderTrace("test.span") {
+    def response = runUnderServerTrace("test.span") {
       resources.client().resource(resource).post(String)
     }
 
@@ -70,7 +70,7 @@ class JerseyTest extends AgentTestRunner {
 
     when:
     // start a trace because the test doesn't go through any servlet or other instrumentation.
-    def response = runUnderTrace("test.span") {
+    def response = runUnderServerTrace("test.span") {
       resources.client().resource(resource).post(String)
     }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JerseyRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JerseyRequestContextInstrumentation.java
@@ -42,7 +42,7 @@ public class JerseyRequestContextInstrumentation extends AbstractRequestContextI
         @Advice.This final ContainerRequestContext context) {
       UriInfo uriInfo = context.getUriInfo();
 
-      if (context.getProperty(JaxRsAnnotationsDecorator.ABORT_HANDLED) == null
+      if (context.getProperty(JaxRsAnnotationsTracer.ABORT_HANDLED) == null
           && uriInfo instanceof ResourceInfo) {
 
         ResourceInfo resourceInfo = (ResourceInfo) uriInfo;

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/Resteasy30RequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/Resteasy30RequestContextInstrumentation.java
@@ -42,7 +42,7 @@ public class Resteasy30RequestContextInstrumentation extends AbstractRequestCont
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope decorateAbortSpan(
         @Advice.This final ContainerRequestContext context) {
-      if (context.getProperty(JaxRsAnnotationsDecorator.ABORT_HANDLED) == null
+      if (context.getProperty(JaxRsAnnotationsTracer.ABORT_HANDLED) == null
           && context instanceof PostMatchContainerRequestContext) {
 
         ResourceMethodInvoker resourceMethodInvoker =

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/Resteasy31RequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/Resteasy31RequestContextInstrumentation.java
@@ -41,7 +41,7 @@ public class Resteasy31RequestContextInstrumentation extends AbstractRequestCont
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope decorateAbortSpan(
         @Advice.This final ContainerRequestContext context) {
-      if (context.getProperty(JaxRsAnnotationsDecorator.ABORT_HANDLED) == null
+      if (context.getProperty(JaxRsAnnotationsTracer.ABORT_HANDLED) == null
           && context instanceof PostMatchContainerRequestContext) {
 
         ResourceMethodInvoker resourceMethodInvoker =

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/ContainerRequestFilterInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/ContainerRequestFilterInstrumentation.java
@@ -71,7 +71,7 @@ public class ContainerRequestFilterInstrumentation extends Instrumenter.Default 
     public static void setFilterClass(
         @Advice.This final ContainerRequestFilter filter,
         @Advice.Argument(0) final ContainerRequestContext context) {
-      context.setProperty(JaxRsAnnotationsDecorator.ABORT_FILTER_CLASS, filter.getClass());
+      context.setProperty(JaxRsAnnotationsTracer.ABORT_FILTER_CLASS, filter.getClass());
     }
   }
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.auto.instrumentation.jaxrs.v2_0;
 
-import static io.opentelemetry.auto.instrumentation.jaxrs.v2_0.JaxRsAnnotationsDecorator.DECORATE;
+import static io.opentelemetry.auto.instrumentation.jaxrs.v2_0.JaxRsAnnotationsTracer.TRACER;
 import static io.opentelemetry.auto.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.auto.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
 import static java.util.Collections.singletonMap;
@@ -65,7 +65,7 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
     return new String[] {
       "io.opentelemetry.auto.tooling.ClassHierarchyIterable",
       "io.opentelemetry.auto.tooling.ClassHierarchyIterable$ClassIterator",
-      packageName + ".JaxRsAnnotationsDecorator",
+      packageName + ".JaxRsAnnotationsTracer",
     };
   }
 
@@ -95,8 +95,7 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
       Span span = contextStore.get(asyncResponse);
       if (span != null) {
         contextStore.put(asyncResponse, null);
-        DECORATE.beforeFinish(span);
-        span.end();
+        TRACER.end(span);
       }
     }
   }
@@ -114,9 +113,7 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
       Span span = contextStore.get(asyncResponse);
       if (span != null) {
         contextStore.put(asyncResponse, null);
-        DECORATE.onError(span, throwable);
-        DECORATE.beforeFinish(span);
-        span.end();
+        TRACER.endExceptionally(span, throwable);
       }
     }
   }
@@ -133,8 +130,7 @@ public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Defaul
       if (span != null) {
         contextStore.put(asyncResponse, null);
         span.setAttribute("canceled", true);
-        DECORATE.beforeFinish(span);
-        span.end();
+        TRACER.end(span);
       }
     }
   }

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
@@ -15,9 +15,9 @@
  */
 
 import io.opentelemetry.auto.bootstrap.WeakMap
-import io.opentelemetry.auto.instrumentation.jaxrs.v2_0.JaxRsAnnotationsDecorator
+import io.opentelemetry.auto.instrumentation.jaxrs.v2_0.JaxRsAnnotationsTracer
 import io.opentelemetry.auto.test.AgentTestRunner
-
+import java.lang.reflect.Method
 import javax.ws.rs.DELETE
 import javax.ws.rs.GET
 import javax.ws.rs.HEAD
@@ -25,9 +25,8 @@ import javax.ws.rs.OPTIONS
 import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
-import java.lang.reflect.Method
 
-import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderServerTrace
 
 class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
 
@@ -55,7 +54,7 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
   def "span named '#name' from annotations on class when is not root span"() {
     setup:
     def startingCacheSize = spanNames.size()
-    runUnderTrace("test") {
+    runUnderServerTrace("test") {
       obj.call()
     }
 
@@ -80,7 +79,7 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
     spanNames.get(obj.class).size() == 1
 
     when: "multiple calls to the same method"
-    runUnderTrace("test") {
+    runUnderServerTrace("test") {
       (1..10).each {
         obj.call()
       }
@@ -143,13 +142,13 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
     className = getClassName(obj.class)
 
     // JavaInterfaces classes are loaded on a different classloader, so we need to find the right cache instance.
-    decorator = obj.class.classLoader.loadClass(JaxRsAnnotationsDecorator.name).getField("DECORATE").get(null)
+    decorator = obj.class.classLoader.loadClass(JaxRsAnnotationsTracer.name).getField("TRACER").get(null)
     spanNames = (WeakMap<Class, Map<Method, String>>) decorator.spanNames
   }
 
   def "no annotations has no effect"() {
     setup:
-    runUnderTrace("test") {
+    runUnderServerTrace("test") {
       obj.call()
     }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
@@ -16,6 +16,13 @@
 
 import io.dropwizard.testing.junit.ResourceTestRule
 import io.opentelemetry.auto.test.AgentTestRunner
+import javax.ws.rs.client.Entity
+import javax.ws.rs.container.ContainerRequestContext
+import javax.ws.rs.container.ContainerRequestFilter
+import javax.ws.rs.container.PreMatching
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+import javax.ws.rs.ext.Provider
 import org.jboss.resteasy.core.Dispatcher
 import org.jboss.resteasy.mock.MockDispatcherFactory
 import org.jboss.resteasy.mock.MockHttpRequest
@@ -24,15 +31,7 @@ import org.junit.ClassRule
 import spock.lang.Shared
 import spock.lang.Unroll
 
-import javax.ws.rs.client.Entity
-import javax.ws.rs.container.ContainerRequestContext
-import javax.ws.rs.container.ContainerRequestFilter
-import javax.ws.rs.container.PreMatching
-import javax.ws.rs.core.MediaType
-import javax.ws.rs.core.Response
-import javax.ws.rs.ext.Provider
-
-import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderServerTrace
 import static io.opentelemetry.trace.Span.Kind.INTERNAL
 
 @Unroll
@@ -57,7 +56,7 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
     def responseStatus
 
     // start a trace because the test doesn't go through any servlet or other instrumentation.
-    runUnderTrace("test.span") {
+    runUnderServerTrace("test.span") {
       (responseText, responseStatus) = makeRequest(resource)
     }
 
@@ -114,7 +113,7 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
     def responseStatus
 
     // start a trace because the test doesn't go through any servlet or other instrumentation.
-    runUnderTrace("test.span") {
+    runUnderServerTrace("test.span") {
       (responseText, responseStatus) = makeRequest(resource)
     }
 

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
@@ -17,8 +17,9 @@
 package io.opentelemetry.auto.instrumentation.netty.v4_1.server;
 
 import static io.opentelemetry.auto.instrumentation.netty.v4_1.server.NettyHttpServerTracer.TRACER;
-import static io.opentelemetry.trace.TracingContextUtils.currentContextWith;
+import static io.opentelemetry.context.ContextUtils.withScopedContext;
 
+import io.grpc.Context;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -33,11 +34,11 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     Channel channel = ctx.channel();
 
     if (!(msg instanceof HttpRequest)) {
-      Span serverSpan = TRACER.getServerSpan(channel);
-      if (serverSpan == null) {
+      Context serverContext = TRACER.getServerContext(channel);
+      if (serverContext == null) {
         ctx.fireChannelRead(msg);
       } else {
-        try (Scope ignored = currentContextWith(serverSpan)) {
+        try (Scope ignored = withScopedContext(serverContext)) {
           ctx.fireChannelRead(msg);
         }
       }

--- a/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_3/PlayInstrumentation.java
+++ b/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_3/PlayInstrumentation.java
@@ -50,7 +50,7 @@ public final class PlayInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".PlayDecorator", packageName + ".RequestCompleteCallback"};
+    return new String[] {packageName + ".PlayTracer", packageName + ".RequestCompleteCallback"};
   }
 
   @Override

--- a/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_3/PlayTracer.java
+++ b/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_3/PlayTracer.java
@@ -16,39 +16,34 @@
 
 package io.opentelemetry.auto.instrumentation.play.v2_3;
 
-import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
+import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseTracer;
 import io.opentelemetry.trace.Span;
-import io.opentelemetry.trace.Tracer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import play.api.mvc.Request;
 import scala.Option;
 
-public class PlayDecorator extends BaseDecorator {
-  public static final PlayDecorator DECORATE = new PlayDecorator();
+public class PlayTracer extends BaseTracer {
+  public static final PlayTracer TRACER = new PlayTracer();
 
-  public static final Tracer TRACER =
-      OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.play-2.4");
-
-  public Span updateSpanName(final Span span, final Request request) {
-    if (request != null) {
-      // more about routes here:
-      // https://github.com/playframework/playframework/blob/master/documentation/manual/releases/release26/migration26/Migration26.md#router-tags-are-now-attributes
-      Option pathOption = request.tags().get("ROUTE_PATTERN");
-      if (!pathOption.isEmpty()) {
-        String path = (String) pathOption.get();
-        span.updateName(request.method() + " " + path);
-      }
+  public Span updateSpanName(final Span span, final Request<?> request) {
+    Option<String> pathOption = request.tags().get("ROUTE_PATTERN");
+    if (!pathOption.isEmpty()) {
+      String path = pathOption.get();
+      span.updateName(request.method() + " " + path);
     }
     return span;
   }
 
   @Override
-  public Span onError(final Span span, Throwable throwable) {
-    if (throwable != null
-        // This can be moved to instanceof check when using Java 8.
-        && throwable.getClass().getName().equals("java.util.concurrent.CompletionException")
+  protected String getInstrumentationName() {
+    return "io.opentelemetry.auto.play-2.3";
+  }
+
+  @Override
+  protected Throwable unwrapThrowable(Throwable throwable) {
+    // This can be moved to instanceof check when using Java 8.
+    if (throwable.getClass().getName().equals("java.util.concurrent.CompletionException")
         && throwable.getCause() != null) {
       throwable = throwable.getCause();
     }
@@ -57,6 +52,6 @@ public class PlayDecorator extends BaseDecorator {
         && throwable.getCause() != null) {
       throwable = throwable.getCause();
     }
-    return super.onError(span, throwable);
+    return throwable;
   }
 }

--- a/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_3/RequestCompleteCallback.java
+++ b/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_3/RequestCompleteCallback.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.auto.instrumentation.play.v2_3;
 
-import static io.opentelemetry.auto.instrumentation.play.v2_3.PlayDecorator.DECORATE;
+import static io.opentelemetry.auto.instrumentation.play.v2_3.PlayTracer.TRACER;
 
 import io.opentelemetry.trace.Span;
 import org.slf4j.Logger;
@@ -38,13 +38,12 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
   public Object apply(final Try<Result> result) {
     try {
       if (result.isFailure()) {
-        DECORATE.onError(span, result.failed().get());
+        TRACER.endExceptionally(span, result.failed().get());
+      } else {
+        TRACER.end(span);
       }
-      DECORATE.beforeFinish(span);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
-    } finally {
-      span.end();
     }
     return null;
   }

--- a/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_4/PlayAdvice.java
+++ b/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_4/PlayAdvice.java
@@ -16,8 +16,7 @@
 
 package io.opentelemetry.auto.instrumentation.play.v2_4;
 
-import static io.opentelemetry.auto.instrumentation.play.v2_4.PlayDecorator.DECORATE;
-import static io.opentelemetry.auto.instrumentation.play.v2_4.PlayDecorator.TRACER;
+import static io.opentelemetry.auto.instrumentation.play.v2_4.PlayTracer.TRACER;
 import static io.opentelemetry.trace.TracingContextUtils.currentContextWith;
 
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
@@ -31,10 +30,8 @@ import scala.concurrent.Future;
 
 public class PlayAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static SpanWithScope onEnter(@Advice.Argument(0) final Request req) {
-    Span span = TRACER.spanBuilder("play.request").startSpan();
-    DECORATE.afterStart(span);
-
+  public static SpanWithScope onEnter(@Advice.Argument(0) final Request<?> req) {
+    Span span = TRACER.startSpan("play.request");
     return new SpanWithScope(span, currentContextWith(span));
   }
 
@@ -43,28 +40,26 @@ public class PlayAdvice {
       @Advice.Enter final SpanWithScope playControllerScope,
       @Advice.This final Object thisAction,
       @Advice.Thrown final Throwable throwable,
-      @Advice.Argument(0) final Request req,
+      @Advice.Argument(0) final Request<?> req,
       @Advice.Return(readOnly = false) final Future<Result> responseFuture) {
     Span playControllerSpan = playControllerScope.getSpan();
 
     // Call onRequest on return after tags are populated.
-    DECORATE.updateSpanName(playControllerSpan, req);
+    TRACER.updateSpanName(playControllerSpan, req);
 
     if (throwable == null) {
       responseFuture.onComplete(
           new RequestCompleteCallback(playControllerSpan),
-          ((Action) thisAction).executionContext());
+          ((Action<?>) thisAction).executionContext());
     } else {
-      DECORATE.onError(playControllerSpan, throwable);
-      DECORATE.beforeFinish(playControllerSpan);
-      playControllerSpan.end();
+      TRACER.endExceptionally(playControllerSpan, throwable);
     }
     playControllerScope.closeScope();
     // span finished in RequestCompleteCallback
 
-    Span rootSpan = TRACER.getCurrentSpan();
+    Span rootSpan = TRACER.getCurrentServerSpan();
     // set the span name on the upstream akka/netty span
-    DECORATE.updateSpanName(rootSpan, req);
+    TRACER.updateSpanName(rootSpan, req);
   }
 
   // Unused method for muzzle

--- a/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_4/PlayInstrumentation.java
+++ b/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_4/PlayInstrumentation.java
@@ -50,7 +50,7 @@ public final class PlayInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".PlayDecorator", packageName + ".RequestCompleteCallback"};
+    return new String[] {packageName + ".PlayTracer", packageName + ".RequestCompleteCallback"};
   }
 
   @Override

--- a/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_4/RequestCompleteCallback.java
+++ b/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_4/RequestCompleteCallback.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.auto.instrumentation.play.v2_4;
 
-import static io.opentelemetry.auto.instrumentation.play.v2_4.PlayDecorator.DECORATE;
+import static io.opentelemetry.auto.instrumentation.play.v2_4.PlayTracer.TRACER;
 
 import io.opentelemetry.trace.Span;
 import org.slf4j.Logger;
@@ -38,13 +38,12 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
   public Object apply(final Try<Result> result) {
     try {
       if (result.isFailure()) {
-        DECORATE.onError(span, result.failed().get());
+        TRACER.endExceptionally(span, result.failed().get());
+      } else {
+        TRACER.end(span);
       }
-      DECORATE.beforeFinish(span);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
-    } finally {
-      span.end();
     }
     return null;
   }

--- a/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_6/PlayInstrumentation.java
+++ b/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_6/PlayInstrumentation.java
@@ -50,7 +50,7 @@ public final class PlayInstrumentation extends Instrumenter.Default {
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {packageName + ".PlayDecorator", packageName + ".RequestCompleteCallback"};
+    return new String[] {packageName + ".PlayTracer", packageName + ".RequestCompleteCallback"};
   }
 
   @Override

--- a/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_6/PlayTracer.java
+++ b/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_6/PlayTracer.java
@@ -17,9 +17,8 @@
 package io.opentelemetry.auto.instrumentation.play.v2_6;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
+import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseTracer;
 import io.opentelemetry.trace.Span;
-import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -30,8 +29,8 @@ import play.libs.typedmap.TypedKey;
 import play.routing.Router;
 import scala.Option;
 
-public class PlayDecorator extends BaseDecorator {
-  public static final PlayDecorator DECORATE = new PlayDecorator();
+public class PlayTracer extends BaseTracer {
+  public static final PlayTracer DECORATE = new PlayTracer();
 
   public static final Tracer TRACER =
       OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto.play-2.6");
@@ -79,11 +78,14 @@ public class PlayDecorator extends BaseDecorator {
   }
 
   @Override
-  public Span onError(final Span span, Throwable throwable) {
-    span.setStatus(Status.UNKNOWN);
-    if (throwable != null
-        // This can be moved to instanceof check when using Java 8.
-        && throwable.getClass().getName().equals("java.util.concurrent.CompletionException")
+  protected String getInstrumentationName() {
+    return "io.opentelemetry.auto.play-2.6";
+  }
+
+  @Override
+  protected Throwable unwrapThrowable(Throwable throwable) {
+    // This can be moved to instanceof check when using Java 8.
+    if (throwable.getClass().getName().equals("java.util.concurrent.CompletionException")
         && throwable.getCause() != null) {
       throwable = throwable.getCause();
     }
@@ -92,6 +94,6 @@ public class PlayDecorator extends BaseDecorator {
         && throwable.getCause() != null) {
       throwable = throwable.getCause();
     }
-    return super.onError(span, throwable);
+    return throwable;
   }
 }

--- a/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_6/RequestCompleteCallback.java
+++ b/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_6/RequestCompleteCallback.java
@@ -16,7 +16,7 @@
 
 package io.opentelemetry.auto.instrumentation.play.v2_6;
 
-import static io.opentelemetry.auto.instrumentation.play.v2_6.PlayDecorator.DECORATE;
+import static io.opentelemetry.auto.instrumentation.play.v2_6.PlayTracer.DECORATE;
 
 import io.opentelemetry.trace.Span;
 import org.slf4j.Logger;
@@ -38,13 +38,12 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
   public Object apply(final Try<Result> result) {
     try {
       if (result.isFailure()) {
-        DECORATE.onError(span, result.failed().get());
+        DECORATE.endExceptionally(span, result.failed().get());
+      } else {
+        DECORATE.end(span);
       }
-      DECORATE.beforeFinish(span);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
-    } finally {
-      span.end();
     }
     return null;
   }

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/AdviceUtils.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/AdviceUtils.java
@@ -39,8 +39,6 @@ public class AdviceUtils {
 
   public static final String CONTEXT_ATTRIBUTE =
       "io.opentelemetry.auto.instrumentation.springwebflux.Context";
-  public static final String PARENT_CONTEXT_ATTRIBUTE =
-      "io.opentelemetry.auto.instrumentation.springwebflux.ParentContext";
 
   public static String parseOperationName(final Object handler) {
     String className = DECORATE.spanNameForClass(handler.getClass());

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
@@ -19,7 +19,6 @@ package io.opentelemetry.auto.instrumentation.springwebflux.server;
 import static io.opentelemetry.auto.instrumentation.springwebflux.server.SpringWebfluxHttpServerDecorator.DECORATE;
 import static io.opentelemetry.auto.instrumentation.springwebflux.server.SpringWebfluxHttpServerDecorator.TRACER;
 import static io.opentelemetry.context.ContextUtils.withScopedContext;
-import static io.opentelemetry.trace.TracingContextUtils.getSpan;
 import static io.opentelemetry.trace.TracingContextUtils.withSpan;
 
 import io.grpc.Context;
@@ -40,20 +39,13 @@ public class DispatcherHandlerAdvice {
       @Advice.Argument(0) final ServerWebExchange exchange,
       @Advice.Local("otelScope") Scope otelScope,
       @Advice.Local("otelContext") Context otelContext) {
-    // Unfortunately Netty EventLoop is not instrumented well enough to attribute all work to the
-    // right things so we have to store the context in request itself.
-    // We also store parent (netty's) context so we could update resource name.
-    Context parentContext = Context.current();
-    exchange.getAttributes().put(AdviceUtils.PARENT_CONTEXT_ATTRIBUTE, parentContext);
 
-    Span span =
-        TRACER
-            .spanBuilder("DispatcherHandler.handle")
-            .setParent(getSpan(parentContext))
-            .startSpan();
+    Span span = TRACER.spanBuilder("DispatcherHandler.handle").startSpan();
     DECORATE.afterStart(span);
 
-    otelContext = withSpan(span, parentContext);
+    otelContext = withSpan(span, Context.current());
+    // Unfortunately Netty EventLoop is not instrumented well enough to attribute all work to the
+    // right things so we have to store the context in request itself.
     exchange.getAttributes().put(AdviceUtils.CONTEXT_ATTRIBUTE, otelContext);
 
     otelScope = withScopedContext(otelContext);

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
@@ -17,6 +17,7 @@
 package io.opentelemetry.auto.instrumentation.springwebflux.server;
 
 import io.grpc.Context;
+import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseTracer;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.TracingContextUtils;
 import java.util.function.BiConsumer;
@@ -50,11 +51,11 @@ public class RouteOnSuccessOrError implements BiConsumer<HandlerFunction<?>, Thr
         if (context != null) {
           Span span = TracingContextUtils.getSpan(context);
           span.setAttribute("request.predicate", predicateString);
-        }
-        Context parentContext =
-            (Context) serverRequest.attributes().get(AdviceUtils.PARENT_CONTEXT_ATTRIBUTE);
-        if (parentContext != null) {
-          TracingContextUtils.getSpan(parentContext).updateName(parseRoute(predicateString));
+
+          Span serverSpan = BaseTracer.CONTEXT_SERVER_SPAN_KEY.get(context);
+          if (serverSpan != null) {
+            serverSpan.updateName(parseRoute(predicateString));
+          }
         }
       }
     }

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
@@ -133,7 +133,6 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
       if (span.getContext().isValid() && exception != null) {
         // We want to capture the stacktrace, but that doesn't mean it should be an error.
         // We rely on a decorator to set the error state based on response code. (5xx -> error)
-        // TODO sooo this adds throwable but does not end the span?
         TRACER.addThrowable(span, exception);
       }
     }

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
@@ -16,8 +16,7 @@
 
 package io.opentelemetry.auto.instrumentation.springwebmvc;
 
-import static io.opentelemetry.auto.instrumentation.springwebmvc.SpringWebMvcDecorator.DECORATE;
-import static io.opentelemetry.auto.instrumentation.springwebmvc.SpringWebMvcDecorator.TRACER;
+import static io.opentelemetry.auto.instrumentation.springwebmvc.SpringWebMvcTracer.TRACER;
 import static io.opentelemetry.trace.TracingContextUtils.currentContextWith;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isProtected;
@@ -56,7 +55,7 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".SpringWebMvcDecorator", packageName + ".HandlerMappingResourceNameFilter"
+      packageName + ".SpringWebMvcTracer", packageName + ".HandlerMappingResourceNameFilter"
     };
   }
 
@@ -110,9 +109,7 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope onEnter(@Advice.Argument(0) final ModelAndView mv) {
-      Span span = TRACER.spanBuilder(DECORATE.spanNameOnRender(mv)).startSpan();
-      DECORATE.afterStart(span);
-      DECORATE.onRender(span, mv);
+      Span span = TRACER.startSpan(mv);
       return new SpanWithScope(span, currentContextWith(span));
     }
 
@@ -120,9 +117,11 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
     public static void stopSpan(
         @Advice.Enter final SpanWithScope spanWithScope, @Advice.Thrown final Throwable throwable) {
       Span span = spanWithScope.getSpan();
-      DECORATE.onError(span, throwable);
-      DECORATE.beforeFinish(span);
-      span.end();
+      if (throwable == null) {
+        TRACER.end(span);
+      } else {
+        TRACER.endExceptionally(span, throwable);
+      }
       spanWithScope.closeScope();
     }
   }
@@ -134,7 +133,8 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
       if (span.getContext().isValid() && exception != null) {
         // We want to capture the stacktrace, but that doesn't mean it should be an error.
         // We rely on a decorator to set the error state based on response code. (5xx -> error)
-        DECORATE.addThrowable(span, exception);
+        // TODO sooo this adds throwable but does not end the span?
+        TRACER.addThrowable(span, exception);
       }
     }
   }

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/WebApplicationContextInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/WebApplicationContextInstrumentation.java
@@ -57,7 +57,7 @@ public class WebApplicationContextInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".SpringWebMvcDecorator",
+      packageName + ".SpringWebMvcTracer",
       packageName + ".HandlerMappingResourceNameFilter",
       packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",
     };

--- a/testing-common/src/main/groovy/io/opentelemetry/auto/test/utils/TraceUtils.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/auto/test/utils/TraceUtils.groovy
@@ -43,7 +43,7 @@ class TraceUtils {
       //TODO following two lines are duplicated from io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpServerTracer
       //Find a way to put this management into one place.
       def span = TRACER.spanBuilder(rootOperationName).setSpanKind(Span.Kind.SERVER).startSpan()
-      Context newContext = withSpan(span, Context.current().withValue(BaseTracer.CONTEXT_SERVER_SPAN_KEY, span));
+      Context newContext = withSpan(span, Context.current().withValue(BaseTracer.CONTEXT_SERVER_SPAN_KEY, span))
 
       Scope scope = withScopedContext(newContext)
 

--- a/testing-common/src/main/groovy/io/opentelemetry/auto/test/utils/TraceUtils.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/auto/test/utils/TraceUtils.groovy
@@ -16,8 +16,10 @@
 
 package io.opentelemetry.auto.test.utils
 
+import io.grpc.Context
 import io.opentelemetry.OpenTelemetry
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator
+import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseTracer
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.context.Scope
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -25,7 +27,9 @@ import io.opentelemetry.trace.Span
 import io.opentelemetry.trace.Tracer
 import java.util.concurrent.Callable
 
+import static io.opentelemetry.context.ContextUtils.withScopedContext
 import static io.opentelemetry.trace.TracingContextUtils.currentContextWith
+import static io.opentelemetry.trace.TracingContextUtils.withSpan
 
 class TraceUtils {
 
@@ -33,6 +37,29 @@ class TraceUtils {
   }
 
   private static final Tracer TRACER = OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto")
+
+  static <T> T runUnderServerTrace(final String rootOperationName, final Callable<T> r) {
+    try {
+      //TODO following two lines are duplicated from io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpServerTracer
+      //Find a way to put this management into one place.
+      def span = TRACER.spanBuilder(rootOperationName).setSpanKind(Span.Kind.SERVER).startSpan()
+      Context newContext = withSpan(span, Context.current().withValue(BaseTracer.CONTEXT_SERVER_SPAN_KEY, span));
+
+      Scope scope = withScopedContext(newContext)
+
+      try {
+        return r.call()
+      } catch (final Exception e) {
+        DECORATE.onError(span, e)
+        throw e
+      } finally {
+        scope.close()
+        span.end()
+      }
+    } catch (Throwable t) {
+      throw ExceptionUtils.sneakyThrow(t)
+    }
+  }
 
   static <T> T runUnderTrace(final String rootOperationName, final Callable<T> r) {
     try {


### PR DESCRIPTION
Closes #575 

I have updated all places I have found where supposedly server span name was changed. Except for [Spark](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/instrumentation/spark-web-framework-2.3/src/main/java/io/opentelemetry/auto/instrumentation/sparkjava/RoutesInstrumentation.java#L77)

Corresponding Decorators were rewritten to be Tracers.