### PR TITLE
Fix grizzly instrumentation

### DIFF
--- a/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyHttpServerTracer.java
+++ b/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyHttpServerTracer.java
@@ -61,16 +61,16 @@ public class GrizzlyHttpServerTracer
   protected URI url(final HttpRequestPacket httpRequest) throws URISyntaxException {
     return new URI(
         (httpRequest.isSecure() ? "https://" : "http://")
-            + httpRequest.getRemoteHost()
+            + httpRequest.serverName()
             + ":"
-            + httpRequest.getLocalPort()
+            + httpRequest.getServerPort()
             + httpRequest.getRequestURI()
             + (httpRequest.getQueryString() != null ? "?" + httpRequest.getQueryString() : ""));
   }
 
   @Override
   protected String peerHostIP(final HttpRequestPacket httpRequest) {
-    return httpRequest.getLocalHost();
+    return httpRequest.getRemoteHost();
   }
 
   @Override
@@ -95,6 +95,6 @@ public class GrizzlyHttpServerTracer
 
   @Override
   protected Integer peerPort(final HttpRequestPacket httpRequest) {
-    return httpRequest.getLocalPort();
+    return httpRequest.getRemotePort();
   }
 }

--- a/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyHttpServerTracer.java
+++ b/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyHttpServerTracer.java
@@ -70,7 +70,7 @@ public class GrizzlyHttpServerTracer
 
   @Override
   protected String peerHostIP(final HttpRequestPacket httpRequest) {
-    return httpRequest.getRemoteHost();
+    return httpRequest.getRemoteAddress();
   }
 
   @Override


### PR DESCRIPTION
The grizzly instrumentation tests were failing on Windows (`localhost` vs `127.0.0.1`), and surprisingly pointed to a real issue!

cc: @tylerbenson 