### PR TITLE
Update suppressing-instrumentation.md

### DIFF
--- a/docs/suppressing-instrumentation.md
+++ b/docs/suppressing-instrumentation.md
@@ -1,7 +1,7 @@
 ## Suppressing specific auto-instrumentation
 
 You can suppress auto-instrumentation of specific libraries by using
-`-Dota.integration.[id].enabled=false`.
+`-Dotel.integration.[id].enabled=false`.
 
 where `id` is the instrumentation `id`:
 


### PR DESCRIPTION
The main readme references the format `-Dotel.integration.<name>.enabled` and I cannot find any references to `ota`.

https://github.com/open-telemetry/opentelemetry-java-instrumentation/search?q=%22ota.integration%22

There are references to `otel` so this appears to be a typo.
https://github.com/open-telemetry/opentelemetry-java-instrumentation/search?q=%22otel.integration%22