### PR TITLE
clean up spring dependencies

### DIFF
--- a/gradle/instrumentation-library.gradle
+++ b/gradle/instrumentation-library.gradle
@@ -15,7 +15,9 @@ dependencies {
   // TODO(anuraaga): We currently include common instrumentation logic like decorators in the
   // bootstrap, but we need to move it out so manual instrumentation does not depend on code from
   // the agent, like Agent.
-  api project(':auto-bootstrap')
+  api project(':auto-bootstrap'){
+    exclude group: 'org.slf4j', module: 'slf4j-simple'
+  }
 
   api deps.opentelemetryApi
 

--- a/gradle/instrumentation-library.gradle
+++ b/gradle/instrumentation-library.gradle
@@ -7,8 +7,6 @@ group = 'io.opentelemetry.instrumentation'
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 
-apply plugin: 'com.github.johnrengelman.shadow'
-
 archivesBaseName = projectDir.parentFile.name
 
 dependencies {
@@ -24,12 +22,17 @@ dependencies {
   testImplementation project(':testing-common')
 }
 
-shadowJar {
-  archiveClassifier = 'agent'
+if (!ext.properties.noShadow) {
 
-  configurations = []
+  apply plugin: 'com.github.johnrengelman.shadow'
 
-  relocate "io.opentelemetry.instrumentation.${javaSubPackage}", "io.opentelemetry.auto.instrumentation.${javaSubPackage}.shaded"
+  shadowJar {
+    archiveClassifier = 'agent'
+
+    configurations = []
+
+    relocate "io.opentelemetry.instrumentation.${javaSubPackage}", "io.opentelemetry.auto.instrumentation.${javaSubPackage}.shaded"
+  }
 }
 
 afterEvaluate {

--- a/gradle/instrumentation-library.gradle
+++ b/gradle/instrumentation-library.gradle
@@ -15,7 +15,7 @@ dependencies {
   // TODO(anuraaga): We currently include common instrumentation logic like decorators in the
   // bootstrap, but we need to move it out so manual instrumentation does not depend on code from
   // the agent, like Agent.
-  api project(':auto-bootstrap'){
+  api(project(':auto-bootstrap')){
     exclude group: 'org.slf4j', module: 'slf4j-simple'
   }
 

--- a/instrumentation-core/servlet/servlet.gradle
+++ b/instrumentation-core/servlet/servlet.gradle
@@ -2,11 +2,9 @@ group = 'io.opentelemetry.instrumentation'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
+apply from: "$rootDir/gradle/instrumentation-library.gradle"
 
 dependencies {
-  api deps.opentelemetryApi
-  api project(':auto-bootstrap')
-
   implementation deps.slf4j
 
   compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.3'

--- a/instrumentation-core/servlet/servlet.gradle
+++ b/instrumentation-core/servlet/servlet.gradle
@@ -1,6 +1,5 @@
 ext {
-  noShadowPublish = false
-  javaSubPackage = 'servlet'
+  javaSubPackage = ''
 }
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
 

--- a/instrumentation-core/servlet/servlet.gradle
+++ b/instrumentation-core/servlet/servlet.gradle
@@ -1,5 +1,5 @@
 ext {
-  javaSubPackage = ''
+  javaSubPackage = 'servlet'
 }
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
 

--- a/instrumentation-core/servlet/servlet.gradle
+++ b/instrumentation-core/servlet/servlet.gradle
@@ -1,7 +1,7 @@
-group = 'io.opentelemetry.instrumentation'
-
-apply from: "$rootDir/gradle/java.gradle"
-apply from: "$rootDir/gradle/publish.gradle"
+ext {
+  noShadowPublish = false
+  javaSubPackage = 'servlet'
+}
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
 
 dependencies {
@@ -9,4 +9,3 @@ dependencies {
 
   compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.3'
 }
-

--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation project(':instrumentation-core:spring:spring-web-3.1')
   implementation project(':instrumentation-core:spring:spring-webflux-5.0')
 
-  compileOnly group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
+  compileOnly group: 'io.grpc', name: 'grpc-api', version: '1.30.2'
   compileOnly deps.opentelemetryLogging
   compileOnly deps.opentelemetryJaeger
   compileOnly deps.opentelemetryOtlp
@@ -33,8 +33,8 @@ dependencies {
   }
   
   testImplementation deps.opentelemetrySdk
-  testImplementation group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
-  testImplementation group: "io.grpc", name: "grpc-netty-shaded", version: "1.24.0"
+  testImplementation group: 'io.grpc', name: 'grpc-api', version: '1.30.2'
+  testImplementation group: "io.grpc", name: "grpc-netty-shaded", version: '1.30.2'
   testImplementation deps.opentelemetryLogging
   testImplementation deps.opentelemetryJaeger
   testImplementation deps.opentelemetryOtlp

--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -34,7 +34,7 @@ dependencies {
   
   testImplementation deps.opentelemetrySdk
   testImplementation group: 'io.grpc', name: 'grpc-api', version: '1.30.2'
-  testImplementation group: "io.grpc", name: "grpc-netty-shaded", version: '1.30.2'
+  testImplementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.30.2'
   testImplementation deps.opentelemetryLogging
   testImplementation deps.opentelemetryJaeger
   testImplementation deps.opentelemetryOtlp

--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -14,15 +14,9 @@ dependencies {
   annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-autoconfigure-processor', version: versions.springboot
   implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
 
-  implementation(project(':instrumentation-core:spring:spring-webmvc-3.1')) {
-    exclude group: 'org.slf4j', module: 'slf4j-simple'
-  }
-  implementation(project(':instrumentation-core:spring:spring-web-3.1')) {
-    exclude group: 'org.slf4j', module: 'slf4j-simple'
-  }
-  implementation(project(':instrumentation-core:spring:spring-webflux-5.0')) {
-    exclude group: 'org.slf4j', module: 'slf4j-simple'
-  }
+  implementation project(':instrumentation-core:spring:spring-webmvc-3.1') 
+  implementation project(':instrumentation-core:spring:spring-web-3.1')
+  implementation project(':instrumentation-core:spring:spring-webflux-5.0')
 
   compileOnly group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
   compileOnly deps.opentelemetryLogging

--- a/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -14,6 +14,8 @@ dependencies {
   annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-autoconfigure-processor', version: versions.springboot
   implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
 
+  compileOnly group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springboot
+  compileOnly group: 'org.springframework.boot', name: 'spring-boot-starter-webflux', version: versions.springboot
   implementation project(':instrumentation-core:spring:spring-webmvc-3.1') 
   implementation project(':instrumentation-core:spring:spring-web-3.1')
   implementation project(':instrumentation-core:spring:spring-webflux-5.0')
@@ -24,6 +26,7 @@ dependencies {
   compileOnly deps.opentelemetryOtlp
   compileOnly deps.opentelemetryZipkin
 
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-webflux', version: versions.springboot
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springboot
   testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springboot) {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMVCFilterAutoConfiguration.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMVCFilterAutoConfiguration.java
@@ -18,15 +18,18 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.webmvc;
 
 import io.opentelemetry.instrumentation.springwebmvc.WebMVCTracingFilter;
 import io.opentelemetry.trace.Tracer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 /** Configures {@link WebMVCFilter} for tracing. */
 @Configuration
 @EnableConfigurationProperties(WebMVCProperties.class)
 @ConditionalOnProperty(prefix = "opentelemetry.trace.web", name = "enabled", matchIfMissing = true)
+@ConditionalOnClass(OncePerRequestFilter.class)
 public class WebMVCFilterAutoConfiguration {
 
   @Bean

--- a/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
+++ b/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
@@ -2,24 +2,9 @@ group = 'io.opentelemetry.instrumentation'
 
 apply plugin: 'java'
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/instrumentation-library.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 
 dependencies {
-  
-  // copy-paste from instrumentation-core-aws-sdk:aws-sdk-2.2-core:
-  // TODO(anuraaga): We currently include common instrumentation logic like decorators in the
-  // bootstrap, but we need to move it out so manual instrumentation does not depend on code from
-  // the agent, like Agent.
-  api project(':auto-bootstrap')
-  
-  api "org.springframework:spring-web:3.1.0.RELEASE"
-  api deps.opentelemetryApi
-
-  testImplementation "org.springframework:spring-test:3.1.0.RELEASE"
-}
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
+  compileOnly "org.springframework:spring-web:3.1.0.RELEASE"
 }

--- a/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
+++ b/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
@@ -1,4 +1,6 @@
+ext{
   noShadow = true
+}
 
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
 

--- a/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
+++ b/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
@@ -1,5 +1,4 @@
 ext {
-  minJavaVersionForTests = JavaVersion.VERSION_1_8
   javaSubPackage = ''
 }
 

--- a/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
+++ b/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
@@ -1,9 +1,10 @@
-group = 'io.opentelemetry.instrumentation'
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_1_8
+  noShadowPublish = false
+  javaSubPackage = 'spring-web'
+}
 
-apply plugin: 'java'
-apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
-apply from: "$rootDir/gradle/publish.gradle"
 
 dependencies {
   compileOnly "org.springframework:spring-web:3.1.0.RELEASE"

--- a/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
+++ b/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
@@ -1,7 +1,6 @@
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
-  noShadowPublish = false
-  javaSubPackage = 'spring-web'
+  javaSubPackage = ''
 }
 
 apply from: "$rootDir/gradle/instrumentation-library.gradle"

--- a/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
+++ b/instrumentation-core/spring/spring-web-3.1/spring-web-3.1.gradle
@@ -1,6 +1,4 @@
-ext {
-  javaSubPackage = ''
-}
+  noShadow = true
 
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
 

--- a/instrumentation-core/spring/spring-webflux-5.0/spring-webflux-5.0.gradle
+++ b/instrumentation-core/spring/spring-webflux-5.0/spring-webflux-5.0.gradle
@@ -1,25 +1,11 @@
-plugins {
-  id "com.github.johnrengelman.shadow"
-}
-
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
-  noShadowPublish = true
+  javaSubPackage = 'springwebflux.client'
 }
 
-group = 'io.opentelemetry.instrumentation'
-
-apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
-apply from: "$rootDir/gradle/publish.gradle"
 
 dependencies {
   compileOnly group: 'org.springframework', name: 'spring-webflux', version: '5.0.0.RELEASE'
   compileOnly group: 'io.projectreactor.ipc', name: 'reactor-netty', version: '0.7.0.RELEASE'
-}
-
-shadowJar {
-  archiveClassifier = 'agent'
-  configurations = []
-  relocate 'io.opentelemetry.instrumentation.springwebflux.client', 'io.opentelemetry.auto.instrumentation.springwebflux.client.shaded'
 }

--- a/instrumentation-core/spring/spring-webflux-5.0/spring-webflux-5.0.gradle
+++ b/instrumentation-core/spring/spring-webflux-5.0/spring-webflux-5.0.gradle
@@ -10,24 +10,16 @@ ext {
 group = 'io.opentelemetry.instrumentation'
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/instrumentation-library.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 
 dependencies {
-  compileOnly project(':auto-bootstrap')
-
-  api group: 'org.springframework', name: 'spring-webflux', version: '5.0.0.RELEASE'
-  api group: 'io.projectreactor.ipc', name: 'reactor-netty', version: '0.7.0.RELEASE'
-  api deps.opentelemetryApi
+  compileOnly group: 'org.springframework', name: 'spring-webflux', version: '5.0.0.RELEASE'
+  compileOnly group: 'io.projectreactor.ipc', name: 'reactor-netty', version: '0.7.0.RELEASE'
 }
 
 shadowJar {
   archiveClassifier = 'agent'
   configurations = []
   relocate 'io.opentelemetry.instrumentation.springwebflux.client', 'io.opentelemetry.auto.instrumentation.springwebflux.client.shaded'
-}
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
-  }
 }

--- a/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,4 +1,7 @@
-noShadow = true
+ext{
+  noShadow = true
+}
+
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
 
 dependencies {
@@ -7,4 +10,3 @@ dependencies {
   compileOnly group: 'org.springframework', name: 'spring-webmvc', version: '3.1.0.RELEASE'
   compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
 }
-

--- a/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,8 +1,8 @@
-group = 'io.opentelemetry.instrumentation'
-
-apply from: "$rootDir/gradle/java.gradle"
+ext {
+  noShadowPublish = false
+  javaSubPackage = 'spring-webmvc'
+}
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
-apply from: "$rootDir/gradle/publish.gradle"
 
 dependencies {
   api project(':instrumentation-core:servlet')

--- a/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,24 +1,13 @@
 group = 'io.opentelemetry.instrumentation'
 
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/instrumentation-library.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 
 dependencies {
-  // copy-paste from instrumentation-core-aws-sdk:aws-sdk-2.2-core:
-  // TODO(anuraaga): We currently include common instrumentation logic like decorators in the
-  // bootstrap, but we need to move it out so manual instrumentation does not depend on code from
-  // the agent, like Agent.
-  api project(':auto-bootstrap')
-
-  api deps.opentelemetryApi
-  compileOnly group: 'org.springframework', name: 'spring-webmvc', version: '3.1.0.RELEASE'
-  
-  compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
   api project(':instrumentation-core:servlet')
   
-  testImplementation group: 'org.springframework', name: 'spring-test', version: '3.1.0.RELEASE'
+  compileOnly group: 'org.springframework', name: 'spring-webmvc', version: '3.1.0.RELEASE'
+  compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
 }
 
-test {
-  useJUnitPlatform()
-}

--- a/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,6 +1,5 @@
 ext {
-  noShadowPublish = false
-  javaSubPackage = 'spring-webmvc'
+  javaSubPackage = ''
 }
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
 

--- a/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation-core/spring/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,6 +1,4 @@
-ext {
-  javaSubPackage = ''
-}
+noShadow = true
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
 
 dependencies {


### PR DESCRIPTION
1. Apply gradle/instrumentation-library.gradle to spring library instrumentation
2. Change spring api/implementation dependencies to compileOnly 
3. Exclude `org.slf4j.slf4j-simple` from agent-bootstrap (agent-bootstrap exposes sl4j-simple artifact and this can conflict with loggers in a user's application)

Next steps will include:
- following the instructions in [writing-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/docs/contributing/writing-instrumentation.md) to move library instrumentation from instrumentation-core to instrumentation/..../library
