### PR TITLE
Review our usage of gradle cache

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,11 +7,39 @@ on:
   workflow_dispatch:
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11 for running checks
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Build
+        uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: jdk11
+          remote-build-cache-proxy-enabled: false
+          arguments: build --stacktrace
+
+      - name: Aggregate test reports with ciMate
+        if: always()
+        continue-on-error: true
+        env:
+          CIMATE_PROJECT_ID: mz1jo49x
+          CIMATE_CI_KEY: "PR / jdk11"
+        run: |
+          wget -q https://get.cimate.io/release/linux/cimate
+          chmod +x cimate
+          ./cimate -v "**/TEST-*.xml"
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 15]
+        java: [ 8, 15 ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -22,12 +50,6 @@ jobs:
       - name: Set JDK ${{ matrix.java }} home
         run: echo JAVA_${{ matrix.java }}_HOME=${{ env.JAVA_HOME }} >> $GITHUB_ENV
 
-      - name: Set up JDK 11 for running Gradle
-        if: matrix.java != 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
       - name: Test
         uses: burrunan/gradle-cache-action@v1.5
         env:
@@ -35,7 +57,8 @@ jobs:
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           job-id: jdk${{ matrix.java }}
-          arguments: testJava${{ matrix.java }} --stacktrace -Dorg.gradle.caching.debug=true
+          remote-build-cache-proxy-enabled: false
+          arguments: testJava${{ matrix.java }} --stacktrace
 
       - name: Aggregate test reports with ciMate
         if: always()
@@ -59,12 +82,13 @@ jobs:
 
       - name: Test
         uses: burrunan/gradle-cache-action@v1.5
-        with:
-          job-id: latestDepTest
-          arguments: test -PtestLatestDeps=true --stacktrace
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+        with:
+          job-id: latestDepTest
+          remote-build-cache-proxy-enabled: false
+          arguments: test -PtestLatestDeps=true --stacktrace
 
       - name: Aggregate test reports with ciMate
         if: always()
@@ -79,7 +103,7 @@ jobs:
 
   issue:
     name: Open issue on failure
-    needs: [test, testLatestDep]
+    needs: [ test, testLatestDep ]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,6 +24,9 @@ jobs:
 
       - name: Build
         uses: nick-invision/retry@v1
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           command: ./gradlew build --stacktrace
           timeout_minutes: 90

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,12 +17,17 @@ jobs:
         with:
           java-version: 11
 
-      - name: Build
+      - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.5
         with:
           job-id: jdk11
-          remote-build-cache-proxy-enabled: false
-          arguments: build --stacktrace
+
+      - name: Build
+        uses: nick-invision/retry@v1
+        with:
+          command: ./gradlew build --stacktrace
+          timeout_minutes: 90
+          max_attempts: 3
 
       - name: Aggregate test reports with ciMate
         if: always()
@@ -50,15 +55,26 @@ jobs:
       - name: Set JDK ${{ matrix.java }} home
         run: echo JAVA_${{ matrix.java }}_HOME=${{ env.JAVA_HOME }} >> $GITHUB_ENV
 
-      - name: Test
+      - name: Set up JDK 11 for running Gradle
+        if: matrix.java == 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: jdk${{ matrix.java }}
+
+      - name: Test
+        uses: nick-invision/retry@v1
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          job-id: jdk${{ matrix.java }}
-          remote-build-cache-proxy-enabled: false
-          arguments: testJava${{ matrix.java }} --stacktrace
+          command: ./gradlew testJava${{ matrix.java }} --stacktrace
+          timeout_minutes: 90
+          max_attempts: 3
 
       - name: Aggregate test reports with ciMate
         if: always()
@@ -80,15 +96,20 @@ jobs:
         with:
           java-version: 11
 
-      - name: Test
+      - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: latestDepTest
+
+      - name: Test
+        uses: nick-invision/retry@v1
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          job-id: latestDepTest
-          remote-build-cache-proxy-enabled: false
-          arguments: test -PtestLatestDeps=true --stacktrace
+          command: ./gradlew test -PtestLatestDeps=true --stacktrace
+          timeout_minutes: 60
+          max_attempts: 3
 
       - name: Aggregate test reports with ciMate
         if: always()

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,10 +17,10 @@ jobs:
         with:
           java-version: 11
 
-   #   - name: Restore cache
-   #     uses: burrunan/gradle-cache-action@v1.5
-   #     with:
-   #       job-id: jdk11
+      - name: Restore cache
+        uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: jdk11
 
       - name: Build
         uses: nick-invision/retry@v1
@@ -64,10 +64,10 @@ jobs:
         with:
           java-version: 11
 
-     # - name: Restore cache
-     #   uses: burrunan/gradle-cache-action@v1.5
-     #   with:
-     #     job-id: jdk${{ matrix.java }}
+      - name: Restore cache
+        uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: jdk${{ matrix.java }}
 
       - name: Test
         uses: nick-invision/retry@v1
@@ -99,10 +99,10 @@ jobs:
         with:
           java-version: 11
 
-     # - name: Restore cache
-     #   uses: burrunan/gradle-cache-action@v1.5
-     #   with:
-     #     job-id: latestDepTest
+      - name: Restore cache
+        uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: latestDepTest
 
       - name: Test
         uses: nick-invision/retry@v1

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -125,9 +125,32 @@ jobs:
           chmod +x cimate
           ./cimate -v "**/TEST-*.xml"
 
+  snapshot:
+    runs-on: ubuntu-latest
+    needs: [ build, test, testLatestDep ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11 for running checks
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Restore cache
+        uses: burrunan/gradle-cache-action@v1.5
+        with:
+          job-id: jdk11
+
+      - name: Publish snapshot
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+        run: ./gradlew snapshot --stacktrace
+
+
   issue:
     name: Open issue on failure
-    needs: [ test, testLatestDep ]
+    needs: [ build, test, testLatestDep, snapshot ]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,10 +17,10 @@ jobs:
         with:
           java-version: 11
 
-      - name: Restore cache
-        uses: burrunan/gradle-cache-action@v1.5
-        with:
-          job-id: jdk11
+   #   - name: Restore cache
+   #     uses: burrunan/gradle-cache-action@v1.5
+   #     with:
+   #       job-id: jdk11
 
       - name: Build
         uses: nick-invision/retry@v1
@@ -64,10 +64,10 @@ jobs:
         with:
           java-version: 11
 
-      - name: Restore cache
-        uses: burrunan/gradle-cache-action@v1.5
-        with:
-          job-id: jdk${{ matrix.java }}
+     # - name: Restore cache
+     #   uses: burrunan/gradle-cache-action@v1.5
+     #   with:
+     #     job-id: jdk${{ matrix.java }}
 
       - name: Test
         uses: nick-invision/retry@v1
@@ -99,10 +99,10 @@ jobs:
         with:
           java-version: 11
 
-      - name: Restore cache
-        uses: burrunan/gradle-cache-action@v1.5
-        with:
-          job-id: latestDepTest
+     # - name: Restore cache
+     #   uses: burrunan/gradle-cache-action@v1.5
+     #   with:
+     #     job-id: latestDepTest
 
       - name: Test
         uses: nick-invision/retry@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,11 +13,20 @@ jobs:
         with:
           java-version: 11
 
-      - name: Build
+      - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.5
         with:
           job-id: jdk11
-          arguments: build --stacktrace -x :smoke-tests:test
+
+      - name: Build
+        uses: nick-invision/retry@v1
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+        with:
+          command: ./gradlew check --stacktrace -x :smoke-tests:test
+          timeout_minutes: 90
+          max_attempts: 3
 
       - name: Aggregate test reports with ciMate
         if: always()
@@ -50,11 +59,20 @@ jobs:
         with:
           java-version: 11
 
-      - name: Test
+      - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.5
         with:
           job-id: jdk${{ matrix.java }}
-          arguments: testJava${{ matrix.java }} --stacktrace -x :smoke-tests:test
+
+      - name: Test
+        uses: nick-invision/retry@v1
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+        with:
+          command: ./gradlew testJava${{ matrix.java }} --stacktrace -x :smoke-tests:test
+          timeout_minutes: 90
+          max_attempts: 3
 
       - name: Aggregate test reports with ciMate
         if: always()
@@ -77,11 +95,20 @@ jobs:
         with:
           java-version: 11
 
-      - name: Test
+      - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.5
         with:
-          job-id: jdk11
-          arguments: :smoke-tests:test
+          job-id: smokeTests
+
+      - name: Test
+        uses: nick-invision/retry@v1
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+        with:
+          command: ./gradlew :smoke-tests:test
+          timeout_minutes: 90
+          max_attempts: 3
 
       - name: Aggregate test reports with ciMate
         if: always()

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,9 +20,6 @@ jobs:
 
       - name: Build
         uses: nick-invision/retry@v1
-        env:
-          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
-          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           command: ./gradlew check --stacktrace -x :smoke-tests:test
           timeout_minutes: 90
@@ -66,9 +63,6 @@ jobs:
 
       - name: Test
         uses: nick-invision/retry@v1
-        env:
-          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
-          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           command: ./gradlew testJava${{ matrix.java }} --stacktrace -x :smoke-tests:test
           timeout_minutes: 90
@@ -102,9 +96,6 @@ jobs:
 
       - name: Test
         uses: nick-invision/retry@v1
-        env:
-          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
-          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
           command: ./gradlew :smoke-tests:test
           timeout_minutes: 90

--- a/instrumentation/akka-http-10.0/akka-http-10.0.gradle
+++ b/instrumentation/akka-http-10.0/akka-http-10.0.gradle
@@ -1,12 +1,12 @@
-apply from: "$rootDir/gradle/instrumentation.gradle"
-apply from: "$rootDir/gradle/test-with-scala.gradle"
-apply plugin: 'org.unbroken-dome.test-sets'
-
 ext {
   // TODO remove once Scala/akka supports Java 15
   // https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
   maxJavaVersionForTests = JavaVersion.VERSION_14
 }
+
+apply from: "$rootDir/gradle/instrumentation.gradle"
+apply from: "$rootDir/gradle/test-with-scala.gradle"
+apply plugin: 'org.unbroken-dome.test-sets'
 
 testSets {
   version101Test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,8 +24,9 @@ def awsAccessKeyId = System.getenv("S3_BUILD_CACHE_ACCESS_KEY_ID")
 buildCache {
   remote(com.github.burrunan.s3cache.AwsS3BuildCache) {
     region = 'us-west-2'
-    bucket = 'opentelemetry-java-instrumentation-gradle-nikem'
+    bucket = 'opentelemetry-java-instrumentation-gradle-cache'
     push = isCI && awsAccessKeyId != null && !awsAccessKeyId.isEmpty()
+    lookupDefaultAwsCredentials = true
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,7 +24,7 @@ def awsAccessKeyId = System.getenv("S3_BUILD_CACHE_ACCESS_KEY_ID")
 buildCache {
   remote(com.github.burrunan.s3cache.AwsS3BuildCache) {
     region = 'us-west-2'
-    bucket = 'opentelemetry-java-instrumentation-gradle-test1'
+    bucket = 'opentelemetry-java-instrumentation-gradle-nikem'
     push = isCI && awsAccessKeyId != null && !awsAccessKeyId.isEmpty()
   }
 }


### PR DESCRIPTION
- Gradle cache now uses new S3 bucket created under CNCF account
- Switched off using GHA as Gradle remote cache, as this created problems for us. We still use both GHA cache and Gradle remote S3 cache, but separately, not through `burrunan/gradle-multi-cache`
- Nightly build on GHA now publishes snapshot

After this and #1450 are merged, we can remove CirceCI configuration and mark #678 as closed