### PR TITLE
mapping redis (jedis) connection net.peer attributes

### DIFF
--- a/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/instrumentation/auto/jedis/v1_4/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/instrumentation/auto/jedis/v1_4/JedisInstrumentation.java
@@ -28,6 +28,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import io.opentelemetry.instrumentation.auto.api.CallDepthThreadLocalMap;
 import io.opentelemetry.instrumentation.auto.api.SpanWithScope;
 import io.opentelemetry.javaagent.tooling.Instrumenter;
@@ -89,6 +90,7 @@ public final class JedisInstrumentation extends Instrumenter.Default {
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, connection);
       DECORATE.onStatement(span, command.name());
+      NetPeerUtils.setNetPeer(span, connection.getHost(), connection.getPort());
       return new SpanWithScope(span, currentContextWith(span));
     }
 

--- a/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -67,6 +67,9 @@ class JedisClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
           }
         }
       }
@@ -90,6 +93,9 @@ class JedisClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
           }
         }
       }
@@ -101,6 +107,9 @@ class JedisClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
           }
         }
       }
@@ -124,6 +133,9 @@ class JedisClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
           }
         }
       }
@@ -135,6 +147,9 @@ class JedisClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
           }
         }
       }

--- a/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/instrumentation/auto/jedis/v3_0/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/instrumentation/auto/jedis/v3_0/JedisInstrumentation.java
@@ -26,6 +26,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import io.opentelemetry.instrumentation.auto.api.CallDepthThreadLocalMap;
 import io.opentelemetry.instrumentation.auto.api.SpanWithScope;
 import io.opentelemetry.javaagent.tooling.Instrumenter;
@@ -87,10 +88,12 @@ public final class JedisInstrumentation extends Instrumenter.Default {
         // us if that changes
         query = new String(command.getRaw(), StandardCharsets.UTF_8);
       }
+
       Span span = TRACER.spanBuilder(query).setSpanKind(CLIENT).startSpan();
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, connection);
       DECORATE.onStatement(span, query);
+      NetPeerUtils.setNetPeer(span, connection.getHost(), connection.getPort());
       return new SpanWithScope(span, currentContextWith(span));
     }
 

--- a/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -67,6 +67,9 @@ class Jedis30ClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
           }
         }
       }
@@ -90,6 +93,9 @@ class Jedis30ClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
           }
         }
       }
@@ -101,6 +107,9 @@ class Jedis30ClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "GET"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
           }
         }
       }
@@ -124,6 +133,9 @@ class Jedis30ClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "SET"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
           }
         }
       }
@@ -135,6 +147,9 @@ class Jedis30ClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "localhost:$port"
             "${SemanticAttributes.DB_STATEMENT.key()}" "RANDOMKEY"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_NAME.key()}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
           }
         }
       }

--- a/instrumentation/lettuce/lettuce-4.0/src/main/java/io/opentelemetry/instrumentation/auto/lettuce/v4_0/LettuceAbstractDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-4.0/src/main/java/io/opentelemetry/instrumentation/auto/lettuce/v4_0/LettuceAbstractDatabaseClientTracer.java
@@ -21,7 +21,6 @@ import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import io.opentelemetry.instrumentation.auto.api.jdbc.DbSystem;
 import io.opentelemetry.trace.Span;
-import io.opentelemetry.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
 
 public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
@@ -50,9 +49,7 @@ public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
   @Override
   public Span onConnection(Span span, RedisURI connection) {
     if (connection != null) {
-      NetPeerUtils.setNetPeer(span, connection.getHost(), null);
-      span.setAttribute(SemanticAttributes.NET_PEER_PORT.key(), connection.getPort());
-
+      NetPeerUtils.setNetPeer(span, connection.getHost(), connection.getPort());
       span.setAttribute("db.redis.dbIndex", connection.getDatabase());
     }
     return super.onConnection(span, connection);

--- a/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -40,7 +40,7 @@ import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
 
 class LettuceAsyncClientTest extends AgentTestRunner {
-  public static final String HOST = "127.0.0.1"
+  public static final String HOST = "localhost"
   public static final int DB_INDEX = 0
   // Disable autoreconnect so we do not get stray traces popping up on server shutdown
   public static final ClientOptions CLIENT_OPTIONS = new ClientOptions.Builder().autoReconnect(false).build()
@@ -131,6 +131,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errored false
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key()}" HOST
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"
@@ -165,6 +166,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           errorEvent RedisConnectionException, String
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key()}" HOST
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" incorrectPort
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"

--- a/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/src/test/groovy/LettuceSyncClientTest.groovy
@@ -113,6 +113,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errored false
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key()}" HOST
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" port
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"
@@ -145,6 +146,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
           errorEvent RedisConnectionException, String
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key()}" HOST
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key()}" incorrectPort
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "CONNECT"

--- a/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/instrumentation/auto/lettuce/v5_0/LettuceAbstractDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/instrumentation/auto/lettuce/v5_0/LettuceAbstractDatabaseClientTracer.java
@@ -51,7 +51,9 @@ public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
 
   @Override
   public Span onConnection(Span span, RedisURI connection) {
-    span.setAttribute("db.redis.dbIndex", connection.getDatabase());
+    if (connection != null) {
+      span.setAttribute("db.redis.dbIndex", connection.getDatabase());
+    }
     return super.onConnection(span, connection);
   }
 }


### PR DESCRIPTION
Changes to 
- set net.peer.* semantic attributes for jedis instrumentation.- both 1.4 and 3.0
- utilising existing helper utils 
- making extra effort to resolve address (if hostname, not IP)
- slight refactor of the utils for method delegation

