### PR TITLE
JMX Metrics gatherer

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -60,7 +60,7 @@ ext {
       dependencies.create(group: 'org.objenesis', name: 'objenesis', version: '2.6') // Last version to support Java7
     ],
     groovy                      : "org.codehaus.groovy:groovy-all:${versions.groovy}",
-    testcontainers              : "org.testcontainers:testcontainers:1.12.2",
+    testcontainers              : "org.testcontainers:testcontainers:1.14.3",
     testLogging                 : [
       dependencies.create(group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback),
       dependencies.create(group: 'org.slf4j', name: 'log4j-over-slf4j', version: versions.slf4j),

--- a/instrumentation-core/jmx-metrics/README.md
+++ b/instrumentation-core/jmx-metrics/README.md
@@ -1,0 +1,110 @@
+# JMX Metric Gatherer
+
+This utility provides an easy framework for gathering and reporting metrics based on queried
+MBeans from a JMX server.  It loads a custom Groovy script and establishes a helpful, bound `otel`
+object with methods for obtaining MBeans and constructing synchronous OpenTelemetry instruments:
+
+### Usage
+
+```bash
+$ java -D<otel.jmx.metrics.property=value> -jar opentelemetry-jmx-metrics-<version>-all.jar [-config ./optional_config.properties]
+```
+
+##### `optional_config.properties` example
+
+```properties
+otel.jmx.metrics.service.url = service:jmx:rmi:///jndi/rmi://<my-jmx-host>:<my-jmx-port>/jmxrmi
+otel.jmx.metrics.groovy.script = /opt/script.groovy
+otel.jmx.metrics.interval.seconds = 5
+otel.jmx.metrics.exporter.type = otlp
+otel.jmx.metrics.exporter.endpoint = my-opentelemetry-collector:55680
+otel.jmx.metrics.username = my-username
+otel.jmx.metrics.password = my-password
+```
+
+##### `script.groovy` example
+
+```groovy
+import io.opentelemetry.common.Labels
+
+def loadMatches = otel.queryJmx("org.apache.cassandra.metrics:type=Storage,name=Load")
+def load = loadMatches.first()
+
+def lvr = otel.longValueRecorder(
+        "cassandra.storage.load",
+        "Size, in bytes, of the on disk data size this node manages",
+        "By", [myConstantLabelKey:"myConstantLabelValue"]
+)
+
+lvr.record(load.Count, Labels.of("myKey", "myVal"))
+```
+
+As configured in the example, this metric extension will configure an otlp gRPC metric exporter
+at the `otel.jmx.metrics.exporter.endpoint` and establish an MBean server connection using the
+provided `otel.jmx.metrics.service.url`. After loading the Groovy script whose path is specified
+via `otel.jmx.metrics.groovy.script`, it will then run the script on the specified
+`otel.jmx.metrics.interval.seconds` and export the resulting metrics.
+
+### JMX Query Helpers
+
+- `otel.queryJmx(String objectNameStr)`
+   - This method will query the connected JMX application for the given `objectName`, which can
+   include wildcards.  The return value will be a `List<GroovyMBean>` of zero or more
+   [`GroovyMBean` objects](http://docs.groovy-lang.org/latest/html/api/groovy/jmx/GroovyMBean.html),
+   which are conveniently wrapped to make accessing attributes on the MBean simple.
+   See http://groovy-lang.org/jmx.html for more information about their usage.
+
+- `otel.queryJmx(javax.management.ObjectName objectName)`
+   - This helper has the same functionality as its other signature, but takes an `ObjectName`
+   instance if constructing raw names is undesired.
+
+### OpenTelemetry Synchronous Instrument Helpers
+
+- `otel.doubleCounter(String name, String description, String unit, Map<String, String> labels)`
+
+- `otel.longCounter(String name, String description, String unit, Map<String, String> labels)`
+
+- `otel.doubleUpDownCounter(String name, String description, String unit, Map<String, String> labels)`
+
+- `otel.longUpDownCounter(String name, String description, String unit, Map<String, String> labels)`
+
+- `otel.doubleValueRecorder(String name, String description, String unit, Map<String, String> labels)`
+
+- `otel.longValueRecorder(String name, String description, String unit, Map<String, String> labels)`
+
+These methods will return a new or previously registered instance of the applicable metric
+instruments.  Each one provides three additional signatures  where labels, unit, and description
+aren't desired upon invocation.
+
+- `otel.<meterMethod>(String name, String description, String unit)` - `labels` are empty map.
+
+- `otel.<meterMethod>(String name, String description)` - `unit` is "1" and `labels` are empty map.
+
+- `otel.<meterMethod>(String name)` - `description` is empty string, `unit` is "1" and `labels` are empty map.
+
+### Compatibility
+
+This metric extension supports Java 7+, though SASL is only supported where
+`com.sun.security.sasl.Provider` is available.
+
+### Configuration
+
+The following properties are supported via the command line or specified config properties file `(-config)`.
+Those provided as command line properties take priority of those contained in a properties file.
+
+| Property | Required | Description |
+| ------------- | -------- | ----------- |
+| `otel.jmx.metrics.service.url` | **yes** | The service URL for the JMX RMI/JMXMP endpoint (generally of the form `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi` or `service:jmx:jmxmp://<host>:<port>`).|
+| `otel.jmx.metrics.groovy.script` | **yes** | The path for the desired Groovy script. |
+| `otel.jmx.metrics.interval.seconds` | no | How often, in seconds, the Groovy script should be run and its resulting metrics exported. 10 by default. |
+| `otel.jmx.metrics.exporter.type` | no | The type of `io.opentelemetry.sdk.metrics.export.MetricExporter` to use: (`otlp`, `inmemory`, `logging`).  `logging` by default. |
+| `otel.jmx.metrics.exporter.endpoint` | no | The exporter endpoint to use.  Required for `otlp`. |
+| `otel.jmx.metrics.username` | no | Username for JMX authentication, if applicable. |
+| `otel.jmx.metrics.password` | no | Password for JMX authentication, if applicable. |
+| `otel.jmx.metrics.keystore.path` | no | The key store path is required if client authentication is enabled on the target JVM. |
+| `otel.jmx.metrics.keystore.password` | no | The key store file password if required. |
+| `otel.jmx.metrics.keystore.type` | no | The key store type. |
+| `otel.jmx.metrics.truststore.path` | no | The trusted store path if the TLS profile is required. |
+| `otel.jmx.metrics.truststore.password` | no | The trust store file password if required. |
+| `otel.jmx.metrics.remote.profiles` | no | Supported JMX remote profiles are TLS in combination with SASL profiles: SASL/PLAIN, SASL/DIGEST-MD5 and SASL/CRAM-MD5. Thus valid `jmxRemoteProfiles` values are: `SASL/PLAIN`, `SASL/DIGEST-MD5`, `SASL/CRAM-MD5`, `TLS SASL/PLAIN`, `TLS SASL/DIGEST-MD5` and `TLS SASL/CRAM-MD5`. |
+| `otel.jmx.metrics.realm` | no | The realm is required by profile SASL/DIGEST-MD5. |

--- a/instrumentation-core/jmx-metrics/jmx-metrics.gradle
+++ b/instrumentation-core/jmx-metrics/jmx-metrics.gradle
@@ -1,0 +1,69 @@
+apply from: "$rootDir/gradle/instrumentation-library.gradle"
+archivesBaseName = "jmx-metrics"
+
+apply plugin: 'groovy'
+apply plugin: 'org.unbroken-dome.test-sets'
+apply plugin: 'com.github.johnrengelman.shadow'
+
+description = 'JMX metrics gathering Groovy script runner'
+
+// we are joint compiling so rely on groovy plugin entirely
+sourceSets.main.groovy.srcDirs = ["src/main/java", "src/main/groovy"]
+sourceSets.test.groovy.srcDirs = ["src/test/java", "src/test/groovy"]
+sourceSets.main.java.srcDirs = []
+sourceSets.test.java.srcDirs = []
+
+ext{
+  grpcVersion = '1.30.2'
+  protobufVersion = '3.11.4'
+}
+
+jar {
+  manifest {
+    attributes(
+      'Main-Class': 'io.opentelemetry.instrumentation.jmxmetrics.JmxMetrics'
+    )
+  }
+}
+
+dependencies {
+    implementation "com.google.guava:guava:25.0-jre",
+         "com.google.protobuf:protobuf-java:${protobufVersion}",
+         "com.google.protobuf:protobuf-java-util:${protobufVersion}",
+         "io.grpc:grpc-netty-shaded:${grpcVersion}",
+         "org.codehaus.groovy:groovy-jmx:${versions.groovy}",
+         "org.codehaus.groovy:groovy:${versions.groovy}",
+         dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporters-inmemory', version: versions.opentelemetryOther),
+         deps.opentelemetryApi,
+         deps.opentelemetryLogging,
+         deps.opentelemetryOtlp,
+         deps.opentelemetrySdk,
+         deps.slf4j,
+         dependencies.create(group: 'org.slf4j', name: 'slf4j-simple', version: versions.slf4j)
+
+    runtime "org.terracotta:jmxremote_optional-tc:1.0.5"
+
+    testImplementation "io.grpc:grpc-api:${grpcVersion}",
+        "io.grpc:grpc-protobuf:${grpcVersion}",
+        "io.grpc:grpc-stub:${grpcVersion}",
+        "io.grpc:grpc-testing:${grpcVersion}",
+        "org.codehaus.groovy:groovy-test:${versions.groovy}",
+        'io.rest-assured:rest-assured:4.2.0',
+        'org.awaitility:awaitility:3.0.0',
+        deps.testcontainers,
+        dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-proto', version: versions.opentelemetryOther)
+}
+
+tasks.withType(Test) {
+    dependsOn shadowJar
+    // there is likely a better way but shadowJar.archiveFileName is missing the opentelemetry- prefix
+    // from instrumentation-library's afterEvaluate
+    def shadowJarDir = tasks.shadowJar.destinationDirectory.asFile.get().path
+    def shadowJarFilename = tasks.shadowJar.archiveFileName.get()
+    systemProperty 'shadow.jar.path', "${shadowJarDir}/opentelemetry-${shadowJarFilename}"
+}
+
+spotbugs {
+  // tests require more memory than default
+  maxHeapSize = '1g'
+}

--- a/instrumentation-core/jmx-metrics/src/main/groovy/io/opentelemetry/instrumentation/jmxmetrics/OtelHelper.groovy
+++ b/instrumentation-core/jmx-metrics/src/main/groovy/io/opentelemetry/instrumentation/jmxmetrics/OtelHelper.groovy
@@ -1,0 +1,158 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics
+
+import io.opentelemetry.metrics.DoubleCounter
+import io.opentelemetry.metrics.DoubleUpDownCounter
+import io.opentelemetry.metrics.DoubleValueRecorder
+import io.opentelemetry.metrics.LongCounter
+import io.opentelemetry.metrics.LongUpDownCounter
+import io.opentelemetry.metrics.LongValueRecorder
+
+import javax.management.MBeanServerConnection
+import javax.management.ObjectName
+
+class OtelHelper {
+
+    private final JmxClient jmxClient
+    private final GroovyUtils groovyUtils
+
+    final String scalar = '1'
+
+    OtelHelper(JmxClient jmxClient, GroovyUtils groovyUtils) {
+        this.jmxClient = jmxClient
+        this.groovyUtils = groovyUtils
+    }
+
+    /**
+     * Returns a list of {@link GroovyMBean} for a given object name String.
+     * @param objNameStr - the {@link String} representation of an object name or pattern, to be
+     * used as the argument to the basic {@link ObjectName} constructor for the JmxClient query.
+     * @return a {@link List<GroovyMBean>} from which to create metrics.
+     */
+    List<GroovyMBean> queryJmx(String objNameStr) {
+        return queryJmx(new ObjectName(objNameStr))
+    }
+
+    /**
+     * Returns a list of {@link GroovyMBean} for a given {@link ObjectName}.
+     * @param objName - the {@link ObjectName} used for the JmxClient query.
+     * @return a {@link List<GroovyMBean>} from which to create metrics.
+     */
+    List<GroovyMBean> queryJmx(ObjectName objName) {
+        Set<ObjectName> names = jmxClient.query(objName)
+        MBeanServerConnection server = jmxClient.connection
+        return names.collect { new GroovyMBean(server, it) }
+    }
+
+    DoubleCounter doubleCounter(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getDoubleCounter(name, description, unit, labels)
+    }
+
+    DoubleCounter doubleCounter(String name, String description, String unit) {
+        return doubleCounter(name, description, unit, null)
+    }
+
+    DoubleCounter doubleCounter(String name, String description) {
+        return doubleCounter(name, description, scalar)
+    }
+
+    DoubleCounter doubleCounter(String name) {
+        return doubleCounter(name, '')
+    }
+
+    LongCounter longCounter(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getLongCounter(name, description, unit, labels)
+    }
+
+    LongCounter longCounter(String name, String description, String unit) {
+        return longCounter(name, description, unit, null)
+    }
+
+    LongCounter longCounter(String name, String description) {
+        return longCounter(name, description, scalar)
+    }
+
+    LongCounter longCounter(String name) {
+        return longCounter(name, '')
+    }
+
+    DoubleUpDownCounter doubleUpDownCounter(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getDoubleUpDownCounter(name, description, unit, labels)
+    }
+
+    DoubleUpDownCounter doubleUpDownCounter(String name, String description, String unit) {
+        return doubleUpDownCounter(name, description, unit, null)
+    }
+
+    DoubleUpDownCounter doubleUpDownCounter(String name, String description) {
+        return doubleUpDownCounter(name, description, scalar)
+    }
+
+    DoubleUpDownCounter doubleUpDownCounter(String name) {
+        return doubleUpDownCounter(name, '')
+    }
+
+    LongUpDownCounter longUpDownCounter(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getLongUpDownCounter(name, description, unit, labels)
+    }
+
+    LongUpDownCounter longUpDownCounter(String name, String description, String unit) {
+        return longUpDownCounter(name, description, unit, null)
+    }
+
+    LongUpDownCounter longUpDownCounter(String name, String description) {
+        return longUpDownCounter(name, description, scalar)
+    }
+
+    LongUpDownCounter longUpDownCounter(String name) {
+        return longUpDownCounter(name, '')
+    }
+
+    DoubleValueRecorder doubleValueRecorder(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getDoubleValueRecorder(name, description, unit, labels)
+    }
+
+    DoubleValueRecorder doubleValueRecorder(String name, String description, String unit) {
+        return doubleValueRecorder(name, description, unit, null)
+    }
+
+    DoubleValueRecorder doubleValueRecorder(String name, String description) {
+        return doubleValueRecorder(name, description, scalar)
+    }
+
+    DoubleValueRecorder doubleValueRecorder(String name) {
+        return doubleValueRecorder(name, '')
+    }
+
+    LongValueRecorder longValueRecorder(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getLongValueRecorder(name, description, unit, labels)
+    }
+
+    LongValueRecorder longValueRecorder(String name, String description, String unit) {
+        return longValueRecorder(name, description, unit, null)
+    }
+
+    LongValueRecorder longValueRecorder(String name, String description) {
+        return longValueRecorder(name, description, scalar)
+    }
+
+    LongValueRecorder longValueRecorder(String name) {
+        return longValueRecorder(name, '')
+    }
+
+}

--- a/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/ClientCallbackHandler.java
+++ b/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/ClientCallbackHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics;
+
+import javax.annotation.Nullable;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+
+public class ClientCallbackHandler implements CallbackHandler {
+  private final String username;
+  @Nullable private char[] password;
+  private final String realm;
+
+  /**
+   * Constructor for the {@link ClientCallbackHandler}, a CallbackHandler implementation for
+   * authenticating with an MBean server.
+   *
+   * @param username - authenticating username
+   * @param password - authenticating password (plaintext)
+   * @param realm - authenticating realm
+   */
+  public ClientCallbackHandler(String username, String password, String realm) {
+    this.username = username;
+    if (password != null) {
+      this.password = password.toCharArray();
+    }
+    this.realm = realm;
+  }
+
+  @Override
+  public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+    for (Callback callback : callbacks) {
+      if (callback instanceof NameCallback) {
+        ((NameCallback) callback).setName(this.username);
+      } else if (callback instanceof PasswordCallback) {
+        ((PasswordCallback) callback).setPassword(this.password);
+      } else if (callback instanceof RealmCallback) {
+        ((RealmCallback) callback).setText(this.realm);
+      } else {
+        throw new UnsupportedCallbackException(callback);
+      }
+    }
+  }
+}

--- a/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/ConfigureError.java
+++ b/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/ConfigureError.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics;
+
+public class ConfigureError extends RuntimeException {
+  private static final long serialVersionUID = 0L;
+
+  public ConfigureError(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public ConfigureError(final String message) {
+    super(message);
+  }
+}

--- a/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/GroovyRunner.java
+++ b/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/GroovyRunner.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
+import groovy.lang.Script;
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.codehaus.groovy.control.CompilationFailedException;
+
+public class GroovyRunner {
+  private static final Logger logger = Logger.getLogger(GroovyRunner.class.getName());
+
+  private final GroovyShell gshell = new GroovyShell();
+
+  private final Script script;
+  private final GroovyUtils gutil;
+
+  GroovyRunner(String groovyScript, JmxClient jmxClient, GroovyUtils gutil) {
+    this.gutil = gutil;
+
+    String scriptSource;
+    try {
+      scriptSource = getFileAsString(groovyScript);
+    } catch (IOException e) {
+      logger.log(Level.SEVERE, "Failed to read groovy script", e);
+      throw new ConfigureError("Failed to read groovy script", e);
+    }
+
+    try {
+      this.script = gshell.parse(scriptSource);
+    } catch (CompilationFailedException e) {
+      logger.log(Level.SEVERE, "Failed to compile groovy script", e);
+      throw new ConfigureError("Failed to compile groovy script", e);
+    }
+
+    Binding binding = new Binding();
+    binding.setVariable("log", logger);
+
+    OtelHelper otelHelper = new OtelHelper(jmxClient, gutil);
+    binding.setVariable("otel", otelHelper);
+
+    script.setBinding(binding);
+  }
+
+  static String getFileAsString(String fileName) throws IOException {
+    try (InputStream is = new FileInputStream(fileName)) {
+      return getFileFromInputStream(is);
+    }
+  }
+
+  static String getFileFromInputStream(InputStream is) throws IOException {
+    if (is == null) {
+      return null;
+    }
+    try (InputStreamReader isr = new InputStreamReader(is, UTF_8);
+        BufferedReader reader = new BufferedReader(isr)) {
+      StringBuilder file = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        file.append(System.lineSeparator());
+        file.append(line);
+      }
+      return file.toString();
+    }
+  }
+
+  public void run() {
+    script.run();
+    flush();
+  }
+
+  public void flush() {
+    gutil.exportMetrics();
+  }
+}

--- a/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/GroovyUtils.java
+++ b/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/GroovyUtils.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics;
+
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.common.Labels;
+import io.opentelemetry.common.Labels.Builder;
+import io.opentelemetry.exporters.inmemory.InMemoryMetricExporter;
+import io.opentelemetry.exporters.logging.LoggingMetricExporter;
+import io.opentelemetry.exporters.otlp.OtlpGrpcMetricExporter;
+import io.opentelemetry.metrics.DoubleCounter;
+import io.opentelemetry.metrics.DoubleUpDownCounter;
+import io.opentelemetry.metrics.DoubleValueRecorder;
+import io.opentelemetry.metrics.LongCounter;
+import io.opentelemetry.metrics.LongUpDownCounter;
+import io.opentelemetry.metrics.LongValueRecorder;
+import io.opentelemetry.metrics.Meter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.Collection;
+import java.util.Map;
+
+public class GroovyUtils {
+
+  public Meter meter;
+  public MetricExporter exporter;
+
+  /**
+   * A central context for creating and exporting metrics, to be used by groovy scripts via {@link
+   * io.opentelemetry.instrumentation.jmxmetrics.OtelHelper}.
+   *
+   * @param config - used to establish exporter type (logging by default) and connection info
+   * @param instrumentationName - meter's instrumentationName
+   * @param instrumentationVersion - meter's instrumentationVersion
+   */
+  public GroovyUtils(JmxConfig config, String instrumentationName, String instrumentationVersion) {
+    meter = OpenTelemetry.getMeter(instrumentationName, instrumentationVersion);
+
+    switch (config.exporterType.toLowerCase()) {
+      case "otlp":
+        exporter = OtlpGrpcMetricExporter.newBuilder().setEndpoint(config.exporterEndpoint).build();
+        break;
+      case "inmemory":
+        exporter = InMemoryMetricExporter.create();
+        break;
+      default:
+        exporter = new LoggingMetricExporter();
+        break;
+    }
+  }
+
+  /**
+   * Configures with default meter identifiers.
+   *
+   * @param config - used to establish exporter type (logging by default) and connection info
+   */
+  public GroovyUtils(JmxConfig config) {
+    this(config, "jmx-metrics", "0.0.1");
+  }
+
+  /** Will collect all metrics from OpenTelemetrySdk and export via configured exporter. */
+  public void exportMetrics() {
+    Collection<MetricData> md =
+        OpenTelemetrySdk.getMeterProvider().getMetricProducer().collectAllMetrics();
+    exporter.export(md);
+  }
+
+  private static Labels mapToLabels(Map<String, String> labelMap) {
+    Builder labels = new Builder();
+    if (labelMap != null) {
+      for (Map.Entry<String, String> kv : labelMap.entrySet()) {
+        labels.setLabel(kv.getKey(), kv.getValue());
+      }
+    }
+    return labels.build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link DoubleCounter}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link DoubleCounter}
+   */
+  public DoubleCounter getDoubleCounter(
+      String name, String description, String unit, Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .doubleCounterBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link LongCounter}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link LongCounter}
+   */
+  public LongCounter getLongCounter(
+      String name, String description, String unit, Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .longCounterBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link DoubleUpDownCounter}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link DoubleUpDownCounter}
+   */
+  public DoubleUpDownCounter getDoubleUpDownCounter(
+      String name, String description, String unit, Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .doubleUpDownCounterBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link LongUpDownCounter}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link LongUpDownCounter}
+   */
+  public LongUpDownCounter getLongUpDownCounter(
+      String name, String description, String unit, Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .longUpDownCounterBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link DoubleValueRecorder}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link DoubleValueRecorder}
+   */
+  public DoubleValueRecorder getDoubleValueRecorder(
+      String name, String description, String unit, Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .doubleValueRecorderBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link LongValueRecorder}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link LongValueRecorder}
+   */
+  public LongValueRecorder getLongValueRecorder(
+      String name, String description, String unit, Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .longValueRecorderBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+}

