### PR TITLE
Replace string values with constants.

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbCassandraSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbCassandraSpan.java
@@ -59,7 +59,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setDbSystem(String dbSystem) {
-    delegate.setAttribute("db.system", dbSystem);
+    delegate.setAttribute(DB_SYSTEM, dbSystem);
     return this;
   }
 
@@ -71,7 +71,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setDbConnectionString(String dbConnectionString) {
-    delegate.setAttribute("db.connection_string", dbConnectionString);
+    delegate.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
     return this;
   }
 
@@ -82,7 +82,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setDbUser(String dbUser) {
-    delegate.setAttribute("db.user", dbUser);
+    delegate.setAttribute(DB_USER, dbUser);
     return this;
   }
 
@@ -95,7 +95,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-    delegate.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+    delegate.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
     return this;
   }
 
@@ -109,7 +109,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setDbName(String dbName) {
-    delegate.setAttribute("db.name", dbName);
+    delegate.setAttribute(DB_NAME, dbName);
     return this;
   }
 
@@ -121,7 +121,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setDbStatement(String dbStatement) {
-    delegate.setAttribute("db.statement", dbStatement);
+    delegate.setAttribute(DB_STATEMENT, dbStatement);
     return this;
   }
 
@@ -137,7 +137,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setDbOperation(String dbOperation) {
-    delegate.setAttribute("db.operation", dbOperation);
+    delegate.setAttribute(DB_OPERATION, dbOperation);
     return this;
   }
 
@@ -194,7 +194,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
    */
   @Override
   public DbCassandraSemanticConvention setDbCassandraKeyspace(String dbCassandraKeyspace) {
-    delegate.setAttribute("db.cassandra.keyspace", dbCassandraKeyspace);
+    delegate.setAttribute(CASSANDRA_KEYSPACE, dbCassandraKeyspace);
     return this;
   }
 
@@ -240,7 +240,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      *     See below for a list of well-known identifiers.
      */
     public DbCassandraSpanBuilder setDbSystem(String dbSystem) {
-      internalBuilder.setAttribute("db.system", dbSystem);
+      internalBuilder.setAttribute(DB_SYSTEM, dbSystem);
       return this;
     }
 
@@ -251,7 +251,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      *     <p>It is recommended to remove embedded credentials.
      */
     public DbCassandraSpanBuilder setDbConnectionString(String dbConnectionString) {
-      internalBuilder.setAttribute("db.connection_string", dbConnectionString);
+      internalBuilder.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
       return this;
     }
 
@@ -261,7 +261,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      * @param dbUser Username for accessing the database.
      */
     public DbCassandraSpanBuilder setDbUser(String dbUser) {
-      internalBuilder.setAttribute("db.user", dbUser);
+      internalBuilder.setAttribute(DB_USER, dbUser);
       return this;
     }
 
@@ -273,7 +273,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      *     used to connect.
      */
     public DbCassandraSpanBuilder setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-      internalBuilder.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+      internalBuilder.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
       return this;
     }
 
@@ -286,7 +286,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbCassandraSpanBuilder setDbName(String dbName) {
-      internalBuilder.setAttribute("db.name", dbName);
+      internalBuilder.setAttribute(DB_NAME, dbName);
       return this;
     }
 
@@ -297,7 +297,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      *     <p>The value may be sanitized to exclude sensitive information.
      */
     public DbCassandraSpanBuilder setDbStatement(String dbStatement) {
-      internalBuilder.setAttribute("db.statement", dbStatement);
+      internalBuilder.setAttribute(DB_STATEMENT, dbStatement);
       return this;
     }
 
@@ -312,7 +312,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      *     `db.statement` just to get this property (the back end can do that if required).
      */
     public DbCassandraSpanBuilder setDbOperation(String dbOperation) {
-      internalBuilder.setAttribute("db.operation", dbOperation);
+      internalBuilder.setAttribute(DB_OPERATION, dbOperation);
       return this;
     }
 
@@ -364,7 +364,7 @@ public class DbCassandraSpan extends DelegatingSpan implements DbCassandraSemant
      *     generic `db.name` attribute.
      */
     public DbCassandraSpanBuilder setDbCassandraKeyspace(String dbCassandraKeyspace) {
-      internalBuilder.setAttribute("db.cassandra.keyspace", dbCassandraKeyspace);
+      internalBuilder.setAttribute(CASSANDRA_KEYSPACE, dbCassandraKeyspace);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbHbaseSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbHbaseSpan.java
@@ -59,7 +59,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setDbSystem(String dbSystem) {
-    delegate.setAttribute("db.system", dbSystem);
+    delegate.setAttribute(DB_SYSTEM, dbSystem);
     return this;
   }
 
@@ -71,7 +71,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setDbConnectionString(String dbConnectionString) {
-    delegate.setAttribute("db.connection_string", dbConnectionString);
+    delegate.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
     return this;
   }
 
@@ -82,7 +82,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setDbUser(String dbUser) {
-    delegate.setAttribute("db.user", dbUser);
+    delegate.setAttribute(DB_USER, dbUser);
     return this;
   }
 
@@ -95,7 +95,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-    delegate.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+    delegate.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
     return this;
   }
 
@@ -109,7 +109,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setDbName(String dbName) {
-    delegate.setAttribute("db.name", dbName);
+    delegate.setAttribute(DB_NAME, dbName);
     return this;
   }
 
@@ -121,7 +121,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setDbStatement(String dbStatement) {
-    delegate.setAttribute("db.statement", dbStatement);
+    delegate.setAttribute(DB_STATEMENT, dbStatement);
     return this;
   }
 
@@ -137,7 +137,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setDbOperation(String dbOperation) {
-    delegate.setAttribute("db.operation", dbOperation);
+    delegate.setAttribute(DB_OPERATION, dbOperation);
     return this;
   }
 
@@ -194,7 +194,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
    */
   @Override
   public DbHbaseSemanticConvention setDbHbaseNamespace(String dbHbaseNamespace) {
-    delegate.setAttribute("db.hbase.namespace", dbHbaseNamespace);
+    delegate.setAttribute(HBASE_NAMESPACE, dbHbaseNamespace);
     return this;
   }
 
@@ -240,7 +240,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      *     See below for a list of well-known identifiers.
      */
     public DbHbaseSpanBuilder setDbSystem(String dbSystem) {
-      internalBuilder.setAttribute("db.system", dbSystem);
+      internalBuilder.setAttribute(DB_SYSTEM, dbSystem);
       return this;
     }
 
@@ -251,7 +251,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      *     <p>It is recommended to remove embedded credentials.
      */
     public DbHbaseSpanBuilder setDbConnectionString(String dbConnectionString) {
-      internalBuilder.setAttribute("db.connection_string", dbConnectionString);
+      internalBuilder.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
       return this;
     }
 
@@ -261,7 +261,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      * @param dbUser Username for accessing the database.
      */
     public DbHbaseSpanBuilder setDbUser(String dbUser) {
-      internalBuilder.setAttribute("db.user", dbUser);
+      internalBuilder.setAttribute(DB_USER, dbUser);
       return this;
     }
 
@@ -273,7 +273,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      *     used to connect.
      */
     public DbHbaseSpanBuilder setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-      internalBuilder.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+      internalBuilder.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
       return this;
     }
 
@@ -286,7 +286,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbHbaseSpanBuilder setDbName(String dbName) {
-      internalBuilder.setAttribute("db.name", dbName);
+      internalBuilder.setAttribute(DB_NAME, dbName);
       return this;
     }
 
@@ -297,7 +297,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      *     <p>The value may be sanitized to exclude sensitive information.
      */
     public DbHbaseSpanBuilder setDbStatement(String dbStatement) {
-      internalBuilder.setAttribute("db.statement", dbStatement);
+      internalBuilder.setAttribute(DB_STATEMENT, dbStatement);
       return this;
     }
 
@@ -312,7 +312,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      *     `db.statement` just to get this property (the back end can do that if required).
      */
     public DbHbaseSpanBuilder setDbOperation(String dbOperation) {
-      internalBuilder.setAttribute("db.operation", dbOperation);
+      internalBuilder.setAttribute(DB_OPERATION, dbOperation);
       return this;
     }
 
@@ -364,7 +364,7 @@ public class DbHbaseSpan extends DelegatingSpan implements DbHbaseSemanticConven
      *     being accessed. To be used instead of the generic `db.name` attribute.
      */
     public DbHbaseSpanBuilder setDbHbaseNamespace(String dbHbaseNamespace) {
-      internalBuilder.setAttribute("db.hbase.namespace", dbHbaseNamespace);
+      internalBuilder.setAttribute(HBASE_NAMESPACE, dbHbaseNamespace);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbMongodbSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbMongodbSpan.java
@@ -59,7 +59,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setDbSystem(String dbSystem) {
-    delegate.setAttribute("db.system", dbSystem);
+    delegate.setAttribute(DB_SYSTEM, dbSystem);
     return this;
   }
 
@@ -71,7 +71,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setDbConnectionString(String dbConnectionString) {
-    delegate.setAttribute("db.connection_string", dbConnectionString);
+    delegate.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
     return this;
   }
 
@@ -82,7 +82,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setDbUser(String dbUser) {
-    delegate.setAttribute("db.user", dbUser);
+    delegate.setAttribute(DB_USER, dbUser);
     return this;
   }
 
@@ -95,7 +95,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-    delegate.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+    delegate.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
     return this;
   }
 
@@ -109,7 +109,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setDbName(String dbName) {
-    delegate.setAttribute("db.name", dbName);
+    delegate.setAttribute(DB_NAME, dbName);
     return this;
   }
 
@@ -121,7 +121,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setDbStatement(String dbStatement) {
-    delegate.setAttribute("db.statement", dbStatement);
+    delegate.setAttribute(DB_STATEMENT, dbStatement);
     return this;
   }
 
@@ -137,7 +137,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setDbOperation(String dbOperation) {
-    delegate.setAttribute("db.operation", dbOperation);
+    delegate.setAttribute(DB_OPERATION, dbOperation);
     return this;
   }
 
@@ -194,7 +194,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
    */
   @Override
   public DbMongodbSemanticConvention setDbMongodbCollection(String dbMongodbCollection) {
-    delegate.setAttribute("db.mongodb.collection", dbMongodbCollection);
+    delegate.setAttribute(MONGODB_COLLECTION, dbMongodbCollection);
     return this;
   }
 
@@ -240,7 +240,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      *     See below for a list of well-known identifiers.
      */
     public DbMongodbSpanBuilder setDbSystem(String dbSystem) {
-      internalBuilder.setAttribute("db.system", dbSystem);
+      internalBuilder.setAttribute(DB_SYSTEM, dbSystem);
       return this;
     }
 
@@ -251,7 +251,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      *     <p>It is recommended to remove embedded credentials.
      */
     public DbMongodbSpanBuilder setDbConnectionString(String dbConnectionString) {
-      internalBuilder.setAttribute("db.connection_string", dbConnectionString);
+      internalBuilder.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
       return this;
     }
 
@@ -261,7 +261,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      * @param dbUser Username for accessing the database.
      */
     public DbMongodbSpanBuilder setDbUser(String dbUser) {
-      internalBuilder.setAttribute("db.user", dbUser);
+      internalBuilder.setAttribute(DB_USER, dbUser);
       return this;
     }
 
@@ -273,7 +273,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      *     used to connect.
      */
     public DbMongodbSpanBuilder setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-      internalBuilder.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+      internalBuilder.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
       return this;
     }
 
@@ -286,7 +286,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbMongodbSpanBuilder setDbName(String dbName) {
-      internalBuilder.setAttribute("db.name", dbName);
+      internalBuilder.setAttribute(DB_NAME, dbName);
       return this;
     }
 
@@ -297,7 +297,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      *     <p>The value may be sanitized to exclude sensitive information.
      */
     public DbMongodbSpanBuilder setDbStatement(String dbStatement) {
-      internalBuilder.setAttribute("db.statement", dbStatement);
+      internalBuilder.setAttribute(DB_STATEMENT, dbStatement);
       return this;
     }
 
@@ -312,7 +312,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      *     `db.statement` just to get this property (the back end can do that if required).
      */
     public DbMongodbSpanBuilder setDbOperation(String dbOperation) {
-      internalBuilder.setAttribute("db.operation", dbOperation);
+      internalBuilder.setAttribute(DB_OPERATION, dbOperation);
       return this;
     }
 
@@ -364,7 +364,7 @@ public class DbMongodbSpan extends DelegatingSpan implements DbMongodbSemanticCo
      *     `db.name`.
      */
     public DbMongodbSpanBuilder setDbMongodbCollection(String dbMongodbCollection) {
-      internalBuilder.setAttribute("db.mongodb.collection", dbMongodbCollection);
+      internalBuilder.setAttribute(MONGODB_COLLECTION, dbMongodbCollection);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbMssqlSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbMssqlSpan.java
@@ -59,7 +59,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setDbSystem(String dbSystem) {
-    delegate.setAttribute("db.system", dbSystem);
+    delegate.setAttribute(DB_SYSTEM, dbSystem);
     return this;
   }
 
@@ -71,7 +71,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setDbConnectionString(String dbConnectionString) {
-    delegate.setAttribute("db.connection_string", dbConnectionString);
+    delegate.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
     return this;
   }
 
@@ -82,7 +82,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setDbUser(String dbUser) {
-    delegate.setAttribute("db.user", dbUser);
+    delegate.setAttribute(DB_USER, dbUser);
     return this;
   }
 
@@ -95,7 +95,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-    delegate.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+    delegate.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
     return this;
   }
 
