### PR TITLE
Rename javaagent-bootstrap's Agent class to AgentInitializer

### DIFF
--- a/docs/contributing/javaagent-jar-components.md
+++ b/docs/contributing/javaagent-jar-components.md
@@ -18,14 +18,14 @@ agent](https://docs.oracle.com/javase/7/docs/api/java/lang/instrument/package-su
 This class is loaded during application startup by application classloader.
 Its sole responsibility is to push agent's classes into JVM's bootstrap
 classloader and immediately delegate to
-`io.opentelemetry.javaagent.bootstrap.Agent` (now in the bootstrap class loader)
+`io.opentelemetry.javaagent.bootstrap.AgentInitializer` (now in the bootstrap class loader)
 class from there.
 
 ### Modules that live in the bootstrap class loader
 
 #### `javaagent-bootstrap` module
 
-`io.opentelemetry.javaagent.bootstrap.Agent` and a few other classes that live in the bootstrap class
+`io.opentelemetry.javaagent.bootstrap.AgentInitializer` and a few other classes that live in the bootstrap class
 loader but are not used directly by auto-instrumentation
 
 #### `instrumentation-api` and `auto-api` modules
@@ -56,7 +56,7 @@ host application. This is achieved in the following way:
 folder inside final jar file, called`inst`.
 In addition, the extension of all class files is changed from `class` to `classdata`.
 This ensures that general classloaders cannot find nor load these classes.
-- When `io.opentelemetry.javaagent.bootstrap.Agent` starts up, it creates an
+- When `io.opentelemetry.javaagent.bootstrap.AgentInitializer` starts up, it creates an
 instance of `io.opentelemetry.instrumentation.auto.api.AgentClassLoader`, loads an
 `io.opentelemetry.javaagent.tooling.AgentInstaller` from that `AgentClassLoader`
 and then passes control on to the `AgentInstaller` (now in the

--- a/docs/contributing/javaagent-jar-components.md
+++ b/docs/contributing/javaagent-jar-components.md
@@ -56,7 +56,7 @@ host application. This is achieved in the following way:
 folder inside final jar file, called`inst`.
 In addition, the extension of all class files is changed from `class` to `classdata`.
 This ensures that general classloaders cannot find nor load these classes.
-- When `io.opentelemetry.javaagent.bootstrap.AgentInitializer` starts up, it creates an
+- When `io.opentelemetry.javaagent.bootstrap.AgentInitializer` is invoked, it creates an
 instance of `io.opentelemetry.instrumentation.auto.api.AgentClassLoader`, loads an
 `io.opentelemetry.javaagent.tooling.AgentInstaller` from that `AgentClassLoader`
 and then passes control on to the `AgentInstaller` (now in the

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
@@ -55,7 +55,7 @@ public class AgentInitializer {
   // fields must be managed under class lock
   private static ClassLoader AGENT_CLASSLOADER = null;
 
-  public static void start(Instrumentation inst, URL bootstrapURL) {
+  public static void initialize(Instrumentation inst, URL bootstrapURL) {
     startAgent(inst, bootstrapURL);
 
     boolean appUsingCustomLogManager = isAppUsingCustomLogManager();

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * <p>The intention is for this class to be loaded by bootstrap classloader to make sure we have
  * unimpeded access to the rest of agent parts.
  */
-public class Agent {
+public class AgentInitializer {
 
   private static final String SIMPLE_LOGGER_SHOW_DATE_TIME_PROPERTY =
       "io.opentelemetry.javaagent.slf4j.simpleLogger.showDateTime";
@@ -49,7 +49,7 @@ public class Agent {
     // We can configure logger here because io.opentelemetry.auto.AgentBootstrap doesn't touch
     // it.
     configureLogger();
-    log = LoggerFactory.getLogger(Agent.class);
+    log = LoggerFactory.getLogger(AgentInitializer.class);
   }
 
   // fields must be managed under class lock

--- a/javaagent/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/javaagent/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -71,7 +71,7 @@ public class OpenTelemetryAgent {
           ClassLoader.getSystemClassLoader()
               .loadClass("io.opentelemetry.javaagent.bootstrap.AgentInitializer");
       Method startMethod =
-          agentInitializerClass.getMethod("start", Instrumentation.class, URL.class);
+          agentInitializerClass.getMethod("initialize", Instrumentation.class, URL.class);
       startMethod.invoke(null, inst, bootstrapURL);
     } catch (Throwable ex) {
       // Don't rethrow.  We don't have a log manager here, so just print.

--- a/javaagent/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/javaagent/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -35,7 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Entry point for initializing the agent.
+ * Premain-Class for the OpenTelemetry Java agent.
  *
  * <p>The bootstrap process of the agent is somewhat complicated and care has to be taken to make
  * sure things do not get broken by accident.
@@ -67,10 +67,11 @@ public class OpenTelemetryAgent {
 
       URL bootstrapURL = installBootstrapJar(inst);
 
-      Class<?> agentClass =
+      Class<?> agentInitializerClass =
           ClassLoader.getSystemClassLoader()
-              .loadClass("io.opentelemetry.javaagent.bootstrap.Agent");
-      Method startMethod = agentClass.getMethod("start", Instrumentation.class, URL.class);
+              .loadClass("io.opentelemetry.javaagent.bootstrap.AgentInitializer");
+      Method startMethod =
+          agentInitializerClass.getMethod("start", Instrumentation.class, URL.class);
       startMethod.invoke(null, inst, bootstrapURL);
     } catch (Throwable ex) {
       // Don't rethrow.  We don't have a log manager here, so just print.

--- a/javaagent/src/test/java/io/opentelemetry/auto/test/IntegrationTestUtils.java
+++ b/javaagent/src/test/java/io/opentelemetry/auto/test/IntegrationTestUtils.java
@@ -56,7 +56,7 @@ public class IntegrationTestUtils {
     try {
       Class<?> agentClass =
           ClassLoader.getSystemClassLoader()
-              .loadClass("io.opentelemetry.javaagent.bootstrap.Agent");
+              .loadClass("io.opentelemetry.javaagent.bootstrap.AgentInitializer");
       classloaderField = agentClass.getDeclaredField(fieldName);
       classloaderField.setAccessible(true);
       return (ClassLoader) classloaderField.get(null);

--- a/javaagent/src/test/java/jvmbootstraptest/AgentLoadedChecker.java
+++ b/javaagent/src/test/java/jvmbootstraptest/AgentLoadedChecker.java
@@ -23,7 +23,8 @@ public class AgentLoadedChecker {
   public static void main(String[] args) throws ClassNotFoundException {
     // Empty classloader that delegates to bootstrap
     URLClassLoader emptyClassLoader = new URLClassLoader(new URL[] {}, null);
-    Class agentClass = emptyClassLoader.loadClass("io.opentelemetry.javaagent.bootstrap.Agent");
+    Class agentClass =
+        emptyClassLoader.loadClass("io.opentelemetry.javaagent.bootstrap.AgentInitializer");
 
     if (agentClass.getClassLoader() != null) {
       throw new RuntimeException(


### PR DESCRIPTION
Closes #754 (last item left in that issue)

Renames from `io.opentelemetry.javaagent.bootstrap.Agent` to `io.opentelemetry.javaagent.bootstrap.AgentInitializer`.