### PR TITLE
Use ClassValue and full name cache in AWS SDK 1.1

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSClientInstrumentation.java
@@ -54,6 +54,7 @@ public final class AWSClientInstrumentation extends Instrumenter.Default {
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".AwsSdkClientTracer",
+      packageName + ".AwsSdkClientTracer$NamesCache",
       packageName + ".RequestMeta",
       packageName + ".TracingRequestHandler",
     };

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSClientInstrumentation.java
@@ -55,7 +55,6 @@ public final class AWSClientInstrumentation extends Instrumenter.Default {
     return new String[] {
       packageName + ".AwsSdkClientTracer",
       packageName + ".AwsSdkClientTracer$NamesCache",
-      packageName + ".AwsSdkClientTracer$1",
       packageName + ".RequestMeta",
       packageName + ".TracingRequestHandler",
     };

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSClientInstrumentation.java
@@ -55,6 +55,7 @@ public final class AWSClientInstrumentation extends Instrumenter.Default {
     return new String[] {
       packageName + ".AwsSdkClientTracer",
       packageName + ".AwsSdkClientTracer$NamesCache",
+      packageName + ".AwsSdkClientTracer$1",
       packageName + ".RequestMeta",
       packageName + ".TracingRequestHandler",
     };

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSHttpClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSHttpClientInstrumentation.java
@@ -56,7 +56,9 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".AwsSdkClientTracer", packageName + ".RequestMeta",
+      packageName + ".AwsSdkClientTracer",
+      packageName + ".AwsSdkClientTracer$NamesCache",
+      packageName + ".RequestMeta",
     };
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSHttpClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSHttpClientInstrumentation.java
@@ -58,7 +58,6 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Default {
     return new String[] {
       packageName + ".AwsSdkClientTracer",
       packageName + ".AwsSdkClientTracer$NamesCache",
-      packageName + ".AwsSdkClientTracer$1",
       packageName + ".RequestMeta",
     };
   }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSHttpClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AWSHttpClientInstrumentation.java
@@ -58,6 +58,7 @@ public class AWSHttpClientInstrumentation extends Instrumenter.Default {
     return new String[] {
       packageName + ".AwsSdkClientTracer",
       packageName + ".AwsSdkClientTracer$NamesCache",
+      packageName + ".AwsSdkClientTracer$1",
       packageName + ".RequestMeta",
     };
   }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AwsSdkClientTracer.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AwsSdkClientTracer.java
@@ -141,7 +141,7 @@ public class AwsSdkClientTracer extends HttpClientTracer<Request<?>, Request<?>,
     return "io.opentelemetry.auto.aws-sdk-1.11";
   }
 
-  private static class NamesCache extends ClassValue<ConcurrentHashMap<String, String>> {
+  private static final class NamesCache extends ClassValue<ConcurrentHashMap<String, String>> {
     @Override
     protected ConcurrentHashMap<String, String> computeValue(Class<?> type) {
       return new ConcurrentHashMap<>();

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AwsSdkClientTracer.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/instrumentation/auto/awssdk/v1_11/AwsSdkClientTracer.java
@@ -141,7 +141,7 @@ public class AwsSdkClientTracer extends HttpClientTracer<Request<?>, Request<?>,
     return "io.opentelemetry.auto.aws-sdk-1.11";
   }
 
-  private static final class NamesCache extends ClassValue<ConcurrentHashMap<String, String>> {
+  static final class NamesCache extends ClassValue<ConcurrentHashMap<String, String>> {
     @Override
     protected ConcurrentHashMap<String, String> computeValue(Class<?> type) {
       return new ConcurrentHashMap<>();


### PR DESCRIPTION
Alternative to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1089/files#r475355242

I find the `QualifiedNameCache` to bee too complex for a public API, especially the joining functions. One of the reasons it needs to be public is its use in AWS SDK, so I've tried this simpler approach

- AWS SDK client cardinality is guaranteed to be low, `ConcurrentHashMap` is fine
- The actual transformation seems much more readable than having to grok the suffix join functionality IMO