### PR TITLE
Replace `print` with log messages.

### DIFF
--- a/javaagent-exporters/logging/logging.gradle
+++ b/javaagent-exporters/logging/logging.gradle
@@ -15,6 +15,7 @@ dependencies {
 
   compileOnly deps.opentelemetrySdk
   compileOnly deps.opentelemetryApi
+  compileOnly deps.slf4j
 }
 
 jar.enabled = false

--- a/javaagent-exporters/logging/src/main/java/io/opentelemetry/javaagent/exporters/logging/LoggingExporter.java
+++ b/javaagent-exporters/logging/src/main/java/io/opentelemetry/javaagent/exporters/logging/LoggingExporter.java
@@ -44,7 +44,7 @@ public class LoggingExporter implements SpanExporter {
                 @Override
                 public <T> void consume(AttributeKey<T> key, T value) {
 
-                  stringBuilder.append(key).append('=');
+                  stringBuilder.append(key.getKey()).append('=');
 
                   if (key.getType() == AttributeType.STRING) {
                     stringBuilder.append('"').append(value).append('"');

--- a/javaagent-exporters/logging/src/main/java/io/opentelemetry/javaagent/exporters/logging/LoggingExporter.java
+++ b/javaagent-exporters/logging/src/main/java/io/opentelemetry/javaagent/exporters/logging/LoggingExporter.java
@@ -55,7 +55,7 @@ public class LoggingExporter implements SpanExporter {
                 }
               });
     }
-    log.debug(stringBuilder.toString());
+    log.info(stringBuilder.toString());
     return CompletableResultCode.ofSuccess();
   }
 

--- a/javaagent-exporters/logging/src/main/java/io/opentelemetry/javaagent/exporters/logging/LoggingExporter.java
+++ b/javaagent-exporters/logging/src/main/java/io/opentelemetry/javaagent/exporters/logging/LoggingExporter.java
@@ -7,12 +7,16 @@ package io.opentelemetry.javaagent.exporters.logging;
 
 import io.opentelemetry.common.AttributeConsumer;
 import io.opentelemetry.common.AttributeKey;
+import io.opentelemetry.common.AttributeType;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LoggingExporter implements SpanExporter {
+  private static final Logger log = LoggerFactory.getLogger(LoggingExporter.class);
   private final String prefix;
 
   public LoggingExporter(String prefix) {
@@ -21,28 +25,37 @@ public class LoggingExporter implements SpanExporter {
 
   @Override
   public CompletableResultCode export(Collection<SpanData> list) {
+    StringBuilder stringBuilder = new StringBuilder();
     for (SpanData span : list) {
-      System.out.print(
-          prefix + " " + span.getName() + " " + span.getTraceId() + " " + span.getSpanId() + " ");
+
+      stringBuilder
+          .append(prefix)
+          .append(" ")
+          .append(span.getName())
+          .append(" ")
+          .append(span.getTraceId())
+          .append(" ")
+          .append(span.getSpanId())
+          .append(" ");
+
       span.getAttributes()
           .forEach(
               new AttributeConsumer() {
                 @Override
                 public <T> void consume(AttributeKey<T> key, T value) {
-                  System.out.print(key + "=");
-                  switch (key.getType()) {
-                    case STRING:
-                      System.out.print('"' + String.valueOf(value) + '"');
-                      break;
-                    default:
-                      System.out.print(value);
-                      break;
+
+                  stringBuilder.append(key).append('=');
+
+                  if (key.getType() == AttributeType.STRING) {
+                    stringBuilder.append('"').append(value).append('"');
+                  } else {
+                    stringBuilder.append(value);
                   }
-                  System.out.print(" ");
+                  stringBuilder.append(' ');
                 }
               });
     }
-    System.out.println();
+    log.debug(stringBuilder.toString());
     return CompletableResultCode.ofSuccess();
   }
 


### PR DESCRIPTION
Replace `print` with log messages.

* Add `slf4j` compile time dependency to the `javaagent-exporters.logging` module
* Replace `System.out.print` with `log.debug` messages

Concerns:
1. I am not sure about `log.debug`. I can replace it if you think that it should be in other level.
2. `AttributeKey` ls logged using `toString()` method from its implementation. The only implementation right now is `AutoValue_AttributeKeyImpl` which prints the key like `"AttributeKeyImpl{getType=" + this.getType + ", key=" + this.key + "}"`. I think it is not a good idea to use `toString` from objects for logging because anyone can change the method's implementation or provide implementation without `toString` (with default) and it will affect logging quality. I would change it not rely on `toString` output, but I don't know what would the appropriate format for this. If you have ideas please share.

Fixes: #1328