### PR TITLE
Muzzle should recognise mismatch on unimplemented abstract methods at runtime

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCreationPredicate.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCreationPredicate.java
@@ -12,24 +12,25 @@ package io.opentelemetry.javaagent.tooling.muzzle;
  * create references from the method advice and helper classes.
  */
 final class ReferenceCreationPredicate {
-  private static final String REFERENCE_CREATION_PACKAGE = "io.opentelemetry.instrumentation.";
+  // non-shaded packages
+  private static final String AUTO_INSTRUMENTATION_PACKAGE =
+      "io.opentelemetry.instrumentation.auto.";
+  private static final String JAVA_AGENT_TOOLING_PACKAGE = "io.opentelemetry.javaagent.tooling.";
+  private static final String AUTO_INSTRUMENTATION_API_PACKAGE =
+      "io.opentelemetry.instrumentation.auto.api.";
 
-  private static final String JAVA_AGENT_PACKAGE = "io.opentelemetry.javaagent.tooling.";
-
-  private static final String[] REFERENCE_CREATION_PACKAGE_EXCLUDES = {
-    "io.opentelemetry.instrumentation.api.", "io.opentelemetry.instrumentation.auto.api."
-  };
+  // shaded packages
+  private static final String LIBRARY_INSTRUMENTATION_PACKAGE = "io.opentelemetry.instrumentation.";
+  private static final String INSTRUMENTATION_API_PACKAGE = "io.opentelemetry.instrumentation.api.";
 
   static boolean shouldCreateReferenceFor(String className) {
-    if (!className.startsWith(REFERENCE_CREATION_PACKAGE)) {
-      return className.startsWith(JAVA_AGENT_PACKAGE);
+    if (className.startsWith(INSTRUMENTATION_API_PACKAGE)
+        || className.startsWith(AUTO_INSTRUMENTATION_API_PACKAGE)) {
+      return false;
     }
-    for (String exclude : REFERENCE_CREATION_PACKAGE_EXCLUDES) {
-      if (className.startsWith(exclude)) {
-        return false;
-      }
-    }
-    return true;
+    return className.startsWith(AUTO_INSTRUMENTATION_PACKAGE)
+        || className.startsWith(JAVA_AGENT_TOOLING_PACKAGE)
+        || className.startsWith(LIBRARY_INSTRUMENTATION_PACKAGE);
   }
 
   private ReferenceCreationPredicate() {}

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCreationPredicateTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCreationPredicateTest.groovy
@@ -15,9 +15,10 @@ class ReferenceCreationPredicateTest extends Specification {
     ReferenceCreationPredicate.shouldCreateReferenceFor(className)
 
     where:
-    desc                      | className
-    "Instrumentation class"   | "io.opentelemetry.instrumentation.some_instrumentation.Advice"
-    "javaagent-tooling class" | "io.opentelemetry.javaagent.tooling.Constants"
+    desc                            | className
+    "auto instrumentation class"    | "io.opentelemetry.instrumentation.auto.some_instrumentation.Advice"
+    "javaagent-tooling class"       | "io.opentelemetry.javaagent.tooling.Constants"
+    "library instrumentation class" | "io.opentelemetry.instrumentation.LibraryClass"
   }
 
   @Unroll


### PR DESCRIPTION
Fixes #1337

It turns out that `REFERENCE_CREATION_PACKAGE` value at runtime was completely different than at compile time: `relocate` changed the strings it was not supposed to change - see `exclude` below:

```groovy
  // rewrite library instrumentation dependencies
  relocate("io.opentelemetry.instrumentation", "io.opentelemetry.javaagent.shaded.instrumentation") {
    exclude "io.opentelemetry.instrumentation.auto.**"
  }
```

Thanks @pavolloffay for the repro steps!