### PR TITLE
Update grpc-netty version

### DIFF
--- a/javaagent-exporters/jaeger/jaeger.gradle
+++ b/javaagent-exporters/jaeger/jaeger.gradle
@@ -17,8 +17,7 @@ dependencies {
   implementation(deps.opentelemetryJaeger) {
     exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
   }
-  implementation group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
-  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.24.0'
+  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.30.2'
 }
 
 jar.enabled = false

--- a/javaagent-exporters/otlp/otlp.gradle
+++ b/javaagent-exporters/otlp/otlp.gradle
@@ -17,8 +17,7 @@ dependencies {
   implementation(deps.opentelemetryOtlp) {
     exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
   }
-  implementation group: 'io.grpc', name: 'grpc-api', version: '1.24.0'
-  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.24.0'
+  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.30.2'
 }
 
 jar.enabled = false


### PR DESCRIPTION
The actual intent of this PR is to update the Netty version that is used by gRPC. The version that we are currently using contains several known security vulnerabilities.