### PR TITLE
Expand retry of HttpServerTest.setupSpec

### DIFF
--- a/testing-common/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
+++ b/testing-common/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
@@ -20,7 +20,6 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -37,7 +36,6 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Tracer;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
-import java.net.BindException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -183,25 +181,27 @@ public abstract class AgentTestRunner extends AgentSpecification {
 
   /**
    * This is used by setupSpec() methods to auto-retry setup that depends on finding and then using
-   * an available free port, because that kind of setup can fail sporadically with
-   * "java.net.BindException: Address already in use" if the available port gets re-used between
-   * when we find the available port and when we use it.
+   * an available free port, because that kind of setup can fail sporadically if the available port
+   * gets re-used between when we find the available port and when we use it.
    *
    * @param closure the groovy closure to run with retry
    */
-  public static void withRetryOnBindException(final Closure<?> closure) {
-    withRetryOnBindException(closure, 3);
+  public static void withRetryOnAddressAlreadyInUse(final Closure<?> closure) {
+    withRetryOnAddressAlreadyInUse(closure, 3);
   }
 
-  private static void withRetryOnBindException(final Closure<?> closure, final int numRetries) {
+  private static void withRetryOnAddressAlreadyInUse(
+      final Closure<?> closure, final int numRetries) {
     try {
       closure.call();
     } catch (final Throwable t) {
-      if (numRetries == 0 || !(Throwables.getRootCause(t) instanceof BindException)) {
+      // typically this is "java.net.BindException: Address already in use", but also can be
+      // "io.netty.channel.unix.Errors$NativeIoException: bind() failed: Address already in use"
+      if (numRetries == 0 || !t.getMessage().contains("Address already in use")) {
         throw t;
       }
       log.debug("retrying due to bind exception: {}", t.getMessage(), t);
-      withRetryOnBindException(closure, numRetries - 1);
+      withRetryOnAddressAlreadyInUse(closure, numRetries - 1);
     }
   }
 

--- a/testing-common/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
@@ -68,7 +68,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
   URI address
 
   def setupSpec() {
-    withRetryOnBindException({
+    withRetryOnAddressAlreadyInUse({
       setupSpecUnderRetry()
     })
   }


### PR DESCRIPTION
This should help with RatpackForkedHttpServerTest that just failed due to

```
io.netty.channel.unix.Errors$NativeIoException: bind() failed: Address already in use
	at io.netty.channel.unix.Errors.newIOException(Errors.java:109)
	at io.netty.channel.unix.Socket.bind(Socket.java:231)
	at io.netty.channel.epoll.EpollServerSocketChannel.doBind(EpollServerSocketChannel.java:91)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.bind(AbstractChannel.java:554)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.bind(DefaultChannelPipeline.java:1258)
	at io.netty.channel.AbstractChannelHandlerContext.invokeBind(AbstractChannelHandlerContext.java:511)
	at io.netty.channel.AbstractChannelHandlerContext.bind(AbstractChannelHandlerContext.java:496)
	at io.netty.channel.DefaultChannelPipeline.bind(DefaultChannelPipeline.java:980)
	at io.netty.channel.AbstractChannel.bind(AbstractChannel.java:250)
	at io.netty.bootstrap.AbstractBootstrap$2.run(AbstractBootstrap.java:363)
	at io.netty.util.concurrent.SingleThreadEventExecutor.safeExecute(SingleThreadEventExecutor.java:451)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:418)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:306)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:877)
	at ratpack.exec.internal.DefaultExecController$ExecControllerBindingThreadFactory.lambda$newThread$0(DefaultExecController.java:113)
	at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144)
	at java.lang.Thread.run(Thread.java:748)
```

https://16351-210933087-gh.circle-artifacts.com/0/reports/instrumentation/ratpack-1.4/tests/test/classes/server.RatpackForkedHttpServerTest.html