### PR TITLE
Removing some gradle warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import nebula.plugin.release.git.opinion.Strategies
+
 plugins {
   id 'idea'
 
@@ -12,14 +14,14 @@ plugins {
 
   id 'com.dorongold.task-tree' version '1.5'
 
-  id "com.github.johnrengelman.shadow" version "5.2.0"
+  id "com.github.johnrengelman.shadow" version "6.0.0"
 
   id "com.diffplug.gradle.spotless" version "4.3.0"
   id "com.github.spotbugs" version "4.0.1"
 }
 
 release {
-  defaultVersionStrategy = nebula.plugin.release.git.opinion.Strategies.SNAPSHOT
+  defaultVersionStrategy = Strategies.SNAPSHOT
 }
 
 def isCI = System.getenv("CI") != null

--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/AutoInstrumentationPlugin.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/AutoInstrumentationPlugin.java
@@ -151,8 +151,12 @@ public class AutoInstrumentationPlugin implements Plugin<Project> {
   }
 
   private static class BootstrapClasspath implements CommandLineArgumentProvider {
+    private final File bootstrapJar;
+
     @Internal
-    File bootstrapJar;
+    public File getBootstrapJar() {
+      return bootstrapJar;
+    }
 
     public BootstrapClasspath(File bootstrapJar) {
       this.bootstrapJar = bootstrapJar;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,4 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=83fa7c3e5ab84c3c5c4a04fb16947338209efa9aab1f6bf09a5d0e3d2ed87742

--- a/instrumentation/spring/spring-data-1.8/spring-data-1.8.gradle
+++ b/instrumentation/spring/spring-data-1.8/spring-data-1.8.gradle
@@ -1,5 +1,3 @@
-// This file includes software developed at SignalFx
-
 apply from: "$rootDir/gradle/instrumentation.gradle"
 
 muzzle {
@@ -17,12 +15,6 @@ muzzle {
     versions = "[1.2,]"
     extraDependency "org.springframework.data:spring-data-commons:1.8.0.RELEASE"
     assertInverse = true
-  }
-}
-
-testSets {
-  latestDepTest {
-    dirName = 'test'
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -183,7 +183,6 @@ include ":javaagent-exporters:zipkin"
 include ':benchmark'
 include ':benchmark-integration'
 include ':benchmark-integration:jetty-perftest'
-include ':benchmark-integration:play-perftest'
 
 def setBuildFile(project) {
   if (['auto', 'library', 'testing'].contains(project.projectDir.name)) {


### PR DESCRIPTION
More Gradle deprecation warnings fixed. Including removing `perftest-play` from usual build. I don't think `benchmark-integration` is of any use to us atm.