### PR TITLE
Fix redisson Nightly build

### DIFF
--- a/instrumentation/redisson-3.0/redisson-3.0.gradle
+++ b/instrumentation/redisson-3.0/redisson-3.0.gradle
@@ -15,6 +15,9 @@ muzzle {
 
 dependencies {
   library group: 'org.redisson', name: 'redisson', version: '3.0.0'
-  testImplementation group: 'org.redisson', name: 'redisson', version: '3.4.3'
   testImplementation group: 'com.github.kstyrc', name: 'embedded-redis', version: '0.6'
+}
+
+test {
+  systemProperty "testLatestDeps", testLatestDeps
 }

--- a/instrumentation/redisson-3.0/redisson-3.0.gradle
+++ b/instrumentation/redisson-3.0/redisson-3.0.gradle
@@ -15,5 +15,6 @@ muzzle {
 
 dependencies {
   library group: 'org.redisson', name: 'redisson', version: '3.0.0'
+  testImplementation group: 'org.redisson', name: 'redisson', version: '3.4.3'
   testImplementation group: 'com.github.kstyrc', name: 'embedded-redis', version: '0.6'
 }

--- a/instrumentation/redisson-3.0/src/main/java/io/opentelemetry/instrumentation/auto/redisson/RedissonClientTracer.java
+++ b/instrumentation/redisson-3.0/src/main/java/io/opentelemetry/instrumentation/auto/redisson/RedissonClientTracer.java
@@ -43,6 +43,9 @@ public class RedissonClientTracer extends DatabaseClientTracer<RedisConnection, 
       for (CommandData commandData : commands) {
         commandStrings.append(commandData.getCommand().getName()).append(";");
       }
+      if (commandStrings.length() > 0) {
+        commandStrings.deleteCharAt(commandStrings.length() - 1);
+      }
       return commandStrings.toString();
     } else if (args instanceof CommandData) {
       return ((CommandData) args).getCommand().getName();

--- a/instrumentation/redisson-3.0/src/test/groovy/RedissonAsyncClientTest.groovy
+++ b/instrumentation/redisson-3.0/src/test/groovy/RedissonAsyncClientTest.groovy
@@ -46,7 +46,7 @@ class RedissonAsyncClientTest extends AgentTestRunner {
   String address = "localhost:" + port
 
   def setupSpec() {
-    if ("true".equals(System.properties.getProperty("testLatestDeps"))) {
+    if (Boolean.getBoolean("testLatestDeps")) {
       // Newer versions of redisson require scheme, older versions forbid it
       address = "redis://" + address
     }

--- a/instrumentation/redisson-3.0/src/test/groovy/RedissonAsyncClientTest.groovy
+++ b/instrumentation/redisson-3.0/src/test/groovy/RedissonAsyncClientTest.groovy
@@ -55,7 +55,7 @@ class RedissonAsyncClientTest extends AgentTestRunner {
 
   def setup() {
     Config config = new Config()
-    config.useSingleServer().setAddress("localhost:" + port)
+    config.useSingleServer().setAddress("redis://localhost:" + port)
     redisson = Redisson.create(config)
     TEST_WRITER.clear()
   }

--- a/instrumentation/redisson-3.0/src/test/groovy/RedissonAsyncClientTest.groovy
+++ b/instrumentation/redisson-3.0/src/test/groovy/RedissonAsyncClientTest.groovy
@@ -42,8 +42,13 @@ class RedissonAsyncClientTest extends AgentTestRunner {
     .port(port).build()
   @Shared
   RedissonClient redisson
+  @Shared
+  String address = "localhost:" + port
 
   def setupSpec() {
+    if ("true".equals(System.properties.getProperty("testLatestDeps"))) {
+      address = "redis://" + address
+    }
     println "Using redis: $redisServer.args"
     redisServer.start()
   }
@@ -55,7 +60,7 @@ class RedissonAsyncClientTest extends AgentTestRunner {
 
   def setup() {
     Config config = new Config()
-    config.useSingleServer().setAddress("redis://localhost:" + port)
+    config.useSingleServer().setAddress(address)
     redisson = Redisson.create(config)
     TEST_WRITER.clear()
   }

--- a/instrumentation/redisson-3.0/src/test/groovy/RedissonAsyncClientTest.groovy
+++ b/instrumentation/redisson-3.0/src/test/groovy/RedissonAsyncClientTest.groovy
@@ -47,6 +47,7 @@ class RedissonAsyncClientTest extends AgentTestRunner {
 
   def setupSpec() {
     if ("true".equals(System.properties.getProperty("testLatestDeps"))) {
+      // Newer versions of redisson require scheme, older versions forbid it
       address = "redis://" + address
     }
     println "Using redis: $redisServer.args"

--- a/instrumentation/redisson-3.0/src/test/groovy/RedissonClientTest.groovy
+++ b/instrumentation/redisson-3.0/src/test/groovy/RedissonClientTest.groovy
@@ -60,7 +60,7 @@ class RedissonClientTest extends AgentTestRunner {
 
   def setup() {
     Config config = new Config()
-    config.useSingleServer().setAddress("localhost:" + port)
+    config.useSingleServer().setAddress("redis://localhost:" + port)
     redisson = Redisson.create(config)
     TEST_WRITER.clear()
   }

--- a/instrumentation/redisson-3.0/src/test/groovy/RedissonClientTest.groovy
+++ b/instrumentation/redisson-3.0/src/test/groovy/RedissonClientTest.groovy
@@ -52,6 +52,7 @@ class RedissonClientTest extends AgentTestRunner {
 
   def setupSpec() {
     if ("true".equals(System.properties.getProperty("testLatestDeps"))) {
+      // Newer versions of redisson require scheme, older versions forbid it
       address = "redis://" + address
     }
     println "Using redis: $redisServer.args"

--- a/instrumentation/redisson-3.0/src/test/groovy/RedissonClientTest.groovy
+++ b/instrumentation/redisson-3.0/src/test/groovy/RedissonClientTest.groovy
@@ -51,7 +51,7 @@ class RedissonClientTest extends AgentTestRunner {
   String address = "localhost:" + port
 
   def setupSpec() {
-    if ("true".equals(System.properties.getProperty("testLatestDeps"))) {
+    if (Boolean.getBoolean("testLatestDeps")) {
       // Newer versions of redisson require scheme, older versions forbid it
       address = "redis://" + address
     }

--- a/instrumentation/redisson-3.0/src/test/groovy/RedissonClientTest.groovy
+++ b/instrumentation/redisson-3.0/src/test/groovy/RedissonClientTest.groovy
@@ -47,8 +47,13 @@ class RedissonClientTest extends AgentTestRunner {
     .port(port).build()
   @Shared
   RedissonClient redisson
+  @Shared
+  String address = "localhost:" + port
 
   def setupSpec() {
+    if ("true".equals(System.properties.getProperty("testLatestDeps"))) {
+      address = "redis://" + address
+    }
     println "Using redis: $redisServer.args"
     redisServer.start()
   }
@@ -60,7 +65,7 @@ class RedissonClientTest extends AgentTestRunner {
 
   def setup() {
     Config config = new Config()
-    config.useSingleServer().setAddress("redis://localhost:" + port)
+    config.useSingleServer().setAddress(address)
     redisson = Redisson.create(config)
     TEST_WRITER.clear()
   }
@@ -113,7 +118,7 @@ class RedissonClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "SET;SET;"
+          operationName "SET;SET"
           spanKind CLIENT
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
@@ -121,7 +126,7 @@ class RedissonClientTest extends AgentTestRunner {
             "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
-            "${SemanticAttributes.DB_STATEMENT.key()}" "SET;SET;"
+            "${SemanticAttributes.DB_STATEMENT.key()}" "SET;SET"
           }
         }
       }


### PR DESCRIPTION
fixes [https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1143](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1143)

The lastest Redisson version only support completely scheme address like `redis://` or `rediss://`, try to update the testcase to fit it.