--- a/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/JmxClient.java
+++ b/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/JmxClient.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.security.Provider;
+import java.security.Security;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+public class JmxClient {
+  private static final Logger logger = Logger.getLogger(JmxClient.class.getName());
+
+  private final JMXServiceURL url;
+  private final String username;
+  private final String password;
+  private final String realm;
+  private final String jmxRemoteProfiles;
+  @Nullable private JMXConnector jmxConn;
+
+  JmxClient(JmxConfig config) throws MalformedURLException {
+    setSystemProperties(config);
+    this.url = new JMXServiceURL(config.serviceUrl);
+    this.username = config.username;
+    this.password = config.password;
+    this.realm = config.realm;
+    this.jmxRemoteProfiles = config.jmxRemoteProfiles;
+  }
+
+  private static void setSystemProperties(JmxConfig config) {
+    if (!JmxConfig.isBlank(config.keyStorePath)) {
+      System.setProperty("javax.net.ssl.keyStore", config.keyStorePath);
+    }
+    if (!JmxConfig.isBlank(config.keyStorePassword)) {
+      System.setProperty("javax.net.ssl.keyStorePassword", config.keyStorePassword);
+    }
+    if (!JmxConfig.isBlank(config.keyStoreType)) {
+      System.setProperty("javax.net.ssl.keyStoreType", config.keyStoreType);
+    }
+    if (!JmxConfig.isBlank(config.trustStorePath)) {
+      System.setProperty("javax.net.ssl.trustStore", config.trustStorePath);
+    }
+    if (!JmxConfig.isBlank(config.trustStorePassword)) {
+      System.setProperty("javax.net.ssl.trustStorePassword", config.trustStorePassword);
+    }
+  }
+
+  private MBeanServerConnection ensureConnected() {
+    if (jmxConn != null) {
+      try {
+        return jmxConn.getMBeanServerConnection();
+      } catch (IOException e) {
+        // Attempt to connect with authentication below.
+      }
+    }
+    try {
+      Map<String, Object> env = new HashMap<>();
+      if (!JmxConfig.isBlank(username)) {
+        env.put(JMXConnector.CREDENTIALS, new String[] {this.username, this.password});
+      }
+      try {
+        // Not all supported versions of Java contain this Provider
+        Class klass = Class.forName("com.sun.security.sasl.Provider");
+        Provider provider = (Provider) klass.getDeclaredConstructor().newInstance();
+        Security.addProvider(provider);
+
+        env.put("jmx.remote.profiles", this.jmxRemoteProfiles);
+        env.put(
+            "jmx.remote.sasl.callback.handler",
+            new ClientCallbackHandler(this.username, this.password, this.realm));
+      } catch (final ReflectiveOperationException e) {
+        logger.warning("SASL unsupported in current environment: " + e.getMessage());
+      }
+
+      jmxConn = JMXConnectorFactory.connect(url, env);
+      return jmxConn.getMBeanServerConnection();
+    } catch (IOException e) {
+      logger.log(Level.WARNING, "Could not connect to remote JMX server: ", e);
+      return null;
+    }
+  }
+
+  public MBeanServerConnection getConnection() {
+    return ensureConnected();
+  }
+
+  /**
+   * Query the MBean server for a given ObjectName.
+   *
+   * @param objectName ObjectName to query
+   * @return the set of applicable ObjectName instances found by server
+   */
+  public Set<ObjectName> query(ObjectName objectName) {
+    MBeanServerConnection mbsc = ensureConnected();
+    if (mbsc == null) {
+      return null;
+    }
+
+    try {
+      return mbsc.queryNames(objectName, null);
+    } catch (IOException e) {
+      jmxConn = null;
+      return null;
+    }
+  }
+}

