### PR TITLE
Update README to Java 8 and remove duplicate info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,26 +67,3 @@ See [Debugging](docs/contributing/debugging.md)
 ### Understanding Muzzle
 
 See [Understanding Muzzle](docs/contributing/muzzle.md)
-
-### Maintainers, Approvers and Triagers
-
-Maintainers:
-
-- [Anuraag Agrawal](https://github.com/anuraaga), AWS
-- [Nikita Salnikov-Tarnovski](https://github.com/iNikem), Splunk
-- [Trask Stalnaker](https://github.com/trask), Microsoft
-- [Tyler Benson](https://github.com/tylerbenson), DataDog
-
-Approvers:
-
-- [John Watson](https://github.com/jkwatson), Splunk
-- [Mateusz Rzeszutek](https://github.com/mateuszrzeszutek), Splunk
-
-Triagers:
-
-- [Sergei Malafeev](https://github.com/malafeev), Lightstep
-
-#### Become a Triager, Approver or Maintainer
-
-See the [community membership document](https://github.com/open-telemetry/community/blob/master/community-membership.md)
-in OpenTelemetry community repo.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 # <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OpenTelemetry Instrumentation for Java
 
-This project provides a Java agent JAR that can be attached to any Java 7+
+This project provides a Java agent JAR that can be attached to any Java 8+
 application and dynamically injects bytecode to capture telemetry from a
 number of popular libraries and frameworks.
 The telemetry data can be exported in a variety of formats.


### PR DESCRIPTION
Approver/maintainer info is now on README, no need for duplicate in CONTRIBUTING.