### PR TITLE
Use property to control build cache push instead of CI env variable s…

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -39,7 +39,7 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          command: ./gradlew testJava${{ matrix.java }} --stacktrace -PpushBuildCache=true
+          command: ./gradlew testJava${{ matrix.java }} --stacktrace
           timeout_minutes: 60
           max_attempts: 3
 
@@ -63,7 +63,7 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          command: ./gradlew latestDepTest --stacktrace -PpushBuildCache=true
+          command: ./gradlew latestDepTest --stacktrace
           timeout_minutes: 60
           max_attempts: 3
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -39,7 +39,7 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          command: ./gradlew testJava${{ matrix.java }} --stacktrace
+          command: ./gradlew testJava${{ matrix.java }} --stacktrace -PpushBuildCache=true
           timeout_minutes: 60
           max_attempts: 3
 
@@ -63,7 +63,7 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          command: ./gradlew latestDepTest --stacktrace
+          command: ./gradlew latestDepTest --stacktrace -PpushBuildCache=true
           timeout_minutes: 60
           max_attempts: 3
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,7 @@ buildCache {
   remote(com.github.burrunan.s3cache.AwsS3BuildCache) {
     region = 'us-west-2'
     bucket = 'opentelemetry-java-instrumentation-gradle-test1'
-    push = 'true'.equals(gradle.startParameter.projectProperties.get('pushBuildCache'))
+    push = System.getenv('S3_BUILD_CACHE_ACCESS_KEY_ID') != null
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,7 @@ buildCache {
   remote(com.github.burrunan.s3cache.AwsS3BuildCache) {
     region = 'us-west-2'
     bucket = 'opentelemetry-java-instrumentation-gradle-test1'
-    push = isCI
+    push = 'true'.equals(gradle.startParameter.projectProperties.get('pushBuildCache'))
   }
 }
 


### PR DESCRIPTION
…ince many builds have that set.

I noticed that the builds for non-pushing ones, like the PR build, have an authentication failure at the top. I think it's better to more precisely control the check so we don't have the error message and possible trouble - I'm not sure about this S3 cache in particular, but I've used a cache that would be disabled completely including reads if there is ever an error during an operation.