### PR TITLE
Apply new database semantic attributes

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -18,7 +18,6 @@ package io.opentelemetry.auto.bootstrap.instrumentation.decorator;
 
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
-import io.opentelemetry.trace.attributes.StringAttributeSetter;
 
 /** @deprecated use {@link DatabaseClientTracer} instead. */
 @Deprecated
@@ -38,7 +37,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
   @Override
   public Span afterStart(final Span span) {
     assert span != null;
-    span.setAttribute(StringAttributeSetter.create("db.system").key(), dbSystem());
+    span.setAttribute(SemanticAttributes.DB_SYSTEM.key(), dbSystem());
     return super.afterStart(span);
   }
 
@@ -47,10 +46,9 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
     assert span != null;
     if (connection != null) {
       span.setAttribute(SemanticAttributes.DB_USER.key(), dbUser(connection));
-      span.setAttribute(StringAttributeSetter.create("db.name").key(), dbName(connection));
+      span.setAttribute(SemanticAttributes.DB_NAME.key(), dbName(connection));
       span.setAttribute(
-          StringAttributeSetter.create("db.connection_string").key(),
-          dbConnectionString(connection));
+          SemanticAttributes.DB_CONNECTION_STRING.key(), dbConnectionString(connection));
     }
     return span;
   }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientTracer.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientTracer.java
@@ -27,7 +27,6 @@ import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.Tracer;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
-import io.opentelemetry.trace.attributes.StringAttributeSetter;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
@@ -52,7 +51,7 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
         tracer
             .spanBuilder(spanName(normalizedQuery))
             .setSpanKind(CLIENT)
