### PR TITLE
Lettuce 5.1 - Remove redis args from span attributes for command such as AUTH

### DIFF
--- a/instrumentation/lettuce/lettuce-5.1/src/main/java/io/opentelemetry/instrumentation/auto/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/src/main/java/io/opentelemetry/instrumentation/auto/lettuce/v5_1/OpenTelemetryTracing.java
@@ -29,14 +29,13 @@ import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TracingContextUtils;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
-import reactor.util.annotation.Nullable;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import reactor.util.annotation.Nullable;
 
 public enum OpenTelemetryTracing implements Tracing {
   INSTANCE;
@@ -266,7 +265,8 @@ public enum OpenTelemetryTracing implements Tracing {
     public synchronized void finish() {
       if (span != null) {
         if (name != null) {
-          String statement = (args != null && !args.isEmpty()) && !name.equals("AUTH") ? name + " " + args : name;
+          String statement =
+              (args != null && !args.isEmpty()) && !name.equals("AUTH") ? name + " " + args : name;
           SemanticAttributes.DB_STATEMENT.set(span, statement);
         }
         span.end();

--- a/instrumentation/lettuce/lettuce-5.1/src/main/java/io/opentelemetry/instrumentation/auto/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/src/main/java/io/opentelemetry/instrumentation/auto/lettuce/v5_1/OpenTelemetryTracing.java
@@ -29,13 +29,14 @@ import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Status;
 import io.opentelemetry.trace.TracingContextUtils;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
+import reactor.util.annotation.Nullable;
+
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import reactor.util.annotation.Nullable;
 
 public enum OpenTelemetryTracing implements Tracing {
   INSTANCE;
@@ -265,7 +266,7 @@ public enum OpenTelemetryTracing implements Tracing {
     public synchronized void finish() {
       if (span != null) {
         if (name != null) {
-          String statement = args != null && !args.isEmpty() ? name + " " + args : name;
+          String statement = (args != null && !args.isEmpty()) && !name.equals("AUTH") ? name + " " + args : name;
           SemanticAttributes.DB_STATEMENT.set(span, statement);
         }
         span.end();

--- a/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/instrumentation/auto/lettuce/v5_1/LettuceSyncClientAuthTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/instrumentation/auto/lettuce/v5_1/LettuceSyncClientAuthTest.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.instrumentation.auto.lettuce.v5_1
+
+import io.lettuce.core.ClientOptions
+import io.lettuce.core.RedisClient
+import io.opentelemetry.auto.test.AgentTestRunner
+import io.opentelemetry.auto.test.utils.PortUtils
+import io.opentelemetry.trace.attributes.SemanticAttributes
+import redis.embedded.RedisServer
+import spock.lang.Shared
+
+import static io.opentelemetry.trace.Span.Kind.CLIENT
+
+class LettuceSyncClientAuthTest extends AgentTestRunner {
+  public static final String HOST = "127.0.0.1"
+  public static final int DB_INDEX = 0
+  // Disable autoreconnect so we do not get stray traces popping up on server shutdown
+  public static final ClientOptions CLIENT_OPTIONS = ClientOptions.builder().autoReconnect(false).build()
+
+  @Shared
+  int port
+  @Shared
+  String password
+  @Shared
+  String dbAddr
+  @Shared
+  String embeddedDbUri
+
+  @Shared
+  RedisServer redisServer
+
+  RedisClient redisClient
+
+  def setupSpec() {
+    port = PortUtils.randomOpenPort()
+    dbAddr = HOST + ":" + port + "/" + DB_INDEX
+    embeddedDbUri = "redis://" + dbAddr
+    password = "password"
+
+    redisServer = RedisServer.builder()
+    // bind to localhost to avoid firewall popup
+      .setting("bind " + HOST)
+    // set max memory to avoid problems in CI
+      .setting("maxmemory 128M")
+    // Set password
+      .setting("requirepass " + password)
+      .port(port).build()
+  }
+
+  def setup() {
+    redisClient = RedisClient.create(embeddedDbUri)
+    redisClient.setOptions(CLIENT_OPTIONS)
+    redisServer.start()
+  }
+
+  def cleanup() {
+    redisServer.stop()
+  }
+
+  def "auth command"() {
+    setup:
+    def res =  redisClient.connect().sync().auth(password)
+
+    expect:
+    res == "OK"
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          operationName "AUTH"
+          spanKind CLIENT
+          errored false
+          attributes {
+            "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" port
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_STATEMENT.key()}" "AUTH"
+          }
+          event(0) {
+            eventName "redis.encode.start"
+          }
+          event(1) {
+            eventName "redis.encode.end"
+          }
+        }
+      }
+    }
+  }
+}

--- a/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/instrumentation/auto/lettuce/v5_1/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/instrumentation/auto/lettuce/v5_1/LettuceSyncClientTest.groovy
@@ -38,7 +38,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
   @Shared
   int port
   @Shared
+  int authRedisPort
+  @Shared
   int incorrectPort
+  @Shared
+  String password
   @Shared
   String dbAddr
   @Shared
@@ -48,10 +52,17 @@ class LettuceSyncClientTest extends AgentTestRunner {
   @Shared
   String embeddedDbUri
   @Shared
+  String dbAddrForAuthServer
+  @Shared
   String embeddedDbLocalhostUri
+  @Shared
+  String embeddedDbUriWithAuth
 
   @Shared
   RedisServer redisServer
+
+  @Shared
+  RedisServer redisServerWithAuth
 
   @Shared
   Map<String, String> testHashMap = [
@@ -66,12 +77,16 @@ class LettuceSyncClientTest extends AgentTestRunner {
 
   def setupSpec() {
     port = PortUtils.randomOpenPort()
+    authRedisPort = PortUtils.randomOpenPort()
     incorrectPort = PortUtils.randomOpenPort()
     dbAddr = HOST + ":" + port + "/" + DB_INDEX
+    dbAddrForAuthServer = HOST + ":" + authRedisPort + "/" + DB_INDEX
     dbAddrNonExistent = HOST + ":" + incorrectPort + "/" + DB_INDEX
     dbUriNonExistent = "redis://" + dbAddrNonExistent
     embeddedDbUri = "redis://" + dbAddr
     embeddedDbLocalhostUri = "redis://localhost:" + port + "/" + DB_INDEX
+    embeddedDbUriWithAuth = "redis://"  + dbAddrForAuthServer
+    password = "password"
 
     redisServer = RedisServer.builder()
     // bind to localhost to avoid firewall popup
@@ -79,12 +94,22 @@ class LettuceSyncClientTest extends AgentTestRunner {
     // set max memory to avoid problems in CI
       .setting("maxmemory 128M")
       .port(port).build()
+
+    redisServerWithAuth = RedisServer.builder()
+    // bind to localhost to avoid firewall popup
+            .setting("bind " + HOST)
+    // set max memory to avoid problems in CI
+            .setting("maxmemory 64M")
+    // Set password
+            .setting("requirepass " + password)
+            .port(authRedisPort).build()
   }
 
   def setup() {
     redisClient = RedisClient.create(embeddedDbUri)
 
     redisServer.start()
+    redisServerWithAuth.start()
     connection = redisClient.connect()
     syncCommands = connection.sync()
 
@@ -99,6 +124,7 @@ class LettuceSyncClientTest extends AgentTestRunner {
   def cleanup() {
     connection.close()
     redisServer.stop()
+    redisServerWithAuth.stop()
   }
 
   def "connect"() {
@@ -340,6 +366,39 @@ class LettuceSyncClientTest extends AgentTestRunner {
             "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$port"
             "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key()}" "HMSET key<user> key<firstname> value<John> key<lastname> value<Doe> key<age> value<53>"
+          }
+          event(0) {
+            eventName "redis.encode.start"
+          }
+          event(1) {
+            eventName "redis.encode.end"
+          }
+        }
+      }
+    }
+  }
+
+  def "auth command"() {
+    setup:
+    RedisClient testConnectionClient = RedisClient.create(embeddedDbUriWithAuth)
+    testConnectionClient.setOptions(CLIENT_OPTIONS)
+    def res =  testConnectionClient.connect().sync().auth(password)
+
+    expect:
+    res == "OK"
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          operationName "AUTH"
+          spanKind CLIENT
+          errored false
+          attributes {
+            "${SemanticAttributes.NET_TRANSPORT.key()}" "IP.TCP"
+            "${SemanticAttributes.NET_PEER_IP.key()}" "127.0.0.1"
+            "${SemanticAttributes.NET_PEER_PORT.key()}" authRedisPort
+            "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "redis://127.0.0.1:$authRedisPort"
+            "${SemanticAttributes.DB_SYSTEM.key()}" "redis"
+            "${SemanticAttributes.DB_STATEMENT.key()}" "AUTH"
           }
           event(0) {
             eventName "redis.encode.start"

--- a/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/instrumentation/auto/lettuce/v5_1/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/src/test/groovy/io/opentelemetry/instrumentation/auto/lettuce/v5_1/LettuceSyncClientTest.groovy
@@ -386,13 +386,16 @@ class LettuceSyncClientTest extends AgentTestRunner {
   def "debug segfault command (returns void) with no argument produces no span"() {
     setup:
     syncCommands.debugSegfault()
+
     expect:
     // lettuce tracing does not trace debug
     assertTraces(0) {}
   }
+
   def "shutdown command (returns void) produces no span"() {
     setup:
     syncCommands.shutdown(false)
+
     expect:
     // lettuce tracing does not trace shutdown
     assertTraces(0) {}


### PR DESCRIPTION
1. Added `name != "AUTH"` check so that args of AUTH command won't be added in `db.statement` attribute value.
2. Added tests only in `LettuceSyncClientTest.groovy`