### PR TITLE
Allow parenting with the AWS Lambda span itself.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -32,7 +32,8 @@ ext {
     checkerFramework    : "3.6.1",
     errorprone          : "2.4.0",
     nullaway            : "0.8.0",
-    autoValue           : "1.7.4"
+    autoValue           : "1.7.4",
+    systemLambda        : "1.1.0",
   ]
 
   deps = [
@@ -73,6 +74,7 @@ ext {
       dependencies.create(group: 'org.objenesis', name: 'objenesis', version: '2.6') // Last version to support Java7
     ],
     groovy                      : "org.codehaus.groovy:groovy-all:${versions.groovy}",
+    systemLambda                : "com.github.stefanbirkner:system-lambda:${versions.systemLambda}",
     testcontainers              : "org.testcontainers:testcontainers:1.12.2",
     testLogging                 : [
       dependencies.create(group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback),

--- a/instrumentation/aws-lambda-1.0/auto/src/main/java/io/opentelemetry/instrumentation/auto/awslambda/v1_0/AbstractAwsLambdaInstrumentation.java
+++ b/instrumentation/aws-lambda-1.0/auto/src/main/java/io/opentelemetry/instrumentation/auto/awslambda/v1_0/AbstractAwsLambdaInstrumentation.java
@@ -19,7 +19,8 @@ public abstract class AbstractAwsLambdaInstrumentation extends Instrumenter.Defa
       packageName + ".AwsLambdaInstrumentationHelper",
       "io.opentelemetry.instrumentation.awslambda.v1_0.AwsLambdaTracer",
       "io.opentelemetry.instrumentation.awslambda.v1_0.AwsLambdaMessageTracer",
-      "io.opentelemetry.instrumentation.awslambda.v1_0.AwsLambdaMessageTracer$MapGetter"
+      "io.opentelemetry.instrumentation.awslambda.v1_0.AwsLambdaUtil",
+      "io.opentelemetry.instrumentation.awslambda.v1_0.AwsLambdaUtil$MapGetter"
     };
   }
 }

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaMessageTracer.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaMessageTracer.java
@@ -7,10 +7,7 @@ package io.opentelemetry.instrumentation.awslambda.v1_0;
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
-import io.grpc.Context;
-import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
@@ -18,12 +15,9 @@ import io.opentelemetry.trace.SpanContext;
 import io.opentelemetry.trace.Tracer;
 import io.opentelemetry.trace.TracingContextUtils;
 import io.opentelemetry.trace.attributes.SemanticAttributes;