-            .setAttribute(StringAttributeSetter.create("db.system").key(), dbSystem(connection))
+            .setAttribute(SemanticAttributes.DB_SYSTEM.key(), dbSystem(connection))
             .startSpan();
 
     if (connection != null) {
@@ -106,9 +105,9 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
   /** This should be called when the connection is being used, not when it's created. */
   protected Span onConnection(final Span span, final CONNECTION connection) {
     span.setAttribute(SemanticAttributes.DB_USER.key(), dbUser(connection));
-    span.setAttribute(StringAttributeSetter.create("db.name").key(), dbName(connection));
+    span.setAttribute(SemanticAttributes.DB_NAME.key(), dbName(connection));
     span.setAttribute(
-        StringAttributeSetter.create("db.connection_string").key(), dbConnectionString(connection));
+        SemanticAttributes.DB_CONNECTION_STRING.key(), dbConnectionString(connection));
     return span;
   }
 

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
@@ -18,7 +18,6 @@ package io.opentelemetry.auto.bootstrap.instrumentation.decorator
 
 import io.opentelemetry.trace.Span
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 
 class DatabaseClientDecoratorTest extends ClientDecoratorTest {
 
@@ -30,7 +29,7 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     decorator.afterStart(span)
 
     then:
-    1 * span.setAttribute(StringAttributeSetter.create("db.system").key(), "test-db")
+    1 * span.setAttribute(SemanticAttributes.DB_SYSTEM.key(), "test-db")
     0 * _
 
     where:
@@ -47,8 +46,8 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     then:
     if (session) {
       1 * span.setAttribute(SemanticAttributes.DB_USER.key(), session.user)
-      1 * span.setAttribute(StringAttributeSetter.create("db.name").key(), session.name)
-      1 * span.setAttribute(StringAttributeSetter.create("db.connection_string").key(), session.connectionString)
+      1 * span.setAttribute(SemanticAttributes.DB_NAME.key(), session.name)
+      1 * span.setAttribute(SemanticAttributes.DB_CONNECTION_STRING.key(), session.connectionString)
     }
     0 * _
 

--- a/auto-exporters/jaeger/src/main/java/io/opentelemetry/auto/exporters/jaeger/JaegerExporterFactory.java
+++ b/auto-exporters/jaeger/src/main/java/io/opentelemetry/auto/exporters/jaeger/JaegerExporterFactory.java
@@ -25,6 +25,9 @@ public class JaegerExporterFactory implements SpanExporterFactory {
 
   @Override
   public SpanExporter fromConfig(final Config config) {
-    return (SpanExporter) JaegerGrpcSpanExporter.newBuilder();
+    return JaegerGrpcSpanExporter.newBuilder()
+        .readEnvironmentVariables()
+        .readSystemProperties()
+        .build();
   }
 }

--- a/auto-exporters/jaeger/src/main/java/io/opentelemetry/auto/exporters/jaeger/JaegerExporterFactory.java
+++ b/auto-exporters/jaeger/src/main/java/io/opentelemetry/auto/exporters/jaeger/JaegerExporterFactory.java
@@ -25,6 +25,6 @@ public class JaegerExporterFactory implements SpanExporterFactory {
 
   @Override
   public SpanExporter fromConfig(final Config config) {
-    return JaegerGrpcSpanExporter.Builder.fromEnv().build();
+    return (SpanExporter) JaegerGrpcSpanExporter.newBuilder();
   }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,21 +9,21 @@ configurations.all {
 ext {
   versions = [
     // Check https://oss.jfrog.org/libs-snapshot/io/opentelemetry/ for latest snapshot version.
-    opentelemetry: '0.7.0-20200723.154929-27',
+    opentelemetry     : '0.7.0-20200727.220734-34',
     // Snapshot versions can often get split into two suffixes
-    opentelemetryOther: '0.7.0-20200723.154929-26',
+    opentelemetryOther: '0.7.0-20200727.220734-33',
 
-    slf4j        : "1.7.30",
-    guava        : "20.0", // Last version to support Java 7
+    slf4j             : "1.7.30",
+    guava             : "20.0", // Last version to support Java 7
 
-    spock        : "1.3-groovy-$spockGroovyVer",
-    groovy       : groovyVer,
-    logback      : "1.2.3",
-    bytebuddy    : "1.10.10",
-    scala        : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
-    kotlin       : "1.3.72",
-    coroutines   : "1.3.0",
-    springboot   : "2.3.1.RELEASE",
+    spock             : "1.3-groovy-$spockGroovyVer",
+    groovy            : groovyVer,
+    logback           : "1.2.3",
+    bytebuddy         : "1.10.10",
+    scala             : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
+    kotlin            : "1.3.72",
+    coroutines        : "1.3.0",
+    springboot        : "2.3.1.RELEASE",
   ]
 
   deps = [

--- a/instrumentation/cassandra/cassandra-3.0/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-3.0/src/test/groovy/CassandraClientTest.groovy
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+
 import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.Session
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
 import spock.lang.Shared
 
@@ -130,8 +130,8 @@ class CassandraClientTest extends AgentTestRunner {
         "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
         "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
         "${SemanticAttributes.NET_PEER_PORT.key()}" EmbeddedCassandraServerHelper.getNativeTransportPort()
-        "${StringAttributeSetter.create("db.system").key()}" "cassandra"
-        "${StringAttributeSetter.create("db.name").key()}" keyspace
+        "${SemanticAttributes.DB_SYSTEM.key()}" "cassandra"
+        "${SemanticAttributes.DB_NAME.key()}" keyspace
         "${SemanticAttributes.DB_STATEMENT.key()}" statement
       }
     }

--- a/instrumentation/cassandra/cassandra-3.0/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-3.0/src/test/groovy/CassandraClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.Session
 import io.opentelemetry.auto.test.AgentTestRunner

--- a/instrumentation/cassandra/cassandra-4.0/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-4.0/src/test/groovy/CassandraClientTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader
@@ -22,7 +23,6 @@ import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
 
 import java.time.Duration
@@ -113,8 +113,8 @@ class CassandraClientTest extends AgentTestRunner {
         "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
         "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
         "${SemanticAttributes.NET_PEER_PORT.key()}" EmbeddedCassandraServerHelper.getNativeTransportPort()
-        "${StringAttributeSetter.create("db.system").key()}" "cassandra"
-        "${StringAttributeSetter.create("db.name").key()}" keyspace
+        "${SemanticAttributes.DB_SYSTEM.key()}" "cassandra"
+        "${SemanticAttributes.DB_NAME.key()}" keyspace
         "${SemanticAttributes.DB_STATEMENT.key()}" statement
       }
     }

--- a/instrumentation/cassandra/cassandra-4.0/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-4.0/src/test/groovy/CassandraClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_0/CouchbaseOnSubscribe.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_0/CouchbaseOnSubscribe.java
@@ -22,7 +22,6 @@ import static io.opentelemetry.trace.Span.Kind.CLIENT;
 import io.opentelemetry.auto.instrumentation.rxjava.TracedOnSubscribe;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
-import io.opentelemetry.trace.attributes.StringAttributeSetter;
 import java.lang.reflect.Method;
 import rx.Observable;
 
@@ -55,7 +54,7 @@ public class CouchbaseOnSubscribe extends TracedOnSubscribe {
   protected void afterStart(final Span span) {
     super.afterStart(span);
 
-    span.setAttribute(StringAttributeSetter.create("db.name").key(), bucket);
+    span.setAttribute(SemanticAttributes.DB_NAME.key(), bucket);
     span.setAttribute(SemanticAttributes.DB_STATEMENT.key(), query);
   }
 }

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -31,7 +31,6 @@ import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import spock.lang.Shared
 
 import java.util.concurrent.TimeUnit
@@ -127,9 +126,9 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
         childOf((SpanData) parentSpan)
       }
       attributes {
-        "${StringAttributeSetter.create("db.system").key()}" "couchbase"
+        "${SemanticAttributes.DB_SYSTEM.key()}" "couchbase"
         if (bucketName != null) {
-          "${StringAttributeSetter.create("db.name").key()}" bucketName
+          "${SemanticAttributes.DB_NAME.key()}" bucketName
         }
         "${SemanticAttributes.DB_STATEMENT.key()}" name
       }

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 
 import static io.opentelemetry.trace.Span.Kind.CLIENT
 
@@ -40,9 +40,9 @@ class CouchbaseSpanUtil {
         "${SemanticAttributes.NET_PEER_NAME.key()}" { it == "localhost" || it == "127.0.0.1" || it == null }
         "${SemanticAttributes.NET_PEER_PORT.key()}" { it == null || Number }
 
-        "${StringAttributeSetter.create("db.system").key()}" "couchbase"
+        "${SemanticAttributes.DB_SYSTEM.key()}" "couchbase"
         if (bucketName != null) {
-          "${StringAttributeSetter.create("db.name").key()}" bucketName
+          "${SemanticAttributes.DB_NAME.key()}" bucketName
         }
 
         // Because of caching, not all requests hit the server so this tag may be absent

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+
 import groovy.json.JsonSlurper
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -104,7 +104,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_PORT.key()}" httpTransportAddress.port
             "${SemanticAttributes.HTTP_URL.key()}" "_cluster/health"
             "${SemanticAttributes.HTTP_METHOD.key()}" "GET"
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
           }
         }
         span(1) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import groovy.json.JsonSlurper
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
 import io.opentelemetry.auto.test.AgentTestRunner

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+
 import groovy.json.JsonSlurper
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -108,7 +108,7 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_PORT.key()}" httpTransportAddress.port
             "${SemanticAttributes.HTTP_URL.key()}" "_cluster/health"
             "${SemanticAttributes.HTTP_METHOD.key()}" "GET"
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
           }
         }
         span(1) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import groovy.json.JsonSlurper
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
 import io.opentelemetry.auto.test.AgentTestRunner

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import groovy.json.JsonSlurper
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
 import io.opentelemetry.auto.test.AgentTestRunner

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+
 import groovy.json.JsonSlurper
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -109,7 +109,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_PORT.key()}" httpTransportAddress.port
             "${SemanticAttributes.HTTP_URL.key()}" "_cluster/health"
             "${SemanticAttributes.HTTP_METHOD.key()}" "GET"
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
           }
         }
         span(1) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+
 import groovy.json.JsonSlurper
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -104,7 +104,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_PORT.key()}" httpTransportAddress.port
             "${SemanticAttributes.HTTP_URL.key()}" "_cluster/health"
             "${SemanticAttributes.HTTP_METHOD.key()}" "GET"
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
           }
         }
         span(1) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import groovy.json.JsonSlurper
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
 import io.opentelemetry.auto.test.AgentTestRunner

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
-import io.opentelemetry.trace.attributes.StringAttributeSetter
+import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -88,7 +89,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -113,7 +114,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           errored true
           errorEvent IndexNotFoundException, "no such index"
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -172,7 +173,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -184,7 +185,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -195,7 +196,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -210,7 +211,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -222,7 +223,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -234,7 +235,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.action.admin.cluster.stats.ClusterStatsRequest
 import org.elasticsearch.client.transport.TransportClient
@@ -104,7 +104,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -133,7 +133,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterStatsAction"
             "elasticsearch.request" "ClusterStatsRequest"
             "elasticsearch.node.cluster.name" clusterName
@@ -159,7 +159,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           errored true
           errorEvent RemoteTransportException, String
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -229,7 +229,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -244,7 +244,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -258,7 +258,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -273,7 +273,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -288,7 +288,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -304,7 +304,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -17,7 +17,7 @@
 package springdata
 
 import io.opentelemetry.auto.test.AgentTestRunner
