### PR TITLE
Use fixed versions for external-annotation tests.

### DIFF
--- a/instrumentation/external-annotations/external-annotations.gradle
+++ b/instrumentation/external-annotations/external-annotations.gradle
@@ -10,19 +10,19 @@ muzzle {
 }
 
 dependencies {
-  testImplementation group: 'com.newrelic.agent.java', name: 'newrelic-api', version: '+'
+  testImplementation group: 'com.newrelic.agent.java', name: 'newrelic-api', version: '5.14.0'
   testImplementation(group: 'io.opentracing.contrib.dropwizard', name: 'dropwizard-opentracing', version: '0.2.2') {
     transitive = false
   }
-  testImplementation group: 'com.signalfx.public', name: 'signalfx-trace-api', version: '+'
+  testImplementation group: 'com.signalfx.public', name: 'signalfx-trace-api', version: '0.48.0-sfx1'
   //Old and new versions of kamon use different packages for Trace annotation
   testImplementation(group: 'io.kamon', name: 'kamon-annotation_2.11', version: '0.6.7') {
     transitive = false
   }
-  testImplementation group: 'io.kamon', name: 'kamon-annotation-api', version: '+'
-  testImplementation group: 'com.appoptics.agent.java', name: 'appoptics-sdk', version: '+'
-  testImplementation group: 'com.tracelytics.agent.java', name: 'tracelytics-api', version: '+'
-  testImplementation(group: 'org.springframework.cloud', name: 'spring-cloud-sleuth-core', version: '+') {
+  testImplementation group: 'io.kamon', name: 'kamon-annotation-api', version: '2.1.4'
+  testImplementation group: 'com.appoptics.agent.java', name: 'appoptics-sdk', version: '6.20.1'
+  testImplementation group: 'com.tracelytics.agent.java', name: 'tracelytics-api', version: '5.0.10'
+  testImplementation(group: 'org.springframework.cloud', name: 'spring-cloud-sleuth-core', version: '2.2.4.RELEASE') {
     transitive = false
   }
 }


### PR DESCRIPTION
We shouldn't have wildcard dependencies in our normal tests, to reduce unrelated breakage on PRs and reduce load during IDE development.

I can add latestdeptests for these if it seems worthwhile, let me know.

For #730