### PR TITLE
Rename printReferences gradle task to printMuzzleReferences

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -82,7 +82,7 @@ class MuzzlePlugin implements Plugin<Project> {
         println "Muzzle executing for $project"
       }
     }
-    def printReferences = project.task('printReferences') {
+    def printReferences = project.task('printMuzzleReferences') {
       group = 'Muzzle'
       description = "Print references created by instrumentation muzzle"
       doLast {
@@ -101,7 +101,7 @@ class MuzzlePlugin implements Plugin<Project> {
       }
     }
     project.tasks.muzzle.dependsOn(project.tasks.compileMuzzle)
-    project.tasks.printReferences.dependsOn(project.tasks.compileMuzzle)
+    project.tasks.printMuzzleReferences.dependsOn(project.tasks.compileMuzzle)
 
     def hasRelevantTask = project.gradle.startParameter.taskNames.any { taskName ->
       // removing leading ':' if present

--- a/docs/contributing/muzzle.md
+++ b/docs/contributing/muzzle.md
@@ -67,9 +67,9 @@ The gradle plugin defines two tasks:
     ```
     If a new, incompatible version of the instrumented library is published it fails the build.
 
-* `printReferences` task prints all API references in a given module:
+* `printMuzzleReferences` task prints all API references in a given module:
     ```sh
-    ./gradlew :instrumentation:google-http-client-1.19:printReferences
+    ./gradlew :instrumentation:google-http-client-1.19:printMuzzleReferences
     ```
 
 The muzzle plugin needs to be configured in the module's `.gradle` file.

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
@@ -147,7 +147,7 @@ public final class MuzzleGradlePluginUtil {
    * Prints all references from all instrumenters present in the passed {@code
    * instrumentationClassLoader}.
    *
-   * <p>Called by the {@code :printReferences} gradle task.
+   * <p>Called by the {@code printMuzzleReferences} gradle task.
    */
   public static void printMuzzleReferences(ClassLoader instrumentationClassLoader) {
     for (Instrumenter instrumenter :


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>