### PR TITLE
[Bug] Fix for spring-webflux tracer

### DIFF
--- a/instrumentation-core/spring/spring-webflux-5.0/src/main/java/io/opentelemetry/instrumentation/springwebflux/client/WebClientTracingFilter.java
+++ b/instrumentation-core/spring/spring-webflux-5.0/src/main/java/io/opentelemetry/instrumentation/springwebflux/client/WebClientTracingFilter.java
@@ -52,7 +52,7 @@ public class WebClientTracingFilter implements ExchangeFilterFunction {
     Span span = DECORATE.getOrCreateSpan(request, tracer);
     DECORATE.afterStart(span);
 
-    try (Scope scope = TRACER.withSpan(span)) {
+    try (Scope scope = tracer.withSpan(span)) {
       ClientRequest mutatedRequest =
           ClientRequest.from(request)
               .headers(httpHeaders -> DECORATE.inject(Context.current(), httpHeaders))


### PR DESCRIPTION
Right now try with resource block always references the default static tracer. Instead we should use the tracer parameter.