### PR TITLE
Use default zipkin endpoint from otel-java

### DIFF
--- a/auto-exporters/zipkin/src/main/java/io/opentelemetry/auto/exporters/zipkin/ZipkinExporterFactory.java
+++ b/auto-exporters/zipkin/src/main/java/io/opentelemetry/auto/exporters/zipkin/ZipkinExporterFactory.java
@@ -20,25 +20,14 @@ import io.opentelemetry.exporters.zipkin.ZipkinSpanExporter;
 import io.opentelemetry.sdk.extensions.auto.config.Config;
 import io.opentelemetry.sdk.extensions.auto.config.SpanExporterFactory;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import zipkin2.reporter.okhttp3.OkHttpSender;
 
 public class ZipkinExporterFactory implements SpanExporterFactory {
-  private static final String ZIPKIN_ENDPOINT_PROPERTY = "otel.zipkin.endpoint";
-  private static final String ZIPKIN_ENDPOINT_ENV_VARIABLE = "OTEL_ZIPKIN_ENDPOINT";
-  private static final String DEFAULT_ZIPKIN_ENDPOINT = "http://localhost:9411/api/v2/spans";
 
   @Override
   public SpanExporter fromConfig(Config config) {
-    String zipkinEndpoint =
-        System.getProperty(ZIPKIN_ENDPOINT_PROPERTY, System.getenv(ZIPKIN_ENDPOINT_ENV_VARIABLE));
-    if (zipkinEndpoint == null) {
-      zipkinEndpoint = DEFAULT_ZIPKIN_ENDPOINT;
-    }
-
     return ZipkinSpanExporter.newBuilder()
         .readEnvironmentVariables()
         .readSystemProperties()
-        .setSender(OkHttpSender.create(zipkinEndpoint))
         .build();
   }
 }

--- a/auto-exporters/zipkin/zipkin.gradle
+++ b/auto-exporters/zipkin/zipkin.gradle
@@ -10,7 +10,6 @@ dependencies {
     exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
   }
   compileOnly deps.opentelemetrySdkAutoConfig
-  implementation group: 'io.zipkin.reporter2', name: 'zipkin-sender-okhttp3', version: '2.12.2'
 }
 
 shadowJar {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,9 +9,9 @@ configurations.all {
 ext {
   versions = [
     // Check https://oss.jfrog.org/libs-snapshot/io/opentelemetry/ for latest snapshot version.
-    opentelemetry     : '0.7.0-20200727.220734-34',
+    opentelemetry     : '0.7.0-20200729.192920-38',
     // Snapshot versions can often get split into two suffixes
-    opentelemetryOther: '0.7.0-20200727.220734-33',
+    opentelemetryOther: '0.7.0-20200729.192920-37',
 
     slf4j             : "1.7.30",
     guava             : "20.0", // Last version to support Java 7


### PR DESCRIPTION
This is enabled by updating to otel-java snapshot that has https://github.com/open-telemetry/opentelemetry-java/pull/1475