-import io.opentelemetry.trace.attributes.StringAttributeSetter
+import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
@@ -57,7 +57,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -85,7 +85,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -97,7 +97,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -109,7 +109,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -132,7 +132,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -159,7 +159,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -172,7 +172,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -187,7 +187,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -213,7 +213,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "DeleteAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
@@ -226,7 +226,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -241,7 +241,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -17,7 +17,7 @@
 package springdata
 
 import io.opentelemetry.auto.test.AgentTestRunner
-import io.opentelemetry.trace.attributes.StringAttributeSetter
+import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -91,7 +91,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           errored true
           errorEvent IndexNotFoundException, "no such index"
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -139,7 +139,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -151,7 +151,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -162,7 +162,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -175,7 +175,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -187,7 +187,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -199,7 +199,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -214,7 +214,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -291,7 +291,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -84,7 +84,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -109,7 +109,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           errored true
           errorEvent IndexNotFoundException, "no such index"
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -168,7 +168,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -180,7 +180,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -194,7 +194,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "local"
             "${SemanticAttributes.NET_PEER_IP.key()}" "0.0.0.0"
             "${SemanticAttributes.NET_PEER_PORT.key()}" 0
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -212,7 +212,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "local"
             "${SemanticAttributes.NET_PEER_IP.key()}" "0.0.0.0"
             "${SemanticAttributes.NET_PEER_PORT.key()}" 0
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -224,7 +224,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -239,7 +239,7 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "local"
             "${SemanticAttributes.NET_PEER_IP.key()}" "0.0.0.0"
             "${SemanticAttributes.NET_PEER_PORT.key()}" 0
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.action.admin.cluster.stats.ClusterStatsRequest
 import org.elasticsearch.client.transport.TransportClient
@@ -103,7 +103,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -131,7 +131,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterStatsAction"
             "elasticsearch.request" "ClusterStatsRequest"
             "elasticsearch.node.cluster.name" clusterName
@@ -157,7 +157,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           errored true
           errorEvent RemoteTransportException, String
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -227,7 +227,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -242,7 +242,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -256,7 +256,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -271,7 +271,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -286,7 +286,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -302,7 +302,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -16,10 +16,8 @@
 
 package springdata
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
@@ -59,7 +57,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -90,7 +88,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "local"
             "${SemanticAttributes.NET_PEER_IP.key()}" "0.0.0.0"
             "${SemanticAttributes.NET_PEER_PORT.key()}" 0
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -102,7 +100,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -114,7 +112,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -140,7 +138,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "local"
             "${SemanticAttributes.NET_PEER_IP.key()}" "0.0.0.0"
             "${SemanticAttributes.NET_PEER_PORT.key()}" 0
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -170,7 +168,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "local"
             "${SemanticAttributes.NET_PEER_IP.key()}" "0.0.0.0"
             "${SemanticAttributes.NET_PEER_PORT.key()}" 0
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -183,7 +181,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -201,7 +199,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "local"
             "${SemanticAttributes.NET_PEER_IP.key()}" "0.0.0.0"
             "${SemanticAttributes.NET_PEER_PORT.key()}" 0
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -230,7 +228,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "local"
             "${SemanticAttributes.NET_PEER_IP.key()}" "0.0.0.0"
             "${SemanticAttributes.NET_PEER_PORT.key()}" 0
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
@@ -243,7 +241,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -258,7 +256,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -16,10 +16,8 @@
 
 package springdata
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -93,7 +91,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           errored true
           errorEvent IndexNotFoundException, "no such index"
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -141,7 +139,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -153,7 +151,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -164,7 +162,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -180,7 +178,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "local"
             "${SemanticAttributes.NET_PEER_IP.key()}" "0.0.0.0"
             "${SemanticAttributes.NET_PEER_PORT.key()}" 0
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -192,7 +190,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
             "elasticsearch.request.indices" indexName
@@ -204,7 +202,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -219,7 +217,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -295,7 +293,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
-import io.opentelemetry.trace.attributes.StringAttributeSetter
+import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -89,7 +90,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -114,7 +115,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           errorEvent IndexNotFoundException, "no such index"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -174,7 +175,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -186,7 +187,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -197,7 +198,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -212,7 +213,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -228,7 +229,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
           }
@@ -239,7 +240,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
@@ -109,7 +109,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.host
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -134,7 +134,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           errored true
           errorEvent RemoteTransportException, String
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -204,7 +204,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.host
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -219,7 +219,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.host
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -234,7 +234,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
           }
@@ -248,7 +248,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.host
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -268,7 +268,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
-import io.opentelemetry.trace.attributes.StringAttributeSetter
+import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -89,7 +90,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -114,7 +115,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           errored true
           errorEvent IndexNotFoundException, "no such index"
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -174,7 +175,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -186,7 +187,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -197,7 +198,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -212,7 +213,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -229,7 +230,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
           }
@@ -240,7 +241,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
@@ -110,7 +110,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -135,7 +135,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           errored true
           errorEvent RemoteTransportException, String
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -205,7 +205,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -220,7 +220,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -235,7 +235,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
           }
@@ -249,7 +249,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -270,7 +270,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" tcpPublishAddress.host == tcpPublishAddress.address ? null : tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -17,7 +17,7 @@
 package springdata
 
 import io.opentelemetry.auto.test.AgentTestRunner
-import io.opentelemetry.trace.attributes.StringAttributeSetter
+import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
 
@@ -93,7 +93,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           errored false
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -128,7 +128,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -145,7 +145,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
           }
@@ -155,7 +155,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -185,7 +185,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -219,7 +219,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -236,7 +236,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -258,7 +258,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -291,7 +291,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"
             "elasticsearch.request.indices" indexName
@@ -307,7 +307,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -330,7 +330,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -18,7 +18,7 @@ package springdata
 
 import com.google.common.collect.ImmutableSet
 import io.opentelemetry.auto.test.AgentTestRunner
-import io.opentelemetry.trace.attributes.StringAttributeSetter
+import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -110,7 +110,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           errored true
           errorEvent IndexNotFoundException, "no such index"
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -158,7 +158,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -170,7 +170,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -181,7 +181,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -194,7 +194,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -211,7 +211,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
           }
@@ -222,7 +222,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
             "elasticsearch.request.indices" indexName
@@ -237,7 +237,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName
@@ -314,7 +314,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
-import io.opentelemetry.trace.attributes.StringAttributeSetter
+import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -86,7 +87,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -111,7 +112,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           errored true
           errorEvent IndexNotFoundException, "no such index"
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -170,7 +171,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -182,7 +183,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -197,7 +198,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -214,7 +215,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
           }
@@ -225,7 +226,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
@@ -105,7 +105,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
           }
@@ -130,7 +130,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           errored true
           errorEvent RemoteTransportException, String
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -200,7 +200,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
             "elasticsearch.request.indices" indexName
