### PR TITLE
Remove old kotlin coroutine instrumentation

### DIFF
--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/instrumentation/auto/javaconcurrent/AbstractExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/instrumentation/auto/javaconcurrent/AbstractExecutorInstrumentation.java
@@ -96,7 +96,6 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Defau
         "java.util.concurrent.ForkJoinPool",
         "java.util.concurrent.ScheduledThreadPoolExecutor",
         "java.util.concurrent.ThreadPoolExecutor",
-        "kotlinx.coroutines.scheduling.CoroutineScheduler",
         "org.eclipse.jetty.util.thread.QueuedThreadPool",
         "org.eclipse.jetty.util.thread.ReservedThreadExecutor",
         "org.glassfish.grizzly.threadpool.GrizzlyExecutorService",

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/instrumentation/auto/javaconcurrent/NonStandardExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/instrumentation/auto/javaconcurrent/NonStandardExecutorInstrumentation.java
@@ -44,11 +44,6 @@ public final class NonStandardExecutorInstrumentation extends AbstractExecutorIn
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
     Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-    transformers.put( // kotlinx.coroutines.scheduling.CoroutineScheduler
-        named("dispatch")
-            .and(takesArgument(0, Runnable.class))
-            .and(takesArgument(1, named("kotlinx.coroutines.scheduling.TaskContext"))),
-        JavaExecutorInstrumentation.class.getName() + "$SetExecuteRunnableStateAdvice");
 
     transformers.put( // org.eclipse.jetty.util.thread.QueuedThreadPool
         named("dispatch").and(takesArguments(1)).and(takesArgument(0, Runnable.class)),


### PR DESCRIPTION
I doesn't appear we need this old instrumentation anymore after #1168