### PR TITLE
fix and/or ignore spotbugs errors

### DIFF
--- a/auto-api/src/main/java/io/opentelemetry/instrumentation/auto/api/concurrent/State.java
+++ b/auto-api/src/main/java/io/opentelemetry/instrumentation/auto/api/concurrent/State.java
@@ -15,13 +15,7 @@ public class State {
 
   private static final Logger log = LoggerFactory.getLogger(State.class);
 
-  public static ContextStore.Factory<State> FACTORY =
-      new ContextStore.Factory<State>() {
-        @Override
-        public State create() {
-          return new State();
-        }
-      };
+  public static final ContextStore.Factory<State> FACTORY = State::new;
 
   private final AtomicReference<Context> parentContextRef = new AtomicReference<>(null);
 

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -42,11 +42,4 @@
     </Not>
   </Match>
 
-  <Match>
-    <Class name="~TestServlets.*"/>
-    <Not>
-      <Bug code="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/> <!-- can be ignored for servlet doCall() methods in testing -->
-    </Not>
-  </Match>
-
 </FindBugsFilter>

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match>
+    <Class name="io.opentelemetry.instrumentation.auto.jdbc.normalizer.SimpleCharStream"/>
+    <Not>
+      <Bug code="DM_DEFAULT_ENCODING"/> <!-- ignore default encoding for auto-genned class -->
+    </Not>
+  </Match>
+
+  <Match>
+    <Class name="io.opentelemetry.auto.util.gc.GCUtils"/>
+    <Not>
+      <Bug code="DM_GC"/> <!-- forced GC only used in testing -->
+    </Not>
+  </Match>
+
+  <Match>
+    <Class name="~muzzle\.TestClasses.*"/>
+    <Not>
+      <Bug code="MS_SHOULD_BE_FINAL"/> <!-- final field warnings can be ignored for this test class -->
+    </Not>
+  </Match>
+
+  <Match>
+    <Class name="~HttpServletResponseTest\$.*"/>
+    <Not>
+      <Bug code="SE_INNER_CLASS"/> <!-- inner class serialization warning can be ignored for testing purposes -->
+    </Not>
+  </Match>
+
+  <Match>
+    <Class name="~HttpServletTest\$.*"/>
+    <Not>
+      <Bug code="SE_INNER_CLASS"/> <!-- inner class serialization warning can be ignored for testing purposes -->
+    </Not>
+  </Match>
+
+  <Match>
+    <Class name="~SpymemcachedTest\$.*"/>
+    <Not>
+      <Bug code="SE_INNER_CLASS"/> <!-- inner class serialization warning can be ignored for testing purposes -->
+    </Not>
+  </Match>
+
+  <Match>
+    <Class name="~TestServlets.*"/>
+    <Not>
+      <Bug code="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/> <!-- can be ignored for servlet doCall() methods in testing -->
+    </Not>
+  </Match>
+
+</FindBugsFilter>

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -2,44 +2,43 @@
 <FindBugsFilter>
   <Match>
     <Class name="io.opentelemetry.instrumentation.auto.jdbc.normalizer.SimpleCharStream"/>
-    <Not>
-      <Bug code="DM_DEFAULT_ENCODING"/> <!-- ignore default encoding for auto-genned class -->
-    </Not>
+    <Bug pattern="DM_DEFAULT_ENCODING"/> <!-- ignore default encoding for auto-genned class -->
   </Match>
 
   <Match>
     <Class name="io.opentelemetry.auto.util.gc.GCUtils"/>
-    <Not>
-      <Bug code="DM_GC"/> <!-- forced GC only used in testing -->
-    </Not>
+    <Bug pattern="DM_GC"/> <!-- forced GC only used in testing -->
   </Match>
 
   <Match>
     <Class name="~muzzle\.TestClasses.*"/>
-    <Not>
-      <Bug code="MS_SHOULD_BE_FINAL"/> <!-- final field warnings can be ignored for this test class -->
-    </Not>
+    <Bug
+      pattern="MS_SHOULD_BE_FINAL"/> <!-- final field warnings can be ignored for this test class -->
   </Match>
 
   <Match>
     <Class name="~HttpServletResponseTest\$.*"/>
-    <Not>
-      <Bug code="SE_INNER_CLASS"/> <!-- inner class serialization warning can be ignored for testing purposes -->
-    </Not>
+    <Bug
+      pattern="SE_BAD_FIELD_INNER_CLASS"/> <!-- inner class serialization warning can be ignored for testing purposes -->
   </Match>
 
   <Match>
     <Class name="~HttpServletTest\$.*"/>
-    <Not>
-      <Bug code="SE_INNER_CLASS"/> <!-- inner class serialization warning can be ignored for testing purposes -->
-    </Not>
+    <Bug
+      pattern="SE_BAD_FIELD_INNER_CLASS"/> <!-- inner class serialization warning can be ignored for testing purposes -->
   </Match>
 
   <Match>
     <Class name="~SpymemcachedTest\$.*"/>
-    <Not>
-      <Bug code="SE_INNER_CLASS"/> <!-- inner class serialization warning can be ignored for testing purposes -->
-    </Not>
+    <Bug
+      pattern="SE_BAD_FIELD_INNER_CLASS"/> <!-- inner class serialization warning can be ignored for testing purposes -->
+  </Match>
+
+  <Match>
+    <Class name="io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils"/>
+    <Method name="setNetPeer"
+      params="io.opentelemetry.trace.Span,java.lang.String,java.lang.String,int" returns="void"/>
+    <Bug pattern="UC_USELESS_VOID_METHOD"/>
   </Match>
 
 </FindBugsFilter>

--- a/gradle/spotbugs.gradle
+++ b/gradle/spotbugs.gradle
@@ -6,6 +6,7 @@ allprojects {
     reportLevel = "high"
     omitVisitors = ["FindDeadLocalStores"]
     effort = "max"
+    excludeFilter = file("$rootDir/gradle/spotbugs-exclude.xml")
   }
 
 }

