### PR TITLE
Don't mix JUnit4 with JUunit5 in spring tests

### DIFF
--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/resttemplate/RestTemplateBeanPostProcessorTest.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/resttemplate/RestTemplateBeanPostProcessorTest.java
@@ -20,15 +20,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.spring.httpclients.RestTemplateInterceptor;
 import io.opentelemetry.trace.Tracer;
-import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestTemplate;
 
-/** Spring bean post processor test {@link RestTemplateBeanPostProcessor} */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 class RestTemplateBeanPostProcessorTest {
   @Mock Tracer tracer;
 

--- a/instrumentation-core/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/webclient/WebClientBeanPostProcessorTest.java
+++ b/instrumentation-core/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/webclient/WebClientBeanPostProcessorTest.java
@@ -20,15 +20,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.springwebflux.client.WebClientTracingFilter;
 import io.opentelemetry.trace.Tracer;
-import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.reactive.function.client.WebClient;
 
-/** Spring bean post processor test {@link WebClientBeanPostProcessor} */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 class WebClientBeanPostProcessorTest {
 
   @Mock Tracer tracer;


### PR DESCRIPTION
Oops didn't notice this in review. @mabdinur presumably switched to JUnit4 for the runner even though there's an extension instead (nicely provided by spring-boot-test-starter automatically)