### PR TITLE
Log current thread id and name as span attribute

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AddThreadDetailsSpanProcessor.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AddThreadDetailsSpanProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.javaagent.tooling;
+
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.trace.attributes.SemanticAttributes;
+
+public class AddThreadDetailsSpanProcessor implements SpanProcessor {
+  @Override
+  public void onStart(ReadWriteSpan span) {
+    Thread currentThread = Thread.currentThread();
+    SemanticAttributes.THREAD_ID.set(span, currentThread.getId());
+    SemanticAttributes.THREAD_NAME.set(span, currentThread.getName());
+  }
+
+  @Override
+  public boolean isStartRequired() {
+    return true;
+  }
+
+  @Override
+  public void onEnd(ReadableSpan span) {}
+
+  @Override
+  public boolean isEndRequired() {
+    return false;
+  }
+
+  @Override
+  public void shutdown() {}
+
+  @Override
+  public void forceFlush() {}
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TracerInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TracerInstaller.java
@@ -183,10 +183,14 @@ public class TracerInstaller {
   }
 
   private static void configure() {
+    TracerSdkProvider tracerSdkProvider = OpenTelemetrySdk.getTracerProvider();
+
+    // Register additional thread details logging span processor
+    tracerSdkProvider.addSpanProcessor(new AddThreadDetailsSpanProcessor());
+
     // Execute any user-provided (usually vendor-provided) configuration logic.
     ServiceLoader<TracerCustomizer> serviceLoader =
         ServiceLoader.load(TracerCustomizer.class, TracerInstaller.class.getClassLoader());
-    TracerSdkProvider tracerSdkProvider = OpenTelemetrySdk.getTracerProvider();
     for (TracerCustomizer customizer : serviceLoader) {
       customizer.configure(tracerSdkProvider);
     }

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/AddThreadDetailsSpanProcessorTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/AddThreadDetailsSpanProcessorTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.javaagent.tooling
+
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.trace.attributes.SemanticAttributes
+import spock.lang.Specification
+
+class AddThreadDetailsSpanProcessorTest extends Specification {
+  def span = Mock(ReadWriteSpan)
+
+  def processor = new AddThreadDetailsSpanProcessor()
+
+  def "should require onStart call"() {
+    expect:
+    processor.isStartRequired()
+  }
+
+  def "should set thread attributes on span start"() {
+    given:
+    def currentThreadName = Thread.currentThread().name
+    def currentThreadId = Thread.currentThread().id
+
+    when:
+    processor.onStart(span)
+
+    then:
+    1 * span.setAttribute(SemanticAttributes.THREAD_ID.key(), currentThreadId)
+    1 * span.setAttribute(SemanticAttributes.THREAD_NAME.key(), currentThreadName)
+  }
+}

--- a/testing-common/src/main/groovy/io/opentelemetry/auto/test/InMemoryExporter.java
+++ b/testing-common/src/main/groovy/io/opentelemetry/auto/test/InMemoryExporter.java
@@ -63,8 +63,8 @@ public class InMemoryExporter implements SpanProcessor {
   private final AtomicInteger nextSpanOrder = new AtomicInteger();
 
   @Override
-  public void onStart(ReadWriteSpan readableSpan) {
-    SpanData sd = readableSpan.toSpanData();
+  public void onStart(ReadWriteSpan readWriteSpan) {
+    SpanData sd = readWriteSpan.toSpanData();
     log.debug(
         ">>> SPAN START: {} id={} traceid={} parent={}, library={}",
         sd.getName(),
@@ -73,7 +73,7 @@ public class InMemoryExporter implements SpanProcessor {
         sd.getParentSpanId().toLowerBase16(),
         sd.getInstrumentationLibraryInfo());
     synchronized (tracesLock) {
-      spanOrders.put(readableSpan.getSpanContext().getSpanId(), nextSpanOrder.getAndIncrement());
+      spanOrders.put(readWriteSpan.getSpanContext().getSpanId(), nextSpanOrder.getAndIncrement());
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/942

Changes:
* Bump opentelementry-java versions
* Fix all compilation issues
* Add a new `SpanProcessor` that appends thread attributes to each span