@@ -109,7 +109,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setDbName(String dbName) {
-    delegate.setAttribute("db.name", dbName);
+    delegate.setAttribute(DB_NAME, dbName);
     return this;
   }
 
@@ -121,7 +121,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setDbStatement(String dbStatement) {
-    delegate.setAttribute("db.statement", dbStatement);
+    delegate.setAttribute(DB_STATEMENT, dbStatement);
     return this;
   }
 
@@ -137,7 +137,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setDbOperation(String dbOperation) {
-    delegate.setAttribute("db.operation", dbOperation);
+    delegate.setAttribute(DB_OPERATION, dbOperation);
     return this;
   }
 
@@ -197,7 +197,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
    */
   @Override
   public DbMssqlSemanticConvention setDbMssqlInstanceName(String dbMssqlInstanceName) {
-    delegate.setAttribute("db.mssql.instance_name", dbMssqlInstanceName);
+    delegate.setAttribute(MSSQL_SQL_SERVER, dbMssqlInstanceName);
     return this;
   }
 
@@ -243,7 +243,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      *     See below for a list of well-known identifiers.
      */
     public DbMssqlSpanBuilder setDbSystem(String dbSystem) {
-      internalBuilder.setAttribute("db.system", dbSystem);
+      internalBuilder.setAttribute(DB_SYSTEM, dbSystem);
       return this;
     }
 
@@ -254,7 +254,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      *     <p>It is recommended to remove embedded credentials.
      */
     public DbMssqlSpanBuilder setDbConnectionString(String dbConnectionString) {
-      internalBuilder.setAttribute("db.connection_string", dbConnectionString);
+      internalBuilder.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
       return this;
     }
 
@@ -264,7 +264,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      * @param dbUser Username for accessing the database.
      */
     public DbMssqlSpanBuilder setDbUser(String dbUser) {
-      internalBuilder.setAttribute("db.user", dbUser);
+      internalBuilder.setAttribute(DB_USER, dbUser);
       return this;
     }
 
@@ -276,7 +276,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      *     used to connect.
      */
     public DbMssqlSpanBuilder setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-      internalBuilder.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+      internalBuilder.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
       return this;
     }
 
@@ -289,7 +289,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbMssqlSpanBuilder setDbName(String dbName) {
-      internalBuilder.setAttribute("db.name", dbName);
+      internalBuilder.setAttribute(DB_NAME, dbName);
       return this;
     }
 
@@ -300,7 +300,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      *     <p>The value may be sanitized to exclude sensitive information.
      */
     public DbMssqlSpanBuilder setDbStatement(String dbStatement) {
-      internalBuilder.setAttribute("db.statement", dbStatement);
+      internalBuilder.setAttribute(DB_STATEMENT, dbStatement);
       return this;
     }
 
@@ -315,7 +315,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      *     `db.statement` just to get this property (the back end can do that if required).
      */
     public DbMssqlSpanBuilder setDbOperation(String dbOperation) {
-      internalBuilder.setAttribute("db.operation", dbOperation);
+      internalBuilder.setAttribute(DB_OPERATION, dbOperation);
       return this;
     }
 
@@ -370,7 +370,7 @@ public class DbMssqlSpan extends DelegatingSpan implements DbMssqlSemanticConven
      *     still recommended if non-standard).
      */
     public DbMssqlSpanBuilder setDbMssqlInstanceName(String dbMssqlInstanceName) {
-      internalBuilder.setAttribute("db.mssql.instance_name", dbMssqlInstanceName);
+      internalBuilder.setAttribute(MSSQL_SQL_SERVER, dbMssqlInstanceName);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbRedisSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbRedisSpan.java
@@ -59,7 +59,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setDbSystem(String dbSystem) {
-    delegate.setAttribute("db.system", dbSystem);
+    delegate.setAttribute(DB_SYSTEM, dbSystem);
     return this;
   }
 
@@ -71,7 +71,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setDbConnectionString(String dbConnectionString) {
-    delegate.setAttribute("db.connection_string", dbConnectionString);
+    delegate.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
     return this;
   }
 
@@ -82,7 +82,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setDbUser(String dbUser) {
-    delegate.setAttribute("db.user", dbUser);
+    delegate.setAttribute(DB_USER, dbUser);
     return this;
   }
 
@@ -95,7 +95,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-    delegate.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+    delegate.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
     return this;
   }
 
@@ -109,7 +109,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setDbName(String dbName) {
-    delegate.setAttribute("db.name", dbName);
+    delegate.setAttribute(DB_NAME, dbName);
     return this;
   }
 
@@ -121,7 +121,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setDbStatement(String dbStatement) {
-    delegate.setAttribute("db.statement", dbStatement);
+    delegate.setAttribute(DB_STATEMENT, dbStatement);
     return this;
   }
 
@@ -137,7 +137,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setDbOperation(String dbOperation) {
-    delegate.setAttribute("db.operation", dbOperation);
+    delegate.setAttribute(DB_OPERATION, dbOperation);
     return this;
   }
 
@@ -195,7 +195,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
    */
   @Override
   public DbRedisSemanticConvention setDbRedisDatabaseIndex(long dbRedisDatabaseIndex) {
-    delegate.setAttribute("db.redis.database_index", dbRedisDatabaseIndex);
+    delegate.setAttribute(REDIS_DATABASE_INDEX, dbRedisDatabaseIndex);
     return this;
   }
 
@@ -241,7 +241,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      *     See below for a list of well-known identifiers.
      */
     public DbRedisSpanBuilder setDbSystem(String dbSystem) {
-      internalBuilder.setAttribute("db.system", dbSystem);
+      internalBuilder.setAttribute(DB_SYSTEM, dbSystem);
       return this;
     }
 
@@ -252,7 +252,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      *     <p>It is recommended to remove embedded credentials.
      */
     public DbRedisSpanBuilder setDbConnectionString(String dbConnectionString) {
-      internalBuilder.setAttribute("db.connection_string", dbConnectionString);
+      internalBuilder.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
       return this;
     }
 
@@ -262,7 +262,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      * @param dbUser Username for accessing the database.
      */
     public DbRedisSpanBuilder setDbUser(String dbUser) {
-      internalBuilder.setAttribute("db.user", dbUser);
+      internalBuilder.setAttribute(DB_USER, dbUser);
       return this;
     }
 
@@ -274,7 +274,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      *     used to connect.
      */
     public DbRedisSpanBuilder setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-      internalBuilder.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+      internalBuilder.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
       return this;
     }
 
@@ -287,7 +287,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbRedisSpanBuilder setDbName(String dbName) {
-      internalBuilder.setAttribute("db.name", dbName);
+      internalBuilder.setAttribute(DB_NAME, dbName);
       return this;
     }
 
@@ -298,7 +298,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      *     <p>The value may be sanitized to exclude sensitive information.
      */
     public DbRedisSpanBuilder setDbStatement(String dbStatement) {
-      internalBuilder.setAttribute("db.statement", dbStatement);
+      internalBuilder.setAttribute(DB_STATEMENT, dbStatement);
       return this;
     }
 
@@ -313,7 +313,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      *     `db.statement` just to get this property (the back end can do that if required).
      */
     public DbRedisSpanBuilder setDbOperation(String dbOperation) {
-      internalBuilder.setAttribute("db.operation", dbOperation);
+      internalBuilder.setAttribute(DB_OPERATION, dbOperation);
       return this;
     }
 
@@ -366,7 +366,7 @@ public class DbRedisSpan extends DelegatingSpan implements DbRedisSemanticConven
      *     the generic `db.name` attribute.
      */
     public DbRedisSpanBuilder setDbRedisDatabaseIndex(long dbRedisDatabaseIndex) {
-      internalBuilder.setAttribute("db.redis.database_index", dbRedisDatabaseIndex);
+      internalBuilder.setAttribute(REDIS_DATABASE_INDEX, dbRedisDatabaseIndex);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/DbSpan.java
@@ -48,7 +48,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setDbSystem(String dbSystem) {
-    delegate.setAttribute("db.system", dbSystem);
+    delegate.setAttribute(DB_SYSTEM, dbSystem);
     return this;
   }
 
@@ -60,7 +60,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setDbConnectionString(String dbConnectionString) {
-    delegate.setAttribute("db.connection_string", dbConnectionString);
+    delegate.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
     return this;
   }
 
@@ -71,7 +71,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setDbUser(String dbUser) {
-    delegate.setAttribute("db.user", dbUser);
+    delegate.setAttribute(DB_USER, dbUser);
     return this;
   }
 
@@ -84,7 +84,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-    delegate.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+    delegate.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
     return this;
   }
 
@@ -98,7 +98,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setDbName(String dbName) {
-    delegate.setAttribute("db.name", dbName);
+    delegate.setAttribute(DB_NAME, dbName);
     return this;
   }
 
@@ -110,7 +110,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setDbStatement(String dbStatement) {
-    delegate.setAttribute("db.statement", dbStatement);
+    delegate.setAttribute(DB_STATEMENT, dbStatement);
     return this;
   }
 
@@ -126,7 +126,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
    */
   @Override
   public DbSemanticConvention setDbOperation(String dbOperation) {
-    delegate.setAttribute("db.operation", dbOperation);
+    delegate.setAttribute(DB_OPERATION, dbOperation);
     return this;
   }
 
@@ -217,7 +217,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      *     See below for a list of well-known identifiers.
      */
     public DbSpanBuilder setDbSystem(String dbSystem) {
-      internalBuilder.setAttribute("db.system", dbSystem);
+      internalBuilder.setAttribute(DB_SYSTEM, dbSystem);
       return this;
     }
 
@@ -228,7 +228,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      *     <p>It is recommended to remove embedded credentials.
      */
     public DbSpanBuilder setDbConnectionString(String dbConnectionString) {
-      internalBuilder.setAttribute("db.connection_string", dbConnectionString);
+      internalBuilder.setAttribute(DB_CONNECTION_STRING, dbConnectionString);
       return this;
     }
 
@@ -238,7 +238,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      * @param dbUser Username for accessing the database.
      */
     public DbSpanBuilder setDbUser(String dbUser) {
-      internalBuilder.setAttribute("db.user", dbUser);
+      internalBuilder.setAttribute(DB_USER, dbUser);
       return this;
     }
 
@@ -250,7 +250,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      *     used to connect.
      */
     public DbSpanBuilder setDbJdbcDriverClassname(String dbJdbcDriverClassname) {
-      internalBuilder.setAttribute("db.jdbc.driver_classname", dbJdbcDriverClassname);
+      internalBuilder.setAttribute(JDBC_DRIVER_CLASSNAME, dbJdbcDriverClassname);
       return this;
     }
 
@@ -263,7 +263,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      *     <p>In some SQL databases, the database name to be used is called "schema name".
      */
     public DbSpanBuilder setDbName(String dbName) {
-      internalBuilder.setAttribute("db.name", dbName);
+      internalBuilder.setAttribute(DB_NAME, dbName);
       return this;
     }
 
@@ -274,7 +274,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      *     <p>The value may be sanitized to exclude sensitive information.
      */
     public DbSpanBuilder setDbStatement(String dbStatement) {
-      internalBuilder.setAttribute("db.statement", dbStatement);
+      internalBuilder.setAttribute(DB_STATEMENT, dbStatement);
       return this;
     }
 