--- a/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/JmxConfig.java
+++ b/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/JmxConfig.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics;
+
+import java.util.Properties;
+
+public class JmxConfig {
+  public String serviceUrl;
+  public String groovyScript;
+
+  public int intervalSeconds;
+  public String exporterType;
+  public String exporterEndpoint;
+
+  public String username;
+  public String password;
+
+  public String keyStorePath;
+  public String keyStorePassword;
+  public String keyStoreType;
+  public String trustStorePath;
+  public String trustStorePassword;
+  public String jmxRemoteProfiles;
+  public String realm;
+
+  private Properties properties;
+  private static final String prefix = "otel.jmx.metrics.";
+
+  public JmxConfig(Properties properties) {
+    this.properties = new Properties(properties);
+    // command line takes precedence
+    this.properties.putAll(System.getProperties());
+
+    serviceUrl = getProperty("service.url", null);
+    groovyScript = getProperty("groovy.script", null);
+    try {
+      intervalSeconds = Integer.parseInt(getProperty("interval.seconds", "10"));
+    } catch (NumberFormatException e) {
+      throw new ConfigureError("Failed to parse " + prefix + "interval.seconds", e);
+    }
+    exporterType = getProperty("exporter.type", "logging");
+    exporterEndpoint = getProperty("exporter.endpoint", null);
+    username = getProperty("username", null);
+    password = getProperty("password", null);
+    keyStorePath = getProperty("keystore.path", null);
+    keyStorePassword = getProperty("keystore.password", null);
+    keyStoreType = getProperty("keystore.type", null);
+    trustStorePath = getProperty("truststore.path", null);
+    trustStorePassword = getProperty("truststore.password", null);
+    jmxRemoteProfiles = getProperty("remote.profiles", null);
+    realm = getProperty("realm", null);
+  }
+
+  public JmxConfig() {
+    this(new Properties());
+  }
+
+  private String getProperty(String key, String dfault) {
+    return properties.getProperty(prefix + key, dfault);
+  }
+
+  /**
+   * Will determine if parsed config is complete, setting any applicable defaults.
+   *
+   * @throws ConfigureError - Thrown if a configuration value is missing or invalid.
+   */
+  public void validate() throws ConfigureError {
+    if (isBlank(this.serviceUrl)) {
+      throw new ConfigureError("service.url must be specified.");
+    }
+
+    if (isBlank(this.groovyScript)) {
+      throw new ConfigureError("groovy.script must be specified.");
+    }
+
+    if (isBlank(this.exporterEndpoint) && this.exporterType.equalsIgnoreCase("otlp")) {
+      throw new ConfigureError("exporter.endpoint must be specified for otlp format.");
+    }
+
+    if (this.intervalSeconds < 0) {
+      throw new ConfigureError("interval.seconds must be positive.");
+    }
+
+    if (this.intervalSeconds == 0) {
+      this.intervalSeconds = 10;
+    }
+  }
+
+  /**
+   * Determines if a String is null or without non-whitespace chars.
+   *
+   * @param s - {@link String} to evaluate
+   * @return - if s is null or without non-whitespace chars.
+   */
+  public static boolean isBlank(String s) {
+    if (s == null) {
+      return true;
+    }
+    return s.trim().length() == 0;
+  }
+}

