### PR TITLE
Sort instrumentations before adding them to ByteBuddy

### DIFF
--- a/instrumentation/external-annotations/src/main/java/io/opentelemetry/instrumentation/auto/traceannotation/TraceConfigInstrumentation.java
+++ b/instrumentation/external-annotations/src/main/java/io/opentelemetry/instrumentation/auto/traceannotation/TraceConfigInstrumentation.java
@@ -68,6 +68,11 @@ public class TraceConfigInstrumentation implements Instrumenter {
     return agentBuilder;
   }
 
+  @Override
+  public int getOrder() {
+    return 0;
+  }
+
   // Not Using AutoService to hook up this instrumentation
   public static class TracerClassInstrumentation extends Default {
     private final String className;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Instrumenter.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Instrumenter.java
@@ -52,7 +52,8 @@ public interface Instrumenter {
   AgentBuilder instrument(AgentBuilder agentBuilder);
 
   /**
-   * Order of adding instrumentation to ByteBuddy.
+   * Order of adding instrumentation to ByteBuddy. For example instrumentation with order 1 runs
+   * after an instrumentation with order 0 (default) matched on the same API.
    *
    * @return the order of adding an instrumentation to ByteBuddy. Default value is 0 - no order.
    */
@@ -146,7 +147,7 @@ public interface Instrumenter {
       return agentBuilder;
     }
 
-    /** @return 0 - no default order. */
+    /** @return 0 - default order. */
     @Override
     public int getOrder() {
       return 0;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Instrumenter.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Instrumenter.java
@@ -51,6 +51,13 @@ public interface Instrumenter {
    */
   AgentBuilder instrument(AgentBuilder agentBuilder);
 
+  /**
+   * Order of adding instrumentation to ByteBuddy.
+   *
+   * @return the order of adding an instrumentation to ByteBuddy. Default value is 0 - no order.
+   */
+  int getOrder();
+
   abstract class Default implements Instrumenter {
 
     private static final Logger log = LoggerFactory.getLogger(Default.class);
@@ -137,6 +144,12 @@ public interface Instrumenter {
                     .advice(entry.getKey(), entry.getValue()));
       }
       return agentBuilder;
+    }
+
+    /** @return 0 - no default order. */
+    @Override
+    public int getOrder() {
+      return 0;
     }
 
     /** Matches classes for which instrumentation is not muzzled. */


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>


Use case: I am adding custom instrumenations that depend on the existing instrumentation from the core (for instance to get the current span).  I want to make sure that the existing instrumentation is added to ByteBuddy before my custom instrumentation.