-import java.util.Collections;
-import java.util.Map;
 
 public class AwsLambdaMessageTracer extends BaseTracer {
 
-  private static final String AWS_TRACE_HEADER_PROPAGATOR_KEY = "X-Amzn-Trace-Id";
   private static final String AWS_TRACE_HEADER_SQS_ATTRIBUTE_KEY = "AWSTraceHeader";
 
   public AwsLambdaMessageTracer() {}
@@ -82,29 +76,11 @@ public class AwsLambdaMessageTracer extends BaseTracer {
   private void addLinkToMessageParent(SQSMessage message, Span.Builder span) {
     String parentHeader = message.getAttributes().get(AWS_TRACE_HEADER_SQS_ATTRIBUTE_KEY);
     if (parentHeader != null) {
-      SpanContext parentCtx = TracingContextUtils.getSpan(extractParent(parentHeader)).getContext();
+      SpanContext parentCtx =
+          TracingContextUtils.getSpan(AwsLambdaUtil.extractParent(parentHeader)).getContext();
       if (parentCtx.isValid()) {
         span.addLink(parentCtx);
       }
-    }
-  }
-
-  private static Context extractParent(String parentHeader) {
-    return OpenTelemetry.getPropagators()
-        .getTextMapPropagator()
-        .extract(
-            Context.current(),
-            Collections.singletonMap(AWS_TRACE_HEADER_PROPAGATOR_KEY, parentHeader),
-            MapGetter.INSTANCE);
-  }
-
-  private static class MapGetter implements Getter<Map<String, String>> {
-
-    private static final MapGetter INSTANCE = new MapGetter();
-
-    @Override
-    public String get(Map<String, String> map, String s) {
-      return map.get(s);
     }
   }
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
@@ -18,6 +18,8 @@ import io.opentelemetry.trace.attributes.SemanticAttributes;
 
 public class AwsLambdaTracer extends BaseTracer {
 
+  private static final String AWS_TRACE_HEADER_ENV_KEY = "_X_AMZN_TRACE_ID";
+
   public AwsLambdaTracer() {}
 
   public AwsLambdaTracer(Tracer tracer) {
@@ -27,6 +29,12 @@ public class AwsLambdaTracer extends BaseTracer {
   Span.Builder createSpan(Context context) {
     Span.Builder span = tracer.spanBuilder(context.getFunctionName());
     span.setAttribute(SemanticAttributes.FAAS_EXECUTION, context.getAwsRequestId());
+
+    String parentTraceHeader = System.getenv(AWS_TRACE_HEADER_ENV_KEY);
+    if (parentTraceHeader != null) {
+      span.setParent(AwsLambdaUtil.extractParent(parentTraceHeader));
+    }
+
     return span;
   }
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaUtil.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awslambda.v1_0;
+
+import io.grpc.Context;
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
+import java.util.Collections;
+import java.util.Map;
+
+final class AwsLambdaUtil {
+  private static final String AWS_TRACE_HEADER_PROPAGATOR_KEY = "X-Amzn-Trace-Id";
+
+  static Context extractParent(String parentHeader) {
+    return OpenTelemetry.getPropagators()
+        .getTextMapPropagator()
+        .extract(
+            Context.current(),
+            Collections.singletonMap(AWS_TRACE_HEADER_PROPAGATOR_KEY, parentHeader),
+            MapGetter.INSTANCE);
+  }
+
+  private static class MapGetter implements Getter<Map<String, String>> {
+
+    private static final MapGetter INSTANCE = new MapGetter();
+
+    @Override
+    public String get(Map<String, String> map, String s) {
+      return map.get(s);
+    }
+  }
+
+  private AwsLambdaUtil() {}
+}

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTest.groovy
@@ -7,9 +7,22 @@ package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
+import io.opentelemetry.OpenTelemetry
 import io.opentelemetry.auto.test.InstrumentationTestTrait
+import io.opentelemetry.context.propagation.DefaultContextPropagators
+import io.opentelemetry.extensions.trace.propagation.AwsXRayPropagator
+import io.opentelemetry.trace.propagation.HttpTraceContext
 
 class AwsLambdaTest extends AbstractAwsLambdaRequestHandlerTest implements InstrumentationTestTrait {
+
+  // Lambda instrumentation requires XRay propagator to be enabled.
+  static {
+    def propagators = DefaultContextPropagators.builder()
+      .addTextMapPropagator(HttpTraceContext.instance)
+      .addTextMapPropagator(AwsXRayPropagator.instance)
+      .build()
+    OpenTelemetry.setPropagators(propagators)
+  }
 
   def cleanup() {
     assert testWriter.forceFlushCalled()

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTest.groovy
@@ -7,22 +7,9 @@ package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
-import io.opentelemetry.OpenTelemetry
 import io.opentelemetry.auto.test.InstrumentationTestTrait
-import io.opentelemetry.context.propagation.DefaultContextPropagators
-import io.opentelemetry.extensions.trace.propagation.AwsXRayPropagator
-import io.opentelemetry.trace.propagation.HttpTraceContext
 
 class AwsLambdaTest extends AbstractAwsLambdaRequestHandlerTest implements InstrumentationTestTrait {
-
-  // Lambda instrumentation requires XRay propagator to be enabled.
-  static {
-    def propagators = DefaultContextPropagators.builder()
-      .addTextMapPropagator(HttpTraceContext.instance)
-      .addTextMapPropagator(AwsXRayPropagator.instance)
-      .build()
-    OpenTelemetry.setPropagators(propagators)
-  }
 
   def cleanup() {
     assert testWriter.forceFlushCalled()

--- a/instrumentation/aws-lambda-1.0/testing/aws-lambda-1.0-testing.gradle
+++ b/instrumentation/aws-lambda-1.0/testing/aws-lambda-1.0-testing.gradle
@@ -28,4 +28,5 @@ dependencies {
   implementation deps.opentelemetryApi
   implementation deps.opentelemetryTraceProps
   implementation deps.spock
+  implementation deps.systemLambda
 }

--- a/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaRequestHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaRequestHandlerTest.groovy
@@ -94,9 +94,9 @@ abstract class AbstractAwsLambdaRequestHandlerTest extends InstrumentationSpecif
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName("my_function")
-          spanKind SERVER
-          parentId("0000000000000456")
+          name("my_function")
+          kind SERVER
+          parentSpanId("0000000000000456")
           traceId("8a3c60f7d188f8fa79d48a391a778fa6")
           attributes {
             "${SemanticAttributes.FAAS_EXECUTION.key}" "1-22-333"

--- a/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaRequestHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaRequestHandlerTest.groovy
@@ -10,10 +10,23 @@ import static io.opentelemetry.trace.Span.Kind.SERVER
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.github.stefanbirkner.systemlambda.SystemLambda
+import io.opentelemetry.OpenTelemetry
 import io.opentelemetry.auto.test.InstrumentationSpecification
+import io.opentelemetry.context.propagation.DefaultContextPropagators
+import io.opentelemetry.extensions.trace.propagation.AwsXRayPropagator
 import io.opentelemetry.trace.attributes.SemanticAttributes
+import io.opentelemetry.trace.propagation.HttpTraceContext
 
 abstract class AbstractAwsLambdaRequestHandlerTest extends InstrumentationSpecification {
+
+  // Lambda instrumentation requires XRay propagator to be enabled.
+  static {
+    def propagators = DefaultContextPropagators.builder()
+      .addTextMapPropagator(HttpTraceContext.instance)
+      .addTextMapPropagator(AwsXRayPropagator.instance)
+      .build()
+    OpenTelemetry.setPropagators(propagators)
+  }
 
   protected static String doHandleRequest(String input, Context context) {
     if (input == "hello") {


### PR DESCRIPTION
AWS Lambda sets an environment variable with a trace header.

For HTTP requests, this is the header for a span which links back to an original HTTP request, for example from API gateway. For X-Ray users, parenting to this will connect back to the client through intermediate spans exported to X-Ray, while showing lambda processing in between. For non-X-ray users, these intermediate spans won't exist and thus the parent must be the client span itself, not the lambda span so the lambda span needs to be ignored.

For SQS requests, this is the header for a span which is a local root for message processing. It never hurts to parent to this, and links will be added which can be used by other tracing backends without problem.

While I considered adding a special configuration for whether to do this parenting or not, it seems that just configuring the propagator works fine so I documented that behavior instead. It means that if a user isn't using X-ray as a backend but wants to use X-Ray trace propagation format for their HTTP requests, it's not supported - I don't think such a user exists in practice though. Let me know if you have any thoughts.