### PR TITLE
Disable local build cache on CI

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -39,7 +39,7 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          command: ./gradlew testJava${{ matrix.java }} --stacktrace
+          command: ./gradlew testJava${{ matrix.java }} --stacktrace -PpushBuildCache=true
           timeout_minutes: 60
           max_attempts: 3
 
@@ -63,7 +63,7 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          command: ./gradlew latestDepTest --stacktrace
+          command: ./gradlew latestDepTest --stacktrace -PpushBuildCache=true
           timeout_minutes: 60
           max_attempts: 3
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ buildCache {
   remote(com.github.burrunan.s3cache.AwsS3BuildCache) {
     region = 'us-west-2'
     bucket = 'opentelemetry-java-instrumentation-gradle-test1'
-    push = isCI
+    push = 'true'.equals(gradle.startParameter.projectProperties.get('pushBuildCache'))
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,9 +20,6 @@ gradleEnterprise {
 apply plugin: 'com.github.burrunan.s3-build-cache'
 
 buildCache {
-  local {
-    enabled = !isCI
-  }
   remote(com.github.burrunan.s3cache.AwsS3BuildCache) {
     region = 'us-west-2'
     bucket = 'opentelemetry-java-instrumentation-gradle-test1'

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,9 @@ gradleEnterprise {
 apply plugin: 'com.github.burrunan.s3-build-cache'
 
 buildCache {
+  local {
+    enabled = !isCI
+  }
   remote(com.github.burrunan.s3cache.AwsS3BuildCache) {
     region = 'us-west-2'
     bucket = 'opentelemetry-java-instrumentation-gradle-test1'


### PR DESCRIPTION
With the addition of the remote build cache, we probably will save by not unnecessarily writing to local build cache / restoring it.