--- a/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/JmxMetrics.java
+++ b/instrumentation-core/jmx-metrics/src/main/java/io/opentelemetry/instrumentation/jmxmetrics/JmxMetrics.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.util.Properties;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class JmxMetrics {
+  private static final Logger logger = Logger.getLogger(JmxMetrics.class.getName());
+
+  private final Timer timer = new Timer();
+  private GroovyRunner runner;
+
+  /**
+   * Begins the core metric scraping and reporting loop on configured interval after parsing and
+   * binding the configured groovy script and establishing the {@link JmxClient} connection.
+   *
+   * @param config - {@link JmxConfig} with Groovy script path, JMX connection info, and metric
+   *     export options.
+   */
+  public void start(JmxConfig config) {
+    JmxClient jmxClient;
+    try {
+      jmxClient = new JmxClient(config);
+    } catch (MalformedURLException e) {
+      throw new ConfigureError("Malformed serviceUrl: ", e);
+    }
+
+    runner = new GroovyRunner(config.groovyScript, jmxClient, new GroovyUtils(config));
+
+    timer.scheduleAtFixedRate(
+        wrapTimerTask(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  runner.run();
+                } catch (Throwable e) {
+                  logger.log(Level.SEVERE, "Error gathering JMX metrics", e);
+                }
+              }
+            }),
+        0,
+        config.intervalSeconds * 1000);
+    logger.info("Started GroovyRunner.");
+  }
+
+  private static TimerTask wrapTimerTask(final Runnable r) {
+    return new TimerTask() {
+      @Override
+      public void run() {
+        r.run();
+      }
+    };
+  }
+
+  private void shutdown() {
+    logger.info("Shutting down JmxMetrics Groovy runner and exporting final metrics.");
+    timer.cancel();
+    runner.flush();
+  }
+
+  private static JmxConfig getConfigFromArgs(String[] args) {
+    if (args.length != 0 && (args.length != 2 || !args[0].equalsIgnoreCase("-config"))) {
+      System.out.println(
+          "Usage: java io.opentelemetry.extensions.metrics.jmx.JmxMonitor "
+              + "-config <path_to_config.properties>");
+      System.exit(1);
+    }
+
+    Properties props = new Properties();
+    if (args.length == 2) {
+      try (InputStream is = new FileInputStream(args[1])) {
+        props.load(is);
+      } catch (IOException e) {
+        System.out.println(
+            "Failed to read config properties file at '" + args[1] + "': " + e.getMessage());
+        System.exit(1);
+      }
+    }
+
+    return new JmxConfig(props);
+  }
+
+  /**
+   * Main method to create and run a {@link JmxMetrics} instance.
+   *
+   * @param args - must be of the form "-config jmx_config_path"
+   */
+  public static void main(String[] args) {
+    JmxConfig config = getConfigFromArgs(args);
+    config.validate();
+
+    final JmxMetrics monitor = new JmxMetrics();
+    try {
+      monitor.start(config);
+    } catch (ConfigureError e) {
+      logger.severe(e.getMessage());
+      System.exit(1);
+    }
+
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread() {
+              @Override
+              public void run() {
+                monitor.shutdown();
+              }
+            });
+  }
+}

