### PR TITLE
Set instrumentation groups to unique values when using auto/library/t…

### DIFF
--- a/gradle/instrumentation-common.gradle
+++ b/gradle/instrumentation-common.gradle
@@ -74,3 +74,12 @@ if (testLatestDeps) {
     }
   }
 }
+
+if (['auto', 'library', 'testing'].contains(projectDir.name)) {
+  // We don't use this group anywhere in our config, but we need to make sure it is unique per
+  // instrumentation so Gradle doesn't merge projects with same name due to a bug in Gradle.
+  // https://github.com/gradle/gradle/issues/847
+  // In publish.gradle, we set the maven group, which is what matters, to the correct
+  // value.
+  group = "io.opentelemetry.${projectDir.parentFile.name}"
+}

--- a/gradle/instrumentation-library.gradle
+++ b/gradle/instrumentation-library.gradle
@@ -1,8 +1,10 @@
-group = 'io.opentelemetry.instrumentation'
-
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 apply from: "$rootDir/gradle/instrumentation-common.gradle"
+
+ext {
+  mavenGroupId = 'io.opentelemetry.instrumentation'
+}
 
 archivesBaseName = projectDir.parentFile.name
 

--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -6,6 +6,7 @@ apply plugin: 'muzzle'
 
 ext {
   packageInAgentBundle = true
+  mavenGroupId = 'io.opentelemetry.instrumentation.auto'
 }
 
 byteBuddy {

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -10,7 +10,7 @@ apply from: "$rootDir/gradle/codenarc.gradle"
 apply from: "$rootDir/gradle/spotbugs.gradle"
 
 afterEvaluate {
-  if (group == 'io.opentelemetry.instrumentation.auto') {
+  if (group == 'io.opentelemetry.instrumentation.auto' || findProperty('mavenGroupId') == 'io.opentelemetry.instrumentation.auto') {
     archivesBaseName = 'opentelemetry-auto-' + archivesBaseName
   } else {
     archivesBaseName = 'opentelemetry-' + archivesBaseName

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -20,6 +20,10 @@ publishing {
       }
 
       afterEvaluate {
+        def mavenGroupId = project.findProperty('mavenGroupId')
+        if (mavenGroupId) {
+          groupId = mavenGroupId
+        }
         artifactId = artifactPrefix(project, archivesBaseName) + archivesBaseName
       }
 


### PR DESCRIPTION
…esting pattern.

This allows us to keep task / folder names short without running into the Gradle's dedupe bug.

See https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1125#issuecomment-683515183

I realized that until fixing this, the agent is missing some instrumentation like aws-sdk-2.2