### PR TITLE
Fix net.peer.* setting for Cassandra 4.+

### DIFF
--- a/instrumentation/cassandra/cassandra-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraDatabaseClientTracer.java
+++ b/instrumentation/cassandra/cassandra-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraDatabaseClientTracer.java
@@ -14,7 +14,7 @@ import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import io.opentelemetry.javaagent.instrumentation.api.db.DbSystem;
 import io.opentelemetry.trace.Span;
 import java.net.InetSocketAddress;
-import java.util.Optional;
+import java.net.SocketAddress;
 
 public class CassandraDatabaseClientTracer extends DatabaseClientTracer<CqlSession, String> {
   public static final CassandraDatabaseClientTracer TRACER = new CassandraDatabaseClientTracer();
@@ -47,8 +47,10 @@ public class CassandraDatabaseClientTracer extends DatabaseClientTracer<CqlSessi
   public void onResponse(Span span, ExecutionInfo executionInfo) {
     Node coordinator = executionInfo.getCoordinator();
     if (coordinator != null) {
-      Optional<InetSocketAddress> address = coordinator.getBroadcastRpcAddress();
-      address.ifPresent(inetSocketAddress -> NetPeerUtils.setNetPeer(span, inetSocketAddress));
+      SocketAddress socketAddress = coordinator.getEndPoint().resolve();
+      if (socketAddress instanceof InetSocketAddress) {
+        NetPeerUtils.setNetPeer(span, ((InetSocketAddress) socketAddress));
+      }
     }
   }
 }


### PR DESCRIPTION
#1427 removed max java version to run Cassandra 4 tests. This allowed `testLatestDep` job to actually run them (as it uses java 11 to run). This exposed that starting from some version of Cassandra client driver the value returned by `node.getBroadcastRpcAddress()` changed to `0.0.0.0` in our tests. This broke tests.

But this also exposed that we used wrong address for `net.peer.*` attributes in the first place. `BroadcastRpcAddress` means the address that Cassandra server accepts RPC connections. In case of containers/proxy this may be completely different address from the one used by client. But `node.getEndPoint()` returns "The information that the driver uses to connect to the node". Which seems like the correct one.

Closes #1478
Closes #1473 
Closes #1472 
Closes #1461 
Closes #1460