### PR TITLE
Small improvements to DB typed spans

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbCassandraSemanticConvention.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbCassandraSemanticConvention.java
@@ -27,70 +27,70 @@ public interface DbCassandraSemanticConvention {
    * Sets a value for db.system
    *
    * @param dbSystem An identifier for the database management system (DBMS) product being used. See
-   *     below for a list of well-known identifiers..
+   *     below for a list of well-known identifiers.
    */
-  public DbCassandraSemanticConvention setDbSystem(String dbSystem);
+  DbCassandraSemanticConvention setDbSystem(String dbSystem);
 
   /**
    * Sets a value for db.connection_string
    *
-   * @param dbConnectionString The connection string used to connect to the database..
+   * @param dbConnectionString The connection string used to connect to the database.
    *     <p>It is recommended to remove embedded credentials.
    */
-  public DbCassandraSemanticConvention setDbConnectionString(String dbConnectionString);
+  DbCassandraSemanticConvention setDbConnectionString(String dbConnectionString);
 
   /**
    * Sets a value for db.user
    *
-   * @param dbUser Username for accessing the database..
+   * @param dbUser Username for accessing the database.
    */
-  public DbCassandraSemanticConvention setDbUser(String dbUser);
+  DbCassandraSemanticConvention setDbUser(String dbUser);
 
   /**
    * Sets a value for db.jdbc.driver_classname
    *
    * @param dbJdbcDriverClassname The fully-qualified class name of the [Java Database Connectivity
    *     (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to
-   *     connect..
+   *     connect.
    */
-  public DbCassandraSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
+  DbCassandraSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
 
   /**
    * Sets a value for db.name
    *
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
-   *     set to the target database (even if the command fails)..
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     set to the target database (even if the command fails).
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
-  public DbCassandraSemanticConvention setDbName(String dbName);
+  DbCassandraSemanticConvention setDbName(String dbName);
 
   /**
    * Sets a value for db.statement
    *
-   * @param dbStatement The database statement being executed..
+   * @param dbStatement The database statement being executed.
    *     <p>The value may be sanitized to exclude sensitive information.
    */
-  public DbCassandraSemanticConvention setDbStatement(String dbStatement);
+  DbCassandraSemanticConvention setDbStatement(String dbStatement);
 
   /**
    * Sets a value for db.operation
    *
    * @param dbOperation The name of the operation being executed, e.g. the [MongoDB command
    *     name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as
-   *     `findAndModify`..
+   *     `findAndModify`.
    *     <p>While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT`
    *     or `INSERT`, it is not recommended to attempt any client-side parsing of `db.statement`
    *     just to get this property (the back end can do that if required).
    */
-  public DbCassandraSemanticConvention setDbOperation(String dbOperation);
+  DbCassandraSemanticConvention setDbOperation(String dbOperation);
 
   /**
    * Sets a value for net.peer.name
    *
-   * @param netPeerName Remote hostname or similar, see note below..
+   * @param netPeerName Remote hostname or similar, see note below.
    */
-  public DbCassandraSemanticConvention setNetPeerName(String netPeerName);
+  DbCassandraSemanticConvention setNetPeerName(String netPeerName);
 
   /**
    * Sets a value for net.peer.ip
@@ -98,27 +98,27 @@ public interface DbCassandraSemanticConvention {
    * @param netPeerIp Remote address of the peer (dotted decimal for IPv4 or
    *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
    */
-  public DbCassandraSemanticConvention setNetPeerIp(String netPeerIp);
+  DbCassandraSemanticConvention setNetPeerIp(String netPeerIp);
 
   /**
    * Sets a value for net.peer.port
    *
-   * @param netPeerPort Remote port number..
+   * @param netPeerPort Remote port number.
    */
-  public DbCassandraSemanticConvention setNetPeerPort(long netPeerPort);
+  DbCassandraSemanticConvention setNetPeerPort(long netPeerPort);
 
   /**
    * Sets a value for net.transport
    *
-   * @param netTransport Transport protocol used. See note below..
+   * @param netTransport Transport protocol used. See note below.
    */
-  public DbCassandraSemanticConvention setNetTransport(String netTransport);
+  DbCassandraSemanticConvention setNetTransport(String netTransport);
 
   /**
    * Sets a value for db.cassandra.keyspace
    *
    * @param dbCassandraKeyspace The name of the keyspace being accessed. To be used instead of the
-   *     generic `db.name` attribute..
+   *     generic `db.name` attribute.
    */
-  public DbCassandraSemanticConvention setDbCassandraKeyspace(String dbCassandraKeyspace);
+  DbCassandraSemanticConvention setDbCassandraKeyspace(String dbCassandraKeyspace);
 }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbCassandraSpan.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbCassandraSpan.java