@@ -215,7 +215,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName
@@ -230,7 +230,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
           }
@@ -244,7 +244,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
             "elasticsearch.request.indices" indexName
@@ -265,7 +265,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
             "${SemanticAttributes.NET_PEER_IP.key()}" tcpPublishAddress.address
             "${SemanticAttributes.NET_PEER_PORT.key()}" tcpPublishAddress.port
-            "${StringAttributeSetter.create("db.system").key()}" "elasticsearch"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
             "elasticsearch.request.indices" indexName

--- a/instrumentation/geode-1.4/src/main/java/io/opentelemetry/auto/instrumentation/geode/GeodeInstrumentation.java
+++ b/instrumentation/geode-1.4/src/main/java/io/opentelemetry/auto/instrumentation/geode/GeodeInstrumentation.java
@@ -32,7 +32,6 @@ import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
-import io.opentelemetry.trace.attributes.StringAttributeSetter;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
@@ -98,7 +97,7 @@ public class GeodeInstrumentation extends Instrumenter.Default {
           TRACER
               .spanBuilder(method.getName())
               .setSpanKind(CLIENT)
-              .setAttribute(StringAttributeSetter.create("db.name").key(), thiz.getName())
+              .setAttribute(SemanticAttributes.DB_NAME.key(), thiz.getName())
               .startSpan();
       DECORATE.afterStart(span);
       return new SpanWithScope(span, currentContextWith(span));
@@ -135,7 +134,7 @@ public class GeodeInstrumentation extends Instrumenter.Default {
           TRACER
               .spanBuilder(method.getName())
               .setSpanKind(CLIENT)
-              .setAttribute(StringAttributeSetter.create("db.name").key(), thiz.getName())
+              .setAttribute(SemanticAttributes.DB_NAME.key(), thiz.getName())
               .setAttribute(SemanticAttributes.DB_STATEMENT.key(), query)
               .startSpan();
       DECORATE.afterStart(span);

--- a/instrumentation/geode-1.4/src/test/groovy/PutGetTest.groovy
+++ b/instrumentation/geode-1.4/src/test/groovy/PutGetTest.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.apache.geode.cache.client.ClientCacheFactory
 import org.apache.geode.cache.client.ClientRegionShortcut
 import spock.lang.Shared
@@ -133,8 +133,8 @@ class PutGetTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "geode"
-            "${StringAttributeSetter.create("db.name").key()}" "test-region"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "geode"
+            "${SemanticAttributes.DB_NAME.key()}" "test-region"
           }
         }
         span(2) {
@@ -142,8 +142,8 @@ class PutGetTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "geode"
-            "${StringAttributeSetter.create("db.name").key()}" "test-region"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "geode"
+            "${SemanticAttributes.DB_NAME.key()}" "test-region"
           }
         }
         span(3) {
@@ -151,8 +151,8 @@ class PutGetTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "geode"
-            "${StringAttributeSetter.create("db.name").key()}" "test-region"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "geode"
+            "${SemanticAttributes.DB_NAME.key()}" "test-region"
             if (query != null) {
               "${SemanticAttributes.DB_STATEMENT.key()}" query
             }

--- a/instrumentation/geode-1.4/src/test/groovy/PutGetTest.groovy
+++ b/instrumentation/geode-1.4/src/test/groovy/PutGetTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.apache.geode.cache.client.ClientCacheFactory

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.hibernate.Criteria
 import org.hibernate.Session

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.hibernate.Criteria
 import org.hibernate.Session
 import org.hibernate.criterion.Order
@@ -59,11 +59,11 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(3) {

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.hibernate.Query
 import org.hibernate.Session

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.hibernate.Query
 import org.hibernate.Session
 
@@ -63,11 +63,11 @@ class QueryTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" String
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(3) {
@@ -100,11 +100,11 @@ class QueryTest extends AbstractHibernateTest {
             spanKind CLIENT
             childOf span(1)
             attributes {
-              "${StringAttributeSetter.create("db.system").key()}" "h2"
-              "${StringAttributeSetter.create("db.name").key()}" "db1"
+              "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+              "${SemanticAttributes.DB_NAME.key()}" "db1"
               "${SemanticAttributes.DB_USER.key()}" "sa"
               "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-              "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+              "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
             }
           }
         }
@@ -172,11 +172,11 @@ class QueryTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(3) {

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.hibernate.LockMode
 import org.hibernate.MappingException

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.hibernate.LockMode
 import org.hibernate.MappingException
 import org.hibernate.Query
@@ -76,11 +76,11 @@ class SessionTest extends AbstractHibernateTest {
             spanKind CLIENT
             childOf span(1)
             attributes {
-              "${StringAttributeSetter.create("db.system").key()}" "h2"
-              "${StringAttributeSetter.create("db.name").key()}" "db1"
+              "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+              "${SemanticAttributes.DB_NAME.key()}" "db1"
               "${SemanticAttributes.DB_USER.key()}" "sa"
               "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-              "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+              "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
             }
           }
           span(3) {
@@ -151,11 +151,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(2)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" String
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
       }
@@ -217,11 +217,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(3) {
@@ -235,11 +235,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(3)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" String
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
       }
@@ -349,11 +349,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(2)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" String
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
       }
@@ -421,11 +421,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" String
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(3) {
@@ -508,11 +508,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^insert /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(6) {
@@ -520,11 +520,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^delete /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(7) {

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.hibernate.Criteria
 import org.hibernate.Session

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.hibernate.Criteria
 import org.hibernate.Session
 import org.hibernate.criterion.Order
@@ -59,11 +59,11 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(3) {

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.hibernate.Query
 import org.hibernate.Session

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.hibernate.Query
 import org.hibernate.Session
 
@@ -63,11 +63,11 @@ class QueryTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" String
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(3) {
@@ -100,11 +100,11 @@ class QueryTest extends AbstractHibernateTest {
             spanKind CLIENT
             childOf span(1)
             attributes {
-              "${StringAttributeSetter.create("db.system").key()}" "h2"
-              "${StringAttributeSetter.create("db.name").key()}" "db1"
+              "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+              "${SemanticAttributes.DB_NAME.key()}" "db1"
               "${SemanticAttributes.DB_USER.key()}" "sa"
               "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-              "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+              "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
             }
           }
         }
@@ -172,11 +172,11 @@ class QueryTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(3) {

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.hibernate.LockMode
 import org.hibernate.MappingException

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.hibernate.LockMode
 import org.hibernate.MappingException
 import org.hibernate.Query
@@ -75,11 +75,11 @@ class SessionTest extends AbstractHibernateTest {
             childOf span(1)
             spanKind CLIENT
             attributes {
-              "${StringAttributeSetter.create("db.system").key()}" "h2"
-              "${StringAttributeSetter.create("db.name").key()}" "db1"
+              "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+              "${SemanticAttributes.DB_NAME.key()}" "db1"
               "${SemanticAttributes.DB_USER.key()}" "sa"
               "${SemanticAttributes.DB_STATEMENT.key()}" String
-              "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+              "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
             }
           }
           span(3) {
@@ -158,11 +158,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(3) {
@@ -176,11 +176,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(3)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" String
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
       }
@@ -290,11 +290,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(2)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" String
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
       }
@@ -362,11 +362,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" String
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(3) {
@@ -449,11 +449,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^insert /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(6) {
@@ -461,11 +461,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^delete /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(7) {
@@ -487,11 +487,11 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(8)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" "db1"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" "db1"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^insert /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
         span(10) {

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.hibernate.Session

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.hibernate.Session
 import org.hibernate.SessionFactory
 import org.hibernate.cfg.Configuration
@@ -102,11 +102,11 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(1)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" "{call TEST_PROC()}"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
         span(3) {

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
 import spring.jpa.Customer
@@ -50,11 +50,11 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }
@@ -76,11 +76,11 @@ class SpringJpaTest extends AgentTestRunner {
             operationName "call next value for hibernate_sequence"
             spanKind CLIENT
             attributes {
-              "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-              "${StringAttributeSetter.create("db.name").key()}" "test"
+              "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+              "${SemanticAttributes.DB_NAME.key()}" "test"
               "${SemanticAttributes.DB_USER.key()}" "sa"
               "${SemanticAttributes.DB_STATEMENT.key()}" "call next value for hibernate_sequence"
-              "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+              "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
             }
           }
         }
@@ -90,11 +90,11 @@ class SpringJpaTest extends AgentTestRunner {
           operationName ~/insert into Customer \(.*\) values \(.*, \?, \?\)/
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/insert into Customer \(.*\) values \(.*, \?, \?\)/
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }
@@ -113,11 +113,11 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }
@@ -126,11 +126,11 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "update Customer set firstName=?, lastName=? where id=?"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" "update Customer set firstName=?, lastName=? where id=?"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }
@@ -149,11 +149,11 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_ where customer0_.lastName=?"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_ where customer0_.lastName=?"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }
@@ -170,11 +170,11 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }
@@ -183,11 +183,11 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "delete from Customer where id=?"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" "delete from Customer where id=?"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.springframework.context.annotation.AnnotationConfigApplicationContext

--- a/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.instrumentation.jdbc.JDBCUtils
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 
 import static io.opentelemetry.trace.Span.Kind.CLIENT
 
@@ -49,11 +49,11 @@ class SlickTest extends AgentTestRunner {
           childOf span(0)
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "h2"
-            "${StringAttributeSetter.create("db.name").key()}" SlickUtils.Db()
+            "${SemanticAttributes.DB_SYSTEM.key()}" "h2"
+            "${SemanticAttributes.DB_NAME.key()}" SlickUtils.Db()
             "${SemanticAttributes.DB_USER.key()}" SlickUtils.Username()
             "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(SlickUtils.TestQuery())
-            "${StringAttributeSetter.create("db.connection_string").key()}" "h2:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "h2:mem:"
           }
         }
       }

--- a/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.instrumentation.jdbc.JDBCUtils
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes

--- a/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import com.mchange.v2.c3p0.ComboPooledDataSource
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
@@ -21,7 +22,6 @@ import io.opentelemetry.auto.instrumentation.jdbc.JDBCUtils
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.ConfigUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.apache.derby.jdbc.EmbeddedDataSource
 import org.apache.derby.jdbc.EmbeddedDriver
 import org.h2.Driver
@@ -204,13 +204,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" system
-            "${StringAttributeSetter.create("db.name").key()}" dbName.toLowerCase()
+            "${SemanticAttributes.DB_SYSTEM.key()}" system
+            "${SemanticAttributes.DB_NAME.key()}" dbName.toLowerCase()
             if (username != null) {
               "${SemanticAttributes.DB_USER.key()}" username
             }
             "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(query)
-            "${StringAttributeSetter.create("db.connection_string").key()}" url
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" url
           }
         }
       }
@@ -260,13 +260,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" system
-            "${StringAttributeSetter.create("db.name").key()}" dbName.toLowerCase()
+            "${SemanticAttributes.DB_SYSTEM.key()}" system
+            "${SemanticAttributes.DB_NAME.key()}" dbName.toLowerCase()
             if (username != null) {
               "${SemanticAttributes.DB_USER.key()}" username
             }
             "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(query)
-            "${StringAttributeSetter.create("db.connection_string").key()}" url
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" url
           }
         }
       }
