### PR TITLE
Only include dependencies from exporters when there are dupes.

### DIFF
--- a/javaagent/javaagent.gradle
+++ b/javaagent/javaagent.gradle
@@ -42,8 +42,14 @@ CopySpec isolateSpec(Collection<Project> projectsWithShadowJar) {
 shadowJar {
   dependsOn ':instrumentation:shadowJar'
   dependsOn ':javaagent-exporters:shadowJar'
-  def projectsWithShadowJar = [project(':instrumentation'), project(':javaagent-exporters')]
+  def projectsWithShadowJar = [project(':javaagent-exporters'), project(':instrumentation')]
   with isolateSpec(projectsWithShadowJar)
+
+  // Exclude dependencies pulled in from instrumentation that exist in javaagent-exporters.
+  // Instrumentation is in the agent class loader, which is the parent for the exporter classloader
+  // and will be used, removing duplicates can prevent issues when downstream projects repackage the
+  // jar.
+  duplicatesStrategy = 'exclude'
 }
 
 //Includes instrumentations, but not exporters

--- a/javaagent/javaagent.gradle
+++ b/javaagent/javaagent.gradle
@@ -45,10 +45,10 @@ shadowJar {
   def projectsWithShadowJar = [project(':javaagent-exporters'), project(':instrumentation')]
   with isolateSpec(projectsWithShadowJar)
 
-  // Exclude dependencies pulled in from instrumentation that exist in javaagent-exporters.
-  // Instrumentation is in the agent class loader, which is the parent for the exporter classloader
-  // and will be used, removing duplicates can prevent issues when downstream projects repackage the
-  // jar.
+  // Exclude class files pulled in from the javaagent-exporters project that are also pulled in from the
+  // instrumentation project.
+  // Removing duplicates reduces jar size and can prevent issues when downstream projects repackage
+  // the jar.
   duplicatesStrategy = 'exclude'
 }
 


### PR DESCRIPTION
I was having a strange linkage error when trying to update my agent distribution to the latest version (copied at bottom). After comparing my distribution and our published jar, the main difference was that the published jar has two copies of opentelemetry-sdk dependencies, such as guava and grpc-context. I tried adding `exclude` in our build and could reproduce the same linkage error in our smoke tests (have to do `./gradlew :javaagent:clean` first! 😭 ). Then reversing the order we add to the jar fixed it. From what I can tell, when I add a dependency on our published artifact, for whatever reason it seems to only read in the first entry of the file (maybe just by nature of how shadow plugin reads zips).

The root cause should be some sort of dependency hell, but I checked `:instrumentation:dependencies` and `:javaagent-exporters:dependencies` and they both have the same version of grpc-context.

So I don't know if this is the right fix, but I'm out of clues on how to investigate more, but I could confirm that when I built my distribution off of the agent from this PR, the error is gone.

```
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: Exception in thread "BatchSpanProcessor_WorkerThread_1" java.lang.VerifyError: Bad return type
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: Exception Details:
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:   Location:
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     io/grpc/Context$LazyStorage.createStorage(Ljava/util/concurrent/atomic/AtomicReference;)Lio/grpc/Context$Storage; @43: areturn
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:   Reason:
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     Type 'io/grpc/ThreadLocalContextStorage' (current frame, stack[0]) is not assignable to 'io/grpc/Context$Storage' (from method signature)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:   Current Frame:
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     bci: @43
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     flags: { }
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     locals: { 'java/util/concurrent/atomic/AtomicReference', 'java/lang/ClassNotFoundException' }
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     stack: { 'io/grpc/ThreadLocalContextStorage' }
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:   Bytecode:
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     0000000: 121c b800 224c 2b12 07b6 0026 03bd 001e
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     0000010: b600 2a03 bd00 04b6 0030 c000 07b0 4c2a
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     0000020: 2bb6 0036 bb00 3859 b700 39b0 4cbb 003b
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     0000030: 5912 3d2b b700 40bf                    
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:   Exception Handler Table:
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     bci [0, 29] => handler: 30
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     bci [0, 29] => handler: 44
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:   Stackmap Table:
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     same_locals_1_stack_item_frame(@30,Object[#24])
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR:     same_locals_1_stack_item_frame(@44,Object[#26])
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.grpc.Context.storage(Context.java:119)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.grpc.Context.current(Context.java:185)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.grpc.internal.CensusTracingModule$TracingClientInterceptor.interceptCall(CensusTracingModule.java:386)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.grpc.ClientInterceptors$InterceptorChannel.newCall(ClientInterceptors.java:156)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.grpc.internal.CensusStatsModule$StatsClientInterceptor.interceptCall(CensusStatsModule.java:691)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.grpc.ClientInterceptors$InterceptorChannel.newCall(ClientInterceptors.java:156)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.grpc.internal.ManagedChannelImpl.newCall(ManagedChannelImpl.java:826)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.grpc.internal.ForwardingManagedChannel.newCall(ForwardingManagedChannel.java:63)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc$TraceServiceFutureStub.export(TraceServiceGrpc.java:234)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.opentelemetry.exporters.otlp.OtlpGrpcSpanExporter.export(OtlpGrpcSpanExporter.java:122)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.exportCurrentBatch(BatchSpanProcessor.java:267)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.run(BatchSpanProcessor.java:218)
[tc-okhttp-stream-1782617518] INFO io.awsobservability.instrumentation.smoketests.runner.SpringBootSmokeTest - STDERR: 	at java.base/java.lang.Thread.run(Unknown Source)
```