--- a/instrumentation-core/jmx-metrics/src/test/groovy/io/opentelemetry/instrumentation/jmxmetrics/JmxMetricsIntegrationTest.groovy
+++ b/instrumentation-core/jmx-metrics/src/test/groovy/io/opentelemetry/instrumentation/jmxmetrics/JmxMetricsIntegrationTest.groovy
@@ -1,0 +1,193 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics
+
+import static io.opentelemetry.proto.metrics.v1.MetricDescriptor.Type.SUMMARY
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+import io.grpc.ServerBuilder
+import io.grpc.stub.StreamObserver
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse
+import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc
+import io.opentelemetry.proto.common.v1.InstrumentationLibrary
+import io.opentelemetry.proto.common.v1.StringKeyValue
+import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics
+import io.opentelemetry.proto.metrics.v1.Metric
+import io.opentelemetry.proto.metrics.v1.MetricDescriptor
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics
+import io.opentelemetry.proto.metrics.v1.SummaryDataPoint
+import java.time.Duration
+import org.testcontainers.Testcontainers
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.images.builder.ImageFromDockerfile
+import org.testcontainers.utility.MountableFile
+import spock.lang.Shared
+import spock.lang.Specification
+
+class JmxMetricsIntegrationTest extends Specification {
+
+  @Shared
+  def cassandraContainer
+
+  @Shared
+  def jmxExtensionAppContainer
+
+  @Shared
+  def collector = new Collector()
+  @Shared
+  def collectorServer = ServerBuilder.forPort(55680).addService(collector).build()
+
+  def setupSpec() {
+    Testcontainers.exposeHostPorts(55680)
+
+    def jarPath = System.getProperty("shadow.jar.path")
+
+    def scriptName = "script.groovy"
+    def scriptPath = ClassLoader.getSystemClassLoader().getResource(scriptName).getPath()
+
+    def configName = "config.properties"
+    def configPath = ClassLoader.getSystemClassLoader().getResource(configName).getPath()
+
+    def cassandraDockerfile = ("FROM cassandra:3.11\n"
+        + "ENV LOCAL_JMX=no\n"
+        + "RUN echo 'cassandra cassandra' > /etc/cassandra/jmxremote.password\n"
+        + "RUN chmod 0400 /etc/cassandra/jmxremote.password\n")
+
+    def network = Network.SHARED
+
+    cassandraContainer =
+          new GenericContainer<>(
+                  new ImageFromDockerfile().withFileFromString("Dockerfile", cassandraDockerfile))
+              .withNetwork(network)
+              .withNetworkAliases("cassandra")
+              .withExposedPorts(7199)
+              .withStartupTimeout(Duration.ofSeconds(120))
+              .waitingFor(Wait.forListeningPort())
+    cassandraContainer.start()
+
+    jmxExtensionAppContainer =
+          new GenericContainer<>("openjdk:7u111-jre-alpine")
+              .withNetwork(network)
+              .withCopyFileToContainer(MountableFile.forHostPath(jarPath), "/app/OpenTelemetryJava.jar")
+              .withCopyFileToContainer(
+                  MountableFile.forHostPath(scriptPath), "/app/${scriptName}")
+              .withCopyFileToContainer(
+                  MountableFile.forHostPath(configPath), "/app/${configName}")
+              .withCommand("java -cp /app/OpenTelemetryJava.jar "
+                      + "-Dotel.jmx.metrics.username=cassandra "
+                      + "-Dotel.jmx.metrics.password=cassandra "
+                      + "io.opentelemetry.instrumentation.jmxmetrics.JmxMetrics "
+                      + "-config /app/config.properties")
+              .withStartupTimeout(Duration.ofSeconds(120))
+              .waitingFor(Wait.forLogMessage(".*Started GroovyRunner.*", 1))
+              .dependsOn(cassandraContainer)
+    jmxExtensionAppContainer.start()
+
+    expect:
+    cassandraContainer.isRunning()
+    jmxExtensionAppContainer.isRunning()
+  }
+
+  def setup() {
+    collectorServer.start()
+  }
+
+  def cleanupSpec() {
+    collectorServer.shutdown()
+  }
+
+  def "end to end"() {
+    when:
+    List<ResourceMetrics> receivedMetrics = collector.getReceivedMetrics()
+    then:
+    assertEquals(1, receivedMetrics.size())
+    ResourceMetrics receivedMetric = receivedMetrics.get(0)
+
+    List<InstrumentationLibraryMetrics> ilMetrics =
+        receivedMetric.getInstrumentationLibraryMetricsList()
+    assertEquals(1, ilMetrics.size())
+    InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
+
+    InstrumentationLibrary il = ilMetric.getInstrumentationLibrary()
+    assertEquals("jmx-metrics", il.getName())
+    assertEquals("0.0.1", il.getVersion())
+
+    List<Metric> metrics = ilMetric.getMetricsList()
+    assertEquals(1, metrics.size())
+
+    Metric metric = metrics.get(0)
+    MetricDescriptor md = metric.getMetricDescriptor()
+    assertEquals("cassandra.storage.load", md.getName())
+    assertEquals("Size, in bytes, of the on disk data size this node manages", md.getDescription())
+    assertEquals("By", md.getUnit())
+    assertEquals(SUMMARY, md.getType())
+
+    List<SummaryDataPoint> datapoints = metric.getSummaryDataPointsList()
+    assertEquals(1, datapoints.size())
+    SummaryDataPoint datapoint = datapoints.get(0)
+
+    List<StringKeyValue> labels = datapoint.getLabelsList()
+    assertEquals(1, labels.size())
+    assertEquals(
+        StringKeyValue.newBuilder().setKey("myKey").setValue("myVal").build(), labels.get(0))
+
+    assertEquals(1, datapoint.getCount())
+    double sum = datapoint.getSum()
+    assertEquals(sum, datapoint.getPercentileValues(0).getValue(), 0)
+    assertEquals(sum, datapoint.getPercentileValues(1).getValue(), 0)
+  }
+
+  static final class Collector extends MetricsServiceGrpc.MetricsServiceImplBase {
+    private final List<ResourceMetrics> receivedMetrics = new ArrayList<>()
+    private final Object monitor = new Object()
+
+    @Override
+    void export(
+        ExportMetricsServiceRequest request,
+        StreamObserver<ExportMetricsServiceResponse> responseObserver) {
+      synchronized (receivedMetrics) {
+        receivedMetrics.addAll(request.getResourceMetricsList())
+      }
+      synchronized (monitor) {
+        monitor.notify()
+      }
+      responseObserver.onNext(ExportMetricsServiceResponse.newBuilder().build())
+      responseObserver.onCompleted()
+    }
+
+    List<ResourceMetrics> getReceivedMetrics() {
+      List<ResourceMetrics> received
+      try {
+        synchronized (monitor) {
+          monitor.wait(15000)
+        }
+      } catch (final InterruptedException e) {
+        assertTrue(e.getMessage(), false)
+      }
+
+      synchronized (receivedMetrics) {
+        received = new ArrayList<>(receivedMetrics)
+        receivedMetrics.clear()
+      }
+      return received
+    }
+  }
+}

