### PR TITLE
Use + instead of printf in logging exporter

### DIFF
--- a/javaagent-exporters/logging/src/main/java/io/opentelemetry/javaagent/exporters/logging/LoggingExporter.java
+++ b/javaagent-exporters/logging/src/main/java/io/opentelemetry/javaagent/exporters/logging/LoggingExporter.java
@@ -33,7 +33,8 @@ public class LoggingExporter implements SpanExporter {
   @Override
   public CompletableResultCode export(Collection<SpanData> list) {
     for (SpanData span : list) {
-      System.out.print(prefix + " " + span.getName() + " " + span.getTraceId() + " " + span.getSpanId() + " ");
+      System.out.print(
+          prefix + " " + span.getName() + " " + span.getTraceId() + " " + span.getSpanId() + " ");
       span.getAttributes()
           .forEach(
               new KeyValueConsumer<String, AttributeValue>() {

--- a/javaagent-exporters/logging/src/main/java/io/opentelemetry/javaagent/exporters/logging/LoggingExporter.java
+++ b/javaagent-exporters/logging/src/main/java/io/opentelemetry/javaagent/exporters/logging/LoggingExporter.java
@@ -33,7 +33,7 @@ public class LoggingExporter implements SpanExporter {
   @Override
   public CompletableResultCode export(Collection<SpanData> list) {
     for (SpanData span : list) {
-      System.out.printf("%s %s %s %s", prefix, span.getName(), span.getTraceId(), span.getSpanId());
+      System.out.print(prefix + " " + span.getName() + " " + span.getTraceId() + " " + span.getSpanId() + " ");
       span.getAttributes()
           .forEach(
               new KeyValueConsumer<String, AttributeValue>() {


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

Created from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1246#discussion_r494045579

@trask @iNikem is there any reason why the agent is not using the logging exporter from the SDK? The only difference is that SDK uses JUL and agent directly stdout.


cc) @anuraaga 