### PR TITLE
Fix HttpURLConnection instrumentation on WebLogic

### DIFF
--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentation.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentation.java
@@ -41,6 +41,10 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Default {
   public ElementMatcher<TypeDescription> typeMatcher() {
     return nameStartsWith("java.net.")
         .or(ElementMatchers.<TypeDescription>nameStartsWith("sun.net"))
+        // In WebLogic, URL.openConnection() returns its own internal implementation of
+        // HttpURLConnection, which does not delegate the methods that have to be instrumented to
+        // the JDK superclass. Therefore it needs to be instrumented directly.
+        .or(named("weblogic.net.http.HttpURLConnection"))
         // This class is a simple delegator. Skip because it does not update its `connected` field.
         .and(not(named("sun.net.www.protocol.https.HttpsURLConnectionImpl")))
         .and(extendsClass(named("java.net.HttpURLConnection")));


### PR DESCRIPTION
In WebLogic, `URL.openConnection()` returns its own internal implementation of `HttpURLConnection`, which does not delegate the methods that have to be instrumented to the JDK superclass.

Instrumenting it directly resolves the issue of outgoing requests made with `URL.openConnection()` not being detected. It has been manually tested with WLS 12.2.1.4 and 14.1.1.0.