### PR TITLE
Add SPI to configure additional bootstrap package prefixes

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/BootstrapPackagePrefixesHolder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/BootstrapPackagePrefixesHolder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.config;
+
+/**
+ * {@link BootstrapPackagePrefixesHolder} in an utility class that holds package prefixes. The
+ * classes from these packages are pushed to the bootstrap classloader.
+ *
+ * <p>The prefixes are loaded by {@code AgentInstaller} and consumed by classloader instrumentation.
+ * The instrumentation does not have access to the installer, therefore this utility class is used
+ * to share package prefixes.
+ */
+public class BootstrapPackagePrefixesHolder {
+
+  private static String[] bootstrapPrefixes;
+
+  public static String[] getBootstrapPrefixes() {
+    return bootstrapPrefixes;
+  }
+
+  public static void setBootstrapPrefixes(String[] prefixes) {
+    bootstrapPrefixes = prefixes;
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/BootstrapPackagePrefixesHolder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/BootstrapPackagePrefixesHolder.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.api.internal;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * {@link BootstrapPackagePrefixesHolder} is an utility class that holds package prefixes. The
  * classes from these packages are pushed to the bootstrap classloader.
@@ -15,13 +18,17 @@ package io.opentelemetry.instrumentation.api.internal;
  */
 public class BootstrapPackagePrefixesHolder {
 
-  private static String[] bootstrapPrefixes;
+  private static volatile List<String> BOOSTRAP_PACKAGE_PREFIXES;
 
-  public static String[] getBootstrapPrefixes() {
-    return bootstrapPrefixes;
+  public static List<String> getBoostrapPackagePrefixes() {
+    return BOOSTRAP_PACKAGE_PREFIXES;
   }
 
-  public static void setBootstrapPrefixes(String[] prefixes) {
-    bootstrapPrefixes = prefixes;
+  public static void setBoostrapPackagePrefixes(List<String> prefixes) {
+    if (BOOSTRAP_PACKAGE_PREFIXES != null) {
+      // Only possible by misuse of this API, just ignore.
+      return;
+    }
+    BOOSTRAP_PACKAGE_PREFIXES = Collections.unmodifiableList(prefixes);
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/BootstrapPackagePrefixesHolder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/BootstrapPackagePrefixesHolder.java
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.api.config;
+package io.opentelemetry.instrumentation.api.internal;
 
 /**
- * {@link BootstrapPackagePrefixesHolder} in an utility class that holds package prefixes. The
+ * {@link BootstrapPackagePrefixesHolder} is an utility class that holds package prefixes. The
  * classes from these packages are pushed to the bootstrap classloader.
  *
  * <p>The prefixes are loaded by {@code AgentInstaller} and consumed by classloader instrumentation.

--- a/instrumentation/java-classloader/src/main/java/io/opentelemetry/javaagent/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
+++ b/instrumentation/java-classloader/src/main/java/io/opentelemetry/javaagent/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
@@ -89,7 +89,7 @@ public final class ClassLoaderInstrumentation extends Instrumenter.Default {
         return null;
       }
       try {
-        for (String prefix : BootstrapPackagePrefixesHolder.getBootstrapPrefixes()) {
+        for (String prefix : BootstrapPackagePrefixesHolder.getBoostrapPackagePrefixes()) {
           if (name.startsWith(prefix)) {
             try {
               return Class.forName(name, false, null);

--- a/instrumentation/java-classloader/src/main/java/io/opentelemetry/javaagent/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
+++ b/instrumentation/java-classloader/src/main/java/io/opentelemetry/javaagent/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
@@ -18,6 +18,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.BootstrapPackagePrefixesHolder;
 import io.opentelemetry.javaagent.instrumentation.api.CallDepthThreadLocalMap;
 import io.opentelemetry.javaagent.tooling.Constants;
 import io.opentelemetry.javaagent.tooling.Instrumenter;
@@ -88,7 +89,7 @@ public final class ClassLoaderInstrumentation extends Instrumenter.Default {
         return null;
       }
       try {
-        for (String prefix : Constants.BOOTSTRAP_PACKAGE_PREFIXES) {
+        for (String prefix : BootstrapPackagePrefixesHolder.getBootstrapPrefixes()) {
           if (name.startsWith(prefix)) {
             try {
               return Class.forName(name, false, null);

--- a/instrumentation/java-classloader/src/main/java/io/opentelemetry/javaagent/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
+++ b/instrumentation/java-classloader/src/main/java/io/opentelemetry/javaagent/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
@@ -18,7 +18,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.instrumentation.api.config.BootstrapPackagePrefixesHolder;
+import io.opentelemetry.instrumentation.api.internal.BootstrapPackagePrefixesHolder;
 import io.opentelemetry.javaagent.instrumentation.api.CallDepthThreadLocalMap;
 import io.opentelemetry.javaagent.tooling.Constants;
 import io.opentelemetry.javaagent.tooling.Instrumenter;

--- a/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/BootstrapPackagesProvider.java
+++ b/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/BootstrapPackagesProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.spi;
+
+import java.util.List;
+
+/**
+ * A service provider to allow adding classes from specified package prefixes to the bootstrap
+ * classloader. The classes in the bootstrap classloader are available to all instrumentations. This
+ * is useful if large number of custom instrumentations are using functionality from common
+ * packages.
+ */
+public interface BootstrapPackagesProvider {
+
+  /**
+   * Classes from returned package prefixes will be available in the bootstrap classloader.
+   *
+   * @return package prefixes.
+   */
+  List<String> getPackagePrefixes();
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -55,7 +55,7 @@ public class AgentInstaller {
   }
 
   static {
-    BootstrapPackagePrefixesHolder.setBootstrapPrefixes(loadBootstrapPackagesPrefixes());
+    BootstrapPackagePrefixesHolder.setBoostrapPackagePrefixes(loadBootstrapPackagePrefixes());
     // WeakMap is used by other classes below, so we need to register the provider first.
     AgentTooling.registerWeakMapProvider();
     // this needs to be done as early as possible - before the first Config.get() call
@@ -211,7 +211,7 @@ public class AgentInstaller {
     return matcher;
   }
 
-  private static String[] loadBootstrapPackagesPrefixes() {
+  private static List<String> loadBootstrapPackagePrefixes() {
     List<String> bootstrapPackages =
         new ArrayList<>(Arrays.asList(Constants.BOOTSTRAP_PACKAGE_PREFIXES));
     Iterable<BootstrapPackagesProvider> bootstrapPackagesProviders =
@@ -225,7 +225,7 @@ public class AgentInstaller {
           packagePrefixes);
       bootstrapPackages.addAll(packagePrefixes);
     }
-    return bootstrapPackages.toArray(new String[] {});
+    return bootstrapPackages;
   }
 
   static class RedefinitionLoggingListener implements AgentBuilder.RedefinitionStrategy.Listener {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -13,15 +13,18 @@ import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
 import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.config.BootstrapPackagePrefixesHolder;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.instrumentation.api.OpenTelemetrySdkAccess;
 import io.opentelemetry.javaagent.instrumentation.api.OpenTelemetrySdkAccess.ForceFlusher;
 import io.opentelemetry.javaagent.instrumentation.api.SafeServiceLoader;
+import io.opentelemetry.javaagent.spi.BootstrapPackagesProvider;
 import io.opentelemetry.javaagent.tooling.config.ConfigInitializer;
 import io.opentelemetry.javaagent.tooling.context.FieldBackedProvider;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.lang.instrument.Instrumentation;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -52,6 +55,7 @@ public class AgentInstaller {
   }
 
   static {
+    BootstrapPackagePrefixesHolder.setBootstrapPrefixes(loadClassPrefixes());
     // WeakMap is used by other classes below, so we need to register the provider first.
     AgentTooling.registerWeakMapProvider();
     // this needs to be done as early as possible - before the first Config.get() call
@@ -205,6 +209,23 @@ public class AgentInstaller {
       matcher = matcher.or(nameStartsWith(prefix));
     }
     return matcher;
+  }
+
+  private static String[] loadClassPrefixes() {
+    List<String> bootstrapPackages =
+        new ArrayList<>(Arrays.asList(Constants.BOOTSTRAP_PACKAGE_PREFIXES));
+    Iterable<BootstrapPackagesProvider> bootstrapPackagesProviders =
+        SafeServiceLoader.load(
+            BootstrapPackagesProvider.class, AgentInstaller.class.getClassLoader());
+    for (BootstrapPackagesProvider provider : bootstrapPackagesProviders) {
+      List<String> packagePrefixes = provider.getPackagePrefixes();
+      log.debug(
+          "Loaded bootstrap package prefixes from {}: {}",
+          provider.getClass().getName(),
+          packagePrefixes);
+      bootstrapPackages.addAll(packagePrefixes);
+    }
+    return bootstrapPackages.toArray(new String[] {});
   }
 
   static class RedefinitionLoggingListener implements AgentBuilder.RedefinitionStrategy.Listener {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -13,8 +13,8 @@ import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.BootstrapPackagePrefixesHolder;
 import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.instrumentation.api.internal.BootstrapPackagePrefixesHolder;
 import io.opentelemetry.javaagent.instrumentation.api.OpenTelemetrySdkAccess;
 import io.opentelemetry.javaagent.instrumentation.api.OpenTelemetrySdkAccess.ForceFlusher;
 import io.opentelemetry.javaagent.instrumentation.api.SafeServiceLoader;
@@ -55,7 +55,7 @@ public class AgentInstaller {
   }
 
   static {
-    BootstrapPackagePrefixesHolder.setBootstrapPrefixes(loadClassPrefixes());
+    BootstrapPackagePrefixesHolder.setBootstrapPrefixes(loadBootstrapPackagesPrefixes());
     // WeakMap is used by other classes below, so we need to register the provider first.
     AgentTooling.registerWeakMapProvider();
     // this needs to be done as early as possible - before the first Config.get() call
@@ -211,7 +211,7 @@ public class AgentInstaller {
     return matcher;
   }
 
-  private static String[] loadClassPrefixes() {
+  private static String[] loadBootstrapPackagesPrefixes() {
     List<String> bootstrapPackages =
         new ArrayList<>(Arrays.asList(Constants.BOOTSTRAP_PACKAGE_PREFIXES));
     Iterable<BootstrapPackagesProvider> bootstrapPackagesProviders =


### PR DESCRIPTION
This feature is useful when a large set of custom instrumentations is
using common classes from a custom package.

cc) @trask 

Signed-off-by: Pavol Loffay <p.loffay@gmail.com>