### PR TITLE
Don't use non-fixed test name for akka executor

### DIFF
--- a/instrumentation/akka-context-propagation/akka-context-propagation.gradle
+++ b/instrumentation/akka-context-propagation/akka-context-propagation.gradle
@@ -1,3 +1,7 @@
+ext {
+  retryTests = true
+}
+
 apply from: "$rootDir/gradle/instrumentation.gradle"
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 

--- a/instrumentation/akka-context-propagation/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/instrumentation/akka-context-propagation/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -52,7 +52,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
   @Shared
   def akkaInvokeForkJoinTask = { e, c -> e.invoke((ForkJoinTask) c) }
 
-  def "#poolImpl '#name' propagates"() {
+  def "#poolName '#name' propagates"() {
     setup:
     def pool = poolImpl
     def m = method
@@ -100,9 +100,10 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
     "submit Callable"      | submitCallable          | new ForkJoinPool()
     "submit ForkJoinTask"  | akkaSubmitForkJoinTask  | new ForkJoinPool()
     "invoke ForkJoinTask"  | akkaInvokeForkJoinTask  | new ForkJoinPool()
+    poolName = poolImpl.class.name
   }
 
-  def "#poolImpl '#name' reports after canceled jobs"() {
+  def "ForkJoinPool '#name' reports after canceled jobs"() {
     setup:
     def pool = poolImpl
     def m = method


### PR DESCRIPTION
I don't think this fixes the issue in https://15978-210933087-gh.circle-artifacts.com/0/reports/instrumentation/akka-http-10.0/tests/test/classes/AkkaHttpServerInstrumentationTestAsync.html where this akka-http test isn't showing any retries in the report. But locally the test did retry when I modified it to fail - will need to dig more for that.

But the akka-context-propagation error is more obvious, Gradle doesn't like the test name changing every run (because Executor.toString includes object ID). I wouldn't be surprised if Spock retry didn't either and just didn't tell us, but didn't confirm this.

For #926 