### PR TITLE
Fix a bug when FieldBackedProvider uses a map and value is set to null

### DIFF
--- a/auto-api/src/main/java/io/opentelemetry/instrumentation/auto/api/WeakMap.java
+++ b/auto-api/src/main/java/io/opentelemetry/instrumentation/auto/api/WeakMap.java
@@ -37,6 +37,8 @@ public interface WeakMap<K, V> {
 
   V computeIfAbsent(K key, ValueSupplier<? super K, ? extends V> supplier);
 
+  V remove(K key);
+
   class Provider {
 
     private static final Logger log = LoggerFactory.getLogger(Provider.class);
@@ -143,6 +145,11 @@ public interface WeakMap<K, V> {
           return value;
         }
       }
+    }
+
+    @Override
+    public V remove(K key) {
+      return map.remove(key);
     }
 
     @Override

--- a/auto-api/src/test/groovy/io/opentelemetry/instrumentation/auto/api/WeakMapTest.groovy
+++ b/auto-api/src/test/groovy/io/opentelemetry/instrumentation/auto/api/WeakMapTest.groovy
@@ -55,6 +55,19 @@ class WeakMapTest extends Specification {
     supplier.counter == 2
   }
 
+  def "remove a value"() {
+    given:
+    weakMap.put('key',  42)
+
+    when:
+    def removed = weakMap.remove('key')
+
+    then:
+    removed == 42
+    weakMap.get('key') == null
+    weakMap.size() == 0
+  }
+
   class CounterSupplier implements WeakMap.ValueSupplier<String, Integer> {
 
     def counter = 0

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/WeakMapSuppliers.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/WeakMapSuppliers.java
@@ -121,6 +121,11 @@ class WeakMapSuppliers {
           }
         }
       }
+
+      @Override
+      public V remove(K key) {
+        return map.remove(key);
+      }
     }
 
     static class Inline implements WeakMap.Implementation {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/context/FieldBackedProvider.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/context/FieldBackedProvider.java
@@ -936,7 +936,11 @@ public class FieldBackedProvider implements InstrumentationContextProvider {
     }
 
     private void mapPut(Object key, Object value) {
-      map.put(key, value);
+      if (value == null) {
+        map.remove(key);
+      } else {
+        map.put(key, value);
+      }
     }
 
     private Object mapSynchronizeInstance(Object key) {

--- a/testing-common/src/test/groovy/context/FieldBackedProviderTest.groovy
+++ b/testing-common/src/test/groovy/context/FieldBackedProviderTest.groovy
@@ -126,6 +126,22 @@ class FieldBackedProviderTest extends AgentTestRunner {
     new UntransformableKeyClass() | _
   }
 
+  def "remove test"() {
+    given:
+    instance1.putContextCount(10)
+
+    when:
+    instance1.removeContextCount()
+
+    then:
+    instance1.getContextCount() == 0
+
+    where:
+    instance1                     | _
+    new KeyClass()                | _
+    new UntransformableKeyClass() | _
+  }
+
   def "works with cglib enhanced instances which duplicates context getter and setter methods"() {
     setup:
     Enhancer enhancer = new Enhancer()


### PR DESCRIPTION
This fixes a small bug that caused `contextStore.put(key, null);` calls to throw NPE when a map-backed context store implementation was used. 