### PR TITLE
Replace `"messaging.operation"` with the constant

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSpan.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.api.typedspan;
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
+import io.opentelemetry.trace.attributes.SemanticAttributes;
 
 public class MessagingConsumerSpan extends DelegatingSpan
     implements MessagingConsumerSemanticConvention {
@@ -273,7 +274,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setMessagingOperation(String messagingOperation) {
-    delegate.setAttribute("messaging.operation", messagingOperation);
+    delegate.setAttribute(SemanticAttributes.MESSAGING_OPERATION, messagingOperation);
     return this;
   }
 
@@ -515,7 +516,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      *     this span describes.
      */
     public MessagingConsumerSpanBuilder setMessagingOperation(String messagingOperation) {
-      internalBuilder.setAttribute("messaging.operation", messagingOperation);
+      internalBuilder.setAttribute(SemanticAttributes.MESSAGING_OPERATION, messagingOperation);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSynchronousSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSynchronousSpan.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.api.typedspan;
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
+import io.opentelemetry.trace.attributes.SemanticAttributes;
 
 public class MessagingConsumerSynchronousSpan extends DelegatingSpan
     implements MessagingConsumerSynchronousSemanticConvention {
@@ -280,7 +281,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingOperation(
       String messagingOperation) {
-    delegate.setAttribute("messaging.operation", messagingOperation);
+    delegate.setAttribute(SemanticAttributes.MESSAGING_OPERATION, messagingOperation);
     return this;
   }
 
@@ -526,7 +527,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      */
     public MessagingConsumerSynchronousSpanBuilder setMessagingOperation(
         String messagingOperation) {
-      internalBuilder.setAttribute("messaging.operation", messagingOperation);
+      internalBuilder.setAttribute(SemanticAttributes.MESSAGING_OPERATION, messagingOperation);
       return this;
     }
   }


### PR DESCRIPTION
Replace `"messaging.operation"` with the constant from Instrumentation API

Fixes: #1375