@@ -289,7 +289,7 @@ public class DbSpan extends DelegatingSpan implements DbSemanticConvention {
      *     `db.statement` just to get this property (the back end can do that if required).
      */
     public DbSpanBuilder setDbOperation(String dbOperation) {
-      internalBuilder.setAttribute("db.operation", dbOperation);
+      internalBuilder.setAttribute(DB_OPERATION, dbOperation);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasDatasourceSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasDatasourceSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -57,7 +59,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
    */
   @Override
   public FaasDatasourceSemanticConvention setFaasTrigger(String faasTrigger) {
-    delegate.setAttribute("faas.trigger", faasTrigger);
+    delegate.setAttribute(FAAS_TRIGGER, faasTrigger);
     return this;
   }
 
@@ -68,7 +70,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
    */
   @Override
   public FaasDatasourceSemanticConvention setFaasExecution(String faasExecution) {
-    delegate.setAttribute("faas.execution", faasExecution);
+    delegate.setAttribute(FAAS_EXECUTION, faasExecution);
     return this;
   }
 
@@ -82,7 +84,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
    */
   @Override
   public FaasDatasourceSemanticConvention setFaasDocumentCollection(String faasDocumentCollection) {
-    delegate.setAttribute("faas.document.collection", faasDocumentCollection);
+    delegate.setAttribute(FAAS_DOCUMENT_COLLECTION, faasDocumentCollection);
     return this;
   }
 
@@ -94,7 +96,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
    */
   @Override
   public FaasDatasourceSemanticConvention setFaasDocumentOperation(String faasDocumentOperation) {
-    delegate.setAttribute("faas.document.operation", faasDocumentOperation);
+    delegate.setAttribute(FAAS_DOCUMENT_OPERATION, faasDocumentOperation);
     return this;
   }
 
@@ -107,7 +109,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
    */
   @Override
   public FaasDatasourceSemanticConvention setFaasDocumentTime(String faasDocumentTime) {
-    delegate.setAttribute("faas.document.time", faasDocumentTime);
+    delegate.setAttribute(FAAS_DOCUMENT_TIME, faasDocumentTime);
     return this;
   }
 
@@ -120,7 +122,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
    */
   @Override
   public FaasDatasourceSemanticConvention setFaasDocumentName(String faasDocumentName) {
-    delegate.setAttribute("faas.document.name", faasDocumentName);
+    delegate.setAttribute(FAAS_DOCUMENT_NAME, faasDocumentName);
     return this;
   }
 
@@ -165,7 +167,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
      * @param faasTrigger Type of the trigger on which the function is executed.
      */
     public FaasDatasourceSpanBuilder setFaasTrigger(String faasTrigger) {
-      internalBuilder.setAttribute("faas.trigger", faasTrigger);
+      internalBuilder.setAttribute(FAAS_TRIGGER, faasTrigger);
       return this;
     }
 
@@ -175,7 +177,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
      * @param faasExecution The execution id of the current function execution.
      */
     public FaasDatasourceSpanBuilder setFaasExecution(String faasExecution) {
-      internalBuilder.setAttribute("faas.execution", faasExecution);
+      internalBuilder.setAttribute(FAAS_EXECUTION, faasExecution);
       return this;
     }
 
@@ -188,7 +190,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
      *     to the database name.
      */
     public FaasDatasourceSpanBuilder setFaasDocumentCollection(String faasDocumentCollection) {
-      internalBuilder.setAttribute("faas.document.collection", faasDocumentCollection);
+      internalBuilder.setAttribute(FAAS_DOCUMENT_COLLECTION, faasDocumentCollection);
       return this;
     }
 
@@ -199,7 +201,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
      *     data.
      */
     public FaasDatasourceSpanBuilder setFaasDocumentOperation(String faasDocumentOperation) {
-      internalBuilder.setAttribute("faas.document.operation", faasDocumentOperation);
+      internalBuilder.setAttribute(FAAS_DOCUMENT_OPERATION, faasDocumentOperation);
       return this;
     }
 
@@ -211,7 +213,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
      *     [UTC](https://www.w3.org/TR/NOTE-datetime).
      */
     public FaasDatasourceSpanBuilder setFaasDocumentTime(String faasDocumentTime) {
-      internalBuilder.setAttribute("faas.document.time", faasDocumentTime);
+      internalBuilder.setAttribute(FAAS_DOCUMENT_TIME, faasDocumentTime);
       return this;
     }
 
@@ -223,7 +225,7 @@ public class FaasDatasourceSpan extends DelegatingSpan implements FaasDatasource
      *     table name.
      */
     public FaasDatasourceSpanBuilder setFaasDocumentName(String faasDocumentName) {
-      internalBuilder.setAttribute("faas.document.name", faasDocumentName);
+      internalBuilder.setAttribute(FAAS_DOCUMENT_NAME, faasDocumentName);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasHttpSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasHttpSpan.java
@@ -58,7 +58,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setFaasTrigger(String faasTrigger) {
-    delegate.setAttribute("faas.trigger", faasTrigger);
+    delegate.setAttribute(FAAS_TRIGGER, faasTrigger);
     return this;
   }
 
@@ -69,7 +69,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setFaasExecution(String faasExecution) {
-    delegate.setAttribute("faas.execution", faasExecution);
+    delegate.setAttribute(FAAS_EXECUTION, faasExecution);
     return this;
   }
 
@@ -80,7 +80,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpMethod(String httpMethod) {
-    delegate.setAttribute("http.method", httpMethod);
+    delegate.setAttribute(HTTP_METHOD, httpMethod);
     return this;
   }
 
@@ -93,7 +93,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpUrl(String httpUrl) {
-    delegate.setAttribute("http.url", httpUrl);
+    delegate.setAttribute(HTTP_URL, httpUrl);
     return this;
   }
 
@@ -104,7 +104,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpTarget(String httpTarget) {
-    delegate.setAttribute("http.target", httpTarget);
+    delegate.setAttribute(HTTP_TARGET, httpTarget);
     return this;
   }
 
@@ -117,7 +117,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpHost(String httpHost) {
-    delegate.setAttribute("http.host", httpHost);
+    delegate.setAttribute(HTTP_HOST, httpHost);
     return this;
   }
 
@@ -128,7 +128,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpScheme(String httpScheme) {
-    delegate.setAttribute("http.scheme", httpScheme);
+    delegate.setAttribute(HTTP_SCHEME, httpScheme);
     return this;
   }
 
@@ -140,7 +140,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpStatusCode(long httpStatusCode) {
-    delegate.setAttribute("http.status_code", httpStatusCode);
+    delegate.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
     return this;
   }
 
@@ -164,7 +164,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpFlavor(String httpFlavor) {
-    delegate.setAttribute("http.flavor", httpFlavor);
+    delegate.setAttribute(HTTP_FLAVOR, httpFlavor);
     return this;
   }
 
@@ -176,7 +176,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpUserAgent(String httpUserAgent) {
-    delegate.setAttribute("http.user_agent", httpUserAgent);
+    delegate.setAttribute(HTTP_USER_AGENT, httpUserAgent);
     return this;
   }
 
@@ -190,7 +190,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpRequestContentLength(long httpRequestContentLength) {
-    delegate.setAttribute("http.request_content_length", httpRequestContentLength);
+    delegate.setAttribute(HTTP_REQUEST_CONTENT_LENGTH, httpRequestContentLength);
     return this;
   }
 
@@ -204,7 +204,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
   public FaasHttpSemanticConvention setHttpRequestContentLengthUncompressed(
       long httpRequestContentLengthUncompressed) {
     delegate.setAttribute(
-        "http.request_content_length_uncompressed", httpRequestContentLengthUncompressed);
+        HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, httpRequestContentLengthUncompressed);
     return this;
   }
 
@@ -218,7 +218,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpResponseContentLength(long httpResponseContentLength) {
-    delegate.setAttribute("http.response_content_length", httpResponseContentLength);
+    delegate.setAttribute(HTTP_RESPONSE_CONTENT_LENGTH, httpResponseContentLength);
     return this;
   }
 
@@ -232,7 +232,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
   public FaasHttpSemanticConvention setHttpResponseContentLengthUncompressed(
       long httpResponseContentLengthUncompressed) {
     delegate.setAttribute(
-        "http.response_content_length_uncompressed", httpResponseContentLengthUncompressed);
+        HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, httpResponseContentLengthUncompressed);
     return this;
   }
 
@@ -249,7 +249,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpServerName(String httpServerName) {
-    delegate.setAttribute("http.server_name", httpServerName);
+    delegate.setAttribute(HTTP_SERVER_NAME, httpServerName);
     return this;
   }
 
@@ -260,7 +260,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpRoute(String httpRoute) {
-    delegate.setAttribute("http.route", httpRoute);
+    delegate.setAttribute(HTTP_ROUTE, httpRoute);
     return this;
   }
 
@@ -275,7 +275,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
    */
   @Override
   public FaasHttpSemanticConvention setHttpClientIp(String httpClientIp) {
-    delegate.setAttribute("http.client_ip", httpClientIp);
+    delegate.setAttribute(HTTP_CLIENT_IP, httpClientIp);
     return this;
   }
 
@@ -398,7 +398,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param faasTrigger Type of the trigger on which the function is executed.
      */
     public FaasHttpSpanBuilder setFaasTrigger(String faasTrigger) {
-      internalBuilder.setAttribute("faas.trigger", faasTrigger);
+      internalBuilder.setAttribute(FAAS_TRIGGER, faasTrigger);
       return this;
     }
 
@@ -408,7 +408,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param faasExecution The execution id of the current function execution.
      */
     public FaasHttpSpanBuilder setFaasExecution(String faasExecution) {
-      internalBuilder.setAttribute("faas.execution", faasExecution);
+      internalBuilder.setAttribute(FAAS_EXECUTION, faasExecution);
       return this;
     }
 
@@ -418,7 +418,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param httpMethod HTTP request method.
      */
     public FaasHttpSpanBuilder setHttpMethod(String httpMethod) {
-      internalBuilder.setAttribute("http.method", httpMethod);
+      internalBuilder.setAttribute(HTTP_METHOD, httpMethod);
       return this;
     }
 
@@ -430,7 +430,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      *     over HTTP, but if it is known, it should be included nevertheless.
      */
     public FaasHttpSpanBuilder setHttpUrl(String httpUrl) {
-      internalBuilder.setAttribute("http.url", httpUrl);
+      internalBuilder.setAttribute(HTTP_URL, httpUrl);
       return this;
     }
 
@@ -440,7 +440,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param httpTarget The full request target as passed in a HTTP request line or equivalent.
      */
     public FaasHttpSpanBuilder setHttpTarget(String httpTarget) {
-      internalBuilder.setAttribute("http.target", httpTarget);
+      internalBuilder.setAttribute(HTTP_TARGET, httpTarget);
       return this;
     }
 
@@ -452,7 +452,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      *     present, this attribute should be the same.
      */
     public FaasHttpSpanBuilder setHttpHost(String httpHost) {
-      internalBuilder.setAttribute("http.host", httpHost);
+      internalBuilder.setAttribute(HTTP_HOST, httpHost);
       return this;
     }
 
@@ -462,7 +462,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param httpScheme The URI scheme identifying the used protocol.
      */
     public FaasHttpSpanBuilder setHttpScheme(String httpScheme) {
-      internalBuilder.setAttribute("http.scheme", httpScheme);
+      internalBuilder.setAttribute(HTTP_SCHEME, httpScheme);
       return this;
     }
 
@@ -473,7 +473,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      *     code](https://tools.ietf.org/html/rfc7231#section-6).
      */
     public FaasHttpSpanBuilder setHttpStatusCode(long httpStatusCode) {
-      internalBuilder.setAttribute("http.status_code", httpStatusCode);
+      internalBuilder.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
       return this;
     }
 
@@ -496,7 +496,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      *     `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
      */
     public FaasHttpSpanBuilder setHttpFlavor(String httpFlavor) {
-      internalBuilder.setAttribute("http.flavor", httpFlavor);
+      internalBuilder.setAttribute(HTTP_FLAVOR, httpFlavor);
       return this;
     }
 
@@ -507,7 +507,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      *     User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the client.
      */
     public FaasHttpSpanBuilder setHttpUserAgent(String httpUserAgent) {
-      internalBuilder.setAttribute("http.user_agent", httpUserAgent);
+      internalBuilder.setAttribute(HTTP_USER_AGENT, httpUserAgent);
       return this;
     }
 
@@ -520,7 +520,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      *     requests using transport encoding, this should be the compressed size.
      */
     public FaasHttpSpanBuilder setHttpRequestContentLength(long httpRequestContentLength) {
-      internalBuilder.setAttribute("http.request_content_length", httpRequestContentLength);
+      internalBuilder.setAttribute(HTTP_REQUEST_CONTENT_LENGTH, httpRequestContentLength);
       return this;
     }
 
@@ -533,7 +533,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
     public FaasHttpSpanBuilder setHttpRequestContentLengthUncompressed(
         long httpRequestContentLengthUncompressed) {
       internalBuilder.setAttribute(
-          "http.request_content_length_uncompressed", httpRequestContentLengthUncompressed);
+          HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, httpRequestContentLengthUncompressed);
       return this;
     }
 
@@ -546,7 +546,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      *     requests using transport encoding, this should be the compressed size.
      */
     public FaasHttpSpanBuilder setHttpResponseContentLength(long httpResponseContentLength) {
-      internalBuilder.setAttribute("http.response_content_length", httpResponseContentLength);
+      internalBuilder.setAttribute(HTTP_RESPONSE_CONTENT_LENGTH, httpResponseContentLength);
       return this;
     }
 
@@ -559,7 +559,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
     public FaasHttpSpanBuilder setHttpResponseContentLengthUncompressed(
         long httpResponseContentLengthUncompressed) {
       internalBuilder.setAttribute(
-          "http.response_content_length_uncompressed", httpResponseContentLengthUncompressed);
+          HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, httpResponseContentLengthUncompressed);
       return this;
     }
 
@@ -575,7 +575,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      *     data that is available.
      */
     public FaasHttpSpanBuilder setHttpServerName(String httpServerName) {
-      internalBuilder.setAttribute("http.server_name", httpServerName);
+      internalBuilder.setAttribute(HTTP_SERVER_NAME, httpServerName);
       return this;
     }
 
@@ -585,7 +585,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      * @param httpRoute The matched route (path template).
      */
     public FaasHttpSpanBuilder setHttpRoute(String httpRoute) {
-      internalBuilder.setAttribute("http.route", httpRoute);
+      internalBuilder.setAttribute(HTTP_ROUTE, httpRoute);
       return this;
     }
 
@@ -599,7 +599,7 @@ public class FaasHttpSpan extends DelegatingSpan implements FaasHttpSemanticConv
      *     network-level peer, which may be a proxy.
      */
     public FaasHttpSpanBuilder setHttpClientIp(String httpClientIp) {
-      internalBuilder.setAttribute("http.client_ip", httpClientIp);
+      internalBuilder.setAttribute(HTTP_CLIENT_IP, httpClientIp);
       return this;
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasPubsubSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasPubsubSpan.java
@@ -59,7 +59,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setFaasTrigger(String faasTrigger) {
-    delegate.setAttribute("faas.trigger", faasTrigger);
+    delegate.setAttribute(FAAS_TRIGGER, faasTrigger);
     return this;
   }
 
@@ -70,7 +70,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setFaasExecution(String faasExecution) {
-    delegate.setAttribute("faas.execution", faasExecution);
+    delegate.setAttribute(FAAS_EXECUTION, faasExecution);
     return this;
   }
 
@@ -81,7 +81,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setMessagingSystem(String messagingSystem) {
-    delegate.setAttribute("messaging.system", messagingSystem);
+    delegate.setAttribute(MESSAGING_SYSTEM, messagingSystem);
     return this;
   }
 
@@ -93,7 +93,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setMessagingDestination(String messagingDestination) {
-    delegate.setAttribute("messaging.destination", messagingDestination);
+    delegate.setAttribute(MESSAGING_DESTINATION, messagingDestination);
     return this;
   }
 
@@ -104,7 +104,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setMessagingDestinationKind(String messagingDestinationKind) {
-    delegate.setAttribute("messaging.destination_kind", messagingDestinationKind);
+    delegate.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
     return this;
   }
 
@@ -116,7 +116,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
   @Override
   public FaasPubsubSemanticConvention setMessagingTempDestination(
       boolean messagingTempDestination) {
-    delegate.setAttribute("messaging.temp_destination", messagingTempDestination);
+    delegate.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
     return this;
   }
 
@@ -127,7 +127,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setMessagingProtocol(String messagingProtocol) {
-    delegate.setAttribute("messaging.protocol", messagingProtocol);
+    delegate.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
     return this;
   }
 
@@ -138,7 +138,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setMessagingProtocolVersion(String messagingProtocolVersion) {
-    delegate.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+    delegate.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
     return this;
   }
 
@@ -149,7 +149,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setMessagingUrl(String messagingUrl) {
-    delegate.setAttribute("messaging.url", messagingUrl);
+    delegate.setAttribute(MESSAGING_URL, messagingUrl);
     return this;
   }
 
@@ -161,7 +161,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setMessagingMessageId(String messagingMessageId) {
-    delegate.setAttribute("messaging.message_id", messagingMessageId);
+    delegate.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
     return this;
   }
 
@@ -173,7 +173,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
    */
   @Override
   public FaasPubsubSemanticConvention setMessagingConversationId(String messagingConversationId) {
-    delegate.setAttribute("messaging.conversation_id", messagingConversationId);
+    delegate.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
     return this;
   }
 
@@ -187,7 +187,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
   @Override
   public FaasPubsubSemanticConvention setMessagingMessagePayloadSizeBytes(
       long messagingMessagePayloadSizeBytes) {
-    delegate.setAttribute("messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+    delegate.setAttribute(MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
     return this;
   }
 
@@ -201,7 +201,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
   public FaasPubsubSemanticConvention setMessagingMessagePayloadCompressedSizeBytes(
       long messagingMessagePayloadCompressedSizeBytes) {
     delegate.setAttribute(
-        "messaging.message_payload_compressed_size_bytes",
+        MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
         messagingMessagePayloadCompressedSizeBytes);
     return this;
   }
@@ -325,7 +325,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param faasTrigger Type of the trigger on which the function is executed.
      */
     public FaasPubsubSpanBuilder setFaasTrigger(String faasTrigger) {
-      internalBuilder.setAttribute("faas.trigger", faasTrigger);
+      internalBuilder.setAttribute(FAAS_TRIGGER, faasTrigger);
       return this;
     }
 
@@ -335,7 +335,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param faasExecution The execution id of the current function execution.
      */
     public FaasPubsubSpanBuilder setFaasExecution(String faasExecution) {
-      internalBuilder.setAttribute("faas.execution", faasExecution);
+      internalBuilder.setAttribute(FAAS_EXECUTION, faasExecution);
       return this;
     }
 
@@ -345,7 +345,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param messagingSystem A string identifying the messaging system.
      */
     public FaasPubsubSpanBuilder setMessagingSystem(String messagingSystem) {
-      internalBuilder.setAttribute("messaging.system", messagingSystem);
+      internalBuilder.setAttribute(MESSAGING_SYSTEM, messagingSystem);
       return this;
     }
 
@@ -356,7 +356,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      *     name but is required nevertheless.
      */
     public FaasPubsubSpanBuilder setMessagingDestination(String messagingDestination) {
-      internalBuilder.setAttribute("messaging.destination", messagingDestination);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION, messagingDestination);
       return this;
     }
 
@@ -366,7 +366,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param messagingDestinationKind The kind of message destination.
      */
     public FaasPubsubSpanBuilder setMessagingDestinationKind(String messagingDestinationKind) {
-      internalBuilder.setAttribute("messaging.destination_kind", messagingDestinationKind);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
       return this;
     }
 
@@ -377,7 +377,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      *     temporary.
      */
     public FaasPubsubSpanBuilder setMessagingTempDestination(boolean messagingTempDestination) {
-      internalBuilder.setAttribute("messaging.temp_destination", messagingTempDestination);
+      internalBuilder.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
       return this;
     }
 
@@ -387,7 +387,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param messagingProtocol The name of the transport protocol.
      */
     public FaasPubsubSpanBuilder setMessagingProtocol(String messagingProtocol) {
-      internalBuilder.setAttribute("messaging.protocol", messagingProtocol);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
       return this;
     }
 
@@ -397,7 +397,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param messagingProtocolVersion The version of the transport protocol.
      */
     public FaasPubsubSpanBuilder setMessagingProtocolVersion(String messagingProtocolVersion) {
-      internalBuilder.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
       return this;
     }
 
@@ -407,7 +407,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      * @param messagingUrl Connection string.
      */
     public FaasPubsubSpanBuilder setMessagingUrl(String messagingUrl) {
-      internalBuilder.setAttribute("messaging.url", messagingUrl);
+      internalBuilder.setAttribute(MESSAGING_URL, messagingUrl);
       return this;
     }
 
@@ -418,7 +418,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      *     message, represented as a string.
      */
     public FaasPubsubSpanBuilder setMessagingMessageId(String messagingMessageId) {
-      internalBuilder.setAttribute("messaging.message_id", messagingMessageId);
+      internalBuilder.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
       return this;
     }
 
@@ -429,7 +429,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
      *     belongs, represented as a string. Sometimes called "Correlation ID".
      */
     public FaasPubsubSpanBuilder setMessagingConversationId(String messagingConversationId) {
-      internalBuilder.setAttribute("messaging.conversation_id", messagingConversationId);
+      internalBuilder.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
       return this;
     }
 
@@ -443,7 +443,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
     public FaasPubsubSpanBuilder setMessagingMessagePayloadSizeBytes(
         long messagingMessagePayloadSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+          MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
       return this;
     }
 
@@ -456,7 +456,7 @@ public class FaasPubsubSpan extends DelegatingSpan implements FaasPubsubSemantic
     public FaasPubsubSpanBuilder setMessagingMessagePayloadCompressedSizeBytes(
         long messagingMessagePayloadCompressedSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_compressed_size_bytes",
+          MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
           messagingMessagePayloadCompressedSizeBytes);
       return this;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasSpanSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasSpanSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -45,7 +47,7 @@ public class FaasSpanSpan extends DelegatingSpan implements FaasSpanSemanticConv
    */
   @Override
   public FaasSpanSemanticConvention setFaasTrigger(String faasTrigger) {
-    delegate.setAttribute("faas.trigger", faasTrigger);
+    delegate.setAttribute(FAAS_TRIGGER, faasTrigger);
     return this;
   }
 
@@ -56,7 +58,7 @@ public class FaasSpanSpan extends DelegatingSpan implements FaasSpanSemanticConv
    */
   @Override
   public FaasSpanSemanticConvention setFaasExecution(String faasExecution) {
-    delegate.setAttribute("faas.execution", faasExecution);
+    delegate.setAttribute(FAAS_EXECUTION, faasExecution);
     return this;
   }
 
@@ -101,7 +103,7 @@ public class FaasSpanSpan extends DelegatingSpan implements FaasSpanSemanticConv
      * @param faasTrigger Type of the trigger on which the function is executed.
      */
     public FaasSpanSpanBuilder setFaasTrigger(String faasTrigger) {
-      internalBuilder.setAttribute("faas.trigger", faasTrigger);
+      internalBuilder.setAttribute(FAAS_TRIGGER, faasTrigger);
       return this;
     }
 
@@ -111,7 +113,7 @@ public class FaasSpanSpan extends DelegatingSpan implements FaasSpanSemanticConv
      * @param faasExecution The execution id of the current function execution.
      */
     public FaasSpanSpanBuilder setFaasExecution(String faasExecution) {
-      internalBuilder.setAttribute("faas.execution", faasExecution);
+      internalBuilder.setAttribute(FAAS_EXECUTION, faasExecution);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasTimerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/FaasTimerSpan.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.typedspan;
 
+import static io.opentelemetry.trace.attributes.SemanticAttributes.*;
+
 import io.grpc.Context;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -56,7 +58,7 @@ public class FaasTimerSpan extends DelegatingSpan implements FaasTimerSemanticCo
    */
   @Override
   public FaasTimerSemanticConvention setFaasTrigger(String faasTrigger) {
-    delegate.setAttribute("faas.trigger", faasTrigger);
+    delegate.setAttribute(FAAS_TRIGGER, faasTrigger);
     return this;
   }
 
@@ -67,7 +69,7 @@ public class FaasTimerSpan extends DelegatingSpan implements FaasTimerSemanticCo
    */
   @Override
   public FaasTimerSemanticConvention setFaasExecution(String faasExecution) {
-    delegate.setAttribute("faas.execution", faasExecution);
+    delegate.setAttribute(FAAS_EXECUTION, faasExecution);
     return this;
   }
 
@@ -80,7 +82,7 @@ public class FaasTimerSpan extends DelegatingSpan implements FaasTimerSemanticCo
    */
   @Override
   public FaasTimerSemanticConvention setFaasTime(String faasTime) {
-    delegate.setAttribute("faas.time", faasTime);
+    delegate.setAttribute(FAAS_TIME, faasTime);
     return this;
   }
 
@@ -92,7 +94,7 @@ public class FaasTimerSpan extends DelegatingSpan implements FaasTimerSemanticCo
    */
   @Override
   public FaasTimerSemanticConvention setFaasCron(String faasCron) {
-    delegate.setAttribute("faas.cron", faasCron);
+    delegate.setAttribute(FAAS_CRON, faasCron);
     return this;
   }
 
@@ -137,7 +139,7 @@ public class FaasTimerSpan extends DelegatingSpan implements FaasTimerSemanticCo
      * @param faasTrigger Type of the trigger on which the function is executed.
      */
     public FaasTimerSpanBuilder setFaasTrigger(String faasTrigger) {
-      internalBuilder.setAttribute("faas.trigger", faasTrigger);
+      internalBuilder.setAttribute(FAAS_TRIGGER, faasTrigger);
       return this;
     }
 
@@ -147,7 +149,7 @@ public class FaasTimerSpan extends DelegatingSpan implements FaasTimerSemanticCo
      * @param faasExecution The execution id of the current function execution.
      */
     public FaasTimerSpanBuilder setFaasExecution(String faasExecution) {
-      internalBuilder.setAttribute("faas.execution", faasExecution);
+      internalBuilder.setAttribute(FAAS_EXECUTION, faasExecution);
       return this;
     }
 
@@ -159,7 +161,7 @@ public class FaasTimerSpan extends DelegatingSpan implements FaasTimerSemanticCo
      *     [UTC](https://www.w3.org/TR/NOTE-datetime).
      */
     public FaasTimerSpanBuilder setFaasTime(String faasTime) {
-      internalBuilder.setAttribute("faas.time", faasTime);
+      internalBuilder.setAttribute(FAAS_TIME, faasTime);
       return this;
     }
 
@@ -170,7 +172,7 @@ public class FaasTimerSpan extends DelegatingSpan implements FaasTimerSemanticCo
      *     Expression](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm).
      */
     public FaasTimerSpanBuilder setFaasCron(String faasCron) {
-      internalBuilder.setAttribute("faas.cron", faasCron);
+      internalBuilder.setAttribute(FAAS_CRON, faasCron);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpClientSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpClientSpan.java
@@ -136,7 +136,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setHttpMethod(String httpMethod) {
-    delegate.setAttribute("http.method", httpMethod);
+    delegate.setAttribute(HTTP_METHOD, httpMethod);
     return this;
   }
 
@@ -149,7 +149,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setHttpUrl(String httpUrl) {
-    delegate.setAttribute("http.url", httpUrl);
+    delegate.setAttribute(HTTP_URL, httpUrl);
     return this;
   }
 
@@ -160,7 +160,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setHttpTarget(String httpTarget) {
-    delegate.setAttribute("http.target", httpTarget);
+    delegate.setAttribute(HTTP_TARGET, httpTarget);
     return this;
   }
 
@@ -173,7 +173,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setHttpHost(String httpHost) {
-    delegate.setAttribute("http.host", httpHost);
+    delegate.setAttribute(HTTP_HOST, httpHost);
     return this;
   }
 
@@ -184,7 +184,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setHttpScheme(String httpScheme) {
-    delegate.setAttribute("http.scheme", httpScheme);
+    delegate.setAttribute(HTTP_SCHEME, httpScheme);
     return this;
   }
 
@@ -196,7 +196,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setHttpStatusCode(long httpStatusCode) {
-    delegate.setAttribute("http.status_code", httpStatusCode);
+    delegate.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
     return this;
   }
 
@@ -220,7 +220,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setHttpFlavor(String httpFlavor) {
-    delegate.setAttribute("http.flavor", httpFlavor);
+    delegate.setAttribute(HTTP_FLAVOR, httpFlavor);
     return this;
   }
 
@@ -232,7 +232,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setHttpUserAgent(String httpUserAgent) {
-    delegate.setAttribute("http.user_agent", httpUserAgent);
+    delegate.setAttribute(HTTP_USER_AGENT, httpUserAgent);
     return this;
   }
 
@@ -246,7 +246,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setHttpRequestContentLength(long httpRequestContentLength) {
-    delegate.setAttribute("http.request_content_length", httpRequestContentLength);
+    delegate.setAttribute(HTTP_REQUEST_CONTENT_LENGTH, httpRequestContentLength);
     return this;
   }
 
@@ -260,7 +260,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
   public HttpClientSemanticConvention setHttpRequestContentLengthUncompressed(
       long httpRequestContentLengthUncompressed) {
     delegate.setAttribute(
-        "http.request_content_length_uncompressed", httpRequestContentLengthUncompressed);
+        HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, httpRequestContentLengthUncompressed);
     return this;
   }
 
@@ -274,7 +274,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
    */
   @Override
   public HttpClientSemanticConvention setHttpResponseContentLength(long httpResponseContentLength) {
-    delegate.setAttribute("http.response_content_length", httpResponseContentLength);
+    delegate.setAttribute(HTTP_RESPONSE_CONTENT_LENGTH, httpResponseContentLength);
     return this;
   }
 
@@ -288,7 +288,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
   public HttpClientSemanticConvention setHttpResponseContentLengthUncompressed(
       long httpResponseContentLengthUncompressed) {
     delegate.setAttribute(
-        "http.response_content_length_uncompressed", httpResponseContentLengthUncompressed);
+        HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, httpResponseContentLengthUncompressed);
     return this;
   }
 
@@ -404,7 +404,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      * @param httpMethod HTTP request method.
      */
     public HttpClientSpanBuilder setHttpMethod(String httpMethod) {
-      internalBuilder.setAttribute("http.method", httpMethod);
+      internalBuilder.setAttribute(HTTP_METHOD, httpMethod);
       return this;
     }
 
@@ -416,7 +416,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      *     over HTTP, but if it is known, it should be included nevertheless.
      */
     public HttpClientSpanBuilder setHttpUrl(String httpUrl) {
-      internalBuilder.setAttribute("http.url", httpUrl);
+      internalBuilder.setAttribute(HTTP_URL, httpUrl);
       return this;
     }
 
@@ -426,7 +426,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      * @param httpTarget The full request target as passed in a HTTP request line or equivalent.
      */
     public HttpClientSpanBuilder setHttpTarget(String httpTarget) {
-      internalBuilder.setAttribute("http.target", httpTarget);
+      internalBuilder.setAttribute(HTTP_TARGET, httpTarget);
       return this;
     }
 
@@ -438,7 +438,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      *     present, this attribute should be the same.
      */
     public HttpClientSpanBuilder setHttpHost(String httpHost) {
-      internalBuilder.setAttribute("http.host", httpHost);
+      internalBuilder.setAttribute(HTTP_HOST, httpHost);
       return this;
     }
 
@@ -448,7 +448,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      * @param httpScheme The URI scheme identifying the used protocol.
      */
     public HttpClientSpanBuilder setHttpScheme(String httpScheme) {
-      internalBuilder.setAttribute("http.scheme", httpScheme);
+      internalBuilder.setAttribute(HTTP_SCHEME, httpScheme);
       return this;
     }
 
@@ -459,7 +459,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      *     code](https://tools.ietf.org/html/rfc7231#section-6).
      */
     public HttpClientSpanBuilder setHttpStatusCode(long httpStatusCode) {
-      internalBuilder.setAttribute("http.status_code", httpStatusCode);
+      internalBuilder.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
       return this;
     }
 
@@ -482,7 +482,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      *     `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
      */
     public HttpClientSpanBuilder setHttpFlavor(String httpFlavor) {
-      internalBuilder.setAttribute("http.flavor", httpFlavor);
+      internalBuilder.setAttribute(HTTP_FLAVOR, httpFlavor);
       return this;
     }
 
@@ -493,7 +493,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      *     User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the client.
      */
     public HttpClientSpanBuilder setHttpUserAgent(String httpUserAgent) {
-      internalBuilder.setAttribute("http.user_agent", httpUserAgent);
+      internalBuilder.setAttribute(HTTP_USER_AGENT, httpUserAgent);
       return this;
     }
 
@@ -506,7 +506,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      *     requests using transport encoding, this should be the compressed size.
      */
     public HttpClientSpanBuilder setHttpRequestContentLength(long httpRequestContentLength) {
-      internalBuilder.setAttribute("http.request_content_length", httpRequestContentLength);
+      internalBuilder.setAttribute(HTTP_REQUEST_CONTENT_LENGTH, httpRequestContentLength);
       return this;
     }
 
@@ -519,7 +519,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
     public HttpClientSpanBuilder setHttpRequestContentLengthUncompressed(
         long httpRequestContentLengthUncompressed) {
       internalBuilder.setAttribute(
-          "http.request_content_length_uncompressed", httpRequestContentLengthUncompressed);
+          HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, httpRequestContentLengthUncompressed);
       return this;
     }
 
@@ -532,7 +532,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
      *     requests using transport encoding, this should be the compressed size.
      */
     public HttpClientSpanBuilder setHttpResponseContentLength(long httpResponseContentLength) {
-      internalBuilder.setAttribute("http.response_content_length", httpResponseContentLength);
+      internalBuilder.setAttribute(HTTP_RESPONSE_CONTENT_LENGTH, httpResponseContentLength);
       return this;
     }
 
@@ -545,7 +545,7 @@ public class HttpClientSpan extends DelegatingSpan implements HttpClientSemantic
     public HttpClientSpanBuilder setHttpResponseContentLengthUncompressed(
         long httpResponseContentLengthUncompressed) {
       internalBuilder.setAttribute(
-          "http.response_content_length_uncompressed", httpResponseContentLengthUncompressed);
+          HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, httpResponseContentLengthUncompressed);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpServerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpServerSpan.java
@@ -136,7 +136,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpMethod(String httpMethod) {
-    delegate.setAttribute("http.method", httpMethod);
+    delegate.setAttribute(HTTP_METHOD, httpMethod);
     return this;
   }
 
@@ -149,7 +149,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpUrl(String httpUrl) {
-    delegate.setAttribute("http.url", httpUrl);
+    delegate.setAttribute(HTTP_URL, httpUrl);
     return this;
   }
 
@@ -160,7 +160,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpTarget(String httpTarget) {
-    delegate.setAttribute("http.target", httpTarget);
+    delegate.setAttribute(HTTP_TARGET, httpTarget);
     return this;
   }
 
@@ -173,7 +173,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpHost(String httpHost) {
-    delegate.setAttribute("http.host", httpHost);
+    delegate.setAttribute(HTTP_HOST, httpHost);
     return this;
   }
 
@@ -184,7 +184,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpScheme(String httpScheme) {
-    delegate.setAttribute("http.scheme", httpScheme);
+    delegate.setAttribute(HTTP_SCHEME, httpScheme);
     return this;
   }
 
@@ -196,7 +196,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpStatusCode(long httpStatusCode) {
-    delegate.setAttribute("http.status_code", httpStatusCode);
+    delegate.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
     return this;
   }
 
@@ -220,7 +220,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpFlavor(String httpFlavor) {
-    delegate.setAttribute("http.flavor", httpFlavor);
+    delegate.setAttribute(HTTP_FLAVOR, httpFlavor);
     return this;
   }
 
@@ -232,7 +232,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpUserAgent(String httpUserAgent) {
-    delegate.setAttribute("http.user_agent", httpUserAgent);
+    delegate.setAttribute(HTTP_USER_AGENT, httpUserAgent);
     return this;
   }
 
@@ -246,7 +246,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpRequestContentLength(long httpRequestContentLength) {
-    delegate.setAttribute("http.request_content_length", httpRequestContentLength);
+    delegate.setAttribute(HTTP_REQUEST_CONTENT_LENGTH, httpRequestContentLength);
     return this;
   }
 
@@ -260,7 +260,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
   public HttpServerSemanticConvention setHttpRequestContentLengthUncompressed(
       long httpRequestContentLengthUncompressed) {
     delegate.setAttribute(
-        "http.request_content_length_uncompressed", httpRequestContentLengthUncompressed);
+        HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, httpRequestContentLengthUncompressed);
     return this;
   }
 