--- a/instrumentation-core/jmx-metrics/src/test/groovy/io/opentelemetry/instrumentation/jmxmetrics/JmxMetricsIntegrationTest.groovy
+++ b/instrumentation-core/jmx-metrics/src/test/groovy/io/opentelemetry/instrumentation/jmxmetrics/JmxMetricsIntegrationTest.groovy
@@ -39,9 +39,12 @@ import org.testcontainers.containers.Network
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.images.builder.ImageFromDockerfile
 import org.testcontainers.utility.MountableFile
+import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Specification
 
+// Test containers is only supported on machine CircleCI resource
+@Requires({"true" != System.getenv("CIRCLECI")})
 class JmxMetricsIntegrationTest extends Specification {
 
   @Shared

--- a/instrumentation-core/jmx-metrics/src/test/groovy/io/opentelemetry/instrumentation/jmxmetrics/OtelHelperJmxTest.groovy
+++ b/instrumentation-core/jmx-metrics/src/test/groovy/io/opentelemetry/instrumentation/jmxmetrics/OtelHelperJmxTest.groovy
@@ -1,0 +1,122 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics
+
+import static java.lang.management.ManagementFactory.getPlatformMBeanServer
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+import javax.management.ObjectName
+import javax.management.remote.JMXConnectorServer
+import javax.management.remote.JMXConnectorServerFactory
+import javax.management.remote.JMXServiceURL
+import spock.lang.Shared
+import spock.lang.Specification
+
+
+class OtelHelperJmxTest extends Specification {
+
+    static String thingName = 'io.opentelemetry.extensions.metrics.jmx:type=OtelHelperJmxTest.Thing'
+
+    @Shared
+    JMXConnectorServer jmxServer
+
+    def setupSpec() {
+        def thing = new Thing()
+        def mbeanServer = getPlatformMBeanServer()
+        mbeanServer.registerMBean(thing, new ObjectName(thingName))
+    }
+
+    def cleanup() {
+        jmxServer.stop()
+    }
+
+    private JMXServiceURL setupServer(Map env) {
+        def serviceUrl = new JMXServiceURL('rmi', 'localhost', 0)
+        jmxServer = JMXConnectorServerFactory.newJMXConnectorServer(serviceUrl, env, getPlatformMBeanServer())
+        jmxServer.start()
+        return jmxServer.getAddress()
+    }
+
+    private OtelHelper setupHelper(JmxConfig config) {
+        return new OtelHelper(new JmxClient(config), new GroovyUtils(config))
+    }
+
+    private void verifyClient(JmxConfig config) {
+        config.groovyScript = "myscript.groovy"
+        config.validate()
+        def otel = setupHelper(config)
+        def mbeans = otel.queryJmx(thingName)
+
+        assertEquals(1, mbeans.size())
+        assertEquals('This is the attribute', mbeans[0].SomeAttribute)
+    }
+
+    def "no authentication"() {
+      when:
+        def serverAddr = setupServer([:])
+        def config = new JmxConfig().tap {
+            serviceUrl = serverAddr
+        }
+      then:
+        verifyClient(config)
+    }
+
+    def "password authentication"() {
+      when:
+        def pwFile = ClassLoader.getSystemClassLoader().getResource('jmxremote.password').getPath()
+        def serverAddr = setupServer(['jmx.remote.x.password.file':pwFile])
+
+        def config = new JmxConfig().tap {
+            serviceUrl = serverAddr
+            username = 'wrongUsername'
+            password = 'wrongPassword'
+        }
+      then:
+        try {
+            verifyClient(config)
+            assertTrue('Authentication should have failed.', false)
+        } catch (final SecurityException e) {
+            // desired
+        }
+
+      when:
+        config = new JmxConfig().tap {
+            serviceUrl = serverAddr
+            username = 'correctUsername'
+            password = 'correctPassword'
+        }
+      then:
+        verifyClient(config)
+    }
+
+    interface ThingMBean {
+
+        String getSomeAttribute()
+
+    }
+
+    static class Thing implements ThingMBean {
+
+        @Override
+        String getSomeAttribute() {
+            return 'This is the attribute'
+        }
+
+    }
+
+}

--- a/instrumentation-core/jmx-metrics/src/test/groovy/io/opentelemetry/instrumentation/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
+++ b/instrumentation-core/jmx-metrics/src/test/groovy/io/opentelemetry/instrumentation/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
@@ -1,0 +1,656 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.jmxmetrics
+
+import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.MONOTONIC_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.MONOTONIC_LONG
+import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.NON_MONOTONIC_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.NON_MONOTONIC_LONG
+import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.SUMMARY
+
+import io.opentelemetry.common.Labels
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import org.junit.Rule
+import org.junit.rules.TestName
+import org.junit.rules.TestRule
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class OtelHelperSynchronousMetricTest extends Specification{
+
+    @Shared
+    GroovyUtils gutil
+
+    @Shared
+    OtelHelper otel
+
+    @Rule public final TestRule name = new TestName()
+
+    def setup() {
+        // Set up a MeterSdk per test to be able to collect its metrics alone
+        gutil = new GroovyUtils(
+                new JmxConfig().tap {
+                    exporterType = 'inmemory'
+                },
+                name.methodName, ''
+        )
+        otel = new OtelHelper(null, gutil)
+    }
+
+    def exportMetrics() {
+        def provider = OpenTelemetrySdk.meterProvider.get(name.methodName, '')
+        return provider.collectAll().sort { md1, md2 ->
+            def p1 = md1.points[0]
+            def p2 = md2.points[0]
+            def s1 = p1.startEpochNanos
+            def s2 = p2.startEpochNanos
+            if (s1 == s2) {
+                if (md1.descriptor.type == SUMMARY) {
+                    return p1.percentileValues[0].value <=> p2.percentileValues[0].value
+                }
+                return p1.value <=> p2.value
+            }
+            s1 <=> s2
+        }
+    }
+
+    def "double counter"() {
+      when:
+        def dc = otel.doubleCounter(
+                'double-counter', 'a double counter',
+                 'ms', [key1:'value1', key2:'value2']
+        )
+        dc.add(123.456, Labels.of('key', 'value'))
+
+        dc = otel.doubleCounter('my-double-counter', 'another double counter', 'µs')
+        dc.add(234.567, Labels.of('myKey', 'myValue'))
+
+        dc = otel.doubleCounter('another-double-counter', 'double counter')
+        dc.add(345.678, Labels.of('anotherKey', 'anotherValue'))
+
+        dc = otel.doubleCounter('yet-another-double-counter')
+        dc.add(456.789, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+      then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'double-counter'
+        assert first.descriptor.description == 'a double counter'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+                'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == MONOTONIC_DOUBLE
+        assert first.points.size() == 1
+        assert first.points[0].value == 123.456
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-double-counter'
+        assert second.descriptor.description == 'another double counter'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == MONOTONIC_DOUBLE
+        assert second.points.size() == 1
+        assert second.points[0].value == 234.567
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-double-counter'
+        assert third.descriptor.description == 'double counter'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == MONOTONIC_DOUBLE
+        assert third.points.size() == 1
+        assert third.points[0].value == 345.678
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-double-counter'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == MONOTONIC_DOUBLE
+        assert fourth.points.size() == 1
+        assert fourth.points[0].value == 456.789
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+    def "double counter memoization"() {
+      when:
+        def dcOne = otel.doubleCounter('dc', 'double')
+        dcOne.add(10.1, Labels.of('key', 'value'))
+        def dcTwo = otel.doubleCounter('dc', 'double')
+        dcTwo.add(10.1, Labels.of('key', 'value'))
+
+      then:
+        assert dcOne.is(dcTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'dc'
+        assert metric.descriptor.description == 'double'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == MONOTONIC_DOUBLE
+        assert metric.points.size() == 1
+        assert metric.points[0].value == 20.2
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+    def "long counter"() {
+      when:
+        def lc = otel.longCounter(
+                'long-counter', 'a long counter',
+                'ms', [key1:'value1', key2:'value2']
+        )
+        lc.add(123, Labels.of('key', 'value'))
+
+        lc = otel.longCounter('my-long-counter', 'another long counter', 'µs')
+        lc.add(234, Labels.of('myKey', 'myValue'))
+
+        lc = otel.longCounter('another-long-counter', 'long counter')
+        lc.add(345, Labels.of('anotherKey', 'anotherValue'))
+
+        lc = otel.longCounter('yet-another-long-counter')
+        lc.add(456, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+      then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'long-counter'
+        assert first.descriptor.description == 'a long counter'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+                'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == MONOTONIC_LONG
+        assert first.points.size() == 1
+        assert first.points[0].value == 123
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-long-counter'
+        assert second.descriptor.description == 'another long counter'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == MONOTONIC_LONG
+        assert second.points.size() == 1
+        assert second.points[0].value == 234
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-long-counter'
+        assert third.descriptor.description == 'long counter'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == MONOTONIC_LONG
+        assert third.points.size() == 1
+        assert third.points[0].value == 345
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-long-counter'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == MONOTONIC_LONG
+        assert fourth.points.size() == 1
+        assert fourth.points[0].value == 456
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+    def "long counter memoization"() {
+      when:
+        def lcOne = otel.longCounter('lc', 'long')
+        lcOne.add(10, Labels.of('key', 'value'))
+        def lcTwo = otel.longCounter('lc', 'long')
+        lcTwo.add(10, Labels.of('key', 'value'))
+
+      then:
+        assert lcOne.is(lcTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'lc'
+        assert metric.descriptor.description == 'long'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == MONOTONIC_LONG
+        assert metric.points.size() == 1
+        assert metric.points[0].value == 20
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+    def "double up down counter"() {
+      when:
+        def dudc = otel.doubleUpDownCounter(
+                'double-up-down-counter', 'a double up-down-counter',
+                'ms', [key1:'value1', key2:'value2']
+        )
+        dudc.add(-234.567, Labels.of('key', 'value'))
+
+        dudc = otel.doubleUpDownCounter('my-double-up-down-counter', 'another double up-down-counter', 'µs')
+        dudc.add(-123.456, Labels.of('myKey', 'myValue'))
+
+        dudc = otel.doubleUpDownCounter('another-double-up-down-counter', 'double up-down-counter')
+        dudc.add(345.678, Labels.of('anotherKey', 'anotherValue'))
+
+        dudc = otel.doubleUpDownCounter('yet-another-double-up-down-counter')
+        dudc.add(456.789, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+      then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'double-up-down-counter'
+        assert first.descriptor.description == 'a double up-down-counter'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+                'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert first.points.size() == 1
+        assert first.points[0].value == -234.567
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-double-up-down-counter'
+        assert second.descriptor.description == 'another double up-down-counter'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert second.points.size() == 1
+        assert second.points[0].value == -123.456
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-double-up-down-counter'
+        assert third.descriptor.description == 'double up-down-counter'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert third.points.size() == 1
+        assert third.points[0].value == 345.678
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-double-up-down-counter'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert fourth.points.size() == 1
+        assert fourth.points[0].value == 456.789
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+  def "double up down counter memoization"() {
+    when:
+        def dudcOne = otel.doubleUpDownCounter('dudc', 'double up down')
+        dudcOne.add(10.1, Labels.of('key', 'value'))
+        def dudcTwo = otel.doubleUpDownCounter('dudc', 'double up down')
+        dudcTwo.add(-10.1, Labels.of('key', 'value'))
+
+    then:
+        assert dudcOne.is(dudcTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'dudc'
+        assert metric.descriptor.description == 'double up down'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert metric.points.size() == 1
+        assert metric.points[0].value == 0
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+  def "long up down counter"() {
+    when:
+        def ludc = otel.longUpDownCounter(
+                'long-up-down-counter', 'a long up-down-counter',
+                'ms', [key1:'value1', key2:'value2']
+        )
+        ludc.add(-234, Labels.of('key', 'value'))
+
+        ludc = otel.longUpDownCounter('my-long-up-down-counter', 'another long up-down-counter', 'µs')
+        ludc.add(-123, Labels.of('myKey', 'myValue'))
+
+        ludc = otel.longUpDownCounter('another-long-up-down-counter', 'long up-down-counter')
+        ludc.add(345, Labels.of('anotherKey', 'anotherValue'))
+
+        ludc = otel.longUpDownCounter('yet-another-long-up-down-counter')
+        ludc.add(456, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+    then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'long-up-down-counter'
+        assert first.descriptor.description == 'a long up-down-counter'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+                'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == NON_MONOTONIC_LONG
+        assert first.points.size() == 1
+        assert first.points[0].value == -234
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-long-up-down-counter'
+        assert second.descriptor.description == 'another long up-down-counter'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == NON_MONOTONIC_LONG
+        assert second.points.size() == 1
+        assert second.points[0].value == -123
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-long-up-down-counter'
+        assert third.descriptor.description == 'long up-down-counter'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == NON_MONOTONIC_LONG
+        assert third.points.size() == 1
+        assert third.points[0].value == 345
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-long-up-down-counter'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == NON_MONOTONIC_LONG
+        assert fourth.points.size() == 1
+        assert fourth.points[0].value == 456
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+  def "long up down counter memoization"() {
+    when:
+        def ludcOne = otel.longUpDownCounter('ludc', 'long up down')
+        ludcOne.add(10, Labels.of('key', 'value'))
+        def ludcTwo = otel.longUpDownCounter('ludc', 'long up down')
+        ludcTwo.add(-10, Labels.of('key', 'value'))
+
+    then:
+        assert ludcOne.is(ludcTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'ludc'
+        assert metric.descriptor.description == 'long up down'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == NON_MONOTONIC_LONG
+        assert metric.points.size() == 1
+        assert metric.points[0].value == 0
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+  def "double value recorder"() {
+    when:
+        def dvr = otel.doubleValueRecorder(
+                'double-value-recorder', 'a double value-recorder',
+                'ms', [key1:'value1', key2:'value2']
+        )
+        dvr.record(-234.567, Labels.of('key', 'value'))
+
+        dvr = otel.doubleValueRecorder('my-double-value-recorder', 'another double value-recorder', 'µs')
+        dvr.record(-123.456, Labels.of('myKey', 'myValue'))
+
+        dvr = otel.doubleValueRecorder('another-double-value-recorder', 'double value-recorder')
+        dvr.record(345.678, Labels.of('anotherKey', 'anotherValue'))
+
+        dvr = otel.doubleValueRecorder('yet-another-double-value-recorder')
+        dvr.record(456.789, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+    then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'double-value-recorder'
+        assert first.descriptor.description == 'a double value-recorder'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+                'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == SUMMARY
+        assert first.points.size() == 1
+        assert first.points[0].count == 1
+        assert first.points[0].sum == -234.567
+        assert first.points[0].percentileValues[0].percentile == 0
+        assert first.points[0].percentileValues[0].value ==  -234.567
+        assert first.points[0].percentileValues[1].percentile == 100
+        assert first.points[0].percentileValues[1].value == -234.567
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-double-value-recorder'
+        assert second.descriptor.description == 'another double value-recorder'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == SUMMARY
+        assert second.points.size() == 1
+        assert second.points[0].count == 1
+        assert second.points[0].sum == -123.456
+        assert second.points[0].percentileValues[0].percentile == 0
+        assert second.points[0].percentileValues[0].value == -123.456
+        assert second.points[0].percentileValues[1].percentile == 100
+        assert second.points[0].percentileValues[1].value == -123.456
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-double-value-recorder'
+        assert third.descriptor.description == 'double value-recorder'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == SUMMARY
+        assert third.points.size() == 1
+        assert third.points[0].count == 1
+        assert third.points[0].sum == 345.678
+        assert third.points[0].percentileValues[0].percentile == 0
+        assert third.points[0].percentileValues[0].value == 345.678
+        assert third.points[0].percentileValues[1].percentile == 100
+        assert third.points[0].percentileValues[1].value == 345.678
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-double-value-recorder'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == SUMMARY
+        assert fourth.points.size() == 1
+        assert fourth.points[0].count == 1
+        assert fourth.points[0].sum == 456.789
+        assert fourth.points[0].percentileValues[0].percentile == 0
+        assert fourth.points[0].percentileValues[0].value == 456.789
+        assert fourth.points[0].percentileValues[1].percentile == 100
+        assert fourth.points[0].percentileValues[1].value == 456.789
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+  def "double value recorder memoization"() {
+    when:
+        def dvrOne = otel.doubleValueRecorder('dvr', 'double value')
+        dvrOne.record(10.1, Labels.of('key', 'value'))
+        def dvrTwo = otel.doubleValueRecorder('dvr', 'double value')
+        dvrTwo.record(-10.1, Labels.of('key', 'value'))
+
+    then:
+        assert dvrOne.is(dvrTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'dvr'
+        assert metric.descriptor.description == 'double value'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == SUMMARY
+        assert metric.points.size() == 1
+        assert metric.points[0].count == 2
+        assert metric.points[0].sum == 0
+        assert metric.points[0].percentileValues[0].percentile == 0
+        assert metric.points[0].percentileValues[0].value == -10.1
+        assert metric.points[0].percentileValues[1].percentile == 100
+        assert metric.points[0].percentileValues[1].value == 10.1
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+  def "long value recorder"() {
+    when:
+        def lvr = otel.longValueRecorder(
+                'long-value-recorder', 'a long value-recorder',
+                'ms', [key1:'value1', key2:'value2']
+        )
+        lvr.record(-234, Labels.of('key', 'value'))
+
+        lvr = otel.longValueRecorder('my-long-value-recorder', 'another long value-recorder', 'µs')
+        lvr.record(-123, Labels.of('myKey', 'myValue'))
+
+        lvr = otel.longValueRecorder('another-long-value-recorder', 'long value-recorder')
+        lvr.record(345, Labels.of('anotherKey', 'anotherValue'))
+
+        lvr = otel.longValueRecorder('yet-another-long-value-recorder')
+        lvr.record(456, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+    then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'long-value-recorder'
+        assert first.descriptor.description == 'a long value-recorder'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+                'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == SUMMARY
+        assert first.points.size() == 1
+        assert first.points[0].count == 1
+        assert first.points[0].sum == -234
+        assert first.points[0].percentileValues[0].percentile == 0
+        assert first.points[0].percentileValues[0].value == -234
+        assert first.points[0].percentileValues[1].percentile == 100
+        assert first.points[0].percentileValues[1].value == -234
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-long-value-recorder'
+        assert second.descriptor.description == 'another long value-recorder'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == SUMMARY
+        assert second.points.size() == 1
+        assert second.points[0].count == 1
+        assert second.points[0].sum == -123
+        assert second.points[0].percentileValues[0].percentile == 0
+        assert second.points[0].percentileValues[0].value == -123
+        assert second.points[0].percentileValues[1].percentile == 100
+        assert second.points[0].percentileValues[1].value == -123
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-long-value-recorder'
+        assert third.descriptor.description == 'long value-recorder'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == SUMMARY
+        assert third.points.size() == 1
+        assert third.points[0].count == 1
+        assert third.points[0].sum == 345
+        assert third.points[0].percentileValues[0].percentile == 0
+        assert third.points[0].percentileValues[0].value == 345
+        assert third.points[0].percentileValues[1].percentile == 100
+        assert third.points[0].percentileValues[1].value == 345
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-long-value-recorder'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == SUMMARY
+        assert fourth.points.size() == 1
+        assert fourth.points[0].count == 1
+        assert fourth.points[0].sum == 456
+        assert fourth.points[0].percentileValues[0].percentile == 0
+        assert fourth.points[0].percentileValues[0].value == 456
+        assert fourth.points[0].percentileValues[1].percentile == 100
+        assert fourth.points[0].percentileValues[1].value == 456
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+  def "long value recorder memoization"() {
+    when:
+        def lvrOne = otel.longValueRecorder('lvr', 'long value')
+        lvrOne.record(10, Labels.of('key', 'value'))
+        def lvrTwo = otel.longValueRecorder('lvr', 'long value')
+        lvrTwo.record(-10, Labels.of('key', 'value'))
+
+    then:
+        assert lvrOne.is(lvrTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'lvr'
+        assert metric.descriptor.description == 'long value'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == SUMMARY
+        assert metric.points.size() == 1
+        assert metric.points[0].count == 2
+        assert metric.points[0].sum == 0
+        assert metric.points[0].percentileValues[0].percentile == 0
+        assert metric.points[0].percentileValues[0].value == -10
+        assert metric.points[0].percentileValues[1].percentile == 100
+        assert metric.points[0].percentileValues[1].value == 10
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+}

--- a/instrumentation-core/jmx-metrics/src/test/resources/config.properties
+++ b/instrumentation-core/jmx-metrics/src/test/resources/config.properties
@@ -1,0 +1,9 @@
+otel.jmx.metrics.interval.seconds = 3
+otel.jmx.metrics.exporter.type = otlp
+otel.jmx.metrics.exporter.endpoint = host.testcontainers.internal:55680
+otel.jmx.metrics.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
+otel.jmx.metrics.groovy.script = /app/script.groovy
+
+# these will be overridden by cmd line
+otel.jmx.metrics.username = wrong_username
+otel.jmx.metrics.password = wrong_password

--- a/instrumentation-core/jmx-metrics/src/test/resources/jmxremote.password
+++ b/instrumentation-core/jmx-metrics/src/test/resources/jmxremote.password
@@ -1,0 +1,1 @@
+correctUsername   correctPassword

--- a/instrumentation-core/jmx-metrics/src/test/resources/script.groovy
+++ b/instrumentation-core/jmx-metrics/src/test/resources/script.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.opentelemetry.common.Labels
+
+def loadMatches = otel.queryJmx("org.apache.cassandra.metrics:type=Storage,name=Load")
+def load = loadMatches.first()
+
+def lvr = otel.longValueRecorder(
+        "cassandra.storage.load",
+        "Size, in bytes, of the on disk data size this node manages",
+        "By"
+)
+lvr.record(load.Count, Labels.of("myKey", "myVal"))

--- a/settings.gradle
+++ b/settings.gradle
@@ -160,6 +160,7 @@ include ':instrumentation-core:spring:spring-boot-autoconfigure'
 include ':instrumentation-core:spring:spring-web-3.1'
 include ':instrumentation-core:spring:spring-webflux-5.0'
 include ':instrumentation-core:spring:spring-webmvc-3.1'
+include ':instrumentation-core:jmx-metrics'
 
 include ':instrumentation-core:spring:starters:spring-starter'
 include ':instrumentation-core:spring:starters:jaeger-exporter-starter'


### PR DESCRIPTION
These changes introduce a new generic JMX Metrics groovy script runner and utilities capable of generating custom metrics for arbitrary Java applications with an accessible MBean server.  As such, this is a standalone utility that doesn't incorporate the existing java agent.  It was originally proposed in https://github.com/open-telemetry/opentelemetry-java/pull/1523.

It currently only supports synchronous instruments but asynchronous support is intended to be added shortly.