### PR TITLE
Try GC logging when building PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Test
         uses: burrunan/gradle-cache-action@v1
+        env:
+          _JAVA_OPTIONS: '-Xlog:gc,gc+heap,gc+cpu::p,uptime,tags -XX:GCTimeLimit=90 -XX:GCHeapFreeLimit=35'
         with:
           job-id: jdk${{ matrix.java }}
           arguments: testJava${{ matrix.java }} --stacktrace

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,7 @@ buildCache {
   remote(com.github.burrunan.s3cache.AwsS3BuildCache) {
     region = 'us-west-2'
     bucket = 'opentelemetry-java-instrumentation-gradle-test1'
-    push = isCI && !System.getenv('S3_BUILD_CACHE_ACCESS_KEY_ID')?.isBlank()
+    push = isCI && System.getenv('S3_BUILD_CACHE_ACCESS_KEY_ID')?.isBlank() == false
   }
 }
 


### PR DESCRIPTION
This is not meant to be merged, however, I wonder if GC logs should be collected by default.

I see there are `build cache timeouts`, which might be related to Gradle process pauses.
Gradle uses 30sec timeout by default:

```java
    public static final String CONNECTION_TIMEOUT_SYSTEM_PROPERTY = "org.gradle.internal.http.connectionTimeout";
    public static final String SOCKET_TIMEOUT_SYSTEM_PROPERTY = "org.gradle.internal.http.socketTimeout";
    public static final int DEFAULT_CONNECTION_TIMEOUT = 30000;
    public static final int DEFAULT_SOCKET_TIMEOUT = 30000;
```

https://scans.gradle.com/s/rd4jzbtbobzq2/performance/buildCache#remote-cache-failures