### PR TITLE
Limit twilio muzzle range

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ provide the path to a JAR file including an SPI implementation using the system 
 | [Spring Web MVC](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/servlet/mvc/package-summary.html)     | 3.1+                           |
 | [Spring Webflux](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/reactive/package-summary.html)        | 5.0+                           |
 | [Spymemcached](https://github.com/couchbase/spymemcached)                                                                             | 2.12+                          |
-| [Twilio](https://github.com/twilio/twilio-java)                                                                                       | 6.6+                           |
+| [Twilio](https://github.com/twilio/twilio-java)                                                                                       | 6.6+ (not including 8.x yet)   |
 | [Vert.x](https://vertx.io)                                                                                                            | 3.0+                           |
 | [Vert.x RxJava2](https://vertx.io/docs/vertx-rx/java2/)                                                                               | 3.5+                           |
 

--- a/instrumentation/twilio-6.6/twilio-6.6.gradle
+++ b/instrumentation/twilio-6.6/twilio-6.6.gradle
@@ -5,7 +5,7 @@ muzzle {
     group = 'com.twilio.sdk'
     module = 'twilio'
     // this is first version in maven central (there's a 0.0.1 but that is really 7.14.4)
-    versions = "[6.6.9,)"
+    versions = "[6.6.9,8.0.0)"
   }
 }
 
@@ -15,4 +15,6 @@ dependencies {
   testImplementation project(':instrumentation:apache-httpclient:apache-httpclient-4.0')
   // Last version to support Java7
   testImplementation group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version: '2.5.2'
+
+  latestDepTestLibrary group: 'com.twilio.sdk', name: 'twilio', version: '7.+'
 }


### PR DESCRIPTION
twilio 8.0.0 was just released today

there's already a tracking issue to review all instrumentation libraries with latestDepTestLibrary upper limit #749