### PR TITLE
Make muzzle task depend on instrumentation project runtimeclasspath

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -327,6 +327,7 @@ class MuzzlePlugin implements Plugin<Project> {
     }
 
     def muzzleTask = instrumentationProject.task(taskName) {
+      dependsOn(instrumentationProject.configurations.named("runtimeClasspath"))
       doLast {
         ClassLoader instrumentationCL = createInstrumentationClassloader(instrumentationProject, toolingProject)
         def ccl = Thread.currentThread().contextClassLoader


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>


This is related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1225. See the hacks what I did in regards to runtime classpath of the plugin. Maybe the plugin could expose a setting to configure javaagent-tooling and javaagent-bootstrap classpath (a similar what bytebuddy plugin does https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/ee0e0a96974fac8eba802b400201ff2a5ee9da75/gradle/instrumentation.gradle#L36)


I am using muzzle plugin in my custom OTEL agent build. There are a couple of hacks that I had to make:
* copy buildSrc to my project (obvious and ugly!)
* define `javaagent-tooling` and `javaagent-bootstrap` subprojects that pull in appropriate OTEL artifacts
* move my instrumentation classes to `io.opentelemetry.instrumentation.`  https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1395
* set correctly classpath in bytebuddy plugin (`instrumentationMuzzle`)

With all this I was able to run muzzle task and properly generate `instrumentationMuzzle`. However the build was passing only after `./gradlew assemble`. Running `./gradlew clean muzzle` was always failing. The following fixed the build on a clean project.
