### PR TITLE
Use archivesBaseName when publishing.

### DIFF
--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -15,6 +15,11 @@ byteBuddy {
   }
 }
 
+// TODO(anuraaga): This needs to be added before adding publish.gradle, clean up this ordering restraint.
+afterEvaluate {
+  archivesBaseName = 'opentelemetry-auto-' + archivesBaseName
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 if (project.ext.find("skipPublish") != true) {
   apply from: "$rootDir/gradle/publish.gradle"
@@ -22,8 +27,6 @@ if (project.ext.find("skipPublish") != true) {
 
 
 afterEvaluate {
-  archivesBaseName = 'opentelemetry-auto-' + archivesBaseName
-
   byteBuddy {
     transformation {
       tasks = ['compileJava', 'compileScala', 'compileKotlin']

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -19,7 +19,9 @@ publishing {
         from components.java
       }
 
-      artifactId = artifactPrefix(project) + artifactId
+      afterEvaluate {
+        artifactId = artifactPrefix(project) + archivesBaseName
+      }
 
       pom {
         name = 'OpenTelemetry Instrumentation for Java'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -20,7 +20,7 @@ publishing {
       }
 
       afterEvaluate {
-        artifactId = artifactPrefix(project) + archivesBaseName
+        artifactId = artifactPrefix(project, archivesBaseName) + archivesBaseName
       }
 
       pom {
@@ -59,7 +59,10 @@ publishing {
   }
 }
 
-private String artifactPrefix(Project p) {
+private String artifactPrefix(Project p, String archivesBaseName) {
+  if (archivesBaseName.startsWith("opentelemetry")) {
+    return ''
+  }
   if (p.name.startsWith("opentelemetry")) {
     return ''
   }


### PR DESCRIPTION
By default `project.name` (gradle tasks) == `archivesBaseName` (jar built by assemble) == artifactId (jar published to maven). But for these new directories, we override `archivesBaseName` since project.name is generic. So we also need to set maven `artifactId` to use `archivesBaseName` to ensure assemble and publish have the same naming.