### PR TITLE
Add operation and collection attributes for MongoDB spans

### DIFF
--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.javaagent.instrumentation.mongo.MongoClientTracer
-
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
-import static io.opentelemetry.trace.Span.Kind.CLIENT
-
 import com.mongodb.MongoClient
 import com.mongodb.MongoClientOptions
 import com.mongodb.MongoTimeoutException
@@ -22,6 +16,10 @@ import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
+
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.trace.Span.Kind.CLIENT
 
 class MongoClientTest extends MongoBaseTest {
 
@@ -50,7 +48,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create",collectionName)
+        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create", collectionName)
       }
     }
 

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -279,7 +279,7 @@ class MongoClientTest extends MongoBaseTest {
         "${SemanticAttributes.DB_SYSTEM.key()}" "mongodb"
         "${SemanticAttributes.DB_NAME.key()}" instance
         "${SemanticAttributes.DB_OPERATION.key()}" operation
-        "${MongoClientTracer.DB_MONGODB_COLLECTION.key()}" collection
+        "${SemanticAttributes.MONGODB_COLLECTION.key()}" collection
       }
     }
   }

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
-import static io.opentelemetry.trace.Span.Kind.CLIENT
-
 import com.mongodb.MongoClient
 import com.mongodb.MongoClientOptions
 import com.mongodb.MongoTimeoutException
@@ -20,6 +16,10 @@ import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
+
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.trace.Span.Kind.CLIENT
 
 class MongoClientTest extends MongoBaseTest {
 
@@ -48,7 +48,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create", collectionName)
+        mongoSpan(it, 0, "create", collectionName, "{\"create\":\"$collectionName\",\"capped\":\"?\"}")
       }
     }
 
@@ -72,7 +72,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create", collectionName)
+        mongoSpan(it, 0, "create", collectionName, "{\"create\":\"$collectionName\",\"capped\":\"?\"}")
       }
     }
 
@@ -91,7 +91,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create", collectionName, dbName)
+        mongoSpan(it, 0, "create", collectionName, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", dbName)
       }
     }
 
@@ -111,7 +111,7 @@ class MongoClientTest extends MongoBaseTest {
     count == 0
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
+        mongoSpan(it, 0, "count", collectionName, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
 
@@ -137,10 +137,10 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 1
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}", "insert", collectionName)
+        mongoSpan(it, 0, "insert", collectionName, "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}")
       }
       trace(1, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
+        mongoSpan(it, 0, "count", collectionName, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
 
@@ -171,10 +171,10 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 1
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}", "update", collectionName)
+        mongoSpan(it, 0, "update", collectionName, "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}")
       }
       trace(1, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
+        mongoSpan(it, 0, "count", collectionName, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
 
@@ -203,10 +203,10 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 0
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}", "delete", collectionName)
+        mongoSpan(it, 0, "delete", collectionName, "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}")
       }
       trace(1, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
+        mongoSpan(it, 0, "count", collectionName, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
 
@@ -257,7 +257,7 @@ class MongoClientTest extends MongoBaseTest {
     collectionName = "testCollection"
   }
 
-  def mongoSpan(TraceAssert trace, int index, String statement, String operation, String collection, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
+  def mongoSpan(TraceAssert trace, int index, String operation, String collection, String statement, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
       name { it.replace(" ", "") == statement }
       kind CLIENT

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.trace.Span.Kind.CLIENT
+
 import com.mongodb.MongoClient
 import com.mongodb.MongoClientOptions
 import com.mongodb.MongoTimeoutException
@@ -16,10 +20,6 @@ import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
-
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
-import static io.opentelemetry.trace.Span.Kind.CLIENT
 
 class MongoClientTest extends MongoBaseTest {
 

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.javaagent.instrumentation.mongo.MongoClientTracer
+
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static io.opentelemetry.trace.Span.Kind.CLIENT
@@ -48,7 +50,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}")
+        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create",collectionName)
       }
     }
 
@@ -72,7 +74,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}")
+        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create", collectionName)
       }
     }
 
@@ -91,7 +93,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", dbName)
+        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create", collectionName, dbName)
       }
     }
 
@@ -111,7 +113,7 @@ class MongoClientTest extends MongoBaseTest {
     count == 0
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
       }
     }
 
@@ -137,10 +139,10 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 1
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}")
+        mongoSpan(it, 0, "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}", "insert", collectionName)
       }
       trace(1, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
       }
     }
 
@@ -171,10 +173,10 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 1
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}")
+        mongoSpan(it, 0, "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}", "update", collectionName)
       }
       trace(1, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
       }
     }
 
@@ -203,10 +205,10 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 0
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}")
+        mongoSpan(it, 0, "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}", "delete", collectionName)
       }
       trace(1, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
       }
     }
 