@@ -274,7 +274,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpResponseContentLength(long httpResponseContentLength) {
-    delegate.setAttribute("http.response_content_length", httpResponseContentLength);
+    delegate.setAttribute(HTTP_RESPONSE_CONTENT_LENGTH, httpResponseContentLength);
     return this;
   }
 
@@ -288,7 +288,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
   public HttpServerSemanticConvention setHttpResponseContentLengthUncompressed(
       long httpResponseContentLengthUncompressed) {
     delegate.setAttribute(
-        "http.response_content_length_uncompressed", httpResponseContentLengthUncompressed);
+        HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, httpResponseContentLengthUncompressed);
     return this;
   }
 
@@ -305,7 +305,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpServerName(String httpServerName) {
-    delegate.setAttribute("http.server_name", httpServerName);
+    delegate.setAttribute(HTTP_SERVER_NAME, httpServerName);
     return this;
   }
 
@@ -316,7 +316,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpRoute(String httpRoute) {
-    delegate.setAttribute("http.route", httpRoute);
+    delegate.setAttribute(HTTP_ROUTE, httpRoute);
     return this;
   }
 
@@ -331,7 +331,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
    */
   @Override
   public HttpServerSemanticConvention setHttpClientIp(String httpClientIp) {
-    delegate.setAttribute("http.client_ip", httpClientIp);
+    delegate.setAttribute(HTTP_CLIENT_IP, httpClientIp);
     return this;
   }
 
