### PR TITLE
Add context leak debugger

### DIFF
--- a/testing-common/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
+++ b/testing-common/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
@@ -79,6 +79,11 @@ public abstract class AgentTestRunner extends AgentSpecification {
 
   private static final org.slf4j.Logger log = LoggerFactory.getLogger(AgentTestRunner.class);
 
+  static {
+    // always run with the thread propagation debugger to help track down sporadic test failures
+    System.setProperty("otel.threadPropagationDebugger", "true");
+  }
+
   /**
    * For test runs, agent's global tracer will report to this list writer.
    *


### PR DESCRIPTION
Based on @iNikem's findings in #787.

E.g. in #787, @iNikem found that the context leak sometimes leaks into the Tomcat thread pool via `AsyncContext.dispatch()`. And so to prevent that particular leak we could instrument `AsyncContext.dispatch()` and push an empty context into scope.

This debug option (which is enabled by default when running tests) will hopefully help to track down the source of these leaks, and then we can see if we can fix them (similar to `AsyncContext.dispatch()` example above).