--- a/instrumentation/geode-1.4/src/main/java/io/opentelemetry/instrumentation/auto/geode/GeodeTracer.java
+++ b/instrumentation/geode-1.4/src/main/java/io/opentelemetry/instrumentation/auto/geode/GeodeTracer.java
@@ -15,7 +15,7 @@ import java.net.InetSocketAddress;
 import org.apache.geode.cache.Region;
 
 public class GeodeTracer extends DatabaseClientTracer<Region<?, ?>, String> {
-  public static GeodeTracer TRACER = new GeodeTracer();
+  public static final GeodeTracer TRACER = new GeodeTracer();
 
   public Span startSpan(String operation, Region<?, ?> connection, String query) {
     String normalizedQuery = normalizeQuery(query);

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/instrumentation/auto/grpc/common/GrpcHelper.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/instrumentation/auto/grpc/common/GrpcHelper.java
@@ -48,7 +48,9 @@ public final class GrpcHelper {
     String methodName = slash == -1 ? null : fullMethodName.substring(slash + 1);
 
     span.setAttribute(SemanticAttributes.RPC_SERVICE, serviceName);
-    span.setAttribute(SemanticAttributes.RPC_METHOD, methodName);
+    if (methodName != null) {
+      span.setAttribute(SemanticAttributes.RPC_METHOD, methodName);
+    }
 
     if (peerAddress != null) {
       span.setAttribute(SemanticAttributes.NET_PEER_PORT, (long) peerAddress.getPort());

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/instrumentation/auto/ratpack/TracingHandler.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/instrumentation/auto/ratpack/TracingHandler.java
@@ -18,7 +18,7 @@ import ratpack.handling.Context;
 import ratpack.handling.Handler;
 
 public final class TracingHandler implements Handler {
-  public static Handler INSTANCE = new TracingHandler();
+  public static final Handler INSTANCE = new TracingHandler();
 
   /**
    * This constant is copied over from

--- a/instrumentation/servlet/glassfish-testing/src/test/groovy/TestServlets.java
+++ b/instrumentation/servlet/glassfish-testing/src/test/groovy/TestServlets.java
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import groovy.lang.Closure;
 import io.opentelemetry.auto.test.base.HttpServerTest;
+
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.concurrent.Callable;
 
 public class TestServlets {
 
@@ -20,8 +21,9 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          new Closure(null) {
-            public Object doCall() throws Exception {
+          new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
               resp.setContentType("text/plain");
               resp.setStatus(endpoint.getStatus());
               resp.getWriter().print(endpoint.getBody());
@@ -39,8 +41,8 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          new Closure(null) {
-            public Object doCall() throws Exception {
+          new Callable<Object>() {
+            public Object call() throws Exception {
               resp.setContentType("text/plain");
               resp.setStatus(endpoint.getStatus());
               resp.getWriter().print(req.getQueryString());
@@ -58,8 +60,8 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          new Closure(null) {
-            public Object doCall() throws Exception {
+          new Callable<Object>() {
+            public Object call() throws Exception {
               resp.sendRedirect(endpoint.getBody());
               return null;
             }
@@ -75,8 +77,8 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          new Closure(null) {
-            public Object doCall() throws Exception {
+          new Callable<Object>() {
+            public Object call() throws Exception {
               resp.setContentType("text/plain");
               resp.sendError(endpoint.getStatus(), endpoint.getBody());
               return null;
@@ -93,8 +95,8 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          new Closure(null) {
-            public Object doCall() throws Exception {
+          new Callable<Object>() {
+            public Object call() throws Exception {
               throw new Exception(endpoint.getBody());
             }
           });

--- a/instrumentation/servlet/glassfish-testing/src/test/groovy/TestServlets.java
+++ b/instrumentation/servlet/glassfish-testing/src/test/groovy/TestServlets.java
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import groovy.lang.Closure;
 import io.opentelemetry.auto.test.base.HttpServerTest;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -19,11 +20,13 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          () -> {
-            resp.setContentType("text/plain");
-            resp.setStatus(endpoint.getStatus());
-            resp.getWriter().print(endpoint.getBody());
-            return null;
+          new Closure(null) {
+            public Object doCall() throws Exception {
+              resp.setContentType("text/plain");
+              resp.setStatus(endpoint.getStatus());
+              resp.getWriter().print(endpoint.getBody());
+              return null;
+            }
           });
     }
   }
@@ -36,11 +39,13 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          () -> {
-            resp.setContentType("text/plain");
-            resp.setStatus(endpoint.getStatus());
-            resp.getWriter().print(req.getQueryString());
-            return null;
+          new Closure(null) {
+            public Object doCall() throws Exception {
+              resp.setContentType("text/plain");
+              resp.setStatus(endpoint.getStatus());
+              resp.getWriter().print(req.getQueryString());
+              return null;
+            }
           });
     }
   }
@@ -53,9 +58,11 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          () -> {
-            resp.sendRedirect(endpoint.getBody());
-            return null;
+          new Closure(null) {
+            public Object doCall() throws Exception {
+              resp.sendRedirect(endpoint.getBody());
+              return null;
+            }
           });
     }
   }
@@ -68,10 +75,12 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          () -> {
-            resp.setContentType("text/plain");
-            resp.sendError(endpoint.getStatus(), endpoint.getBody());
-            return null;
+          new Closure(null) {
+            public Object doCall() throws Exception {
+              resp.setContentType("text/plain");
+              resp.sendError(endpoint.getStatus(), endpoint.getBody());
+              return null;
+            }
           });
     }
   }
@@ -84,8 +93,10 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          () -> {
-            throw new Exception(endpoint.getBody());
+          new Closure(null) {
+            public Object doCall() throws Exception {
+              throw new Exception(endpoint.getBody());
+            }
           });
     }
   }

--- a/instrumentation/servlet/glassfish-testing/src/test/groovy/TestServlets.java
+++ b/instrumentation/servlet/glassfish-testing/src/test/groovy/TestServlets.java
@@ -4,12 +4,11 @@
  */
 
 import io.opentelemetry.auto.test.base.HttpServerTest;
-
+import java.util.concurrent.Callable;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.concurrent.Callable;
 
 public class TestServlets {
 

--- a/instrumentation/servlet/glassfish-testing/src/test/groovy/TestServlets.java
+++ b/instrumentation/servlet/glassfish-testing/src/test/groovy/TestServlets.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import groovy.lang.Closure;
 import io.opentelemetry.auto.test.base.HttpServerTest;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -20,13 +19,11 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          new Closure(null) {
-            public Object doCall() throws Exception {
-              resp.setContentType("text/plain");
-              resp.setStatus(endpoint.getStatus());
-              resp.getWriter().print(endpoint.getBody());
-              return null;
-            }
+          () -> {
+            resp.setContentType("text/plain");
+            resp.setStatus(endpoint.getStatus());
+            resp.getWriter().print(endpoint.getBody());
+            return null;
           });
     }
   }
@@ -39,13 +36,11 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          new Closure(null) {
-            public Object doCall() throws Exception {
-              resp.setContentType("text/plain");
-              resp.setStatus(endpoint.getStatus());
-              resp.getWriter().print(req.getQueryString());
-              return null;
-            }
+          () -> {
+            resp.setContentType("text/plain");
+            resp.setStatus(endpoint.getStatus());
+            resp.getWriter().print(req.getQueryString());
+            return null;
           });
     }
   }
@@ -58,11 +53,9 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          new Closure(null) {
-            public Object doCall() throws Exception {
-              resp.sendRedirect(endpoint.getBody());
-              return null;
-            }
+          () -> {
+            resp.sendRedirect(endpoint.getBody());
+            return null;
           });
     }
   }
