### PR TITLE
Allow vendor distribution to provide default configuration

### DIFF
--- a/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/config/PropertySource.java
+++ b/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/config/PropertySource.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.javaagent.spi.config;
+
+import java.util.Map;
+
+/**
+ * A service provider that allows to override default OTel agent configuration. Properties returned
+ * by implementations of this interface will be used after the following methods fail to find a
+ * non-empty property value: system properties, environment variables, properties configuration
+ * file.
+ */
+public interface PropertySource {
+  /**
+   * @return all properties whose default values are overridden by this property source. Key of the
+   *     map is the propertyName (same as system property name, e.g. {@code otel.exporter}), value
+   *     is the property value.
+   */
+  Map<String, String> getProperties();
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigBuilder.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigBuilder.java
@@ -78,9 +78,13 @@ public final class ConfigBuilder
     return configMap;
   }
 
-  ConfigBuilder readPropertiesFromAllSources(Properties configurationFile) {
+  ConfigBuilder readPropertiesFromAllSources(
+      Properties spiConfiguration, Properties configurationFile) {
     // ordering from least to most important
-    return readProperties(configurationFile).readEnvironmentVariables().readSystemProperties();
+    return readProperties(spiConfiguration)
+        .readProperties(configurationFile)
+        .readEnvironmentVariables()
+        .readSystemProperties();
   }
 
   @Override


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1213

As an additional benefit, now all SDK `ConfigBuilder`s can use properties from both SPI and the `otel.trace.config` file (which they did not use before).

Needs to be merged after https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1254