### PR TITLE
Fix running tests locally

### DIFF
--- a/instrumentation/akka-context-propagation-2.5/src/test/groovy/AkkaActorTest.groovy
+++ b/instrumentation/akka-context-propagation-2.5/src/test/groovy/AkkaActorTest.groovy
@@ -7,6 +7,18 @@ import io.opentelemetry.auto.test.AgentTestRunner
 
 class AkkaActorTest extends AgentTestRunner {
 
+  // TODO this test doesn't really depend on otel.integration.akka_context_propagation.enabled=true
+  //  but setting this property here is needed when running both this test
+  //  and AkkaExecutorInstrumentationTest in the run, otherwise get
+  //  "class redefinition failed: attempted to change superclass or interfaces"
+  //  on whichever test runs second
+  //  (related question is what's the purpose of this test if it doesn't depend on any of the
+  //  instrumentation in this module, is it just to verify that the instrumentation doesn't break
+  //  this scenario?)
+  static {
+    System.setProperty("otel.integration.akka_context_propagation.enabled", "true")
+  }
+
   def "akka #testMethod"() {
     setup:
     AkkaActors akkaTester = new AkkaActors()


### PR DESCRIPTION
I suspect similar reason as @mateuszrzeszutek mentioned in #1310 why they are passing in CI but not when running locally:

> Why did it work on the CI: we use retries on the CI, but not when running tests locally. I suspect that Gradle only re-ran the failing tests (since that would be the sane thing to do), so with each retry NetPeerUtils would be loaded again, but with different property value. And so on until it passed - we use 5 retries (java.gradle) so that should be enough.