@@ -308,13 +308,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" system
-            "${StringAttributeSetter.create("db.name").key()}" dbName.toLowerCase()
+            "${SemanticAttributes.DB_SYSTEM.key()}" system
+            "${SemanticAttributes.DB_NAME.key()}" dbName.toLowerCase()
             if (username != null) {
               "${SemanticAttributes.DB_USER.key()}" username
             }
             "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(query)
-            "${StringAttributeSetter.create("db.connection_string").key()}" url
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" url
 
           }
         }
@@ -357,13 +357,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" system
-            "${StringAttributeSetter.create("db.name").key()}" dbName.toLowerCase()
+            "${SemanticAttributes.DB_SYSTEM.key()}" system
+            "${SemanticAttributes.DB_NAME.key()}" dbName.toLowerCase()
             if (username != null) {
               "${SemanticAttributes.DB_USER.key()}" username
             }
             "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(query)
-            "${StringAttributeSetter.create("db.connection_string").key()}" url
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" url
 
           }
         }
@@ -406,13 +406,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" system
-            "${StringAttributeSetter.create("db.name").key()}" dbName.toLowerCase()
+            "${SemanticAttributes.DB_SYSTEM.key()}" system
+            "${SemanticAttributes.DB_NAME.key()}" dbName.toLowerCase()
             if (username != null) {
               "${SemanticAttributes.DB_USER.key()}" username
             }
             "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(query)
-            "${StringAttributeSetter.create("db.connection_string").key()}" url
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" url
 
           }
         }
@@ -458,13 +458,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" system
-            "${StringAttributeSetter.create("db.name").key()}" dbName.toLowerCase()
+            "${SemanticAttributes.DB_SYSTEM.key()}" system
+            "${SemanticAttributes.DB_NAME.key()}" dbName.toLowerCase()
             if (username != null) {
               "${SemanticAttributes.DB_USER.key()}" username
             }
             "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(query)
-            "${StringAttributeSetter.create("db.connection_string").key()}" url
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" url
 
           }
         }
