### PR TITLE
Gradle cache will ignore bootstrap class path for tests

### DIFF
--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/AutoInstrumentationPlugin.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/AutoInstrumentationPlugin.java
@@ -81,9 +81,8 @@ public class AutoInstrumentationPlugin implements Plugin<Project> {
         Arrays.copyOf(
             BOOTSTRAP_PACKAGE_PREFIXES_COPY,
             BOOTSTRAP_PACKAGE_PREFIXES_COPY.length + testBS.length);
-    for (int i = 0; i < testBS.length; ++i) {
-      TEST_BOOTSTRAP_PREFIXES[i + BOOTSTRAP_PACKAGE_PREFIXES_COPY.length] = testBS[i];
-    }
+    System.arraycopy(testBS, 0, TEST_BOOTSTRAP_PREFIXES, BOOTSTRAP_PACKAGE_PREFIXES_COPY.length,
+        testBS.length);
     for (int i = 0; i < TEST_BOOTSTRAP_PREFIXES.length; i++) {
       TEST_BOOTSTRAP_PREFIXES[i] = TEST_BOOTSTRAP_PREFIXES[i].replace('.', '/');
     }
@@ -166,8 +165,8 @@ public class AutoInstrumentationPlugin implements Plugin<Project> {
   }
 
   private static boolean isBootstrapClass(String filePath) {
-    for (int i = 0; i < TEST_BOOTSTRAP_PREFIXES.length; ++i) {
-      if (filePath.startsWith(TEST_BOOTSTRAP_PREFIXES[i])) {
+    for (String testBootstrapPrefix : TEST_BOOTSTRAP_PREFIXES) {
+      if (filePath.startsWith(testBootstrapPrefix)) {
         return true;
       }
     }

--- a/instrumentation/apache-httpasyncclient-4.0/apache-httpasyncclient-4.0.gradle
+++ b/instrumentation/apache-httpasyncclient-4.0/apache-httpasyncclient-4.0.gradle
@@ -16,23 +16,3 @@ muzzle {
 dependencies {
   library group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.0'
 }
-
-//gradle.taskGraph.afterTask { task ->
-//  if (task.name == 'testBootstrapJar') {
-//    StringBuffer taskDetails = new StringBuffer()
-//    taskDetails << """"-------------
-//name:$task.name group:$task.group : $task.description
-//conv:$task.convention.plugins
-//inputs:
-//"""
-//    task.inputs.files.each { it ->
-//      taskDetails << "${it.absolutePath}\n"
-//    }
-//    taskDetails << "outputs:\n"
-//    task.outputs.files.each { it ->
-//      taskDetails << "${it.absolutePath}\n"
-//    }
-//    taskDetails << "-------------"
-//    println taskDetails
-//  }
-//}


### PR DESCRIPTION
Replace direct manipulating of test tasks' `jvmArgs` options with `CommandLineArgumentProvider`, which allowed to ignore bootstrap jar for the purposes of gradle cache calculation. My assumption is that as test task still depends on runtime classpath configuration in the usual gradle way, no harm will be done.