@@ -447,7 +447,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      * @param httpMethod HTTP request method.
      */
     public HttpServerSpanBuilder setHttpMethod(String httpMethod) {
-      internalBuilder.setAttribute("http.method", httpMethod);
+      internalBuilder.setAttribute(HTTP_METHOD, httpMethod);
       return this;
     }
 
@@ -459,7 +459,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      *     over HTTP, but if it is known, it should be included nevertheless.
      */
     public HttpServerSpanBuilder setHttpUrl(String httpUrl) {
-      internalBuilder.setAttribute("http.url", httpUrl);
+      internalBuilder.setAttribute(HTTP_URL, httpUrl);
       return this;
     }
 
@@ -469,7 +469,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      * @param httpTarget The full request target as passed in a HTTP request line or equivalent.
      */
     public HttpServerSpanBuilder setHttpTarget(String httpTarget) {
-      internalBuilder.setAttribute("http.target", httpTarget);
+      internalBuilder.setAttribute(HTTP_TARGET, httpTarget);
       return this;
     }
 
@@ -481,7 +481,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      *     present, this attribute should be the same.
      */
     public HttpServerSpanBuilder setHttpHost(String httpHost) {
-      internalBuilder.setAttribute("http.host", httpHost);
+      internalBuilder.setAttribute(HTTP_HOST, httpHost);
       return this;
     }
 
@@ -491,7 +491,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      * @param httpScheme The URI scheme identifying the used protocol.
      */
     public HttpServerSpanBuilder setHttpScheme(String httpScheme) {
-      internalBuilder.setAttribute("http.scheme", httpScheme);
+      internalBuilder.setAttribute(HTTP_SCHEME, httpScheme);
       return this;
     }
 
