### PR TITLE
Replace `net.*`, `rpc.*`, `enduser.*` with constants

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbCassandraSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbCassandraSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -146,7 +148,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -158,7 +160,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -169,7 +171,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -180,7 +182,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -320,7 +322,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public DbCassandraSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -331,7 +333,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public DbCassandraSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -341,7 +343,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      * @param netPeerPort Remote port number.
      */
     public DbCassandraSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -351,7 +353,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      * @param netTransport Transport protocol used. See note below.
      */
     public DbCassandraSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbHbaseSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbHbaseSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -146,7 +148,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -158,7 +160,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -169,7 +171,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -180,7 +182,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -320,7 +322,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public DbHbaseSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -331,7 +333,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public DbHbaseSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -341,7 +343,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      * @param netPeerPort Remote port number.
      */
     public DbHbaseSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -351,7 +353,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      * @param netTransport Transport protocol used. See note below.
      */
     public DbHbaseSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbMongodbSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbMongodbSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -146,7 +148,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -158,7 +160,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -169,7 +171,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -180,7 +182,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -320,7 +322,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public DbMongodbSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -331,7 +333,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public DbMongodbSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -341,7 +343,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      * @param netPeerPort Remote port number.
      */
     public DbMongodbSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -351,7 +353,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      * @param netTransport Transport protocol used. See note below.
      */
     public DbMongodbSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbMssqlSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbMssqlSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -146,7 +148,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -158,7 +160,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -169,7 +171,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -180,7 +182,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -323,7 +325,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public DbMssqlSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -334,7 +336,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public DbMssqlSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -344,7 +346,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      * @param netPeerPort Remote port number.
      */
     public DbMssqlSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -354,7 +356,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      * @param netTransport Transport protocol used. See note below.
      */
     public DbMssqlSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbRedisSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbRedisSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -146,7 +148,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -158,7 +160,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -169,7 +171,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -180,7 +182,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -321,7 +323,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public DbRedisSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -332,7 +334,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public DbRedisSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -342,7 +344,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      * @param netPeerPort Remote port number.
      */
     public DbRedisSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -352,7 +354,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      * @param netTransport Transport protocol used. See note below.
      */
     public DbRedisSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -135,7 +137,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -147,7 +149,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -158,7 +160,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -169,7 +171,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -297,7 +299,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public DbSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -308,7 +310,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public DbSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -318,7 +320,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      * @param netPeerPort Remote port number.
      */
     public DbSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -328,7 +330,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      * @param netTransport Transport protocol used. See note below.
      */
     public DbSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasHttpSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasHttpSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -284,7 +286,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -296,7 +298,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -307,7 +309,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -318,7 +320,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -329,7 +331,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -340,7 +342,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -351,7 +353,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -607,7 +609,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param netTransport Transport protocol used. See note below.
      */
     public FaasHttpSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 
@@ -618,7 +620,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public FaasHttpSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -628,7 +630,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param netPeerPort Remote port number.
      */
     public FaasHttpSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -638,7 +640,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public FaasHttpSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -648,7 +650,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public FaasHttpSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -658,7 +660,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public FaasHttpSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -668,7 +670,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param netHostName Local hostname or similar, see note below.
      */
     public FaasHttpSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasPubsubSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasPubsubSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -211,7 +213,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -222,7 +224,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -234,7 +236,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -245,7 +247,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -256,7 +258,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -267,7 +269,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -278,7 +280,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -465,7 +467,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param netPeerPort Remote port number.
      */
     public FaasPubsubSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -475,7 +477,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param netTransport Strongly recommended for in-process queueing systems.
      */
     public FaasPubsubSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 
@@ -486,7 +488,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public FaasPubsubSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -496,7 +498,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public FaasPubsubSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -506,7 +508,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public FaasPubsubSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -516,7 +518,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public FaasPubsubSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -526,7 +528,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param netHostName Local hostname or similar, see note below.
      */
     public FaasPubsubSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/GrpcClientSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/GrpcClientSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -56,7 +58,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
    */
   @Override
   public GrpcClientSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -68,7 +70,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
    */
   @Override
   public GrpcClientSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -79,7 +81,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
    */
   @Override
   public GrpcClientSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -90,7 +92,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
    */
   @Override
   public GrpcClientSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -101,7 +103,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
    */
   @Override
   public GrpcClientSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -112,7 +114,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
    */
   @Override
   public GrpcClientSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -123,7 +125,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
    */
   @Override
   public GrpcClientSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -134,7 +136,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
    */
   @Override
   public GrpcClientSemanticConvention setRpcService(String rpcService) {
-    delegate.setAttribute("rpc.service", rpcService);
+    delegate.setAttribute(RPC_SERVICE, rpcService);
     return this;
   }
 