@@ -257,7 +259,7 @@ class MongoClientTest extends MongoBaseTest {
     collectionName = "testCollection"
   }
 
-  def mongoSpan(TraceAssert trace, int index, String statement, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
+  def mongoSpan(TraceAssert trace, int index, String statement, String operation, String collection, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
       name { it.replace(" ", "") == statement }
       kind CLIENT
@@ -276,6 +278,8 @@ class MongoClientTest extends MongoBaseTest {
         "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "mongodb://localhost:" + port
         "${SemanticAttributes.DB_SYSTEM.key()}" "mongodb"
         "${SemanticAttributes.DB_NAME.key()}" instance
+        "${SemanticAttributes.DB_OPERATION.key()}" operation
+        "${MongoClientTracer.DB_MONGODB_COLLECTION.key()}" collection
       }
     }
   }

--- a/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import com.mongodb.MongoClientSettings
 import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress

--- a/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
-import static io.opentelemetry.trace.Span.Kind.CLIENT
 
 import com.mongodb.MongoClientSettings
 import com.mongodb.MongoTimeoutException
@@ -21,6 +18,10 @@ import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
+
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.trace.Span.Kind.CLIENT
 
 class MongoClientTest extends MongoBaseTest {
 
@@ -52,7 +53,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create", collectionName)
+        mongoSpan(it, 0, "create", collectionName, "{\"create\":\"$collectionName\",\"capped\":\"?\"}")
       }
     }
 
@@ -82,7 +83,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create", collectionName)
+        mongoSpan(it, 0, "create", collectionName, "{\"create\":\"$collectionName\",\"capped\":\"?\"}")
       }
     }
 
@@ -101,7 +102,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", "create", collectionName, dbName)
+        mongoSpan(it, 0, "create", collectionName, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", dbName)
       }
     }
 
@@ -121,7 +122,7 @@ class MongoClientTest extends MongoBaseTest {
     count == 0
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
+        mongoSpan(it, 0, "count", collectionName, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
 
@@ -147,10 +148,10 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 1
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}", "insert", collectionName)
+        mongoSpan(it, 0, "insert", collectionName, "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}")
       }
       trace(1, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
+        mongoSpan(it, 0, "count", collectionName, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
 
@@ -181,10 +182,10 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 1
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}", "update", collectionName)
+        mongoSpan(it, 0, "update", collectionName, "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}")
       }
       trace(1, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
+        mongoSpan(it, 0, "count", collectionName, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
 
@@ -213,10 +214,10 @@ class MongoClientTest extends MongoBaseTest {
     collection.count() == 0
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}", "delete", collectionName)
+        mongoSpan(it, 0, "delete", collectionName, "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}")
       }
       trace(1, 1) {
-        mongoSpan(it, 0, "{\"count\":\"$collectionName\",\"query\":{}}", "count", collectionName)
+        mongoSpan(it, 0, "count", collectionName, "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
 
@@ -266,7 +267,7 @@ class MongoClientTest extends MongoBaseTest {
     collectionName = "testCollection"
   }
 
-  def mongoSpan(TraceAssert trace, int index, String statement, String operation, String collection, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
+  def mongoSpan(TraceAssert trace, int index, String operation, String collection, String statement, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
       name { it.replace(" ", "") == statement }
       kind CLIENT

--- a/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.javaagent.instrumentation.mongo.MongoClientTracer
-
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
-import static io.opentelemetry.trace.Span.Kind.CLIENT
-
 import com.mongodb.MongoClientSettings
 import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress
@@ -23,6 +17,10 @@ import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
+
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.trace.Span.Kind.CLIENT
 
 class MongoClientTest extends MongoBaseTest {
 
@@ -288,7 +286,7 @@ class MongoClientTest extends MongoBaseTest {
         "${SemanticAttributes.DB_CONNECTION_STRING.key()}" "mongodb://localhost:" + port
         "${SemanticAttributes.DB_NAME.key()}" instance
         "${SemanticAttributes.DB_OPERATION.key()}" operation
-        "${MongoClientTracer.DB_MONGODB_COLLECTION.key()}" collection
+        "${SemanticAttributes.MONGODB_COLLECTION.key()}" collection
       }
     }
   }

--- a/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.trace.Span.Kind.CLIENT
+
 import com.mongodb.MongoClientSettings
 import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress
@@ -17,10 +21,6 @@ import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
-
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
-import static io.opentelemetry.trace.Span.Kind.CLIENT
 
 class MongoClientTest extends MongoBaseTest {
 

--- a/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.javaagent.instrumentation.mongo.MongoClientTracer
-
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
-import static io.opentelemetry.trace.Span.Kind.CLIENT
-
 import com.mongodb.ConnectionString
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.async.client.MongoClient
@@ -21,13 +16,17 @@ import com.mongodb.connection.ClusterSettings
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CountDownLatch
 import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
 import spock.lang.Timeout
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.trace.Span.Kind.CLIENT
 
 @Timeout(10)
 class MongoAsyncClientTest extends MongoBaseTest {

--- a/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -59,11 +59,11 @@ class MongoAsyncClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, {
+        mongoSpan(it, 0, "create", collectionName) {
           assert it.replaceAll(" ", "") == "{\"create\":\"$collectionName\",\"capped\":\"?\"}" ||
             it == "{\"create\": \"$collectionName\", \"capped\": \"?\", \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
           true
-        }, "create", collectionName)
+        }
       }
     }
 
@@ -87,11 +87,11 @@ class MongoAsyncClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, {
+        mongoSpan(it, 0, "create", collectionName) {
           assert it.replaceAll(" ", "") == "{\"create\":\"$collectionName\",\"capped\":\"?\"}" ||
             it == "{\"create\": \"$collectionName\", \"capped\": \"?\", \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
           true
-        }, "create", collectionName)
+        }
       }
     }
 