@@ -525,13 +525,13 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             if (prepareStatement) {
             } else {
             }
-            "${StringAttributeSetter.create("db.system").key()}" system
-            "${StringAttributeSetter.create("db.name").key()}" dbName.toLowerCase()
+            "${SemanticAttributes.DB_SYSTEM.key()}" system
+            "${SemanticAttributes.DB_NAME.key()}" dbName.toLowerCase()
             if (username != null) {
               "${SemanticAttributes.DB_USER.key()}" username
             }
             "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(query)
-            "${StringAttributeSetter.create("db.connection_string").key()}" url
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" url
 
           }
         }
@@ -629,9 +629,9 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "testdb"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "testdb"
             "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(query)
-            "${StringAttributeSetter.create("db.connection_string").key()}" "testdb://localhost"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "testdb://localhost"
           }
         }
       }
@@ -689,11 +689,11 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" dbName.toLowerCase()
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" dbName.toLowerCase()
             "${SemanticAttributes.DB_USER.key()}" "SA"
             "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(query)
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
 
           }
         }
@@ -705,11 +705,11 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             spanKind CLIENT
             errored false
             attributes {
-              "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-              "${StringAttributeSetter.create("db.name").key()}" dbName.toLowerCase()
+              "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+              "${SemanticAttributes.DB_NAME.key()}" dbName.toLowerCase()
               "${SemanticAttributes.DB_USER.key()}" "SA"
               "${SemanticAttributes.DB_STATEMENT.key()}" JDBCUtils.normalizeSql(query)
-              "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+              "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
 
             }
           }

--- a/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import com.mchange.v2.c3p0.ComboPooledDataSource
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource

--- a/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import redis.clients.jedis.Jedis
 import redis.embedded.RedisServer
 import spock.lang.Shared
@@ -65,8 +65,8 @@ class JedisClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -88,8 +88,8 @@ class JedisClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -99,8 +99,8 @@ class JedisClientTest extends AgentTestRunner {
           operationName "GET"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -122,8 +122,8 @@ class JedisClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -133,8 +133,8 @@ class JedisClientTest extends AgentTestRunner {
           operationName "RANDOMKEY"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
           }
         }

--- a/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes

--- a/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import redis.clients.jedis.Jedis
 import redis.embedded.RedisServer
 import spock.lang.Shared
@@ -65,8 +65,8 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -88,8 +88,8 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -99,8 +99,8 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "GET"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -122,8 +122,8 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -133,8 +133,8 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "RANDOMKEY"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
           }
         }

--- a/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes

--- a/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient
 import com.lambdaworks.redis.RedisConnectionException

--- a/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient
 import com.lambdaworks.redis.RedisConnectionException
@@ -27,7 +28,6 @@ import com.lambdaworks.redis.protocol.AsyncCommand
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import redis.embedded.RedisServer
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
@@ -134,7 +134,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key()}" HOST
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"
             "db.redis.dbIndex" 0
           }
@@ -168,7 +168,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key()}" HOST
             "${SemanticAttributes.NET_PEER_PORT.key()}" incorrectPort
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"
             "db.redis.dbIndex" 0
           }
@@ -191,7 +191,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -224,7 +224,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -271,7 +271,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -304,7 +304,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
           }
         }
@@ -356,7 +356,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HMSET"
           }
         }
@@ -367,7 +367,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HGETALL"
           }
         }
@@ -409,7 +409,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored true
           errorEvent(IllegalStateException, "TestException")
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "DEL"
           }
         }
@@ -444,7 +444,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SADD"
             "db.command.cancelled" true
           }
@@ -465,7 +465,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "DEBUG"
           }
         }
@@ -486,7 +486,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SHUTDOWN"
           }
         }

--- a/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceSyncClientTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient
 import com.lambdaworks.redis.RedisConnectionException
@@ -22,7 +23,6 @@ import com.lambdaworks.redis.api.sync.RedisCommands
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
@@ -115,7 +115,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key()}" HOST
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"
             "db.redis.dbIndex" 0
           }
@@ -147,7 +147,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key()}" HOST
             "${SemanticAttributes.NET_PEER_PORT.key()}" incorrectPort
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"
             "db.redis.dbIndex" 0
           }
@@ -169,7 +169,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -190,7 +190,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -211,7 +211,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -232,7 +232,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
           }
         }
@@ -253,7 +253,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "LPUSH"
           }
         }
@@ -274,7 +274,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HMSET"
           }
         }
@@ -295,7 +295,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HGETALL"
           }
         }
@@ -315,7 +315,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "DEBUG"
           }
         }
@@ -335,7 +335,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SHUTDOWN"
           }
         }

--- a/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceSyncClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient
 import com.lambdaworks.redis.RedisConnectionException

--- a/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.ConnectionFuture
 import io.lettuce.core.RedisClient
@@ -27,7 +28,6 @@ import io.lettuce.core.protocol.AsyncCommand
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import redis.embedded.RedisServer
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
@@ -139,7 +139,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" PEER_NAME
             "${SemanticAttributes.NET_PEER_IP.key()}" PEER_IP
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"
             "db.redis.dbIndex" 0
           }
@@ -175,7 +175,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" PEER_NAME
             "${SemanticAttributes.NET_PEER_IP.key()}" PEER_IP
             "${SemanticAttributes.NET_PEER_PORT.key()}" incorrectPort
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"
             "db.redis.dbIndex" 0
           }
@@ -198,7 +198,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -231,7 +231,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -278,7 +278,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -311,7 +311,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
           }
         }
@@ -362,7 +362,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HMSET"
           }
         }
@@ -373,7 +373,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HGETALL"
           }
         }
@@ -415,7 +415,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored true
           errorEvent(IllegalStateException, "TestException")
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "DEL"
           }
         }
@@ -450,7 +450,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SADD"
             "db.command.cancelled" true
           }
@@ -471,7 +471,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "DEBUG"
           }
         }
@@ -492,7 +492,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SHUTDOWN"
           }
         }

--- a/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.ConnectionFuture
 import io.lettuce.core.RedisClient

--- a/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulConnection
@@ -22,7 +23,6 @@ import io.lettuce.core.api.sync.RedisCommands
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import reactor.core.scheduler.Schedulers
 import redis.embedded.RedisServer
 import spock.lang.Shared
@@ -112,7 +112,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -136,7 +136,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -168,7 +168,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -198,7 +198,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
           }
         }
@@ -218,7 +218,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "COMMAND"
             "db.command.results.count" 157
           }
@@ -239,7 +239,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "COMMAND"
             "db.command.cancelled" true
             "db.command.results.count" 2
@@ -273,7 +273,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "DEBUG"
           }
         }
@@ -293,7 +293,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SHUTDOWN"
           }
         }