@@ -502,7 +502,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      *     code](https://tools.ietf.org/html/rfc7231#section-6).
      */
     public HttpServerSpanBuilder setHttpStatusCode(long httpStatusCode) {
-      internalBuilder.setAttribute("http.status_code", httpStatusCode);
+      internalBuilder.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
       return this;
     }
 
@@ -525,7 +525,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      *     `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
      */
     public HttpServerSpanBuilder setHttpFlavor(String httpFlavor) {
-      internalBuilder.setAttribute("http.flavor", httpFlavor);
+      internalBuilder.setAttribute(HTTP_FLAVOR, httpFlavor);
       return this;
     }
 
@@ -536,7 +536,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      *     User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the client.
      */
     public HttpServerSpanBuilder setHttpUserAgent(String httpUserAgent) {
-      internalBuilder.setAttribute("http.user_agent", httpUserAgent);
+      internalBuilder.setAttribute(HTTP_USER_AGENT, httpUserAgent);
       return this;
     }
 
@@ -549,7 +549,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      *     requests using transport encoding, this should be the compressed size.
      */
     public HttpServerSpanBuilder setHttpRequestContentLength(long httpRequestContentLength) {
-      internalBuilder.setAttribute("http.request_content_length", httpRequestContentLength);
+      internalBuilder.setAttribute(HTTP_REQUEST_CONTENT_LENGTH, httpRequestContentLength);
       return this;
     }
 
@@ -562,7 +562,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
     public HttpServerSpanBuilder setHttpRequestContentLengthUncompressed(
         long httpRequestContentLengthUncompressed) {
       internalBuilder.setAttribute(
-          "http.request_content_length_uncompressed", httpRequestContentLengthUncompressed);
+          HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, httpRequestContentLengthUncompressed);
       return this;
     }
 
@@ -575,7 +575,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      *     requests using transport encoding, this should be the compressed size.
      */
     public HttpServerSpanBuilder setHttpResponseContentLength(long httpResponseContentLength) {
-      internalBuilder.setAttribute("http.response_content_length", httpResponseContentLength);
+      internalBuilder.setAttribute(HTTP_RESPONSE_CONTENT_LENGTH, httpResponseContentLength);
       return this;
     }
 
@@ -588,7 +588,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
     public HttpServerSpanBuilder setHttpResponseContentLengthUncompressed(
         long httpResponseContentLengthUncompressed) {
       internalBuilder.setAttribute(
-          "http.response_content_length_uncompressed", httpResponseContentLengthUncompressed);
+          HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, httpResponseContentLengthUncompressed);
       return this;
     }
 
@@ -604,7 +604,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      *     data that is available.
      */
     public HttpServerSpanBuilder setHttpServerName(String httpServerName) {
-      internalBuilder.setAttribute("http.server_name", httpServerName);
+      internalBuilder.setAttribute(HTTP_SERVER_NAME, httpServerName);
       return this;
     }
 
@@ -614,7 +614,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      * @param httpRoute The matched route (path template).
      */
     public HttpServerSpanBuilder setHttpRoute(String httpRoute) {
-      internalBuilder.setAttribute("http.route", httpRoute);
+      internalBuilder.setAttribute(HTTP_ROUTE, httpRoute);
       return this;
     }
 
@@ -628,7 +628,7 @@ public class HttpServerSpan extends DelegatingSpan implements HttpServerSemantic
      *     network-level peer, which may be a proxy.
      */
     public HttpServerSpanBuilder setHttpClientIp(String httpClientIp) {
-      internalBuilder.setAttribute("http.client_ip", httpClientIp);
+      internalBuilder.setAttribute(HTTP_CLIENT_IP, httpClientIp);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/HttpSpan.java
@@ -125,7 +125,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setHttpMethod(String httpMethod) {
-    delegate.setAttribute("http.method", httpMethod);
+    delegate.setAttribute(HTTP_METHOD, httpMethod);
     return this;
   }
 
@@ -138,7 +138,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setHttpUrl(String httpUrl) {
-    delegate.setAttribute("http.url", httpUrl);
+    delegate.setAttribute(HTTP_URL, httpUrl);
     return this;
   }
 
@@ -149,7 +149,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setHttpTarget(String httpTarget) {
-    delegate.setAttribute("http.target", httpTarget);
+    delegate.setAttribute(HTTP_TARGET, httpTarget);
     return this;
   }
 
@@ -162,7 +162,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setHttpHost(String httpHost) {
-    delegate.setAttribute("http.host", httpHost);
+    delegate.setAttribute(HTTP_HOST, httpHost);
     return this;
   }
 
@@ -173,7 +173,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setHttpScheme(String httpScheme) {
-    delegate.setAttribute("http.scheme", httpScheme);
+    delegate.setAttribute(HTTP_SCHEME, httpScheme);
     return this;
   }
 
@@ -185,7 +185,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setHttpStatusCode(long httpStatusCode) {
-    delegate.setAttribute("http.status_code", httpStatusCode);
+    delegate.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
     return this;
   }
 
@@ -209,7 +209,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setHttpFlavor(String httpFlavor) {
-    delegate.setAttribute("http.flavor", httpFlavor);
+    delegate.setAttribute(HTTP_FLAVOR, httpFlavor);
     return this;
   }
 
@@ -221,7 +221,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setHttpUserAgent(String httpUserAgent) {
-    delegate.setAttribute("http.user_agent", httpUserAgent);
+    delegate.setAttribute(HTTP_USER_AGENT, httpUserAgent);
     return this;
   }
 
@@ -235,7 +235,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setHttpRequestContentLength(long httpRequestContentLength) {
-    delegate.setAttribute("http.request_content_length", httpRequestContentLength);
+    delegate.setAttribute(HTTP_REQUEST_CONTENT_LENGTH, httpRequestContentLength);
     return this;
   }
 
@@ -249,7 +249,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
   public HttpSemanticConvention setHttpRequestContentLengthUncompressed(
       long httpRequestContentLengthUncompressed) {
     delegate.setAttribute(
-        "http.request_content_length_uncompressed", httpRequestContentLengthUncompressed);
+        HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, httpRequestContentLengthUncompressed);
     return this;
   }
 
@@ -263,7 +263,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
    */
   @Override
   public HttpSemanticConvention setHttpResponseContentLength(long httpResponseContentLength) {
-    delegate.setAttribute("http.response_content_length", httpResponseContentLength);
+    delegate.setAttribute(HTTP_RESPONSE_CONTENT_LENGTH, httpResponseContentLength);
     return this;
   }
 
@@ -277,7 +277,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
   public HttpSemanticConvention setHttpResponseContentLengthUncompressed(
       long httpResponseContentLengthUncompressed) {
     delegate.setAttribute(
-        "http.response_content_length_uncompressed", httpResponseContentLengthUncompressed);
+        HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, httpResponseContentLengthUncompressed);
     return this;
   }
 
@@ -393,7 +393,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      * @param httpMethod HTTP request method.
      */
     public HttpSpanBuilder setHttpMethod(String httpMethod) {
-      internalBuilder.setAttribute("http.method", httpMethod);
+      internalBuilder.setAttribute(HTTP_METHOD, httpMethod);
       return this;
     }
 
@@ -405,7 +405,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      *     over HTTP, but if it is known, it should be included nevertheless.
      */
     public HttpSpanBuilder setHttpUrl(String httpUrl) {
-      internalBuilder.setAttribute("http.url", httpUrl);
+      internalBuilder.setAttribute(HTTP_URL, httpUrl);
       return this;
     }
 
@@ -415,7 +415,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      * @param httpTarget The full request target as passed in a HTTP request line or equivalent.
      */
     public HttpSpanBuilder setHttpTarget(String httpTarget) {
-      internalBuilder.setAttribute("http.target", httpTarget);
+      internalBuilder.setAttribute(HTTP_TARGET, httpTarget);
       return this;
     }
 
@@ -427,7 +427,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      *     present, this attribute should be the same.
      */
     public HttpSpanBuilder setHttpHost(String httpHost) {
-      internalBuilder.setAttribute("http.host", httpHost);
+      internalBuilder.setAttribute(HTTP_HOST, httpHost);
       return this;
     }
 
@@ -437,7 +437,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      * @param httpScheme The URI scheme identifying the used protocol.
      */
     public HttpSpanBuilder setHttpScheme(String httpScheme) {
-      internalBuilder.setAttribute("http.scheme", httpScheme);
+      internalBuilder.setAttribute(HTTP_SCHEME, httpScheme);
       return this;
     }
 
@@ -448,7 +448,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      *     code](https://tools.ietf.org/html/rfc7231#section-6).
      */
     public HttpSpanBuilder setHttpStatusCode(long httpStatusCode) {
-      internalBuilder.setAttribute("http.status_code", httpStatusCode);
+      internalBuilder.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
       return this;
     }
 
@@ -471,7 +471,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      *     `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
      */
     public HttpSpanBuilder setHttpFlavor(String httpFlavor) {
-      internalBuilder.setAttribute("http.flavor", httpFlavor);
+      internalBuilder.setAttribute(HTTP_FLAVOR, httpFlavor);
       return this;
     }
 
@@ -482,7 +482,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      *     User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the client.
      */
     public HttpSpanBuilder setHttpUserAgent(String httpUserAgent) {
-      internalBuilder.setAttribute("http.user_agent", httpUserAgent);
+      internalBuilder.setAttribute(HTTP_USER_AGENT, httpUserAgent);
       return this;
     }
 
@@ -495,7 +495,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      *     requests using transport encoding, this should be the compressed size.
      */
     public HttpSpanBuilder setHttpRequestContentLength(long httpRequestContentLength) {
-      internalBuilder.setAttribute("http.request_content_length", httpRequestContentLength);
+      internalBuilder.setAttribute(HTTP_REQUEST_CONTENT_LENGTH, httpRequestContentLength);
       return this;
     }
 
@@ -508,7 +508,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
     public HttpSpanBuilder setHttpRequestContentLengthUncompressed(
         long httpRequestContentLengthUncompressed) {
       internalBuilder.setAttribute(
-          "http.request_content_length_uncompressed", httpRequestContentLengthUncompressed);
+          HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, httpRequestContentLengthUncompressed);
       return this;
     }
 
@@ -521,7 +521,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
      *     requests using transport encoding, this should be the compressed size.
      */
     public HttpSpanBuilder setHttpResponseContentLength(long httpResponseContentLength) {
-      internalBuilder.setAttribute("http.response_content_length", httpResponseContentLength);
+      internalBuilder.setAttribute(HTTP_RESPONSE_CONTENT_LENGTH, httpResponseContentLength);
       return this;
     }
 
