### PR TITLE
Use proper case for muzzle skip version check

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -305,12 +305,11 @@ class MuzzlePlugin implements Plugin<Project> {
       if (version == null) {
         return false
       }
-      def versionString = version.toString()
+      def versionString = version.toString().toLowerCase()
       if (skipVersions.contains(versionString)) {
         return false
       }
 
-      versionString = versionString.toLowerCase()
       def draftVersion = versionString.contains("rc") ||
         versionString.contains(".cr") ||
         versionString.contains("alpha") ||


### PR DESCRIPTION
During #1396 I missed that `skipVersions` are always converted to lower case during plugin configuration.