### PR TITLE
Fix running single tests

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/aws-sdk-1.11.gradle
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/aws-sdk-1.11.gradle
@@ -25,7 +25,11 @@ testSets {
   // We test older version in separate test set to test newer version and latest deps in the 'default'
   // test dir. Otherwise we get strange warnings in Idea.
   test_before_1_11_106 {
-    dirName = 'test_before_1_11_106'
+    filter {
+      // this is needed because "test.dependsOn test_before_1_11_106", and so without this,
+      // running a single test in the default test set will fail
+      setFailOnNoMatchingTests(false)
+    }
   }
 }
 

--- a/instrumentation/java-concurrent/java-concurrent.gradle
+++ b/instrumentation/java-concurrent/java-concurrent.gradle
@@ -10,7 +10,13 @@ apply plugin: 'org.unbroken-dome.test-sets'
 //}
 
 testSets {
-  slickTest
+  slickTest {
+    filter {
+      // this is needed because "test.dependsOn slickTest", and so without this,
+      // running a single test in the default test set will fail
+      setFailOnNoMatchingTests(false)
+    }
+  }
 }
 
 compileSlickTestGroovy {

--- a/instrumentation/jms-1.1/jms-1.1.gradle
+++ b/instrumentation/jms-1.1/jms-1.1.gradle
@@ -16,6 +16,11 @@ muzzle {
 
 testSets {
   jms2Test {
+    filter {
+      // this is needed because "test.dependsOn jms2Test", and so without this,
+      // running a single test in the default test set will fail
+      setFailOnNoMatchingTests(false)
+    }
   }
 }
 


### PR DESCRIPTION
This fixes issue running single tests from Intellij, e.g.

```
* What went wrong:
Execution failed for task ':instrumentation:jms-1.1:jms2Test'.
> No tests found for given includes: [JMS1Test](filter.includeTestsMatching)
```