@@ -534,7 +534,7 @@ public class HttpSpan extends DelegatingSpan implements HttpSemanticConvention {
     public HttpSpanBuilder setHttpResponseContentLengthUncompressed(
         long httpResponseContentLengthUncompressed) {
       internalBuilder.setAttribute(
-          "http.response_content_length_uncompressed", httpResponseContentLengthUncompressed);
+          HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, httpResponseContentLengthUncompressed);
       return this;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSpan.java
@@ -118,7 +118,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setMessagingSystem(String messagingSystem) {
-    delegate.setAttribute("messaging.system", messagingSystem);
+    delegate.setAttribute(MESSAGING_SYSTEM, messagingSystem);
     return this;
   }
 
@@ -130,7 +130,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setMessagingDestination(String messagingDestination) {
-    delegate.setAttribute("messaging.destination", messagingDestination);
+    delegate.setAttribute(MESSAGING_DESTINATION, messagingDestination);
     return this;
   }
 
@@ -142,7 +142,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSemanticConvention setMessagingDestinationKind(
       String messagingDestinationKind) {
-    delegate.setAttribute("messaging.destination_kind", messagingDestinationKind);
+    delegate.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
     return this;
   }
 
@@ -154,7 +154,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSemanticConvention setMessagingTempDestination(
       boolean messagingTempDestination) {
-    delegate.setAttribute("messaging.temp_destination", messagingTempDestination);
+    delegate.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
     return this;
   }
 
@@ -165,7 +165,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setMessagingProtocol(String messagingProtocol) {
-    delegate.setAttribute("messaging.protocol", messagingProtocol);
+    delegate.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
     return this;
   }
 
@@ -177,7 +177,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSemanticConvention setMessagingProtocolVersion(
       String messagingProtocolVersion) {
-    delegate.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+    delegate.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
     return this;
   }
 
@@ -188,7 +188,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setMessagingUrl(String messagingUrl) {
-    delegate.setAttribute("messaging.url", messagingUrl);
+    delegate.setAttribute(MESSAGING_URL, messagingUrl);
     return this;
   }
 
@@ -200,7 +200,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSemanticConvention setMessagingMessageId(String messagingMessageId) {
-    delegate.setAttribute("messaging.message_id", messagingMessageId);
+    delegate.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
     return this;
   }
 
@@ -213,7 +213,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSemanticConvention setMessagingConversationId(
       String messagingConversationId) {
-    delegate.setAttribute("messaging.conversation_id", messagingConversationId);
+    delegate.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
     return this;
   }
 
@@ -227,7 +227,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSemanticConvention setMessagingMessagePayloadSizeBytes(
       long messagingMessagePayloadSizeBytes) {
-    delegate.setAttribute("messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+    delegate.setAttribute(MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
     return this;
   }
 
@@ -241,7 +241,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
   public MessagingConsumerSemanticConvention setMessagingMessagePayloadCompressedSizeBytes(
       long messagingMessagePayloadCompressedSizeBytes) {
     delegate.setAttribute(
-        "messaging.message_payload_compressed_size_bytes",
+        MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
         messagingMessagePayloadCompressedSizeBytes);
     return this;
   }
@@ -372,7 +372,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      * @param messagingSystem A string identifying the messaging system.
      */
     public MessagingConsumerSpanBuilder setMessagingSystem(String messagingSystem) {
-      internalBuilder.setAttribute("messaging.system", messagingSystem);
+      internalBuilder.setAttribute(MESSAGING_SYSTEM, messagingSystem);
       return this;
     }
 
@@ -383,7 +383,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      *     name but is required nevertheless.
      */
     public MessagingConsumerSpanBuilder setMessagingDestination(String messagingDestination) {
-      internalBuilder.setAttribute("messaging.destination", messagingDestination);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION, messagingDestination);
       return this;
     }
 
@@ -394,7 +394,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      */
     public MessagingConsumerSpanBuilder setMessagingDestinationKind(
         String messagingDestinationKind) {
-      internalBuilder.setAttribute("messaging.destination_kind", messagingDestinationKind);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
       return this;
     }
 
@@ -406,7 +406,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      */
     public MessagingConsumerSpanBuilder setMessagingTempDestination(
         boolean messagingTempDestination) {
-      internalBuilder.setAttribute("messaging.temp_destination", messagingTempDestination);
+      internalBuilder.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
       return this;
     }
 
@@ -416,7 +416,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      * @param messagingProtocol The name of the transport protocol.
      */
     public MessagingConsumerSpanBuilder setMessagingProtocol(String messagingProtocol) {
-      internalBuilder.setAttribute("messaging.protocol", messagingProtocol);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
       return this;
     }
 
@@ -427,7 +427,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      */
     public MessagingConsumerSpanBuilder setMessagingProtocolVersion(
         String messagingProtocolVersion) {
-      internalBuilder.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
       return this;
     }
 
@@ -437,7 +437,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      * @param messagingUrl Connection string.
      */
     public MessagingConsumerSpanBuilder setMessagingUrl(String messagingUrl) {
-      internalBuilder.setAttribute("messaging.url", messagingUrl);
+      internalBuilder.setAttribute(MESSAGING_URL, messagingUrl);
       return this;
     }
 
@@ -448,7 +448,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      *     message, represented as a string.
      */
     public MessagingConsumerSpanBuilder setMessagingMessageId(String messagingMessageId) {
-      internalBuilder.setAttribute("messaging.message_id", messagingMessageId);
+      internalBuilder.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
       return this;
     }
 
@@ -459,7 +459,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
      *     belongs, represented as a string. Sometimes called "Correlation ID".
      */
     public MessagingConsumerSpanBuilder setMessagingConversationId(String messagingConversationId) {
-      internalBuilder.setAttribute("messaging.conversation_id", messagingConversationId);
+      internalBuilder.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
       return this;
     }
 
@@ -473,7 +473,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
     public MessagingConsumerSpanBuilder setMessagingMessagePayloadSizeBytes(
         long messagingMessagePayloadSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+          MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
       return this;
     }
 
@@ -486,7 +486,7 @@ public class MessagingConsumerSpan extends DelegatingSpan
     public MessagingConsumerSpanBuilder setMessagingMessagePayloadCompressedSizeBytes(
         long messagingMessagePayloadCompressedSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_compressed_size_bytes",
+          MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
           messagingMessagePayloadCompressedSizeBytes);
       return this;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSynchronousSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingConsumerSynchronousSpan.java
@@ -120,7 +120,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingSystem(String messagingSystem) {
-    delegate.setAttribute("messaging.system", messagingSystem);
+    delegate.setAttribute(MESSAGING_SYSTEM, messagingSystem);
     return this;
   }
 
@@ -133,7 +133,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingDestination(
       String messagingDestination) {
-    delegate.setAttribute("messaging.destination", messagingDestination);
+    delegate.setAttribute(MESSAGING_DESTINATION, messagingDestination);
     return this;
   }
 
@@ -145,7 +145,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingDestinationKind(
       String messagingDestinationKind) {
-    delegate.setAttribute("messaging.destination_kind", messagingDestinationKind);
+    delegate.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
     return this;
   }
 
@@ -157,7 +157,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingTempDestination(
       boolean messagingTempDestination) {
-    delegate.setAttribute("messaging.temp_destination", messagingTempDestination);
+    delegate.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
     return this;
   }
 
@@ -169,7 +169,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingProtocol(
       String messagingProtocol) {
-    delegate.setAttribute("messaging.protocol", messagingProtocol);
+    delegate.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
     return this;
   }
 
@@ -181,7 +181,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingProtocolVersion(
       String messagingProtocolVersion) {
-    delegate.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+    delegate.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
     return this;
   }
 
@@ -192,7 +192,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingUrl(String messagingUrl) {
-    delegate.setAttribute("messaging.url", messagingUrl);
+    delegate.setAttribute(MESSAGING_URL, messagingUrl);
     return this;
   }
 
@@ -205,7 +205,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingMessageId(
       String messagingMessageId) {
-    delegate.setAttribute("messaging.message_id", messagingMessageId);
+    delegate.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
     return this;
   }
 
@@ -218,7 +218,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingConversationId(
       String messagingConversationId) {
-    delegate.setAttribute("messaging.conversation_id", messagingConversationId);
+    delegate.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
     return this;
   }
 
@@ -232,7 +232,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingConsumerSynchronousSemanticConvention setMessagingMessagePayloadSizeBytes(
       long messagingMessagePayloadSizeBytes) {
-    delegate.setAttribute("messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+    delegate.setAttribute(MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
     return this;
   }
 
@@ -247,7 +247,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
       setMessagingMessagePayloadCompressedSizeBytes(
           long messagingMessagePayloadCompressedSizeBytes) {
     delegate.setAttribute(
-        "messaging.message_payload_compressed_size_bytes",
+        MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
         messagingMessagePayloadCompressedSizeBytes);
     return this;
   }
@@ -379,7 +379,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      * @param messagingSystem A string identifying the messaging system.
      */
     public MessagingConsumerSynchronousSpanBuilder setMessagingSystem(String messagingSystem) {
-      internalBuilder.setAttribute("messaging.system", messagingSystem);
+      internalBuilder.setAttribute(MESSAGING_SYSTEM, messagingSystem);
       return this;
     }
 
@@ -391,7 +391,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      */
     public MessagingConsumerSynchronousSpanBuilder setMessagingDestination(
         String messagingDestination) {
-      internalBuilder.setAttribute("messaging.destination", messagingDestination);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION, messagingDestination);
       return this;
     }
 
@@ -402,7 +402,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      */
     public MessagingConsumerSynchronousSpanBuilder setMessagingDestinationKind(
         String messagingDestinationKind) {
-      internalBuilder.setAttribute("messaging.destination_kind", messagingDestinationKind);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
       return this;
     }
 
@@ -414,7 +414,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      */
     public MessagingConsumerSynchronousSpanBuilder setMessagingTempDestination(
         boolean messagingTempDestination) {
-      internalBuilder.setAttribute("messaging.temp_destination", messagingTempDestination);
+      internalBuilder.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
       return this;
     }
 
@@ -424,7 +424,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      * @param messagingProtocol The name of the transport protocol.
      */
     public MessagingConsumerSynchronousSpanBuilder setMessagingProtocol(String messagingProtocol) {
-      internalBuilder.setAttribute("messaging.protocol", messagingProtocol);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
       return this;
     }
 
@@ -435,7 +435,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      */
     public MessagingConsumerSynchronousSpanBuilder setMessagingProtocolVersion(
         String messagingProtocolVersion) {
-      internalBuilder.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
       return this;
     }
 
@@ -445,7 +445,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      * @param messagingUrl Connection string.
      */
     public MessagingConsumerSynchronousSpanBuilder setMessagingUrl(String messagingUrl) {
-      internalBuilder.setAttribute("messaging.url", messagingUrl);
+      internalBuilder.setAttribute(MESSAGING_URL, messagingUrl);
       return this;
     }
 
@@ -457,7 +457,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      */
     public MessagingConsumerSynchronousSpanBuilder setMessagingMessageId(
         String messagingMessageId) {
-      internalBuilder.setAttribute("messaging.message_id", messagingMessageId);
+      internalBuilder.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
       return this;
     }
 
@@ -469,7 +469,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
      */
     public MessagingConsumerSynchronousSpanBuilder setMessagingConversationId(
         String messagingConversationId) {
-      internalBuilder.setAttribute("messaging.conversation_id", messagingConversationId);
+      internalBuilder.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
       return this;
     }
 
@@ -483,7 +483,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
     public MessagingConsumerSynchronousSpanBuilder setMessagingMessagePayloadSizeBytes(
         long messagingMessagePayloadSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+          MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
       return this;
     }
 
@@ -496,7 +496,7 @@ public class MessagingConsumerSynchronousSpan extends DelegatingSpan
     public MessagingConsumerSynchronousSpanBuilder setMessagingMessagePayloadCompressedSizeBytes(
         long messagingMessagePayloadCompressedSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_compressed_size_bytes",
+          MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
           messagingMessagePayloadCompressedSizeBytes);
       return this;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingProducerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingProducerSpan.java
@@ -117,7 +117,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setMessagingSystem(String messagingSystem) {
-    delegate.setAttribute("messaging.system", messagingSystem);
+    delegate.setAttribute(MESSAGING_SYSTEM, messagingSystem);
     return this;
   }
 
@@ -129,7 +129,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setMessagingDestination(String messagingDestination) {
-    delegate.setAttribute("messaging.destination", messagingDestination);
+    delegate.setAttribute(MESSAGING_DESTINATION, messagingDestination);
     return this;
   }
 
@@ -141,7 +141,7 @@ public class MessagingProducerSpan extends DelegatingSpan
   @Override
   public MessagingProducerSemanticConvention setMessagingDestinationKind(
       String messagingDestinationKind) {
-    delegate.setAttribute("messaging.destination_kind", messagingDestinationKind);
+    delegate.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
     return this;
   }
 
@@ -153,7 +153,7 @@ public class MessagingProducerSpan extends DelegatingSpan
   @Override
   public MessagingProducerSemanticConvention setMessagingTempDestination(
       boolean messagingTempDestination) {
-    delegate.setAttribute("messaging.temp_destination", messagingTempDestination);
+    delegate.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
     return this;
   }
 
@@ -164,7 +164,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setMessagingProtocol(String messagingProtocol) {
-    delegate.setAttribute("messaging.protocol", messagingProtocol);
+    delegate.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
     return this;
   }
 
@@ -176,7 +176,7 @@ public class MessagingProducerSpan extends DelegatingSpan
   @Override
   public MessagingProducerSemanticConvention setMessagingProtocolVersion(
       String messagingProtocolVersion) {
-    delegate.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+    delegate.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
     return this;
   }
 
@@ -187,7 +187,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setMessagingUrl(String messagingUrl) {
-    delegate.setAttribute("messaging.url", messagingUrl);
+    delegate.setAttribute(MESSAGING_URL, messagingUrl);
     return this;
   }
 
@@ -199,7 +199,7 @@ public class MessagingProducerSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSemanticConvention setMessagingMessageId(String messagingMessageId) {
-    delegate.setAttribute("messaging.message_id", messagingMessageId);
+    delegate.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
     return this;
   }
 
@@ -212,7 +212,7 @@ public class MessagingProducerSpan extends DelegatingSpan
   @Override
   public MessagingProducerSemanticConvention setMessagingConversationId(
       String messagingConversationId) {
-    delegate.setAttribute("messaging.conversation_id", messagingConversationId);
+    delegate.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
     return this;
   }
 
@@ -226,7 +226,7 @@ public class MessagingProducerSpan extends DelegatingSpan
   @Override
   public MessagingProducerSemanticConvention setMessagingMessagePayloadSizeBytes(
       long messagingMessagePayloadSizeBytes) {
-    delegate.setAttribute("messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+    delegate.setAttribute(MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
     return this;
   }
 
@@ -240,7 +240,7 @@ public class MessagingProducerSpan extends DelegatingSpan
   public MessagingProducerSemanticConvention setMessagingMessagePayloadCompressedSizeBytes(
       long messagingMessagePayloadCompressedSizeBytes) {
     delegate.setAttribute(
-        "messaging.message_payload_compressed_size_bytes",
+        MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
         messagingMessagePayloadCompressedSizeBytes);
     return this;
   }
@@ -359,7 +359,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      * @param messagingSystem A string identifying the messaging system.
      */
     public MessagingProducerSpanBuilder setMessagingSystem(String messagingSystem) {
-      internalBuilder.setAttribute("messaging.system", messagingSystem);
+      internalBuilder.setAttribute(MESSAGING_SYSTEM, messagingSystem);
       return this;
     }
 
@@ -370,7 +370,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      *     name but is required nevertheless.
      */
     public MessagingProducerSpanBuilder setMessagingDestination(String messagingDestination) {
-      internalBuilder.setAttribute("messaging.destination", messagingDestination);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION, messagingDestination);
       return this;
     }
 
@@ -381,7 +381,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      */
     public MessagingProducerSpanBuilder setMessagingDestinationKind(
         String messagingDestinationKind) {
-      internalBuilder.setAttribute("messaging.destination_kind", messagingDestinationKind);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
       return this;
     }
 
@@ -393,7 +393,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      */
     public MessagingProducerSpanBuilder setMessagingTempDestination(
         boolean messagingTempDestination) {
-      internalBuilder.setAttribute("messaging.temp_destination", messagingTempDestination);
+      internalBuilder.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
       return this;
     }
 
@@ -403,7 +403,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      * @param messagingProtocol The name of the transport protocol.
      */
     public MessagingProducerSpanBuilder setMessagingProtocol(String messagingProtocol) {
-      internalBuilder.setAttribute("messaging.protocol", messagingProtocol);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
       return this;
     }
 
@@ -414,7 +414,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      */
     public MessagingProducerSpanBuilder setMessagingProtocolVersion(
         String messagingProtocolVersion) {
-      internalBuilder.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
       return this;
     }
 
@@ -424,7 +424,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      * @param messagingUrl Connection string.
      */
     public MessagingProducerSpanBuilder setMessagingUrl(String messagingUrl) {
-      internalBuilder.setAttribute("messaging.url", messagingUrl);
+      internalBuilder.setAttribute(MESSAGING_URL, messagingUrl);
       return this;
     }
 
@@ -435,7 +435,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      *     message, represented as a string.
      */
     public MessagingProducerSpanBuilder setMessagingMessageId(String messagingMessageId) {
-      internalBuilder.setAttribute("messaging.message_id", messagingMessageId);
+      internalBuilder.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
       return this;
     }
 
@@ -446,7 +446,7 @@ public class MessagingProducerSpan extends DelegatingSpan
      *     belongs, represented as a string. Sometimes called "Correlation ID".
      */
     public MessagingProducerSpanBuilder setMessagingConversationId(String messagingConversationId) {
-      internalBuilder.setAttribute("messaging.conversation_id", messagingConversationId);
+      internalBuilder.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
       return this;
     }
 
@@ -460,7 +460,7 @@ public class MessagingProducerSpan extends DelegatingSpan
     public MessagingProducerSpanBuilder setMessagingMessagePayloadSizeBytes(
         long messagingMessagePayloadSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+          MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
       return this;
     }
 
@@ -473,7 +473,7 @@ public class MessagingProducerSpan extends DelegatingSpan
     public MessagingProducerSpanBuilder setMessagingMessagePayloadCompressedSizeBytes(
         long messagingMessagePayloadCompressedSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_compressed_size_bytes",
+          MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
           messagingMessagePayloadCompressedSizeBytes);
       return this;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingProducerSynchronousSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingProducerSynchronousSpan.java
@@ -117,7 +117,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSynchronousSemanticConvention setMessagingSystem(String messagingSystem) {
-    delegate.setAttribute("messaging.system", messagingSystem);
+    delegate.setAttribute(MESSAGING_SYSTEM, messagingSystem);
     return this;
   }
 
@@ -130,7 +130,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingProducerSynchronousSemanticConvention setMessagingDestination(
       String messagingDestination) {
-    delegate.setAttribute("messaging.destination", messagingDestination);
+    delegate.setAttribute(MESSAGING_DESTINATION, messagingDestination);
     return this;
   }
 
@@ -142,7 +142,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingProducerSynchronousSemanticConvention setMessagingDestinationKind(
       String messagingDestinationKind) {
-    delegate.setAttribute("messaging.destination_kind", messagingDestinationKind);
+    delegate.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
     return this;
   }
 
@@ -154,7 +154,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingProducerSynchronousSemanticConvention setMessagingTempDestination(
       boolean messagingTempDestination) {
-    delegate.setAttribute("messaging.temp_destination", messagingTempDestination);
+    delegate.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
     return this;
   }
 
@@ -166,7 +166,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingProducerSynchronousSemanticConvention setMessagingProtocol(
       String messagingProtocol) {
-    delegate.setAttribute("messaging.protocol", messagingProtocol);
+    delegate.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
     return this;
   }
 
@@ -178,7 +178,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingProducerSynchronousSemanticConvention setMessagingProtocolVersion(
       String messagingProtocolVersion) {
-    delegate.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+    delegate.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
     return this;
   }
 
@@ -189,7 +189,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
    */
   @Override
   public MessagingProducerSynchronousSemanticConvention setMessagingUrl(String messagingUrl) {
-    delegate.setAttribute("messaging.url", messagingUrl);
+    delegate.setAttribute(MESSAGING_URL, messagingUrl);
     return this;
   }
 
@@ -202,7 +202,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingProducerSynchronousSemanticConvention setMessagingMessageId(
       String messagingMessageId) {
-    delegate.setAttribute("messaging.message_id", messagingMessageId);
+    delegate.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
     return this;
   }
 
@@ -215,7 +215,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingProducerSynchronousSemanticConvention setMessagingConversationId(
       String messagingConversationId) {
-    delegate.setAttribute("messaging.conversation_id", messagingConversationId);
+    delegate.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
     return this;
   }
 
@@ -229,7 +229,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
   @Override
   public MessagingProducerSynchronousSemanticConvention setMessagingMessagePayloadSizeBytes(
       long messagingMessagePayloadSizeBytes) {
-    delegate.setAttribute("messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+    delegate.setAttribute(MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
     return this;
   }
 
@@ -244,7 +244,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
       setMessagingMessagePayloadCompressedSizeBytes(
           long messagingMessagePayloadCompressedSizeBytes) {
     delegate.setAttribute(
-        "messaging.message_payload_compressed_size_bytes",
+        MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
         messagingMessagePayloadCompressedSizeBytes);
     return this;
   }
@@ -363,7 +363,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      * @param messagingSystem A string identifying the messaging system.
      */
     public MessagingProducerSynchronousSpanBuilder setMessagingSystem(String messagingSystem) {
-      internalBuilder.setAttribute("messaging.system", messagingSystem);
+      internalBuilder.setAttribute(MESSAGING_SYSTEM, messagingSystem);
       return this;
     }
 
@@ -375,7 +375,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      */
     public MessagingProducerSynchronousSpanBuilder setMessagingDestination(
         String messagingDestination) {
-      internalBuilder.setAttribute("messaging.destination", messagingDestination);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION, messagingDestination);
       return this;
     }
 
@@ -386,7 +386,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      */
     public MessagingProducerSynchronousSpanBuilder setMessagingDestinationKind(
         String messagingDestinationKind) {
-      internalBuilder.setAttribute("messaging.destination_kind", messagingDestinationKind);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
       return this;
     }
 
@@ -398,7 +398,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      */
     public MessagingProducerSynchronousSpanBuilder setMessagingTempDestination(
         boolean messagingTempDestination) {
-      internalBuilder.setAttribute("messaging.temp_destination", messagingTempDestination);
+      internalBuilder.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
       return this;
     }
 
@@ -408,7 +408,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      * @param messagingProtocol The name of the transport protocol.
      */
     public MessagingProducerSynchronousSpanBuilder setMessagingProtocol(String messagingProtocol) {
-      internalBuilder.setAttribute("messaging.protocol", messagingProtocol);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
       return this;
     }
 
@@ -419,7 +419,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      */
     public MessagingProducerSynchronousSpanBuilder setMessagingProtocolVersion(
         String messagingProtocolVersion) {
-      internalBuilder.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
       return this;
     }
 
@@ -429,7 +429,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      * @param messagingUrl Connection string.
      */
     public MessagingProducerSynchronousSpanBuilder setMessagingUrl(String messagingUrl) {
-      internalBuilder.setAttribute("messaging.url", messagingUrl);
+      internalBuilder.setAttribute(MESSAGING_URL, messagingUrl);
       return this;
     }
 
@@ -441,7 +441,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      */
     public MessagingProducerSynchronousSpanBuilder setMessagingMessageId(
         String messagingMessageId) {
-      internalBuilder.setAttribute("messaging.message_id", messagingMessageId);
+      internalBuilder.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
       return this;
     }
 
@@ -453,7 +453,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
      */
     public MessagingProducerSynchronousSpanBuilder setMessagingConversationId(
         String messagingConversationId) {
-      internalBuilder.setAttribute("messaging.conversation_id", messagingConversationId);
+      internalBuilder.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
       return this;
     }
 
@@ -467,7 +467,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
     public MessagingProducerSynchronousSpanBuilder setMessagingMessagePayloadSizeBytes(
         long messagingMessagePayloadSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+          MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
       return this;
     }
 
@@ -480,7 +480,7 @@ public class MessagingProducerSynchronousSpan extends DelegatingSpan
     public MessagingProducerSynchronousSpanBuilder setMessagingMessagePayloadCompressedSizeBytes(
         long messagingMessagePayloadCompressedSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_compressed_size_bytes",
+          MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
           messagingMessagePayloadCompressedSizeBytes);
       return this;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/typedspan/MessagingSpan.java
@@ -103,7 +103,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setMessagingSystem(String messagingSystem) {
-    delegate.setAttribute("messaging.system", messagingSystem);
+    delegate.setAttribute(MESSAGING_SYSTEM, messagingSystem);
     return this;
   }
 
@@ -115,7 +115,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setMessagingDestination(String messagingDestination) {
-    delegate.setAttribute("messaging.destination", messagingDestination);
+    delegate.setAttribute(MESSAGING_DESTINATION, messagingDestination);
     return this;
   }
 
@@ -126,7 +126,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setMessagingDestinationKind(String messagingDestinationKind) {
-    delegate.setAttribute("messaging.destination_kind", messagingDestinationKind);
+    delegate.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
     return this;
   }
 
@@ -137,7 +137,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setMessagingTempDestination(boolean messagingTempDestination) {
-    delegate.setAttribute("messaging.temp_destination", messagingTempDestination);
+    delegate.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
     return this;
   }
 
@@ -148,7 +148,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setMessagingProtocol(String messagingProtocol) {
-    delegate.setAttribute("messaging.protocol", messagingProtocol);
+    delegate.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
     return this;
   }
 
@@ -159,7 +159,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setMessagingProtocolVersion(String messagingProtocolVersion) {
-    delegate.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+    delegate.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
     return this;
   }
 
@@ -170,7 +170,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setMessagingUrl(String messagingUrl) {
-    delegate.setAttribute("messaging.url", messagingUrl);
+    delegate.setAttribute(MESSAGING_URL, messagingUrl);
     return this;
   }
 
@@ -182,7 +182,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setMessagingMessageId(String messagingMessageId) {
-    delegate.setAttribute("messaging.message_id", messagingMessageId);
+    delegate.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
     return this;
   }
 
@@ -194,7 +194,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
    */
   @Override
   public MessagingSemanticConvention setMessagingConversationId(String messagingConversationId) {
-    delegate.setAttribute("messaging.conversation_id", messagingConversationId);
+    delegate.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
     return this;
   }
 
@@ -208,7 +208,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
   @Override
   public MessagingSemanticConvention setMessagingMessagePayloadSizeBytes(
       long messagingMessagePayloadSizeBytes) {
-    delegate.setAttribute("messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+    delegate.setAttribute(MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
     return this;
   }
 
@@ -222,7 +222,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
   public MessagingSemanticConvention setMessagingMessagePayloadCompressedSizeBytes(
       long messagingMessagePayloadCompressedSizeBytes) {
     delegate.setAttribute(
-        "messaging.message_payload_compressed_size_bytes",
+        MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
         messagingMessagePayloadCompressedSizeBytes);
     return this;
   }
@@ -341,7 +341,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param messagingSystem A string identifying the messaging system.
      */
     public MessagingSpanBuilder setMessagingSystem(String messagingSystem) {
-      internalBuilder.setAttribute("messaging.system", messagingSystem);
+      internalBuilder.setAttribute(MESSAGING_SYSTEM, messagingSystem);
       return this;
     }
 
@@ -352,7 +352,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      *     name but is required nevertheless.
      */
     public MessagingSpanBuilder setMessagingDestination(String messagingDestination) {
-      internalBuilder.setAttribute("messaging.destination", messagingDestination);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION, messagingDestination);
       return this;
     }
 
@@ -362,7 +362,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param messagingDestinationKind The kind of message destination.
      */
     public MessagingSpanBuilder setMessagingDestinationKind(String messagingDestinationKind) {
-      internalBuilder.setAttribute("messaging.destination_kind", messagingDestinationKind);
+      internalBuilder.setAttribute(MESSAGING_DESTINATION_KIND, messagingDestinationKind);
       return this;
     }
 
@@ -373,7 +373,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      *     temporary.
      */
     public MessagingSpanBuilder setMessagingTempDestination(boolean messagingTempDestination) {
-      internalBuilder.setAttribute("messaging.temp_destination", messagingTempDestination);
+      internalBuilder.setAttribute(MESSAGING_TEMP_DESTINATION, messagingTempDestination);
       return this;
     }
 
@@ -383,7 +383,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param messagingProtocol The name of the transport protocol.
      */
     public MessagingSpanBuilder setMessagingProtocol(String messagingProtocol) {
-      internalBuilder.setAttribute("messaging.protocol", messagingProtocol);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL, messagingProtocol);
       return this;
     }
 
