### PR TITLE
Allowing to run nightly job manually

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     # strange schedule to reduce the risk of DDOS GitHub infra
     - cron: "24 3 * * *"
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
As per https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#manually-running-a-workflow