### PR TITLE
spring mvc3 - proper span name in case of sec fail (#718)

### DIFF
--- a/docs/contributing/running-tests.md
+++ b/docs/contributing/running-tests.md
@@ -41,3 +41,7 @@ rule will kick in and do the following:
 This works both for tasks named `test` and `latestDepTest`. But currently
 does not work for other custom test tasks, such as those created by test sets
 plugin.
+
+#### Executing single test
+
+Executing `./gradlew :instrumentation:<INSTRUMENTATION_NAME>:test --tests <GROOVY TEST FILE NAME>` will run only the selected test.

--- a/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/spring-webmvc-3.1-auto.gradle
+++ b/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/spring-webmvc-3.1-auto.gradle
@@ -38,10 +38,11 @@ dependencies {
   testImplementation group: 'org.hibernate', name: 'hibernate-validator', version: '5.4.2.Final'
 
   testImplementation group: 'org.spockframework', name: 'spock-spring', version: "$versions.spock"
+  
+  testLibrary group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '1.5.17.RELEASE'
+  testLibrary group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.5.17.RELEASE'
+  testLibrary group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '1.5.17.RELEASE'
 
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '1.5.17.RELEASE'
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.5.17.RELEASE'
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '1.5.17.RELEASE'
   testImplementation group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version: '2.0.16.RELEASE'
 
   // For spring security

--- a/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/src/test/groovy/test/boot/AppConfig.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/src/test/groovy/test/boot/AppConfig.groovy
@@ -16,29 +16,10 @@
 
 package test.boot
 
-import org.apache.catalina.connector.Connector
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory
-import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory
-import org.springframework.context.annotation.Bean
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 @SpringBootApplication
 class AppConfig extends WebMvcConfigurerAdapter {
 
-  @Bean
-  EmbeddedServletContainerFactory servletContainerFactory() {
-    def factory = new TomcatEmbeddedServletContainerFactory()
-
-    factory.addConnectorCustomizers(
-      new TomcatConnectorCustomizer() {
-        @Override
-        void customize(final Connector connector) {
-          connector.setEnableLookups(true)
-        }
-      })
-
-    return factory
-  }
 }

--- a/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/src/test/groovy/test/boot/SecurityConfig.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/src/test/groovy/test/boot/SecurityConfig.groovy
@@ -18,27 +18,55 @@ package test.boot
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig extends WebSecurityConfigurerAdapter {
-
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
-
-    http
-      .authorizeRequests()
-      .antMatchers("/secure/**").authenticated()
-      .and().formLogin()
-      .and().authenticationProvider(applicationContext.getBean(SavingAuthenticationProvider))
-      .csrf().disable()
-  }
+class SecurityConfig {
 
   @Bean
   SavingAuthenticationProvider savingAuthenticationProvider() {
     return new SavingAuthenticationProvider()
   }
+
+  /**
+   * Following configuration is required for unauthorised call tests (form would redirect, we need 401)
+   */
+  @Configuration
+  @Order(1)
+  static class ApiWebSecurityConfigurationAdapter extends WebSecurityConfigurerAdapter {
+
+    protected void configure(HttpSecurity http) throws Exception {
+      http
+        .csrf().disable()
+        .antMatcher("/basicsecured/**")
+        .authorizeRequests()
+        .antMatchers("/basicsecured/**").authenticated()
+        .and()
+        .httpBasic()
+        .and().authenticationProvider(applicationContext.getBean(SavingAuthenticationProvider));
+    }
+  }
+
+  /**
+   * Following configuration is required in order to get form login, needed by password tests
+   */
+  @Configuration
+  static class FormLoginWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      http
+        .csrf().disable()
+        .authorizeRequests()
+        .antMatchers("/formsecured/**").authenticated()
+        .and()
+        .formLogin()
+        .and().authenticationProvider(applicationContext.getBean(SavingAuthenticationProvider))
+    }
+  }
 }
+

--- a/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/src/test/groovy/test/boot/TestController.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/src/test/groovy/test/boot/TestController.groovy
@@ -37,6 +37,14 @@ import org.springframework.web.servlet.view.RedirectView
 @Controller
 class TestController {
 
+  @RequestMapping("/basicsecured/endpoint")
+  @ResponseBody
+  String secureEndpoint() {
+    HttpServerTest.controller(SUCCESS) {
+      SUCCESS.body
+    }
+  }
+
   @RequestMapping("/success")
   @ResponseBody
   String success() {

--- a/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/src/test/groovy/test/filter/FilteredAppConfig.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/src/test/groovy/test/filter/FilteredAppConfig.groovy
@@ -33,11 +33,7 @@ import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import org.apache.catalina.connector.Connector
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory
-import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.http.HttpInputMessage
 import org.springframework.http.HttpOutputMessage
@@ -68,21 +64,6 @@ class FilteredAppConfig extends WebMvcConfigurerAdapter {
           return [MediaType.TEXT_PLAIN]
         }
       })