@@ -75,12 +68,10 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          new Closure(null) {
-            public Object doCall() throws Exception {
-              resp.setContentType("text/plain");
-              resp.sendError(endpoint.getStatus(), endpoint.getBody());
-              return null;
-            }
+          () -> {
+            resp.setContentType("text/plain");
+            resp.sendError(endpoint.getStatus(), endpoint.getBody());
+            return null;
           });
     }
   }
@@ -93,10 +84,8 @@ public class TestServlets {
           HttpServerTest.ServerEndpoint.forPath(req.getServletPath());
       HttpServerTest.controller(
           endpoint,
-          new Closure(null) {
-            public Object doCall() throws Exception {
-              throw new Exception(endpoint.getBody());
-            }
+          () -> {
+            throw new Exception(endpoint.getBody());
           });
     }
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfigBuilder.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfigBuilder.java
@@ -12,12 +12,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-public final class ConfigBuilder
-    extends io.opentelemetry.sdk.common.export.ConfigBuilder<ConfigBuilder> {
+public final class AgentConfigBuilder
+    extends io.opentelemetry.sdk.common.export.ConfigBuilder<AgentConfigBuilder> {
   private final Map<String, String> allProperties = new HashMap<>();
 
   @Override
-  public ConfigBuilder readProperties(Properties properties) {
+  public AgentConfigBuilder readProperties(Properties properties) {
     return this.fromConfigMap(normalizedProperties(properties), NamingConvention.DOT);
   }
 
@@ -29,7 +29,7 @@ public final class ConfigBuilder
     return configMap;
   }
 
-  ConfigBuilder readPropertiesFromAllSources(
+  AgentConfigBuilder readPropertiesFromAllSources(
       Properties spiConfiguration, Properties configurationFile) {
     // ordering from least to most important
     return readProperties(spiConfiguration)
@@ -39,7 +39,7 @@ public final class ConfigBuilder
   }
 
   @Override
-  protected ConfigBuilder fromConfigMap(
+  protected AgentConfigBuilder fromConfigMap(
       Map<String, String> configMap, NamingConvention namingConvention) {
     configMap = namingConvention.normalize(configMap);
     allProperties.putAll(configMap);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfigBuilder.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfigBuilder.java
@@ -8,12 +8,12 @@ package io.opentelemetry.javaagent.tooling.config;
 import static io.opentelemetry.instrumentation.api.config.Config.normalizePropertyName;
 
 import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.sdk.common.export.ConfigBuilder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-public final class AgentConfigBuilder
-    extends io.opentelemetry.sdk.common.export.ConfigBuilder<AgentConfigBuilder> {
+public final class AgentConfigBuilder extends ConfigBuilder<AgentConfigBuilder> {
   private final Map<String, String> allProperties = new HashMap<>();
 
   @Override

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigInitializer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigInitializer.java
@@ -9,9 +9,11 @@ import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.spi.config.PropertySource;
 import io.opentelemetry.javaagent.tooling.AgentInstaller;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import org.slf4j.Logger;
@@ -25,7 +27,7 @@ public final class ConfigInitializer {
 
   public static void initialize() {
     Config.internalInitializeConfig(
-        new ConfigBuilder()
+        new AgentConfigBuilder()
             .readPropertiesFromAllSources(loadSpiConfiguration(), loadConfigurationFile())
             .build());
   }
@@ -69,8 +71,9 @@ public final class ConfigInitializer {
       return properties;
     }
 
-    try (FileReader fileReader = new FileReader(configurationFile)) {
-      properties.load(fileReader);
+    try (InputStreamReader reader =
+        new InputStreamReader(new FileInputStream(configurationFile), StandardCharsets.UTF_8)) {
+      properties.load(reader);
     } catch (FileNotFoundException fnf) {
       log.error("Configuration file '{}' not found.", configurationFilePath);
     } catch (IOException ioe) {

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/config/AgentConfigBuilderTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/config/AgentConfigBuilderTest.groovy
@@ -10,7 +10,7 @@ import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import spock.lang.Specification
 
-class ConfigBuilderTest extends Specification {
+class AgentConfigBuilderTest extends Specification {
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
   @Rule
@@ -25,7 +25,7 @@ class ConfigBuilderTest extends Specification {
     spiConfiguration.put("property4", "spi-4")
 
     when:
-    def config = new ConfigBuilder()
+    def config = new AgentConfigBuilder()
       .readPropertiesFromAllSources(spiConfiguration, new Properties())
       .build()
 
@@ -50,7 +50,7 @@ class ConfigBuilderTest extends Specification {
     configurationFile.put("property3", "cf-3")
 
     when:
-    def config = new ConfigBuilder()
+    def config = new AgentConfigBuilder()
       .readPropertiesFromAllSources(spiConfiguration, configurationFile)
       .build()
 
@@ -78,7 +78,7 @@ class ConfigBuilderTest extends Specification {
     environmentVariables.set("property2", "env-2")
 
     when:
-    def config = new ConfigBuilder()
+    def config = new AgentConfigBuilder()
       .readPropertiesFromAllSources(spiConfiguration, configurationFile)
       .build()
 
@@ -108,7 +108,7 @@ class ConfigBuilderTest extends Specification {
     System.setProperty("property1", "sp-1")
 
     when:
-    def config = new ConfigBuilder()
+    def config = new AgentConfigBuilder()
       .readPropertiesFromAllSources(spiConfiguration, configurationFile)
       .build()
 
@@ -132,7 +132,7 @@ class ConfigBuilderTest extends Specification {
     System.setProperty("otel.some-system_property", "value")
 
     when:
-    def config = new ConfigBuilder()
+    def config = new AgentConfigBuilder()
       .readPropertiesFromAllSources(spiConfiguration, configurationFile)
       .build()
 

--- a/javaagent/src/test/java/io/opentelemetry/auto/test/IntegrationTestUtils.java
+++ b/javaagent/src/test/java/io/opentelemetry/auto/test/IntegrationTestUtils.java
@@ -16,6 +16,7 @@ import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -255,7 +256,8 @@ public class IntegrationTestUtils {
     @Override
     public void run() {
       try {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+        BufferedReader reader =
+            new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
         String line = null;
         while ((line = reader.readLine()) != null) {
           if (print) {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PlaySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PlaySmokeTest.groovy
@@ -21,7 +21,7 @@ class PlaySmokeTest extends SmokeTest {
     def request = new Request.Builder().url(url).get().build()
 
     when:
-    def response = CLIENT.newCall(request).execute()
+    def response = client.newCall(request).execute()
     Collection<ExportTraceServiceRequest> traces = waitForTraces()
 
     then:

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PlaySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PlaySmokeTest.groovy
@@ -21,7 +21,7 @@ class PlaySmokeTest extends SmokeTest {
     def request = new Request.Builder().url(url).get().build()
 
     when:
-    def response = client.newCall(request).execute()
+    def response = CLIENT.newCall(request).execute()
     Collection<ExportTraceServiceRequest> traces = waitForTraces()
 
     then:

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
@@ -35,7 +35,7 @@ abstract class SmokeTest extends Specification {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
 
-  protected static final OkHttpClient CLIENT = OkHttpUtils.client()
+  protected static final OkHttpClient client = OkHttpUtils.client()
 
   @Shared
   private Network network = Network.newNetwork()
@@ -97,7 +97,7 @@ abstract class SmokeTest extends Specification {
   }
 
   def cleanup() {
-    CLIENT.newCall(new Request.Builder()
+    client.newCall(new Request.Builder()
       .url("http://localhost:${backend.getMappedPort(8080)}/clear-requests")
       .build())
       .execute()
@@ -149,7 +149,7 @@ abstract class SmokeTest extends Specification {
     long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30)
     String content = "[]"
     while (System.currentTimeMillis() < deadline) {
-      def body = content = CLIENT.newCall(new Request.Builder()
+      def body = content = client.newCall(new Request.Builder()
         .url("http://localhost:${backend.getMappedPort(8080)}/get-requests")
         .build())
         .execute()

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
@@ -35,7 +35,7 @@ abstract class SmokeTest extends Specification {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
 
-  protected static final OkHttpClient client = OkHttpUtils.client()
+  protected static final OkHttpClient CLIENT = OkHttpUtils.client()
 
   @Shared
   private Network network = Network.newNetwork()
@@ -97,7 +97,7 @@ abstract class SmokeTest extends Specification {
   }
 
   def cleanup() {
-    client.newCall(new Request.Builder()
+    CLIENT.newCall(new Request.Builder()
       .url("http://localhost:${backend.getMappedPort(8080)}/clear-requests")
       .build())
       .execute()
@@ -149,7 +149,7 @@ abstract class SmokeTest extends Specification {
     long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30)
     String content = "[]"
     while (System.currentTimeMillis() < deadline) {
-      def body = content = client.newCall(new Request.Builder()
+      def body = content = CLIENT.newCall(new Request.Builder()
         .url("http://localhost:${backend.getMappedPort(8080)}/get-requests")
         .build())
         .execute()

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
@@ -35,7 +35,7 @@ abstract class SmokeTest extends Specification {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
 
-  protected static OkHttpClient client = OkHttpUtils.client()
+  protected static final OkHttpClient CLIENT = OkHttpUtils.client()
 
   @Shared
   private Network network = Network.newNetwork()
@@ -97,7 +97,7 @@ abstract class SmokeTest extends Specification {
   }
 
   def cleanup() {
-    client.newCall(new Request.Builder()
+    CLIENT.newCall(new Request.Builder()
       .url("http://localhost:${backend.getMappedPort(8080)}/clear-requests")
       .build())
       .execute()
@@ -149,7 +149,7 @@ abstract class SmokeTest extends Specification {
     long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30)
     String content = "[]"
     while (System.currentTimeMillis() < deadline) {
-      def body = content = client.newCall(new Request.Builder()
+      def body = content = CLIENT.newCall(new Request.Builder()
         .url("http://localhost:${backend.getMappedPort(8080)}/get-requests")
         .build())
         .execute()

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -30,7 +30,7 @@ class SpringBootSmokeTest extends SmokeTest {
     def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
 
     when:
-    def response = client.newCall(request).execute()
+    def response = CLIENT.newCall(request).execute()
     Collection<ExportTraceServiceRequest> traces = waitForTraces()
 
     then:

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -30,7 +30,7 @@ class SpringBootSmokeTest extends SmokeTest {
     def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
 
     when:
-    def response = CLIENT.newCall(request).execute()
+    def response = client.newCall(request).execute()
     Collection<ExportTraceServiceRequest> traces = waitForTraces()
 
     then:

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootWithSamplingSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootWithSamplingSmokeTest.groovy
@@ -31,7 +31,7 @@ class SpringBootWithSamplingSmokeTest extends SmokeTest {
 
     when:
     for (int i = 1; i <= NUM_TRIES; i++) {
-      client.newCall(request).execute()
+      CLIENT.newCall(request).execute()
     }
     Collection<ExportTraceServiceRequest> traces = waitForTraces()
 

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootWithSamplingSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootWithSamplingSmokeTest.groovy
@@ -31,7 +31,7 @@ class SpringBootWithSamplingSmokeTest extends SmokeTest {
 
     when:
     for (int i = 1; i <= NUM_TRIES; i++) {
-      CLIENT.newCall(request).execute()
+      client.newCall(request).execute()
     }
     Collection<ExportTraceServiceRequest> traces = waitForTraces()
 

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
@@ -23,7 +23,7 @@ class WildflySmokeTest extends SmokeTest {
     def request = new Request.Builder().url(url).get().build()
 
     when:
-    def response = client.newCall(request).execute()
+    def response = CLIENT.newCall(request).execute()
 
     then:
     def responseBodyStr = response.body().string()

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
@@ -23,7 +23,7 @@ class WildflySmokeTest extends SmokeTest {
     def request = new Request.Builder().url(url).get().build()
 
     when:
-    def response = CLIENT.newCall(request).execute()
+    def response = client.newCall(request).execute()
 
     then:
     def responseBodyStr = response.body().string()

--- a/testing-common/src/main/groovy/io/opentelemetry/auto/test/utils/ConfigUtils.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/auto/test/utils/ConfigUtils.groovy
@@ -7,7 +7,7 @@ package io.opentelemetry.auto.test.utils
 
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.instrumentation.api.config.Config
-import io.opentelemetry.javaagent.tooling.config.ConfigBuilder
+import io.opentelemetry.javaagent.tooling.config.AgentConfigBuilder
 import io.opentelemetry.javaagent.tooling.config.ConfigInitializer
 import java.util.concurrent.Callable
 
@@ -18,7 +18,7 @@ class ConfigUtils {
       def existingConfig = Config.get()
       Properties properties = new Properties()
       properties.put(name, value)
-      setConfig(new ConfigBuilder()
+      setConfig(new AgentConfigBuilder()
         .readProperties(existingConfig.asJavaProperties())
         .readProperties(properties)
         .build())


### PR DESCRIPTION
There are a couple of spotbugs complaints that I'd like some feedback on

```
H C NP: Null passed for non-null parameter of io.opentelemetry.trace.Span.setAttribute(AttributeKey, Object) in io.opentelemetry.instrumentation.auto.grpc.common.GrpcHelper.prepareSpan(Span, String, InetSocketAddress, boolean)  Method invoked at GrpcHelper.java:[line 62]
```
API for `setAttribute` strongly advises against `null`. If it's still ok to pass `null` here we can add a spotbugs exclusion otherwise, is an empty string an acceptable value?

---

```
H B Nm: The class name io.opentelemetry.javaagent.tooling.config.ConfigBuilder shadows the simple name of the superclass io.opentelemetry.sdk.common.export.ConfigBuilder  At ConfigBuilder.java:[lines 26-61]
```
I _think_ this can be safely ignored

---

```
H D UC: Method io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils.setNetPeer(Span, String, String, int) seems to be useless  At NetPeerUtils.java:[line 86]
```
This is probably a false positive as it is used in `HttpClientTracer`, do you agree?