@@ -324,7 +324,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -334,7 +334,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -365,7 +365,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -375,7 +375,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -407,7 +407,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -417,7 +417,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }

--- a/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulConnection

--- a/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisConnectionException

--- a/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisConnectionException
@@ -22,7 +23,6 @@ import io.lettuce.core.api.sync.RedisCommands
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
@@ -119,7 +119,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" PEER_NAME
             "${SemanticAttributes.NET_PEER_IP.key()}" PEER_IP
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"
             "db.redis.dbIndex" 0
           }
@@ -152,7 +152,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" PEER_NAME
             "${SemanticAttributes.NET_PEER_IP.key()}" PEER_IP
             "${SemanticAttributes.NET_PEER_PORT.key()}" incorrectPort
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"
             "db.redis.dbIndex" 0
           }
@@ -174,7 +174,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
           }
         }
@@ -195,7 +195,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -216,7 +216,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
           }
         }
@@ -237,7 +237,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
           }
         }
@@ -258,7 +258,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "LPUSH"
           }
         }
@@ -279,7 +279,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HMSET"
           }
         }
@@ -300,7 +300,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HGETALL"
           }
         }
@@ -320,7 +320,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "DEBUG"
           }
         }
@@ -340,7 +340,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SHUTDOWN"
           }
         }

--- a/instrumentation/lettuce/lettuce-5.1/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -29,7 +29,6 @@ import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TracingContextUtils;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
-import io.opentelemetry.trace.attributes.StringAttributeSetter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Instant;
@@ -172,7 +171,7 @@ public enum OpenTelemetryTracing implements Tracing {
               .spanBuilder("redis")
               .setSpanKind(Kind.CLIENT)
               .setParent(parent)
-              .setAttribute(StringAttributeSetter.create("db.system").key(), DbSystem.REDIS);
+              .setAttribute(SemanticAttributes.DB_SYSTEM.key(), DbSystem.REDIS);
     }
 
     @Override
@@ -291,8 +290,7 @@ public enum OpenTelemetryTracing implements Tracing {
         redisUrl.append(":").append(endpoint.port);
       }
 
-      span.setAttribute(
-          StringAttributeSetter.create("db.connection_string").key(), redisUrl.toString());
+      span.setAttribute(SemanticAttributes.DB_CONNECTION_STRING.key(), redisUrl.toString());
     }
 
     private static void fillEndpoint(Span span, OpenTelemetryEndpoint endpoint) {
@@ -313,8 +311,7 @@ public enum OpenTelemetryTracing implements Tracing {
         redisUrl.append(":").append(endpoint.port);
       }
 
-      span.setAttribute(
-          StringAttributeSetter.create("db.connection_string").key(), redisUrl.toString());
+      span.setAttribute(SemanticAttributes.DB_CONNECTION_STRING.key(), redisUrl.toString());
     }
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/auto/instrumentation/lettuce/v5_1/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/auto/instrumentation/lettuce/v5_1/LettuceAsyncClientTest.groovy
@@ -167,8 +167,8 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET key<TESTSETKEY> value<TESTSETVAL>"
           }
           event(0) {
@@ -210,8 +210,8 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET key<TESTKEY>"
           }
           event(0) {
@@ -267,8 +267,8 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET key<NON_EXISTENT_KEY>"
           }
           event(0) {
@@ -310,9 +310,9 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
           }
           event(0) {
             eventName "redis.encode.start"
@@ -371,8 +371,8 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HMSET key<TESTHM> key<firstname> value<John> key<lastname> value<Doe> key<age> value<53>"
           }
           event(0) {
@@ -392,8 +392,8 @@ class LettuceAsyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HGETALL key<TESTHM>"
           }
           event(0) {

--- a/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/auto/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/auto/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
@@ -117,8 +117,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET key<TESTSETKEY> value<TESTSETVAL>"
           }
           event(0) {
@@ -151,8 +151,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET key<TESTKEY>"
           }
           event(0) {
@@ -193,8 +193,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET key<NON_EXISTENT_KEY>"
           }
           event(0) {
@@ -233,9 +233,9 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
           }
           event(0) {
             eventName "redis.encode.start"
@@ -263,9 +263,9 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "COMMAND"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
           }
           event(0) {
             eventName "redis.encode.start"
@@ -316,8 +316,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET key<a> value<1>"
           }
           event(0) {
@@ -336,8 +336,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET key<a>"
           }
           event(0) {
@@ -377,8 +377,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET key<a> value<1>"
           }
           event(0) {
@@ -397,8 +397,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET key<a>"
           }
           event(0) {
@@ -439,8 +439,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET key<a> value<1>"
           }
           event(0) {
@@ -459,8 +459,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET key<a>"
           }
           event(0) {

--- a/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/auto/instrumentation/lettuce/v5_1/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/auto/instrumentation/lettuce/v5_1/LettuceSyncClientTest.groovy
@@ -147,8 +147,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET key<TESTSETKEY> value<TESTSETVAL>"
           }
           event(0) {
@@ -182,8 +182,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "net.peer.name" "localhost"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://localhost:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://localhost:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET key<TESTSETKEY> value<TESTSETVAL>"
           }
           event(0) {
@@ -213,8 +213,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET key<TESTKEY>"
           }
           event(0) {
@@ -244,8 +244,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET key<NON_EXISTENT_KEY>"
           }
           event(0) {
@@ -275,9 +275,9 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
           }
           event(0) {
             eventName "redis.encode.start"
@@ -306,8 +306,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "LPUSH key<TESTLIST> value<TESTLIST ELEMENT>"
           }
           event(0) {
@@ -337,8 +337,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HMSET key<user> key<firstname> value<John> key<lastname> value<Doe> key<age> value<53>"
           }
           event(0) {
@@ -368,8 +368,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "db.connection_string" "redis://127.0.0.1:$port"
-            "db.system" "redis"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HGETALL key<TESTHM>"
           }
           event(0) {

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import com.mongodb.MongoClient
 import com.mongodb.MongoClientOptions
 import com.mongodb.MongoTimeoutException

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import com.mongodb.MongoClient
 import com.mongodb.MongoClientOptions
 import com.mongodb.MongoTimeoutException
@@ -23,7 +24,6 @@ import com.mongodb.client.MongoDatabase
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
@@ -285,9 +285,9 @@ class MongoClientTest extends MongoBaseTest {
         "${SemanticAttributes.DB_STATEMENT.key()}" {
           it.replace(" ", "") == statement
         }
-        "${StringAttributeSetter.create("db.connection_string").key()}" "mongodb://localhost:" + port
-        "${StringAttributeSetter.create("db.system").key()}" "mongodb"
-        "${StringAttributeSetter.create("db.name").key()}" instance
+        "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "mongodb://localhost:" + port
+        "${SemanticAttributes.DB_SYSTEM.key()}" "mongodb"
+        "${SemanticAttributes.DB_NAME.key()}" instance
       }
     }
   }

