### PR TITLE
Add otel prefix to excluded classes properties

### DIFF
--- a/docs/suppressing-instrumentation.md
+++ b/docs/suppressing-instrumentation.md
@@ -23,4 +23,4 @@ so that we can try to come up with a better solution to address your need.
 
 | System property       | Environment variable  | Purpose                                                                                           |
 |-----------------------|-----------------------|---------------------------------------------------------------------------------------------------|
-| trace.classes.exclude | TRACE_CLASSES_EXCLUDE | Suppresses all instrumentation for specific classes, format is "my.package.MyClass,my.package2.*" |
+| otel.trace.classes.exclude | OTEL_TRACE_CLASSES_EXCLUDE | Suppresses all instrumentation for specific classes, format is "my.package.MyClass,my.package2.*" |


### PR DESCRIPTION
The documentation doesn't include the property prefix that is required to use this. The change just adds `otel.` and `OTEL_` prefix to the property table.