@@ -114,7 +114,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
    *     set to the target database (even if the command fails).
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
   @Override
   public DbCassandraSemanticConvention setDbName(String dbName) {
@@ -298,7 +298,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
      *     name of the database being accessed. For commands that switch the database, this should
      *     be set to the target database (even if the command fails).
-     *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+     *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbCassandraSpanBuilder setDbName(String dbName) {
       internalBuilder.setAttribute("db.name", dbName);

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbHbaseSemanticConvention.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbHbaseSemanticConvention.java
@@ -27,70 +27,70 @@ public interface DbHbaseSemanticConvention {
    * Sets a value for db.system
    *
    * @param dbSystem An identifier for the database management system (DBMS) product being used. See
-   *     below for a list of well-known identifiers..
+   *     below for a list of well-known identifiers.
    */
-  public DbHbaseSemanticConvention setDbSystem(String dbSystem);
+  DbHbaseSemanticConvention setDbSystem(String dbSystem);
 
   /**
    * Sets a value for db.connection_string
    *
-   * @param dbConnectionString The connection string used to connect to the database..
+   * @param dbConnectionString The connection string used to connect to the database.
    *     <p>It is recommended to remove embedded credentials.
    */
-  public DbHbaseSemanticConvention setDbConnectionString(String dbConnectionString);
+  DbHbaseSemanticConvention setDbConnectionString(String dbConnectionString);
 
   /**
    * Sets a value for db.user
    *
-   * @param dbUser Username for accessing the database..
+   * @param dbUser Username for accessing the database.
    */
-  public DbHbaseSemanticConvention setDbUser(String dbUser);
+  DbHbaseSemanticConvention setDbUser(String dbUser);
 
   /**
    * Sets a value for db.jdbc.driver_classname
    *
    * @param dbJdbcDriverClassname The fully-qualified class name of the [Java Database Connectivity
    *     (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to
-   *     connect..
+   *     connect.
    */
-  public DbHbaseSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
+  DbHbaseSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
 
   /**
    * Sets a value for db.name
    *
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
-   *     set to the target database (even if the command fails)..
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     set to the target database (even if the command fails).
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
-  public DbHbaseSemanticConvention setDbName(String dbName);
+  DbHbaseSemanticConvention setDbName(String dbName);
 
   /**
    * Sets a value for db.statement
    *
-   * @param dbStatement The database statement being executed..
+   * @param dbStatement The database statement being executed.
    *     <p>The value may be sanitized to exclude sensitive information.
    */
-  public DbHbaseSemanticConvention setDbStatement(String dbStatement);
+  DbHbaseSemanticConvention setDbStatement(String dbStatement);
 
   /**
    * Sets a value for db.operation
    *
    * @param dbOperation The name of the operation being executed, e.g. the [MongoDB command
    *     name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as
-   *     `findAndModify`..
+   *     `findAndModify`.
    *     <p>While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT`
    *     or `INSERT`, it is not recommended to attempt any client-side parsing of `db.statement`
    *     just to get this property (the back end can do that if required).
    */
-  public DbHbaseSemanticConvention setDbOperation(String dbOperation);
+  DbHbaseSemanticConvention setDbOperation(String dbOperation);
 
   /**
    * Sets a value for net.peer.name
    *
-   * @param netPeerName Remote hostname or similar, see note below..
+   * @param netPeerName Remote hostname or similar, see note below.
    */
-  public DbHbaseSemanticConvention setNetPeerName(String netPeerName);
+  DbHbaseSemanticConvention setNetPeerName(String netPeerName);
 
   /**
    * Sets a value for net.peer.ip
@@ -98,27 +98,27 @@ public interface DbHbaseSemanticConvention {
    * @param netPeerIp Remote address of the peer (dotted decimal for IPv4 or
    *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
    */
-  public DbHbaseSemanticConvention setNetPeerIp(String netPeerIp);
+  DbHbaseSemanticConvention setNetPeerIp(String netPeerIp);
 
   /**
    * Sets a value for net.peer.port
    *
-   * @param netPeerPort Remote port number..
+   * @param netPeerPort Remote port number.
    */
-  public DbHbaseSemanticConvention setNetPeerPort(long netPeerPort);
+  DbHbaseSemanticConvention setNetPeerPort(long netPeerPort);
 
   /**
    * Sets a value for net.transport
    *
-   * @param netTransport Transport protocol used. See note below..
+   * @param netTransport Transport protocol used. See note below.
    */
-  public DbHbaseSemanticConvention setNetTransport(String netTransport);
+  DbHbaseSemanticConvention setNetTransport(String netTransport);
 
   /**
    * Sets a value for db.hbase.namespace
    *
    * @param dbHbaseNamespace The [HBase namespace](https://hbase.apache.org/book.html#_namespace)
-   *     being accessed. To be used instead of the generic `db.name` attribute..
+   *     being accessed. To be used instead of the generic `db.name` attribute.
    */
-  public DbHbaseSemanticConvention setDbHbaseNamespace(String dbHbaseNamespace);
+  DbHbaseSemanticConvention setDbHbaseNamespace(String dbHbaseNamespace);
 }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbHbaseSpan.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbHbaseSpan.java
@@ -114,7 +114,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
    *     set to the target database (even if the command fails).
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
   @Override
   public DbHbaseSemanticConvention setDbName(String dbName) {
@@ -298,7 +298,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
      *     name of the database being accessed. For commands that switch the database, this should
      *     be set to the target database (even if the command fails).
-     *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+     *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbHbaseSpanBuilder setDbName(String dbName) {
       internalBuilder.setAttribute("db.name", dbName);

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbMongodbSemanticConvention.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbMongodbSemanticConvention.java
@@ -27,70 +27,70 @@ public interface DbMongodbSemanticConvention {
    * Sets a value for db.system
    *
    * @param dbSystem An identifier for the database management system (DBMS) product being used. See
-   *     below for a list of well-known identifiers..
+   *     below for a list of well-known identifiers.
    */
-  public DbMongodbSemanticConvention setDbSystem(String dbSystem);
+  DbMongodbSemanticConvention setDbSystem(String dbSystem);
 
   /**
    * Sets a value for db.connection_string
    *
-   * @param dbConnectionString The connection string used to connect to the database..
+   * @param dbConnectionString The connection string used to connect to the database.
    *     <p>It is recommended to remove embedded credentials.
    */
-  public DbMongodbSemanticConvention setDbConnectionString(String dbConnectionString);
+  DbMongodbSemanticConvention setDbConnectionString(String dbConnectionString);
 
   /**
    * Sets a value for db.user
    *
-   * @param dbUser Username for accessing the database..
+   * @param dbUser Username for accessing the database.
    */
-  public DbMongodbSemanticConvention setDbUser(String dbUser);
+  DbMongodbSemanticConvention setDbUser(String dbUser);
 
   /**
    * Sets a value for db.jdbc.driver_classname
    *
    * @param dbJdbcDriverClassname The fully-qualified class name of the [Java Database Connectivity
    *     (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to
-   *     connect..
+   *     connect.
    */
-  public DbMongodbSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
+  DbMongodbSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
 
   /**
    * Sets a value for db.name
    *
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
-   *     set to the target database (even if the command fails)..
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     set to the target database (even if the command fails).
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
-  public DbMongodbSemanticConvention setDbName(String dbName);
+  DbMongodbSemanticConvention setDbName(String dbName);
 
   /**
    * Sets a value for db.statement
    *
-   * @param dbStatement The database statement being executed..
+   * @param dbStatement The database statement being executed.
    *     <p>The value may be sanitized to exclude sensitive information.
    */
-  public DbMongodbSemanticConvention setDbStatement(String dbStatement);
+  DbMongodbSemanticConvention setDbStatement(String dbStatement);
 
   /**
    * Sets a value for db.operation
    *
    * @param dbOperation The name of the operation being executed, e.g. the [MongoDB command
    *     name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as
-   *     `findAndModify`..
+   *     `findAndModify`.
    *     <p>While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT`
    *     or `INSERT`, it is not recommended to attempt any client-side parsing of `db.statement`
    *     just to get this property (the back end can do that if required).
    */
-  public DbMongodbSemanticConvention setDbOperation(String dbOperation);
+  DbMongodbSemanticConvention setDbOperation(String dbOperation);
 
   /**
    * Sets a value for net.peer.name
    *
-   * @param netPeerName Remote hostname or similar, see note below..
+   * @param netPeerName Remote hostname or similar, see note below.
    */
-  public DbMongodbSemanticConvention setNetPeerName(String netPeerName);
+  DbMongodbSemanticConvention setNetPeerName(String netPeerName);
 
   /**
    * Sets a value for net.peer.ip
@@ -98,27 +98,27 @@ public interface DbMongodbSemanticConvention {
    * @param netPeerIp Remote address of the peer (dotted decimal for IPv4 or
    *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
    */
-  public DbMongodbSemanticConvention setNetPeerIp(String netPeerIp);
+  DbMongodbSemanticConvention setNetPeerIp(String netPeerIp);
 
   /**
    * Sets a value for net.peer.port
    *
-   * @param netPeerPort Remote port number..
+   * @param netPeerPort Remote port number.
    */
-  public DbMongodbSemanticConvention setNetPeerPort(long netPeerPort);
+  DbMongodbSemanticConvention setNetPeerPort(long netPeerPort);
 
   /**
    * Sets a value for net.transport
    *
-   * @param netTransport Transport protocol used. See note below..
+   * @param netTransport Transport protocol used. See note below.
    */
-  public DbMongodbSemanticConvention setNetTransport(String netTransport);
+  DbMongodbSemanticConvention setNetTransport(String netTransport);
 
   /**
    * Sets a value for db.mongodb.collection
    *
    * @param dbMongodbCollection The collection being accessed within the database stated in
-   *     `db.name`..
+   *     `db.name`.
    */
-  public DbMongodbSemanticConvention setDbMongodbCollection(String dbMongodbCollection);
+  DbMongodbSemanticConvention setDbMongodbCollection(String dbMongodbCollection);
 }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbMongodbSpan.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbMongodbSpan.java
@@ -114,7 +114,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
    *     set to the target database (even if the command fails).
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
   @Override
   public DbMongodbSemanticConvention setDbName(String dbName) {
@@ -298,7 +298,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
      *     name of the database being accessed. For commands that switch the database, this should
      *     be set to the target database (even if the command fails).
-     *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+     *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbMongodbSpanBuilder setDbName(String dbName) {
       internalBuilder.setAttribute("db.name", dbName);

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbMssqlSemanticConvention.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbMssqlSemanticConvention.java
@@ -27,70 +27,70 @@ public interface DbMssqlSemanticConvention {
    * Sets a value for db.system
    *
    * @param dbSystem An identifier for the database management system (DBMS) product being used. See
-   *     below for a list of well-known identifiers..
+   *     below for a list of well-known identifiers.
    */
-  public DbMssqlSemanticConvention setDbSystem(String dbSystem);
+  DbMssqlSemanticConvention setDbSystem(String dbSystem);
 
   /**
    * Sets a value for db.connection_string
    *
-   * @param dbConnectionString The connection string used to connect to the database..
+   * @param dbConnectionString The connection string used to connect to the database.
    *     <p>It is recommended to remove embedded credentials.
    */
-  public DbMssqlSemanticConvention setDbConnectionString(String dbConnectionString);
+  DbMssqlSemanticConvention setDbConnectionString(String dbConnectionString);
 
   /**
    * Sets a value for db.user
    *
-   * @param dbUser Username for accessing the database..
+   * @param dbUser Username for accessing the database.
    */
-  public DbMssqlSemanticConvention setDbUser(String dbUser);
+  DbMssqlSemanticConvention setDbUser(String dbUser);
 
   /**
    * Sets a value for db.jdbc.driver_classname
    *
    * @param dbJdbcDriverClassname The fully-qualified class name of the [Java Database Connectivity
    *     (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to
-   *     connect..
+   *     connect.
    */
-  public DbMssqlSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
+  DbMssqlSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
 
   /**
    * Sets a value for db.name
    *
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
-   *     set to the target database (even if the command fails)..
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     set to the target database (even if the command fails).
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
-  public DbMssqlSemanticConvention setDbName(String dbName);
+  DbMssqlSemanticConvention setDbName(String dbName);
 
   /**
    * Sets a value for db.statement
    *
-   * @param dbStatement The database statement being executed..
+   * @param dbStatement The database statement being executed.
    *     <p>The value may be sanitized to exclude sensitive information.
    */
-  public DbMssqlSemanticConvention setDbStatement(String dbStatement);
+  DbMssqlSemanticConvention setDbStatement(String dbStatement);
 
   /**
    * Sets a value for db.operation
    *
    * @param dbOperation The name of the operation being executed, e.g. the [MongoDB command
    *     name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as
-   *     `findAndModify`..
+   *     `findAndModify`.
    *     <p>While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT`
    *     or `INSERT`, it is not recommended to attempt any client-side parsing of `db.statement`
    *     just to get this property (the back end can do that if required).
    */
-  public DbMssqlSemanticConvention setDbOperation(String dbOperation);
+  DbMssqlSemanticConvention setDbOperation(String dbOperation);
 
   /**
    * Sets a value for net.peer.name
    *
-   * @param netPeerName Remote hostname or similar, see note below..
+   * @param netPeerName Remote hostname or similar, see note below.
    */
-  public DbMssqlSemanticConvention setNetPeerName(String netPeerName);
+  DbMssqlSemanticConvention setNetPeerName(String netPeerName);
 
   /**
    * Sets a value for net.peer.ip
@@ -98,30 +98,30 @@ public interface DbMssqlSemanticConvention {
    * @param netPeerIp Remote address of the peer (dotted decimal for IPv4 or
    *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
    */
-  public DbMssqlSemanticConvention setNetPeerIp(String netPeerIp);
+  DbMssqlSemanticConvention setNetPeerIp(String netPeerIp);
 
   /**
    * Sets a value for net.peer.port
    *
-   * @param netPeerPort Remote port number..
+   * @param netPeerPort Remote port number.
    */
-  public DbMssqlSemanticConvention setNetPeerPort(long netPeerPort);
+  DbMssqlSemanticConvention setNetPeerPort(long netPeerPort);
 
   /**
    * Sets a value for net.transport
    *
-   * @param netTransport Transport protocol used. See note below..
+   * @param netTransport Transport protocol used. See note below.
    */
-  public DbMssqlSemanticConvention setNetTransport(String netTransport);
+  DbMssqlSemanticConvention setNetTransport(String netTransport);
 
   /**
    * Sets a value for db.mssql.instance_name
    *
    * @param dbMssqlInstanceName The Microsoft SQL Server [instance
    *     name](https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15)
-   *     connecting to. This name is used to determine the port of a named instance..
+   *     connecting to. This name is used to determine the port of a named instance.
    *     <p>If setting a `db.mssql.instance_name`, `net.peer.port` is no longer required (but still
    *     recommended if non-standard).
    */
-  public DbMssqlSemanticConvention setDbMssqlInstanceName(String dbMssqlInstanceName);
+  DbMssqlSemanticConvention setDbMssqlInstanceName(String dbMssqlInstanceName);
 }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbMssqlSpan.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbMssqlSpan.java
@@ -114,7 +114,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
    *     set to the target database (even if the command fails).
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
   @Override
   public DbMssqlSemanticConvention setDbName(String dbName) {
@@ -301,7 +301,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
      *     name of the database being accessed. For commands that switch the database, this should
      *     be set to the target database (even if the command fails).
-     *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+     *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbMssqlSpanBuilder setDbName(String dbName) {
       internalBuilder.setAttribute("db.name", dbName);

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbRedisSemanticConvention.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbRedisSemanticConvention.java
@@ -27,70 +27,70 @@ public interface DbRedisSemanticConvention {
    * Sets a value for db.system
    *
    * @param dbSystem An identifier for the database management system (DBMS) product being used. See
-   *     below for a list of well-known identifiers..
+   *     below for a list of well-known identifiers.
    */
-  public DbRedisSemanticConvention setDbSystem(String dbSystem);
+  DbRedisSemanticConvention setDbSystem(String dbSystem);
 
   /**
    * Sets a value for db.connection_string
    *
-   * @param dbConnectionString The connection string used to connect to the database..
+   * @param dbConnectionString The connection string used to connect to the database.
    *     <p>It is recommended to remove embedded credentials.
    */
-  public DbRedisSemanticConvention setDbConnectionString(String dbConnectionString);
+  DbRedisSemanticConvention setDbConnectionString(String dbConnectionString);
 
   /**
    * Sets a value for db.user
    *
-   * @param dbUser Username for accessing the database..
+   * @param dbUser Username for accessing the database.
    */
-  public DbRedisSemanticConvention setDbUser(String dbUser);
+  DbRedisSemanticConvention setDbUser(String dbUser);
 
   /**
    * Sets a value for db.jdbc.driver_classname
    *
    * @param dbJdbcDriverClassname The fully-qualified class name of the [Java Database Connectivity
    *     (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to
-   *     connect..
+   *     connect.
    */
-  public DbRedisSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
+  DbRedisSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
 
   /**
    * Sets a value for db.name
    *
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
-   *     set to the target database (even if the command fails)..
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     set to the target database (even if the command fails).
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
-  public DbRedisSemanticConvention setDbName(String dbName);
+  DbRedisSemanticConvention setDbName(String dbName);
 
   /**
    * Sets a value for db.statement
    *
-   * @param dbStatement The database statement being executed..
+   * @param dbStatement The database statement being executed.
    *     <p>The value may be sanitized to exclude sensitive information.
    */
-  public DbRedisSemanticConvention setDbStatement(String dbStatement);
+  DbRedisSemanticConvention setDbStatement(String dbStatement);
 
   /**
    * Sets a value for db.operation
    *
    * @param dbOperation The name of the operation being executed, e.g. the [MongoDB command
    *     name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as
-   *     `findAndModify`..
+   *     `findAndModify`.
    *     <p>While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT`
    *     or `INSERT`, it is not recommended to attempt any client-side parsing of `db.statement`
    *     just to get this property (the back end can do that if required).
    */
-  public DbRedisSemanticConvention setDbOperation(String dbOperation);
+  DbRedisSemanticConvention setDbOperation(String dbOperation);
 
   /**
    * Sets a value for net.peer.name
    *
-   * @param netPeerName Remote hostname or similar, see note below..
+   * @param netPeerName Remote hostname or similar, see note below.
    */
-  public DbRedisSemanticConvention setNetPeerName(String netPeerName);
+  DbRedisSemanticConvention setNetPeerName(String netPeerName);
 
   /**
    * Sets a value for net.peer.ip
@@ -98,28 +98,28 @@ public interface DbRedisSemanticConvention {
    * @param netPeerIp Remote address of the peer (dotted decimal for IPv4 or
    *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
    */
-  public DbRedisSemanticConvention setNetPeerIp(String netPeerIp);
+  DbRedisSemanticConvention setNetPeerIp(String netPeerIp);
 
   /**
    * Sets a value for net.peer.port
    *
-   * @param netPeerPort Remote port number..
+   * @param netPeerPort Remote port number.
    */
-  public DbRedisSemanticConvention setNetPeerPort(long netPeerPort);
+  DbRedisSemanticConvention setNetPeerPort(long netPeerPort);
 
   /**
    * Sets a value for net.transport
    *
-   * @param netTransport Transport protocol used. See note below..
+   * @param netTransport Transport protocol used. See note below.
    */
-  public DbRedisSemanticConvention setNetTransport(String netTransport);
+  DbRedisSemanticConvention setNetTransport(String netTransport);
 
   /**
    * Sets a value for db.redis.database_index
    *
    * @param dbRedisDatabaseIndex The index of the database being accessed as used in the [`SELECT`
    *     command](https://redis.io/commands/select), provided as an integer. To be used instead of
-   *     the generic `db.name` attribute..
+   *     the generic `db.name` attribute.
    */
-  public DbRedisSemanticConvention setDbRedisDatabaseIndex(long dbRedisDatabaseIndex);
+  DbRedisSemanticConvention setDbRedisDatabaseIndex(long dbRedisDatabaseIndex);
 }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbRedisSpan.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbRedisSpan.java
@@ -114,7 +114,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
    *     set to the target database (even if the command fails).
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
   @Override
   public DbRedisSemanticConvention setDbName(String dbName) {
@@ -299,7 +299,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
      *     name of the database being accessed. For commands that switch the database, this should
      *     be set to the target database (even if the command fails).
-     *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+     *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbRedisSpanBuilder setDbName(String dbName) {
       internalBuilder.setAttribute("db.name", dbName);

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbSemanticConvention.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbSemanticConvention.java
@@ -27,70 +27,70 @@ public interface DbSemanticConvention {
    * Sets a value for db.system
    *
    * @param dbSystem An identifier for the database management system (DBMS) product being used. See
-   *     below for a list of well-known identifiers..
+   *     below for a list of well-known identifiers.
    */
-  public DbSemanticConvention setDbSystem(String dbSystem);
+  DbSemanticConvention setDbSystem(String dbSystem);
 
   /**
    * Sets a value for db.connection_string
    *
-   * @param dbConnectionString The connection string used to connect to the database..
+   * @param dbConnectionString The connection string used to connect to the database.
    *     <p>It is recommended to remove embedded credentials.
    */
-  public DbSemanticConvention setDbConnectionString(String dbConnectionString);
+  DbSemanticConvention setDbConnectionString(String dbConnectionString);
 
   /**
    * Sets a value for db.user
    *
-   * @param dbUser Username for accessing the database..
+   * @param dbUser Username for accessing the database.
    */
-  public DbSemanticConvention setDbUser(String dbUser);
+  DbSemanticConvention setDbUser(String dbUser);
 
   /**
    * Sets a value for db.jdbc.driver_classname
    *
    * @param dbJdbcDriverClassname The fully-qualified class name of the [Java Database Connectivity
    *     (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to
-   *     connect..
+   *     connect.
    */
-  public DbSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
+  DbSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname);
 
   /**
    * Sets a value for db.name
    *
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
-   *     set to the target database (even if the command fails)..
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     set to the target database (even if the command fails).
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
-  public DbSemanticConvention setDbName(String dbName);
+  DbSemanticConvention setDbName(String dbName);
 
   /**
    * Sets a value for db.statement
    *
-   * @param dbStatement The database statement being executed..
+   * @param dbStatement The database statement being executed.
    *     <p>The value may be sanitized to exclude sensitive information.
    */
-  public DbSemanticConvention setDbStatement(String dbStatement);
+  DbSemanticConvention setDbStatement(String dbStatement);
 
   /**
    * Sets a value for db.operation
    *
    * @param dbOperation The name of the operation being executed, e.g. the [MongoDB command
    *     name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as
-   *     `findAndModify`..
+   *     `findAndModify`.
    *     <p>While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT`
    *     or `INSERT`, it is not recommended to attempt any client-side parsing of `db.statement`
    *     just to get this property (the back end can do that if required).
    */
-  public DbSemanticConvention setDbOperation(String dbOperation);
+  DbSemanticConvention setDbOperation(String dbOperation);
 
   /**
    * Sets a value for net.peer.name
    *
-   * @param netPeerName Remote hostname or similar, see note below..
+   * @param netPeerName Remote hostname or similar, see note below.
    */
-  public DbSemanticConvention setNetPeerName(String netPeerName);
+  DbSemanticConvention setNetPeerName(String netPeerName);
 
   /**
    * Sets a value for net.peer.ip
@@ -98,19 +98,19 @@ public interface DbSemanticConvention {
    * @param netPeerIp Remote address of the peer (dotted decimal for IPv4 or
    *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
    */
-  public DbSemanticConvention setNetPeerIp(String netPeerIp);
+  DbSemanticConvention setNetPeerIp(String netPeerIp);
 
   /**
    * Sets a value for net.peer.port
    *
-   * @param netPeerPort Remote port number..
+   * @param netPeerPort Remote port number.
    */
-  public DbSemanticConvention setNetPeerPort(long netPeerPort);
+  DbSemanticConvention setNetPeerPort(long netPeerPort);
 
   /**
    * Sets a value for net.transport
    *
-   * @param netTransport Transport protocol used. See note below..
+   * @param netTransport Transport protocol used. See note below.
    */
-  public DbSemanticConvention setNetTransport(String netTransport);
+  DbSemanticConvention setNetTransport(String netTransport);
 }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbSpan.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/typedspan/DbSpan.java
@@ -103,7 +103,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
    *     name of the database being accessed. For commands that switch the database, this should be
    *     set to the target database (even if the command fails).
-   *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+   *     <p>In some SQL databases, the database name to be used is called "schema name".
    */
   @Override
   public DbSemanticConvention setDbName(String dbName) {
@@ -275,7 +275,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      * @param dbName If no tech-specific attribute is defined, this attribute is used to report the
      *     name of the database being accessed. For commands that switch the database, this should
      *     be set to the target database (even if the command fails).
-     *     <p>In some SQL databases, the database name to be used is called &#34;schema name&#34;.
+     *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbSpanBuilder setDbName(String dbName) {
       internalBuilder.setAttribute("db.name", dbName);


### PR DESCRIPTION
Quotes are not escaped. The documentation for the interfaces does not use a trailing double dot. Remove the `public` keyword from the interfaces.