--- a/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import com.mongodb.MongoClientSettings
 import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress

--- a/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import com.mongodb.MongoClientSettings
 import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress
@@ -24,7 +25,6 @@ import com.mongodb.client.MongoDatabase
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
@@ -294,9 +294,9 @@ class MongoClientTest extends MongoBaseTest {
         "${SemanticAttributes.DB_STATEMENT.key()}" {
           it.replace(" ", "") == statement
         }
-        "${StringAttributeSetter.create("db.system").key()}" "mongodb"
-        "${StringAttributeSetter.create("db.connection_string").key()}" "mongodb://localhost:" + port
-        "${StringAttributeSetter.create("db.name").key()}" instance
+        "${SemanticAttributes.DB_SYSTEM.key()}" "mongodb"
+        "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "mongodb://localhost:" + port
+        "${SemanticAttributes.DB_NAME.key()}" instance
       }
     }
   }

--- a/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import com.mongodb.ConnectionString
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.async.client.MongoClient

--- a/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import com.mongodb.ConnectionString
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.async.client.MongoClient
@@ -27,7 +28,6 @@ import com.mongodb.connection.ClusterSettings
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
@@ -329,10 +329,10 @@ class MongoAsyncClientTest extends MongoBaseTest {
         "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
         "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
         "${SemanticAttributes.NET_PEER_PORT.key()}" port
-        "${StringAttributeSetter.create("db.connection_string").key()}" "mongodb://localhost:" + port
+        "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "mongodb://localhost:" + port
         "${SemanticAttributes.DB_STATEMENT.key()}" statementEval
-        "${StringAttributeSetter.create("db.system").key()}" "mongodb"
-        "${StringAttributeSetter.create("db.name").key()}" instance
+        "${SemanticAttributes.DB_SYSTEM.key()}" "mongodb"
+        "${SemanticAttributes.DB_NAME.key()}" instance
       }
     }
   }

--- a/instrumentation/rediscala-1.8/src/test/groovy/RediscalaClientTest.groovy
+++ b/instrumentation/rediscala-1.8/src/test/groovy/RediscalaClientTest.groovy
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+
 import akka.actor.ActorSystem
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import redis.ByteStringDeserializerDefault
 import redis.ByteStringSerializerLowPriority
 import redis.RedisClient
@@ -89,7 +89,7 @@ class RediscalaClientTest extends AgentTestRunner {
           operationName "Set"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "Set"
           }
         }
@@ -117,7 +117,7 @@ class RediscalaClientTest extends AgentTestRunner {
           operationName "Set"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "Set"
           }
         }
@@ -127,7 +127,7 @@ class RediscalaClientTest extends AgentTestRunner {
           operationName "Get"
           spanKind CLIENT
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "redis"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "Get"
           }
         }

--- a/instrumentation/rediscala-1.8/src/test/groovy/RediscalaClientTest.groovy
+++ b/instrumentation/rediscala-1.8/src/test/groovy/RediscalaClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import akka.actor.ActorSystem
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils

--- a/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spring.jpa.JpaCustomer
 import spring.jpa.JpaCustomerRepository
@@ -82,11 +82,11 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }
@@ -113,11 +113,11 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^insert /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }
@@ -144,11 +144,11 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
         span(2) { // update
@@ -156,11 +156,11 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^update /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }
@@ -185,11 +185,11 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }
@@ -214,11 +214,11 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^select /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
         span(2) { // delete
@@ -226,11 +226,11 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test"
             "${SemanticAttributes.DB_USER.key()}" "sa"
             "${SemanticAttributes.DB_STATEMENT.key()}" ~/^delete /
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }

--- a/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.attributes.SemanticAttributes
 import org.springframework.context.annotation.AnnotationConfigApplicationContext

--- a/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+
 import com.google.common.util.concurrent.MoreExecutors
 import io.opentelemetry.auto.instrumentation.spymemcached.CompletionListener
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import net.spy.memcached.CASResponse
 import net.spy.memcached.ConnectionFactory
 import net.spy.memcached.ConnectionFactoryBuilder
@@ -651,7 +651,7 @@ class SpymemcachedTest extends AgentTestRunner {
       }
 
       attributes {
-        "${StringAttributeSetter.create("db.system").key()}" "memcached"
+        "${SemanticAttributes.DB_SYSTEM.key()}" "memcached"
 
         if (error == "canceled") {
           "${CompletionListener.DB_COMMAND_CANCELLED}" true

--- a/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
@@ -18,6 +18,7 @@ import com.google.common.util.concurrent.MoreExecutors
 import io.opentelemetry.auto.instrumentation.spymemcached.CompletionListener
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
+import io.opentelemetry.trace.attributes.SemanticAttributes
 import net.spy.memcached.CASResponse
 import net.spy.memcached.ConnectionFactory
 import net.spy.memcached.ConnectionFactoryBuilder

--- a/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import com.google.common.util.concurrent.MoreExecutors
 import io.opentelemetry.auto.instrumentation.spymemcached.CompletionListener
 import io.opentelemetry.auto.test.AgentTestRunner

--- a/instrumentation/vertx-reactive-3.5/src/test/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/src/test/groovy/VertxReactivePropagationTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.OkHttpUtils
 import io.opentelemetry.auto.test.utils.PortUtils

--- a/instrumentation/vertx-reactive-3.5/src/test/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/src/test/groovy/VertxReactivePropagationTest.groovy
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.OkHttpUtils
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import io.opentelemetry.trace.attributes.StringAttributeSetter
 import io.vertx.reactivex.core.Vertx
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -83,11 +83,11 @@ class VertxReactivePropagationTest extends AgentTestRunner {
           childOf span(2)
           errored false
           attributes {
-            "${StringAttributeSetter.create("db.system").key()}" "hsqldb"
-            "${StringAttributeSetter.create("db.name").key()}" "test?shutdown=true"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "hsqldb"
+            "${SemanticAttributes.DB_NAME.key()}" "test?shutdown=true"
             "${SemanticAttributes.DB_USER.key()}" "SA"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SELECT id, name, price, weight FROM products"
-            "${StringAttributeSetter.create("db.connection_string").key()}" "hsqldb:mem:"
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "hsqldb:mem:"
           }
         }
       }


### PR DESCRIPTION
Apply new database semantic attributes.

In addition, since updating to the latest SNAPSHOT version, needed to update JaegerExporterFactory to use the new JaegerGrpcSpanExporter builder methods.