@@ -393,7 +393,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param messagingProtocolVersion The version of the transport protocol.
      */
     public MessagingSpanBuilder setMessagingProtocolVersion(String messagingProtocolVersion) {
-      internalBuilder.setAttribute("messaging.protocol_version", messagingProtocolVersion);
+      internalBuilder.setAttribute(MESSAGING_PROTOCOL_VERSION, messagingProtocolVersion);
       return this;
     }
 
@@ -403,7 +403,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      * @param messagingUrl Connection string.
      */
     public MessagingSpanBuilder setMessagingUrl(String messagingUrl) {
-      internalBuilder.setAttribute("messaging.url", messagingUrl);
+      internalBuilder.setAttribute(MESSAGING_URL, messagingUrl);
       return this;
     }
 
@@ -414,7 +414,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      *     message, represented as a string.
      */
     public MessagingSpanBuilder setMessagingMessageId(String messagingMessageId) {
-      internalBuilder.setAttribute("messaging.message_id", messagingMessageId);
+      internalBuilder.setAttribute(MESSAGING_MESSAGE_ID, messagingMessageId);
       return this;
     }
 
@@ -425,7 +425,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
      *     belongs, represented as a string. Sometimes called "Correlation ID".
      */
     public MessagingSpanBuilder setMessagingConversationId(String messagingConversationId) {
-      internalBuilder.setAttribute("messaging.conversation_id", messagingConversationId);
+      internalBuilder.setAttribute(MESSAGING_CONVERSATION_ID, messagingConversationId);
       return this;
     }
 
@@ -439,7 +439,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
     public MessagingSpanBuilder setMessagingMessagePayloadSizeBytes(
         long messagingMessagePayloadSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_size_bytes", messagingMessagePayloadSizeBytes);
+          MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, messagingMessagePayloadSizeBytes);
       return this;
     }
 
@@ -452,7 +452,7 @@ public class MessagingSpan extends DelegatingSpan implements MessagingSemanticCo
     public MessagingSpanBuilder setMessagingMessagePayloadCompressedSizeBytes(
         long messagingMessagePayloadCompressedSizeBytes) {
       internalBuilder.setAttribute(
-          "messaging.message_payload_compressed_size_bytes",
+          MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
           messagingMessagePayloadCompressedSizeBytes);
       return this;
     }


### PR DESCRIPTION
This is a second PR after #1459 to replace string values with respective constants.

This PR covers the following groups: 
- `http.*`
- `peer.*`
- `message.*`
- `db.*`
- `messaging.*`
- `exception.*`
- `faas.*`

Fixes: #1458