-  }
-
-  @Bean
-  EmbeddedServletContainerFactory servletContainerFactory() {
-    def factory = new TomcatEmbeddedServletContainerFactory()
-
-    factory.addConnectorCustomizers(
-      new TomcatConnectorCustomizer() {
-        @Override
-        void customize(final Connector connector) {
-          connector.setEnableLookups(true)
-        }
-      })
-
-    return factory
   }
 
   @Bean

--- a/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/spring-webmvc-3.1-auto/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -22,8 +22,8 @@ import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.PATH
 import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static io.opentelemetry.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.trace.Span.Kind.SERVER
-import static java.util.Collections.singletonMap
 
+import com.google.common.collect.ImmutableMap
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import io.opentelemetry.instrumentation.api.MoreAttributes
@@ -38,7 +38,7 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
   @Override
   ConfigurableApplicationContext startServer(int port) {
     def app = new SpringApplication(FilteredAppConfig, SecurityConfig)
-    app.setDefaultProperties(singletonMap("server.port", port))
+    app.setDefaultProperties(ImmutableMap.of("server.port", port, "server.error.include-message", "always"))
     def context = app.run()
     return context
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -254,13 +254,13 @@ public class AgentInstaller {
     @Override
     public void onComplete(
         String typeName, ClassLoader classLoader, JavaModule module, boolean loaded) {
-      //      log.debug("onComplete {}", typeName);
+      // log.debug("onComplete {}", typeName);
     }
 
     @Override
     public void onDiscovery(
         String typeName, ClassLoader classLoader, JavaModule module, boolean loaded) {
-      //      log.debug("onDiscovery {}", typeName);
+      // log.debug("onDiscovery {}", typeName);
     }
   }
 

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/matcher/AdditionalLibraryIgnoresMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/matcher/AdditionalLibraryIgnoresMatcherTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.javaagent.tooling.matcher
+
+import net.bytebuddy.description.type.TypeDescription
+import spock.lang.Specification
+
+class AdditionalLibraryIgnoresMatcherTest extends Specification {
+
+  def underTest = new AdditionalLibraryIgnoresMatcher()
+
+  def "spring boot - match not instrumented class"() {
+
+    setup:
+    def type = Mock(TypeDescription)
+    type.getActualName() >> typeName
+
+    when:
+    def matches = underTest.matches(type)
+
+    then:
+    matches == true
+
+    where:
+    typeName << ["org.springframework.boot.NotInstrumentedClass",
+                 "org.springframework.boot.embedded.tomcat.NotInstrumentedClass"]
+  }
+
+  def "spring boot - don't match instrumented class"() {
+
+    setup:
+    def type = Mock(TypeDescription)
+    type.getActualName() >> typeName
+
+    when:
+    def matches = underTest.matches(type)
+
+    then:
+    matches == false
+
+    where:
+    typeName << ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext",
+                 "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedWebappClassLoader"]
+  }
+
+  def "spring boot - don't match instrumented inner class"() {
+
+    setup:
+    def type = Mock(TypeDescription)
+    type.getActualName() >> typeName
+
+    when:
+    def matches = underTest.matches(type)
+
+    then:
+    matches == false
+
+    where:
+    typeName << ["org.springframework.boot.autoconfigure.BackgroundPreinitializer\$InnerClass1",
+                 "org.springframework.boot.autoconfigure.condition.OnClassCondition\$ConditionMatch"]
+  }
+}

--- a/testing-common/src/main/groovy/io/opentelemetry/auto/test/InMemoryExporter.java
+++ b/testing-common/src/main/groovy/io/opentelemetry/auto/test/InMemoryExporter.java
@@ -86,11 +86,12 @@ public class InMemoryExporter implements SpanProcessor {
   public void onEnd(ReadableSpan readableSpan) {
     SpanData sd = readableSpan.toSpanData();
     log.debug(
-        "<<< SPAN END: {} id={} traceid={} parent={}, attributes={}",
+        "<<< SPAN END: {} id={} traceid={} parent={}, library={}, attributes={}",
         sd.getName(),
         sd.getSpanId().toLowerBase16(),
         sd.getTraceId().toLowerBase16(),
         sd.getParentSpanId().toLowerBase16(),
+        sd.getInstrumentationLibraryInfo(),
         printSpanAttributes(sd));
     SpanData span = readableSpan.toSpanData();
     synchronized (tracesLock) {

--- a/testing-common/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
@@ -152,6 +152,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     PATH_PARAM("path/123/param", 200, "123"),
     AUTH_REQUIRED("authRequired", 200, null),
     LOGIN("login", 302, null),
+    AUTH_ERROR("basicsecured/endpoint", 401, null)
 
     private final URI uriObj
     private final String path


### PR DESCRIPTION
- fixed the issue - caused by not allowing specific spring boot context implementation (AnnotationConfigServletWebServerApplicationContext) to be instrumented
- added test case for this particular issue
- switched test instrumentation to use spring boot 2 (de facto standard for many years now)
- light refactoring of the AdditionalLibraryIgnoresMatcher
- added instructions for running single test to MD file
- added few missing tests