### PR TITLE
Fix groups / base name for javaagent artifacts

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -10,7 +10,8 @@ apply from: "$rootDir/gradle/codenarc.gradle"
 apply from: "$rootDir/gradle/spotbugs.gradle"
 
 afterEvaluate {
-  if (group == 'io.opentelemetry.instrumentation.auto' || findProperty('mavenGroupId') == 'io.opentelemetry.instrumentation.auto') {
+  if (!archivesBaseName.startsWith('javaagent') &&
+    (group == 'io.opentelemetry.instrumentation.auto' || findProperty('mavenGroupId') == 'io.opentelemetry.instrumentation.auto')) {
     archivesBaseName = 'opentelemetry-auto-' + archivesBaseName
   } else {
     archivesBaseName = 'opentelemetry-' + archivesBaseName

--- a/javaagent-bootstrap/javaagent-bootstrap.gradle
+++ b/javaagent-bootstrap/javaagent-bootstrap.gradle
@@ -1,5 +1,3 @@
-group = 'io.opentelemetry.javaagent'
-
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 

--- a/javaagent-tooling/javaagent-tooling.gradle
+++ b/javaagent-tooling/javaagent-tooling.gradle
@@ -1,5 +1,3 @@
-group = 'io.opentelemetry.javaagent'
-
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 

--- a/javaagent/javaagent.gradle
+++ b/javaagent/javaagent.gradle
@@ -5,7 +5,6 @@ plugins {
 }
 
 description = 'OpenTelemetry Javaagent'
-group = 'io.opentelemetry.javaagent'
 
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"


### PR DESCRIPTION
From what I understand, the intention was

- All javaagent artifacts in group `io.opentelemetry.instrumentation.auto` (our default, so no need to override group in their build files)

- All archives that start with javaagent, including our tooling and exporter modules, should start with `opentelemetry-javaagent` artifact name

While the timing of our snapshots getting moved to `io.opentelemetry` group corresponds to #1145 I can't find what I did there to affect this 🤷 