### PR TITLE
Use platformClassLoader as muzzle parent instead of bootstrap.

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -146,7 +146,7 @@ class MuzzlePlugin implements Plugin<Project> {
           toolingProject.getLogger().info('--' + f)
           urls.add(f.toURI().toURL())
         }
-        def loader = new URLClassLoader(urls.toArray(new URL[0]), (ClassLoader) null)
+        def loader = new URLClassLoader(urls.toArray(new URL[0]), ClassLoader.platformClassLoader)
         assert TOOLING_LOADER.compareAndSet(null, loader)
         return TOOLING_LOADER.get()
       } else {


### PR DESCRIPTION
Java 9+ modules are in the platform classloader, not bootstrap. As we only support building on Java 11, there is no need to have a check here I just always use platform classloader.

I confirmed this fixes muzzle on #1121 