### PR TITLE
Instrument Netty addTask to ensure complete coverage of async Runnables 

### DIFF
--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/instrumentation/auto/javaconcurrent/JavaExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/instrumentation/auto/javaconcurrent/JavaExecutorInstrumentation.java
@@ -50,6 +50,11 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
     transformers.put(
         named("execute").and(takesArgument(0, Runnable.class)).and(takesArguments(1)),
         JavaExecutorInstrumentation.class.getName() + "$SetExecuteRunnableStateAdvice");
+    // Netty uses addTask as the acutal core of their submission; there are non-standard variations like
+    // execute(Runnable,boolean) that aren't caught by standard instrumentation
+    transformers.put(
+        named("addTask").and(takesArgument(0, Runnable.class)).and(takesArguments(1)),
+        JavaExecutorInstrumentation.class.getName() + "$SetExecuteRunnableStateAdvice");
     transformers.put(
         named("execute").and(takesArgument(0, ForkJoinTask.class)),
         JavaExecutorInstrumentation.class.getName() + "$SetJavaForkJoinStateAdvice");

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/instrumentation/auto/javaconcurrent/JavaExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/instrumentation/auto/javaconcurrent/JavaExecutorInstrumentation.java
@@ -50,8 +50,8 @@ public final class JavaExecutorInstrumentation extends AbstractExecutorInstrumen
     transformers.put(
         named("execute").and(takesArgument(0, Runnable.class)).and(takesArguments(1)),
         JavaExecutorInstrumentation.class.getName() + "$SetExecuteRunnableStateAdvice");
-    // Netty uses addTask as the acutal core of their submission; there are non-standard variations like
-    // execute(Runnable,boolean) that aren't caught by standard instrumentation
+    // Netty uses addTask as the acutal core of their submission; there are non-standard variations
+    // like execute(Runnable,boolean) that aren't caught by standard instrumentation
     transformers.put(
         named("addTask").and(takesArgument(0, Runnable.class)).and(takesArguments(1)),
         JavaExecutorInstrumentation.class.getName() + "$SetExecuteRunnableStateAdvice");

--- a/instrumentation/netty/netty-4.1/netty-4.1.gradle
+++ b/instrumentation/netty/netty-4.1/netty-4.1.gradle
@@ -27,7 +27,7 @@ muzzle {
 }
 
 dependencies {
-  library group: 'io.netty', name: 'netty-codec-http', version: '4.1.52.Final'
+  library group: 'io.netty', name: 'netty-codec-http', version: '4.1.0.Final'
 
   testImplementation project(':instrumentation:reactor-3.1')
 
@@ -45,7 +45,7 @@ configurations.testImplementation {
     eachDependency { DependencyResolveDetails details ->
       //specifying a fixed version for all libraries with io.netty' group
       if (details.requested.group == 'io.netty') {
-        details.useVersion "4.1.52.Final"
+        details.useVersion "4.1.0.Final"
       }
     }
   }

--- a/instrumentation/netty/netty-4.1/netty-4.1.gradle
+++ b/instrumentation/netty/netty-4.1/netty-4.1.gradle
@@ -27,7 +27,7 @@ muzzle {
 }
 
 dependencies {
-  library group: 'io.netty', name: 'netty-codec-http', version: '4.1.0.Final'
+  library group: 'io.netty', name: 'netty-codec-http', version: '4.1.52.Final'
 
   testImplementation project(':instrumentation:reactor-3.1')
 
@@ -45,7 +45,7 @@ configurations.testImplementation {
     eachDependency { DependencyResolveDetails details ->
       //specifying a fixed version for all libraries with io.netty' group
       if (details.requested.group == 'io.netty') {
-        details.useVersion "4.1.0.Final"
+        details.useVersion "4.1.52.Final"
       }
     }
   }

--- a/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -26,7 +26,6 @@ import io.netty.handler.codec.http.HttpClientCodec
 import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.HttpMethod
 import io.netty.handler.codec.http.HttpVersion
-import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.auto.netty.v4_1.client.HttpClientTracingHandler
 import java.util.concurrent.ExecutionException
@@ -88,7 +87,7 @@ class Netty41ClientTest extends HttpClientTest {
     EventLoopGroup group = new NioEventLoopGroup()
     Bootstrap b = new Bootstrap()
     b.group(group)
-      .channel(NioSocketChannel.class)
+      .channel(NioSocketChannel)
       .handler(new ChannelInitializer<SocketChannel>() {
         @Override
         protected void initChannel(SocketChannel socketChannel) throws Exception {


### PR DESCRIPTION
We found that certain code paths in RxNetty through vanilla Netty exposed an issue where Netty WriteTasks weren't capturing the correct/any context during submission.  Turns out that newer 4.1 variants of Netty have a backchannel "lazy" execution that uses `execute(Runnable, boolean)`, bypassing the standard `execute(Runnable)`.  Fortunately, all the variants flow through to `addTask(Runnable)`.  

Without the addTask instrumentation addition, the added unit test fails with 3 traces (the second client request shows up under a brand new 3rd trace without any inherited context).