### PR TITLE
Add maven/gradle documentation to manual instrumentation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,29 @@ only supports manual instrumentation using the `opentelemetry-api` version with 
 number as the Java agent you are using. Starting with 1.0.0, the Java agent will start supporting
 multiple (1.0.0+) versions of `opentelemetry-api`.
 
-You can use the OpenTelemetry `getTracer` or the `@WithSpan` annotation to
+You'll need to add a dependency on the `opentelemetry-api` library to get started.
+
+### Maven
+
+```xml
+  <dependencies>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>0.7.0</version>
+    </dependency>
+  </dependencies>
+```
+
+### Gradle
+
+```groovy
+dependencies {
+	compile('io.opentelemetry:opentelemetry-api:0.7.0')
+}
+```
+
+Now you can use the OpenTelemetry `getTracer` or the `@WithSpan` annotation to
 manually instrument your Java application.
 
 ### Configure the OpenTelemetry getTracer

--- a/README.md
+++ b/README.md
@@ -306,6 +306,28 @@ public class MyClass {
 }
 ```
 
+You'll also need to add a dependency for this annotation:
+
+### Maven
+
+```xml
+  <dependencies>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-extension-auto-annotations</artifactId>
+      <version>0.7.0</version>
+    </dependency>
+  </dependencies>
+```
+
+### Gradle
+
+```groovy
+dependencies {
+    compile('io.opentelemetry:opentelemetry-extension-auto-annotations:0.7.0')
+}
+```
+
 Each time the application invokes the annotated method, it creates a span
 that denote its duration and provides any thrown exceptions.
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ You'll need to add a dependency on the `opentelemetry-api` library to get starte
 
 ```groovy
 dependencies {
-	compile('io.opentelemetry:opentelemetry-api:0.7.0')
+    compile('io.opentelemetry:opentelemetry-api:0.7.0')
 }
 ```
 


### PR DESCRIPTION
I had a customer comment that the jump from this README to the Quick Start guide left them confused about what libraries to add (they wound up depending on the SDK and then got lost trying to work with SDK types).  It would be best to be redundant with the base Java README and explicitly spell out here that the `-api` library is how you get started, with the same maven/gradle examples.