@@ -110,11 +110,11 @@ class MongoAsyncClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, {
+        mongoSpan(it, 0, "create", collectionName, {
           assert it.replaceAll(" ", "") == "{\"create\":\"$collectionName\",\"capped\":\"?\"}" ||
             it == "{\"create\": \"$collectionName\", \"capped\": \"?\", \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
           true
-        }, "create", collectionName, dbName)
+        }, dbName)
       }
     }
 
@@ -135,11 +135,11 @@ class MongoAsyncClientTest extends MongoBaseTest {
     count.get() == 0
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, {
+        mongoSpan(it, 0, "count", collectionName) {
           assert it.replaceAll(" ", "") == "{\"count\":\"$collectionName\",\"query\":{}}" ||
             it == "{\"count\": \"$collectionName\", \"query\": {}, \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
           true
-        }, "count", collectionName)
+        }
       }
     }
 
@@ -170,18 +170,18 @@ class MongoAsyncClientTest extends MongoBaseTest {
     count.get() == 1
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, {
+        mongoSpan(it, 0, "insert", collectionName) {
           assert it.replaceAll(" ", "") == "{\"insert\":\"$collectionName\",\"ordered\":\"?\",\"documents\":[{\"_id\":\"?\",\"password\":\"?\"}]}" ||
             it == "{\"insert\": \"$collectionName\", \"ordered\": \"?\", \"\$db\": \"?\", \"documents\": [{\"_id\": \"?\", \"password\": \"?\"}]}"
           true
-        }, "insert", collectionName)
+        }
       }
       trace(1, 1) {
-        mongoSpan(it, 0, {
+        mongoSpan(it, 0, "count", collectionName) {
           assert it.replaceAll(" ", "") == "{\"count\":\"$collectionName\",\"query\":{}}" ||
             it == "{\"count\": \"$collectionName\", \"query\": {}, \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
           true
-        }, "count", collectionName)
+        }
       }
     }
 
@@ -221,18 +221,18 @@ class MongoAsyncClientTest extends MongoBaseTest {
     count.get() == 1
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, {
+        mongoSpan(it, 0, "update", collectionName) {
           assert it.replaceAll(" ", "") == "{\"update\":\"?\",\"ordered\":\"?\",\"updates\":[{\"q\":{\"password\":\"?\"},\"u\":{\"\$set\":{\"password\":\"?\"}}}]}" ||
             it == "{\"update\": \"?\", \"ordered\": \"?\", \"\$db\": \"?\", \"updates\": [{\"q\": {\"password\": \"?\"}, \"u\": {\"\$set\": {\"password\": \"?\"}}}]}"
           true
-        }, "update", collectionName)
+        }
       }
       trace(1, 1) {
-        mongoSpan(it, 0, {
+        mongoSpan(it, 0, "count", collectionName) {
           assert it.replaceAll(" ", "") == "{\"count\":\"$collectionName\",\"query\":{}}" ||
             it == "{\"count\": \"$collectionName\", \"query\": {}, \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
           true
-        }, "count", collectionName)
+        }
       }
     }
 