@@ -179,7 +181,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
      * @param netTransport Transport protocol used. See note below.
      */
     public GrpcClientSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 
@@ -190,7 +192,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public GrpcClientSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -200,7 +202,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
      * @param netPeerPort It describes the server port the client is connecting to.
      */
     public GrpcClientSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -210,7 +212,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public GrpcClientSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -220,7 +222,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public GrpcClientSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -230,7 +232,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public GrpcClientSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -240,7 +242,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
      * @param netHostName Local hostname or similar, see note below.
      */
     public GrpcClientSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 
@@ -250,7 +252,7 @@ public class GrpcClientSpan extends DelegatingSpan implements GrpcClientSemantic
      * @param rpcService The service name, must be equal to the $service part in the span name.
      */
     public GrpcClientSpanBuilder setRpcService(String rpcService) {
-      internalBuilder.setAttribute("rpc.service", rpcService);
+      internalBuilder.setAttribute(RPC_SERVICE, rpcService);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/GrpcServerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/GrpcServerSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -56,7 +58,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
    */
   @Override
   public GrpcServerSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -68,7 +70,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
    */
   @Override
   public GrpcServerSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -79,7 +81,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
    */
   @Override
   public GrpcServerSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -90,7 +92,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
    */
   @Override
   public GrpcServerSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -101,7 +103,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
    */
   @Override
   public GrpcServerSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -112,7 +114,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
    */
   @Override
   public GrpcServerSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -123,7 +125,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
    */
   @Override
   public GrpcServerSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -134,7 +136,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
    */
   @Override
   public GrpcServerSemanticConvention setRpcService(String rpcService) {
-    delegate.setAttribute("rpc.service", rpcService);
+    delegate.setAttribute(RPC_SERVICE, rpcService);
     return this;
   }
 
@@ -179,7 +181,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
      * @param netTransport Transport protocol used. See note below.
      */
     public GrpcServerSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 
@@ -190,7 +192,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public GrpcServerSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -200,7 +202,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
      * @param netPeerPort It describes the port the client is connecting from.
      */
     public GrpcServerSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -210,7 +212,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public GrpcServerSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -220,7 +222,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public GrpcServerSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -230,7 +232,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public GrpcServerSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -240,7 +242,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
      * @param netHostName Local hostname or similar, see note below.
      */
     public GrpcServerSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 
@@ -250,7 +252,7 @@ public class GrpcServerSpan extends DelegatingSpan implements GrpcServerSemantic
      * @param rpcService The service name, must be equal to the $service part in the span name.
      */
     public GrpcServerSpanBuilder setRpcService(String rpcService) {
-      internalBuilder.setAttribute("rpc.service", rpcService);
+      internalBuilder.setAttribute(RPC_SERVICE, rpcService);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpClientSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpClientSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -56,7 +58,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -68,7 +70,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -79,7 +81,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -90,7 +92,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -101,7 +103,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -112,7 +114,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -123,7 +125,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -331,7 +333,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      * @param netTransport Transport protocol used. See note below.
      */
     public HttpClientSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 
@@ -342,7 +344,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public HttpClientSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -352,7 +354,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      * @param netPeerPort Remote port number.
      */
     public HttpClientSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -362,7 +364,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public HttpClientSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -372,7 +374,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public HttpClientSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -382,7 +384,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public HttpClientSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -392,7 +394,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      * @param netHostName Local hostname or similar, see note below.
      */
     public HttpClientSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpServerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpServerSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -56,7 +58,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -68,7 +70,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -79,7 +81,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -90,7 +92,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -101,7 +103,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -112,7 +114,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -123,7 +125,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -374,7 +376,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      * @param netTransport Transport protocol used. See note below.
      */
     public HttpServerSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 
@@ -385,7 +387,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public HttpServerSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -395,7 +397,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      * @param netPeerPort Remote port number.
      */
     public HttpServerSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -405,7 +407,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public HttpServerSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -415,7 +417,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public HttpServerSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -425,7 +427,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public HttpServerSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -435,7 +437,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      * @param netHostName Local hostname or similar, see note below.
      */
     public HttpServerSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -45,7 +47,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -57,7 +59,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -68,7 +70,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -79,7 +81,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -90,7 +92,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -101,7 +103,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -112,7 +114,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -320,7 +322,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      * @param netTransport Transport protocol used. See note below.
      */
     public HttpSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 
@@ -331,7 +333,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public HttpSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -341,7 +343,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      * @param netPeerPort Remote port number.
      */
     public HttpSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -351,7 +353,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public HttpSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -361,7 +363,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public HttpSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -371,7 +373,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public HttpSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -381,7 +383,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      * @param netHostName Local hostname or similar, see note below.
      */
     public HttpSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/IdentitySpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/IdentitySpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -46,7 +48,7 @@ public class IdentitySpan extends DelegatingSpan implements IdentitySemanticConv
    */
   @Override
   public IdentitySemanticConvention setEnduserId(String enduserId) {
-    delegate.setAttribute("enduser.id", enduserId);
+    delegate.setAttribute(ENDUSER_ID, enduserId);
     return this;
   }
 
@@ -58,7 +60,7 @@ public class IdentitySpan extends DelegatingSpan implements IdentitySemanticConv
    */
   @Override
   public IdentitySemanticConvention setEnduserRole(String enduserRole) {
-    delegate.setAttribute("enduser.role", enduserRole);
+    delegate.setAttribute(ENDUSER_ROLE, enduserRole);
     return this;
   }
 
@@ -71,7 +73,7 @@ public class IdentitySpan extends DelegatingSpan implements IdentitySemanticConv
    */
   @Override
   public IdentitySemanticConvention setEnduserScope(String enduserScope) {
-    delegate.setAttribute("enduser.scope", enduserScope);
+    delegate.setAttribute(ENDUSER_SCOPE, enduserScope);
     return this;
   }
 
@@ -117,7 +119,7 @@ public class IdentitySpan extends DelegatingSpan implements IdentitySemanticConv
      *     header in the inbound request from outside the system.
      */
     public IdentitySpanBuilder setEnduserId(String enduserId) {
-      internalBuilder.setAttribute("enduser.id", enduserId);
+      internalBuilder.setAttribute(ENDUSER_ID, enduserId);
       return this;
     }
 
@@ -128,7 +130,7 @@ public class IdentitySpan extends DelegatingSpan implements IdentitySemanticConv
      *     token or application security context.
      */
     public IdentitySpanBuilder setEnduserRole(String enduserRole) {
-      internalBuilder.setAttribute("enduser.role", enduserRole);
+      internalBuilder.setAttribute(ENDUSER_ROLE, enduserRole);
       return this;
     }
 
@@ -140,7 +142,7 @@ public class IdentitySpan extends DelegatingSpan implements IdentitySemanticConv
      *     associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
      */
     public IdentitySpanBuilder setEnduserScope(String enduserScope) {
-      internalBuilder.setAttribute("enduser.scope", enduserScope);
+      internalBuilder.setAttribute(ENDUSER_SCOPE, enduserScope);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -60,7 +62,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -71,7 +73,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -82,7 +84,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -93,7 +95,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -104,7 +106,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -250,7 +252,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -261,7 +263,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -319,7 +321,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public MessagingConsumerSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -329,7 +331,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public MessagingConsumerSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -339,7 +341,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public MessagingConsumerSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -349,7 +351,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public MessagingConsumerSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -359,7 +361,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      * @param netHostName Local hostname or similar, see note below.
      */
     public MessagingConsumerSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 
@@ -494,7 +496,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      * @param netPeerPort Remote port number.
      */
     public MessagingConsumerSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -504,7 +506,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      * @param netTransport Strongly recommended for in-process queueing systems.
      */
     public MessagingConsumerSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSynchronousSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSynchronousSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -62,7 +64,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSynchronousSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -73,7 +75,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSynchronousSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -84,7 +86,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSynchronousSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -95,7 +97,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSynchronousSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -106,7 +108,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSynchronousSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -256,7 +258,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSynchronousSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -267,7 +269,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSynchronousSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -326,7 +328,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public MessagingConsumerSynchronousSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -336,7 +338,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public MessagingConsumerSynchronousSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -346,7 +348,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public MessagingConsumerSynchronousSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -356,7 +358,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public MessagingConsumerSynchronousSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -366,7 +368,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      * @param netHostName Local hostname or similar, see note below.
      */
     public MessagingConsumerSynchronousSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 
@@ -504,7 +506,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      * @param netPeerPort Remote port number.
      */
     public MessagingConsumerSynchronousSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -514,7 +516,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      * @param netTransport Strongly recommended for in-process queueing systems.
      */
     public MessagingConsumerSynchronousSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingProducerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingProducerSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -60,7 +62,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -71,7 +73,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -82,7 +84,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -93,7 +95,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -104,7 +106,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -250,7 +252,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -261,7 +263,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -307,7 +309,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public MessagingProducerSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -317,7 +319,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public MessagingProducerSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -327,7 +329,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public MessagingProducerSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -337,7 +339,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public MessagingProducerSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -347,7 +349,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      * @param netHostName Local hostname or similar, see note below.
      */
     public MessagingProducerSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 
@@ -482,7 +484,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      * @param netPeerPort Remote port number.
      */
     public MessagingProducerSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -492,7 +494,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      * @param netTransport Strongly recommended for in-process queueing systems.
      */
     public MessagingProducerSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingProducerSynchronousSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingProducerSynchronousSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -60,7 +62,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSynchronousSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -71,7 +73,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSynchronousSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -82,7 +84,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSynchronousSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -93,7 +95,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSynchronousSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -104,7 +106,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSynchronousSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -254,7 +256,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSynchronousSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -265,7 +267,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSynchronousSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -311,7 +313,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public MessagingProducerSynchronousSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -321,7 +323,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public MessagingProducerSynchronousSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -331,7 +333,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public MessagingProducerSynchronousSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -341,7 +343,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public MessagingProducerSynchronousSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -351,7 +353,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      * @param netHostName Local hostname or similar, see note below.
      */
     public MessagingProducerSynchronousSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 
@@ -489,7 +491,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      * @param netPeerPort Remote port number.
      */
     public MessagingProducerSynchronousSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -499,7 +501,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      * @param netTransport Strongly recommended for in-process queueing systems.
      */
     public MessagingProducerSynchronousSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -46,7 +48,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -57,7 +59,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -68,7 +70,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -79,7 +81,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -90,7 +92,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -232,7 +234,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -243,7 +245,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -289,7 +291,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public MessagingSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -299,7 +301,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public MessagingSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -309,7 +311,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public MessagingSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -319,7 +321,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public MessagingSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -329,7 +331,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param netHostName Local hostname or similar, see note below.
      */
     public MessagingSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 
@@ -461,7 +463,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param netPeerPort Remote port number.
      */
     public MessagingSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -471,7 +473,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param netTransport Strongly recommended for in-process queueing systems.
      */
     public MessagingSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/NetworkSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/NetworkSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -45,7 +47,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
    */
   @Override
   public NetworkSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -57,7 +59,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
    */
   @Override
   public NetworkSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -68,7 +70,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
    */
   @Override
   public NetworkSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -79,7 +81,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
    */
   @Override
   public NetworkSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -90,7 +92,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
    */
   @Override
   public NetworkSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -101,7 +103,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
    */
   @Override
   public NetworkSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -112,7 +114,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
    */
   @Override
   public NetworkSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -157,7 +159,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
      * @param netTransport Transport protocol used. See note below.
      */
     public NetworkSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 
@@ -168,7 +170,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public NetworkSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -178,7 +180,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
      * @param netPeerPort Remote port number.
      */
     public NetworkSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -188,7 +190,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public NetworkSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -198,7 +200,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public NetworkSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -208,7 +210,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public NetworkSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -218,7 +220,7 @@ public class NetworkSpan extends DelegatingSpan implements NetworkSemanticConven
      * @param netHostName Local hostname or similar, see note below.
      */
     public NetworkSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/RpcSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/RpcSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -45,7 +47,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
    */
   @Override
   public RpcSemanticConvention setNetTransport(String netTransport) {
-    delegate.setAttribute("net.transport", netTransport);
+    delegate.setAttribute(NET_TRANSPORT, netTransport);
     return this;
   }
 
@@ -57,7 +59,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
    */
   @Override
   public RpcSemanticConvention setNetPeerIp(String netPeerIp) {
-    delegate.setAttribute("net.peer.ip", netPeerIp);
+    delegate.setAttribute(NET_PEER_IP, netPeerIp);
     return this;
   }
 
@@ -68,7 +70,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
    */
   @Override
   public RpcSemanticConvention setNetPeerPort(long netPeerPort) {
-    delegate.setAttribute("net.peer.port", netPeerPort);
+    delegate.setAttribute(NET_PEER_PORT, netPeerPort);
     return this;
   }
 
@@ -79,7 +81,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
    */
   @Override
   public RpcSemanticConvention setNetPeerName(String netPeerName) {
-    delegate.setAttribute("net.peer.name", netPeerName);
+    delegate.setAttribute(NET_PEER_NAME, netPeerName);
     return this;
   }
 
@@ -90,7 +92,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
    */
   @Override
   public RpcSemanticConvention setNetHostIp(String netHostIp) {
-    delegate.setAttribute("net.host.ip", netHostIp);
+    delegate.setAttribute(NET_HOST_IP, netHostIp);
     return this;
   }
 
@@ -101,7 +103,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
    */
   @Override
   public RpcSemanticConvention setNetHostPort(long netHostPort) {
-    delegate.setAttribute("net.host.port", netHostPort);
+    delegate.setAttribute(NET_HOST_PORT, netHostPort);
     return this;
   }
 
@@ -112,7 +114,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
    */
   @Override
   public RpcSemanticConvention setNetHostName(String netHostName) {
-    delegate.setAttribute("net.host.name", netHostName);
+    delegate.setAttribute(NET_HOST_NAME, netHostName);
     return this;
   }
 
@@ -123,7 +125,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
    */
   @Override
   public RpcSemanticConvention setRpcService(String rpcService) {
-    delegate.setAttribute("rpc.service", rpcService);
+    delegate.setAttribute(RPC_SERVICE, rpcService);
     return this;
   }
 
@@ -168,7 +170,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
      * @param netTransport Transport protocol used. See note below.
      */
     public RpcSpanBuilder setNetTransport(String netTransport) {
-      internalBuilder.setAttribute("net.transport", netTransport);
+      internalBuilder.setAttribute(NET_TRANSPORT, netTransport);
       return this;
     }
 
@@ -179,7 +181,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
      *     [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
      */
     public RpcSpanBuilder setNetPeerIp(String netPeerIp) {
-      internalBuilder.setAttribute("net.peer.ip", netPeerIp);
+      internalBuilder.setAttribute(NET_PEER_IP, netPeerIp);
       return this;
     }
 
@@ -189,7 +191,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
      * @param netPeerPort Remote port number.
      */
     public RpcSpanBuilder setNetPeerPort(long netPeerPort) {
-      internalBuilder.setAttribute("net.peer.port", netPeerPort);
+      internalBuilder.setAttribute(NET_PEER_PORT, netPeerPort);
       return this;
     }
 
@@ -199,7 +201,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
      * @param netPeerName Remote hostname or similar, see note below.
      */
     public RpcSpanBuilder setNetPeerName(String netPeerName) {
-      internalBuilder.setAttribute("net.peer.name", netPeerName);
+      internalBuilder.setAttribute(NET_PEER_NAME, netPeerName);
       return this;
     }
 
@@ -209,7 +211,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
      * @param netHostIp Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
      */
     public RpcSpanBuilder setNetHostIp(String netHostIp) {
-      internalBuilder.setAttribute("net.host.ip", netHostIp);
+      internalBuilder.setAttribute(NET_HOST_IP, netHostIp);
       return this;
     }
 
@@ -219,7 +221,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
      * @param netHostPort Like `net.peer.port` but for the host port.
      */
     public RpcSpanBuilder setNetHostPort(long netHostPort) {
-      internalBuilder.setAttribute("net.host.port", netHostPort);
+      internalBuilder.setAttribute(NET_HOST_PORT, netHostPort);
       return this;
     }
 
@@ -229,7 +231,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
      * @param netHostName Local hostname or similar, see note below.
      */
     public RpcSpanBuilder setNetHostName(String netHostName) {
-      internalBuilder.setAttribute("net.host.name", netHostName);
+      internalBuilder.setAttribute(NET_HOST_NAME, netHostName);
       return this;
     }
 
@@ -239,7 +241,7 @@ public class RpcSpan extends DelegatingSpan implements RpcSemanticConvention {
      * @param rpcService The service name, must be equal to the $service part in the span name.
      */
     public RpcSpanBuilder setRpcService(String rpcService) {
-      internalBuilder.setAttribute("rpc.service", rpcService);
+      internalBuilder.setAttribute(RPC_SERVICE, rpcService);
       return this;
     }
   }


### PR DESCRIPTION
Replace `net.*`, `rpc.*`, `enduser.*` with constants.

Fixes: #1458