### PR TITLE
Use dependson instead of finalizedby for integrationTest

### DIFF
--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -83,4 +83,4 @@ task integrationTest(type: Test) {
   }
 }
 
-test.finalizedBy integrationTest
+test.dependsOn integrationTest


### PR DESCRIPTION
The idea was it's faster feedback to have faster tests to run before integration tests, but `finalizedBy` will run regardless of failure, so there is no fail fast behavior for the integration tests right now. I think it's fine to just stick with a normal dependsOn even if it changes the order.