@@ -270,18 +270,18 @@ class MongoAsyncClientTest extends MongoBaseTest {
     count.get() == 0
     assertTraces(2) {
       trace(0, 1) {
-        mongoSpan(it, 0, {
+        mongoSpan(it, 0, "delete", collectionName) {
           assert it.replaceAll(" ", "") == "{\"delete\":\"?\",\"ordered\":\"?\",\"deletes\":[{\"q\":{\"password\":\"?\"},\"limit\":\"?\"}]}" ||
             it == "{\"delete\": \"?\", \"ordered\": \"?\", \"\$db\": \"?\", \"deletes\": [{\"q\": {\"password\": \"?\"}, \"limit\": \"?\"}]}"
           true
-        }, "delete", collectionName)
+        }
       }
       trace(1, 1) {
-        mongoSpan(it, 0, {
+        mongoSpan(it, 0, "count", collectionName) {
           assert it.replaceAll(" ", "") == "{\"count\":\"$collectionName\",\"query\":{}}" ||
             it == "{\"count\": \"$collectionName\", \"query\": {}, \"\$db\": \"?\", \"\$readPreference\": {\"mode\": \"?\"}}"
           true
-        }, "count", collectionName)
+        }
       }
     }
 
@@ -303,7 +303,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
     }
   }
 
-  def mongoSpan(TraceAssert trace, int index, Closure<Boolean> statementEval, String operation, String collection, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
+  def mongoSpan(TraceAssert trace, int index, String operation, String collection, Closure<Boolean> statementEval, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
       name statementEval
       kind CLIENT

--- a/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.trace.Span.Kind.CLIENT
+
 import com.mongodb.ConnectionString
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.async.client.MongoClient
@@ -16,17 +19,13 @@ import com.mongodb.connection.ClusterSettings
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.attributes.SemanticAttributes
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
 import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
 import spock.lang.Timeout
-
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CountDownLatch
-
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
-import static io.opentelemetry.trace.Span.Kind.CLIENT
 
 @Timeout(10)
 class MongoAsyncClientTest extends MongoBaseTest {

--- a/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -323,7 +323,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
         "${SemanticAttributes.DB_SYSTEM.key()}" "mongodb"
         "${SemanticAttributes.DB_NAME.key()}" instance
         "${SemanticAttributes.DB_OPERATION.key()}" operation
-        "${MongoClientTracer.DB_MONGODB_COLLECTION.key()}" collection
+        "${SemanticAttributes.MONGODB_COLLECTION.key()}" collection
       }
     }
   }

--- a/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/MongoClientTracer.java
+++ b/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/MongoClientTracer.java
@@ -11,7 +11,6 @@ import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ConnectionId;
 import com.mongodb.connection.ServerId;
 import com.mongodb.event.CommandStartedEvent;
-import io.opentelemetry.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import io.opentelemetry.javaagent.instrumentation.api.jdbc.DbSystem;
 import io.opentelemetry.trace.Span;
@@ -27,9 +26,6 @@ import org.bson.BsonValue;
 
 public class MongoClientTracer extends DatabaseClientTracer<CommandStartedEvent, BsonDocument> {
   public static final MongoClientTracer TRACER = new MongoClientTracer();
-
-  public static final AttributeKey<String> DB_MONGODB_COLLECTION =
-      AttributeKey.stringKey("db.mongodb.collection");
 
   // TODO use tracer names *.mongo-3.1, *.mongo-3.7, *.mongo-async-3.3 respectively in each module
   @Override
@@ -47,7 +43,7 @@ public class MongoClientTracer extends DatabaseClientTracer<CommandStartedEvent,
     span.setAttribute(SemanticAttributes.DB_OPERATION, event.getCommandName());
     String collection = collectionName(event);
     if (collection != null) {
-      span.setAttribute(DB_MONGODB_COLLECTION, collection);
+      span.setAttribute(SemanticAttributes.MONGODB_COLLECTION, collection);
     }
     return super.onConnection(span, event);
   }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
@@ -63,9 +63,7 @@ public class TracerAutoConfiguration {
 
   private void setSampler(TracerProperties tracerProperties) {
     TraceConfig updatedTraceConfig =
-        OpenTelemetrySdk.getTracerManagement()
-            .getActiveTraceConfig()
-            .toBuilder()
+        OpenTelemetrySdk.getTracerManagement().getActiveTraceConfig().toBuilder()
             .setSampler(Samplers.traceIdRatioBased(tracerProperties.getSamplerProbability()))
             .build();
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/TracerAutoConfiguration.java
@@ -63,7 +63,9 @@ public class TracerAutoConfiguration {
 
   private void setSampler(TracerProperties tracerProperties) {
     TraceConfig updatedTraceConfig =
-        OpenTelemetrySdk.getTracerManagement().getActiveTraceConfig().toBuilder()
+        OpenTelemetrySdk.getTracerManagement()
+            .getActiveTraceConfig()
+            .toBuilder()
             .setSampler(Samplers.traceIdRatioBased(tracerProperties.getSamplerProbability()))
             .build();
 


### PR DESCRIPTION
This change introduces `db.operation` and `db.mongodb.collection` attributes to the mongo client instrumentation. Because there is no common functionality for `db.operation` in `DatabaseClientTracer` we are just overriding `onConnect` to add mongo specific attributes.

In the future, this should be refactored when `db.operation` is added across all db instrumetnation.

Fixes #1278