### PR TITLE
Revert "Split muzzle across multiple executors"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,6 @@ jobs:
 
   muzzle:
     <<: *defaults
-    parallelism: 8
     steps:
       - checkout
 
@@ -126,14 +125,11 @@ jobs:
       # restoring/saving than the actual increase in time it takes just downloading the artifacts each time.
 
       - run:
-          name: Gather muzzle tasks
-          command: SKIP_BUILDSCAN="true" ./gradlew writeMuzzleTasksToFile --stacktrace --no-daemon
-      - run:
           name: Verify Muzzle
           command: >-
             SKIP_BUILDSCAN="true"
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx4G -Xms64M' -Dotel.forkedMaxHeapSize=4G -Dotel.forkedMinHeapSize=64M"
-            ./gradlew `circleci tests split workspace/build/muzzleTasks | xargs` --parallel --stacktrace --no-daemon --max-workers=16
+            ./gradlew muzzle --parallel --stacktrace --no-daemon --max-workers=16
 
   publish: &publish
     <<: *defaults

--- a/build.gradle
+++ b/build.gradle
@@ -62,18 +62,6 @@ allprojects {
   }
 }
 
-// Writes tasks to file allowing us to leverage CircleCI's file based task parallelization
-task writeMuzzleTasksToFile {
-  doLast {
-    def muzzleFile = file("${buildDir}/muzzleTasks")
-    assert muzzleFile.parentFile.mkdirs() || muzzleFile.parentFile.directory
-
-    muzzleFile.text = subprojects.findAll { subproject -> subproject.plugins.hasPlugin('muzzle') }
-      .collect { it.path + ":muzzle" }
-      .join('\n')
-  }
-}
-
 apply plugin: 'com.diffplug.gradle.spotless'
 
 spotless {

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -33,7 +33,7 @@ class MuzzlePlugin implements Plugin<Project> {
   /**
    * Select a random set of versions to test
    */
-  private static final int RANGE_COUNT_LIMIT = 25
+  private static final int RANGE_COUNT_LIMIT = 10
   /**
    * Remote repositories used to query version ranges and fetch dependencies
    */


### PR DESCRIPTION
Not sure what's going on, but suddenly `muzzle` build is failing with "INFRASTRUCTURE_FAIL" on CircleCI.

The problem appears to be with CircleCI `parallelism`, so reverting the change that introduced that for now (maybe forever since we are planning to migrate to GitHub Actions).

cc: @tylerbenson in case you run into the same