### PR TITLE
New way to make patch releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,20 +171,6 @@ jobs:
           command: ./gradlew -Prelease.useLastTag=true final
           no_output_timeout: 6h
 
-  patch_release:
-    <<: *defaults
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: .
-
-      - restore_cache:
-          <<: *cache_keys
-
-      - run: ./gradlew -Prelease.useLastTag=true -Prelease.scope=patch final
-
-
 workflows:
   build_test_deploy:
     jobs:
@@ -249,15 +235,5 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              # Only for major and minor releases
-              only: /^v.*\.0$/
-
-  patch_release:
-    jobs:
-      - patch_release:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              # Only for major and minor releases
-              only: /^v.*\.[1-9]+$/
+              # As long as we don't have support branches, we release all tags in the same manner
+              only: /^v.*$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,11 +175,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: |
-          if [[ $(git tag --points-at HEAD | grep "^v") ]]; then
-              echo "Don't make patch release on commit which already has version tag"
-              circleci-agent step halt
-          fi
 
       - attach_workspace:
           at: .
@@ -187,7 +182,7 @@ jobs:
       - restore_cache:
           <<: *cache_keys
 
-      - run: ./gradlew -Prelease.scope=patch final
+      - run: ./gradlew -Prelease.useLastTag=true -Prelease.scope=patch final
 
 
 workflows:
@@ -259,56 +254,10 @@ workflows:
 
   patch_release:
     jobs:
-      - build:
-          filters:
-            branches:
-              only: /\d+\.\d+\.x$/
-
-      - default_test_job:
-          requires:
-            - build
-          prefixTestTask: true
-          name: test_<< matrix.testTask >>
-          matrix:
-            parameters:
-              testTask: ["7", "8", "14"]
-          filters:
-            branches:
-              only: /\d+\.\d+\.x$/
-
-      - default_test_job:
-          requires:
-            - build
-          name: test_11
-          testTask: test jacocoTestReport jacocoTestCoverageVerification
-          filters:
-            branches:
-              only: /\d+\.\d+\.x$/
-
-      - default_test_job:
-          requires:
-            - build
-          name: test_latest
-          testTask: latestDepTest
-          filters:
-            branches:
-              only: /\d+\.\d+\.x$/
-
-      - muzzle:
-          requires:
-            - build
-          filters:
-            branches:
-              only: /\d+\.\d+\.x$/
-
       - patch_release:
-          requires:
-            - test_7
-            - test_8
-            - test_11
-            - test_14
-            - test_latest
-            - muzzle
           filters:
             branches:
-              only: /\d+\.\d+\.x$/
+              ignore: /.*/
+            tags:
+              # Only for major and minor releases
+              only: /^v.*\.[1-9]+$/


### PR DESCRIPTION
Previous patch release job assumed that we have a branch started from a release tag. Patch release then trigged on any new commit to that branch.

Now, before, GA, we actually don't use that. We just want to push a tag, e.g. `v0.6.1` to an already verified commit, a release a version with that tag. In exactly the same way as minor releases.