### PR TITLE
Replace Spock retry with Gradle retry.

### DIFF
--- a/agent-tooling/agent-tooling.gradle
+++ b/agent-tooling/agent-tooling.gradle
@@ -1,3 +1,7 @@
+ext {
+  retryTests = true
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/WeakConcurrentSupplierTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/WeakConcurrentSupplierTest.groovy
@@ -19,14 +19,11 @@ package io.opentelemetry.auto.tooling
 import io.opentelemetry.auto.bootstrap.WeakMap
 import io.opentelemetry.auto.util.gc.GCUtils
 import io.opentelemetry.auto.util.test.AgentSpecification
-import spock.lang.Retry
 import spock.lang.Shared
 
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 
-@Retry
-// These tests fail sometimes in CI.
 class WeakConcurrentSupplierTest extends AgentSpecification {
   @Shared
   def weakConcurrentSupplier = new WeakMapSuppliers.WeakConcurrent()

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ plugins {
   id 'com.jfrog.bintray' version '1.8.5' apply false
   id "nebula.release" version "15.0.1"
 
+  id 'org.gradle.test-retry' version '1.1.8' apply false
+
   id 'org.unbroken-dome.test-sets' version '3.0.1'
   id 'com.github.ben-manes.versions' version '0.27.0'
 

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -277,6 +277,9 @@ tasks.withType(Test).configureEach {
   enabled = isJavaVersionAllowed(JavaVersion.current()) && !project.rootProject.hasProperty("skipTests")
 
   retry {
+    // Retry is opt-in - we don't want our tests to be flaky but currently go ahead and retry them to allow CI
+    // to work. Please continue remove this property from as many projects as possible. You can see tests that
+    // were retried by this mechanism in the collected test reports and build scans.
     maxRetries = findProperty('retryTests') ? 5 : 0
   }
 }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -2,6 +2,7 @@ import java.time.Duration
 
 apply plugin: 'java-library'
 apply plugin: 'groovy'
+apply plugin: 'org.gradle.test-retry'
 
 apply from: "$rootDir/gradle/spotless.gradle"
 apply from: "$rootDir/gradle/checkstyle.gradle"
@@ -274,4 +275,8 @@ tasks.withType(Test).configureEach {
   // Disable all tests if current JVM doesn't match version requirements
   // Disable all tests if skipTests property was specified
   enabled = isJavaVersionAllowed(JavaVersion.current()) && !project.rootProject.hasProperty("skipTests")
+
+  retry {
+    maxRetries = findProperty('retryTests') ? 5 : 0
+  }
 }

--- a/instrumentation/akka-http-10.0/akka-http-10.0.gradle
+++ b/instrumentation/akka-http-10.0/akka-http-10.0.gradle
@@ -1,6 +1,7 @@
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  retryTests = true
 }
 
 apply from: "$rootDir/gradle/instrumentation.gradle"

--- a/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -15,7 +15,6 @@
  */
 
 import io.opentelemetry.auto.test.base.HttpServerTest
-import spock.lang.Retry
 
 abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> {
 
@@ -41,7 +40,6 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> 
   }
 }
 
-@Retry
 class AkkaHttpServerInstrumentationTestSync extends AkkaHttpServerInstrumentationTest {
   @Override
   def startServer(int port) {
@@ -54,7 +52,6 @@ class AkkaHttpServerInstrumentationTestSync extends AkkaHttpServerInstrumentatio
   }
 }
 
-@Retry
 class AkkaHttpServerInstrumentationTestAsync extends AkkaHttpServerInstrumentationTest {
   @Override
   def startServer(int port) {

--- a/instrumentation/couchbase/couchbase-2.0/couchbase-2.0.gradle
+++ b/instrumentation/couchbase/couchbase-2.0/couchbase-2.0.gradle
@@ -1,6 +1,7 @@
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  retryTests = true
 }
 
 apply from: "$rootDir/gradle/instrumentation.gradle"

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -20,7 +20,6 @@ import com.couchbase.client.java.document.JsonDocument
 import com.couchbase.client.java.document.json.JsonObject
 import com.couchbase.client.java.env.CouchbaseEnvironment
 import com.couchbase.client.java.query.N1qlQuery
-import spock.lang.Retry
 import spock.lang.Unroll
 import spock.util.concurrent.BlockingVariable
 import util.AbstractCouchbaseTest
@@ -30,7 +29,6 @@ import java.util.concurrent.TimeUnit
 import static io.opentelemetry.auto.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderTrace
 
-@Retry
 @Unroll
 class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
   static final int TIMEOUT = 10

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -21,14 +21,12 @@ import com.couchbase.client.java.document.JsonDocument
 import com.couchbase.client.java.document.json.JsonObject
 import com.couchbase.client.java.env.CouchbaseEnvironment
 import com.couchbase.client.java.query.N1qlQuery
-import spock.lang.Retry
 import spock.lang.Unroll
 import util.AbstractCouchbaseTest
 
 import static io.opentelemetry.auto.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderTrace
 
-@Retry
 @Unroll
 class CouchbaseClientTest extends AbstractCouchbaseTest {
   def "test hasBucket #type"() {

--- a/instrumentation/dropwizard-testing/dropwizard-testing.gradle
+++ b/instrumentation/dropwizard-testing/dropwizard-testing.gradle
@@ -1,4 +1,7 @@
-ext.skipPublish = true
+ext {
+  skipPublish = true
+  retryTests = true
+}
 apply from: "$rootDir/gradle/instrumentation.gradle"
 
 //apply plugin: 'org.unbroken-dome.test-sets'

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -26,12 +26,12 @@ import io.opentelemetry.auto.test.base.HttpServerTest
 import io.opentelemetry.auto.test.utils.PortUtils
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes
+
 import javax.ws.rs.GET
 import javax.ws.rs.Path
 import javax.ws.rs.PathParam
 import javax.ws.rs.QueryParam
 import javax.ws.rs.core.Response
-import spock.lang.Retry
 
 import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -42,8 +42,6 @@ import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.SUCC
 import static io.opentelemetry.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.trace.Span.Kind.SERVER
 
-// Work around for: address already in use
-@Retry(count = 5, delay = 100)
 class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
 
   @Override

--- a/instrumentation/google-http-client-1.19/google-http-client-1.19.gradle
+++ b/instrumentation/google-http-client-1.19/google-http-client-1.19.gradle
@@ -1,3 +1,7 @@
+ext {
+  retryTests = true
+}
+
 apply from: "$rootDir/gradle/instrumentation.gradle"
 apply plugin: 'org.unbroken-dome.test-sets'
 

--- a/instrumentation/google-http-client-1.19/src/test/groovy/GoogleHttpClientAsyncTest.groovy
+++ b/instrumentation/google-http-client-1.19/src/test/groovy/GoogleHttpClientAsyncTest.groovy
@@ -16,10 +16,8 @@
 
 import com.google.api.client.http.HttpRequest
 import com.google.api.client.http.HttpResponse
-import spock.lang.Retry
 import spock.lang.Timeout
 
-@Retry(condition = { !invocation.method.name.contains('circular redirects') }, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 @Timeout(5)
 class GoogleHttpClientAsyncTest extends AbstractGoogleHttpClientTest {
   def setup() {

--- a/instrumentation/google-http-client-1.19/src/test/groovy/GoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/src/test/groovy/GoogleHttpClientTest.groovy
@@ -16,10 +16,8 @@
 
 import com.google.api.client.http.HttpRequest
 import com.google.api.client.http.HttpResponse
-import spock.lang.Retry
 import spock.lang.Timeout
 
-@Retry(condition = { !invocation.method.name.contains('circular redirects') })
 @Timeout(5)
 class GoogleHttpClientTest extends AbstractGoogleHttpClientTest {
   @Override

--- a/instrumentation/java-concurrent/akka-2.5-testing/akka-2.5-testing.gradle
+++ b/instrumentation/java-concurrent/akka-2.5-testing/akka-2.5-testing.gradle
@@ -2,6 +2,7 @@
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
   skipPublish = true
+  retryTests = true
 }
 
 apply from: "$rootDir/gradle/instrumentation.gradle"

--- a/instrumentation/java-concurrent/akka-testing/akka-testing.gradle
+++ b/instrumentation/java-concurrent/akka-testing/akka-testing.gradle
@@ -1,4 +1,7 @@
-ext.skipPublish = true
+ext {
+  skipPublish = true
+  retryTests = true
+}
 apply from: "$rootDir/gradle/instrumentation.gradle"
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 

--- a/instrumentation/jms-1.1/jms-1.1.gradle
+++ b/instrumentation/jms-1.1/jms-1.1.gradle
@@ -1,3 +1,7 @@
+ext {
+  retryTests = true
+}
+
 apply from: "$rootDir/gradle/instrumentation.gradle"
 apply plugin: 'org.unbroken-dome.test-sets'
 

--- a/instrumentation/jms-1.1/src/test/groovy/SpringTemplateJMS1Test.groovy
+++ b/instrumentation/jms-1.1/src/test/groovy/SpringTemplateJMS1Test.groovy
@@ -20,7 +20,6 @@ import org.apache.activemq.ActiveMQConnectionFactory
 import org.apache.activemq.ActiveMQMessageConsumer
 import org.apache.activemq.junit.EmbeddedActiveMQBroker
 import org.springframework.jms.core.JmsTemplate
-import spock.lang.Retry
 import spock.lang.Shared
 
 import javax.jms.Connection
@@ -31,7 +30,6 @@ import java.util.concurrent.TimeUnit
 import static JMS1Test.consumerSpan
 import static JMS1Test.producerSpan
 
-@Retry
 class SpringTemplateJMS1Test extends AgentTestRunner {
   @Shared
   EmbeddedActiveMQBroker broker = new EmbeddedActiveMQBroker()

--- a/instrumentation/netty/netty-4.1/netty-4.1.gradle
+++ b/instrumentation/netty/netty-4.1/netty-4.1.gradle
@@ -1,6 +1,7 @@
 // Set properties before any plugins get loaded
 ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  retryTests = true
 }
 
 apply from: "$rootDir/gradle/instrumentation.gradle"

--- a/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -23,23 +23,22 @@ import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.codec.http.HttpClientCodec
 import io.opentelemetry.auto.instrumentation.netty.v4_1.client.HttpClientTracingHandler
 import io.opentelemetry.auto.test.base.HttpClientTest
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import org.asynchttpclient.AsyncCompletionHandler
 import org.asynchttpclient.AsyncHttpClient
 import org.asynchttpclient.DefaultAsyncHttpClientConfig
 import org.asynchttpclient.Response
-import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Timeout
+
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 import static io.opentelemetry.auto.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.auto.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderTrace
 import static org.asynchttpclient.Dsl.asyncHttpClient
 
-@Retry
 @Timeout(5)
 class Netty41ClientTest extends HttpClientTest {
 

--- a/instrumentation/play/play-2.6/play-2.6.gradle
+++ b/instrumentation/play/play-2.6/play-2.6.gradle
@@ -2,6 +2,7 @@ ext {
   minJavaVersionForTests = JavaVersion.VERSION_1_8
   // Play doesn't work with Java 9+ until 2.6.12
   maxJavaVersionForTests = JavaVersion.VERSION_1_8
+  retryTests = true
 }
 
 apply from: "$rootDir/gradle/instrumentation.gradle"

--- a/instrumentation/play/play-2.6/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/instrumentation/play/play-2.6/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -22,7 +22,6 @@ import play.libs.concurrent.HttpExecution
 import play.mvc.Results
 import play.routing.RoutingDsl
 import play.server.Server
-import spock.lang.Retry
 import spock.lang.Shared
 
 import java.util.concurrent.CompletableFuture
@@ -35,7 +34,6 @@ import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.QUER
 import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
-@Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class PlayAsyncServerTest extends PlayServerTest {
   @Shared
   def executor = Executors.newCachedThreadPool()

--- a/instrumentation/play/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -16,17 +16,16 @@
 
 package server
 
-
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
-import java.util.function.Supplier
 import play.BuiltInComponents
 import play.Mode
 import play.mvc.Results
 import play.routing.RoutingDsl
 import play.server.Server
-import spock.lang.Retry
+
+import java.util.function.Supplier
 
 import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -35,7 +34,6 @@ import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.REDI
 import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static io.opentelemetry.trace.Span.Kind.INTERNAL
 
-@Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class PlayServerTest extends HttpServerTest<Server> {
   @Override
   Server startServer(int port) {

--- a/smoke-tests/wildfly/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
+++ b/smoke-tests/wildfly/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
@@ -18,10 +18,8 @@ package io.opentelemetry.smoketest
 
 import io.opentelemetry.auto.test.utils.PortUtils
 import okhttp3.Request
-import spock.lang.Retry
 import spock.lang.Shared
 
-@Retry(delay = 1000)
 class WildflySmokeTest extends AbstractServerSmokeTest {
 
   @Shared

--- a/smoke-tests/wildfly/wildfly.gradle
+++ b/smoke-tests/wildfly/wildfly.gradle
@@ -5,6 +5,7 @@ ext {
   serverExtension = 'zip'
 
   minJavaVersionForTests = JavaVersion.VERSION_1_8
+  retryTests = true
 }
 
 repositories {

--- a/utils/thread-utils/src/test/groovy/io/opentelemetry/auto/common/exec/PeriodicSchedulingTest.groovy
+++ b/utils/thread-utils/src/test/groovy/io/opentelemetry/auto/common/exec/PeriodicSchedulingTest.groovy
@@ -17,15 +17,14 @@
 package io.opentelemetry.auto.common.exec
 
 import io.opentelemetry.auto.util.gc.GCUtils
+import spock.lang.Specification
+
 import java.lang.ref.WeakReference
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
-import spock.lang.Retry
-import spock.lang.Specification
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
-@Retry
 class PeriodicSchedulingTest extends Specification {
 
   def "test scheduling"() {

--- a/utils/thread-utils/thread-utils.gradle
+++ b/utils/thread-utils/thread-utils.gradle
@@ -1,3 +1,7 @@
+ext {
+  retryTests = true
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 


### PR DESCRIPTION
I randomly found Gradle has an official retry plugin

https://github.com/gradle/test-retry-gradle-plugin

It seems a little nicer than using spock's retry since the retries are reported, even in the build scan

https://github.com/gradle/test-retry-gradle-plugin#gradle
https://github.com/gradle/test-retry-gradle-plugin#gradle-enterprise

Aside: I was surprised to see `@Retry` already on the akka tests despite how much the fail :O