### PR TITLE
Simplify Spring Boot starter auto config

### DIFF
--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.jaeger;
 
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.exporters.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.instrumentation.spring.autoconfigure.TracerAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
@@ -48,15 +48,10 @@ public class JaegerSpanExporterAutoConfiguration {
   public JaegerGrpcSpanExporter otelJaegerSpanExporter(
       JaegerSpanExporterProperties jaegerSpanExporterProperties) {
 
-    ManagedChannel channel =
-        ManagedChannelBuilder.forTarget(jaegerSpanExporterProperties.getEndpoint())
-            .usePlaintext()
-            .build();
-
     return JaegerGrpcSpanExporter.newBuilder()
         .setServiceName(jaegerSpanExporterProperties.getServiceName())
         .setDeadlineMs(jaegerSpanExporterProperties.getSpanTimeout().toMillis())
-        .setChannel(channel)
+        .setEndpoint(jaegerSpanExporterProperties.getEndpoint())
         .build();
   }
 }

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
@@ -17,7 +17,6 @@
 package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.otlp;
 
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.exporters.otlp.OtlpGrpcSpanExporter;
 import io.opentelemetry.instrumentation.spring.autoconfigure.TracerAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
@@ -47,13 +47,9 @@ public class OtlpGrpcSpanExporterAutoConfiguration {
   @ConditionalOnMissingBean
   public OtlpGrpcSpanExporter otelOtlpGrpcSpanExporter(
       OtlpGrpcSpanExporterProperties otlpGrpcSpanExporterProperties) {
-    ManagedChannel channel =
-        ManagedChannelBuilder.forTarget(otlpGrpcSpanExporterProperties.getEndpoint())
-            .usePlaintext()
-            .build();
 
     return OtlpGrpcSpanExporter.newBuilder()
-        .setChannel(channel)
+        .setEndpoint(otlpGrpcSpanExporterProperties.getEndpoint())
         .setDeadlineMs(otlpGrpcSpanExporterProperties.getSpanTimeout().toMillis())
         .build();
   }


### PR DESCRIPTION
Using the newly available `endpoint` configuration of underlying exporters.