### PR TITLE
Run muzzle once per instrumented library - introducing InstrumentationModule

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.SortedSet;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -137,7 +136,7 @@ public abstract class Config {
   }
 
   public boolean isInstrumentationEnabled(
-      SortedSet<String> instrumentationNames, boolean defaultEnabled) {
+      Iterable<String> instrumentationNames, boolean defaultEnabled) {
     // If default is enabled, we want to enable individually,
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
@@ -13,11 +13,10 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-import com.google.auto.service.AutoService;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
 import io.opentelemetry.javaagent.instrumentation.api.SpanWithScope;
-import io.opentelemetry.javaagent.tooling.Instrumenter;
+import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,23 +28,11 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.ModelAndView;
 
-@AutoService(Instrumenter.class)
-public final class DispatcherServletInstrumentation extends Instrumenter.Default {
-
-  public DispatcherServletInstrumentation() {
-    super("spring-web");
-  }
+public final class DispatcherServletInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     return named("org.springframework.web.servlet.DispatcherServlet");
-  }
-
-  @Override
-  public String[] helperClassNames() {
-    return new String[] {
-      packageName + ".SpringWebMvcTracer", packageName + ".HandlerMappingResourceNameFilter"
-    };
   }
 
   @Override

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
@@ -28,7 +28,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.ModelAndView;
 
-public final class DispatcherServletInstrumentation implements TypeInstrumentation {
+final class DispatcherServletInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.springwebmvc;
 
 import static io.opentelemetry.javaagent.instrumentation.springwebmvc.SpringWebMvcTracer.tracer;
+import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -28,7 +29,13 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-public final class HandlerAdapterInstrumentation implements TypeInstrumentation {
+final class HandlerAdapterInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Optimization for expensive typeMatcher.
+    return hasClassesNamed("org.springframework.web.servlet.HandlerAdapter");
+  }
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.springwebmvc;
 
 import static io.opentelemetry.javaagent.instrumentation.springwebmvc.SpringWebMvcTracer.tracer;
-import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -16,13 +15,12 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-import com.google.auto.service.AutoService;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
 import io.opentelemetry.javaagent.instrumentation.api.SpanWithScope;
-import io.opentelemetry.javaagent.tooling.Instrumenter;
+import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import net.bytebuddy.asm.Advice;
@@ -30,27 +28,11 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-@AutoService(Instrumenter.class)
-public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
-
-  public HandlerAdapterInstrumentation() {
-    super("spring-web");
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    // Optimization for expensive typeMatcher.
-    return hasClassesNamed("org.springframework.web.servlet.HandlerAdapter");
-  }
+public final class HandlerAdapterInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
     return implementsInterface(named("org.springframework.web.servlet.HandlerAdapter"));
-  }
-
-  @Override
-  public String[] helperClassNames() {
-    return new String[] {packageName + ".SpringWebMvcTracer"};
   }
 
   @Override

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringMvcInstrumentationModule.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringMvcInstrumentationModule.java
@@ -5,28 +5,17 @@
 
 package io.opentelemetry.javaagent.instrumentation.springwebmvc;
 
-import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
-import java.util.Arrays;
 import java.util.List;
-import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public final class SpringMvcInstrumentationModule extends InstrumentationModule {
   public SpringMvcInstrumentationModule() {
     super("spring-mvc");
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    // Optimization for expensive typeMatchers.
-    return hasClassesNamed(
-        "org.springframework.context.support.AbstractApplicationContext",
-        "org.springframework.web.context.WebApplicationContext",
-        "org.springframework.web.servlet.HandlerAdapter");
   }
 
   @Override
@@ -40,7 +29,7 @@ public final class SpringMvcInstrumentationModule extends InstrumentationModule 
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return Arrays.asList(
+    return asList(
         new WebApplicationContextInstrumentation(),
         new DispatcherServletInstrumentation(),
         new HandlerAdapterInstrumentation());

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringMvcInstrumentationModule.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringMvcInstrumentationModule.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.springwebmvc;
+
+import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.tooling.InstrumentationModule;
+import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
+import java.util.Arrays;
+import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(InstrumentationModule.class)
+public final class SpringMvcInstrumentationModule extends InstrumentationModule {
+  public SpringMvcInstrumentationModule() {
+    super("spring-mvc");
+  }
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Optimization for expensive typeMatchers.
+    return hasClassesNamed(
+        "org.springframework.context.support.AbstractApplicationContext",
+        "org.springframework.web.context.WebApplicationContext",
+        "org.springframework.web.servlet.HandlerAdapter");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".SpringWebMvcTracer",
+      packageName + ".HandlerMappingResourceNameFilter",
+      packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",
+    };
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return Arrays.asList(
+        new WebApplicationContextInstrumentation(),
+        new DispatcherServletInstrumentation(),
+        new HandlerAdapterInstrumentation());
+  }
+}

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/WebApplicationContextInstrumentation.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/WebApplicationContextInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.springwebmvc;
 
+import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.extendsClass;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
 import static java.util.Collections.singletonMap;
@@ -25,7 +26,15 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
  * This instrumentation adds the HandlerMappingResourceNameFilter definition to the spring context
  * When the context is created, the filter will be added to the beginning of the filter chain
  */
-public final class WebApplicationContextInstrumentation implements TypeInstrumentation {
+final class WebApplicationContextInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    // Optimization for expensive typeMatcher.
+    return hasClassesNamed(
+        "org.springframework.context.support.AbstractApplicationContext",
+        "org.springframework.web.context.WebApplicationContext");
+  }
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/WebApplicationContextInstrumentation.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/WebApplicationContextInstrumentation.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.springwebmvc;
 
-import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.extendsClass;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
 import static java.util.Collections.singletonMap;
@@ -13,8 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
-import com.google.auto.service.AutoService;
-import io.opentelemetry.javaagent.tooling.Instrumenter;
+import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -27,19 +25,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
  * This instrumentation adds the HandlerMappingResourceNameFilter definition to the spring context
  * When the context is created, the filter will be added to the beginning of the filter chain
  */
-@AutoService(Instrumenter.class)
-public class WebApplicationContextInstrumentation extends Instrumenter.Default {
-  public WebApplicationContextInstrumentation() {
-    super("spring-web");
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    // Optimization for expensive typeMatcher.
-    return hasClassesNamed(
-        "org.springframework.context.support.AbstractApplicationContext",
-        "org.springframework.web.context.WebApplicationContext");
-  }
+public final class WebApplicationContextInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
@@ -48,17 +34,7 @@ public class WebApplicationContextInstrumentation extends Instrumenter.Default {
   }
 
   @Override
-  public String[] helperClassNames() {
-    return new String[] {
-      packageName + ".SpringWebMvcTracer",
-      packageName + ".HandlerMappingResourceNameFilter",
-      packageName + ".HandlerMappingResourceNameFilter$BeanDefinition",
-    };
-  }
-
-  @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-
     return singletonMap(
         isMethod()
             .and(named("postProcessBeanFactory"))

--- a/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/SafeServiceLoader.java
+++ b/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/SafeServiceLoader.java
@@ -25,7 +25,7 @@ public class SafeServiceLoader {
    * this should not happen. Please read CONTRIBUTING.md, section "Testing - Java versions" for a
    * background info why this is Ok.
    */
-  public static <T> Iterable<T> load(Class<T> serviceClass, ClassLoader classLoader) {
+  public static <T> List<T> load(Class<T> serviceClass, ClassLoader classLoader) {
     List<T> result = new ArrayList<>();
     java.util.ServiceLoader<T> services = ServiceLoader.load(serviceClass, classLoader);
     for (Iterator<T> iter = services.iterator(); iter.hasNext(); ) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InstrumentationModule.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InstrumentationModule.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.failSafe;
+import static java.util.Arrays.asList;
+import static net.bytebuddy.matcher.ElementMatchers.any;
+import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.tooling.bytebuddy.AgentTransformers;
+import io.opentelemetry.javaagent.tooling.bytebuddy.ExceptionHandlers;
+import io.opentelemetry.javaagent.tooling.context.FieldBackedProvider;
+import io.opentelemetry.javaagent.tooling.context.InstrumentationContextProvider;
+import io.opentelemetry.javaagent.tooling.context.NoopContextProvider;
+import io.opentelemetry.javaagent.tooling.muzzle.matcher.Mismatch;
+import io.opentelemetry.javaagent.tooling.muzzle.matcher.ReferenceMatcher;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.annotation.AnnotationSource;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.utility.JavaModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Instrumentation module groups several connected {@link TypeInstrumentation}s together, sharing
+ * classloader matcher, helper classes, muzzle safety checks, etc. Ideally all types in a single
+ * instrumented library should live in a single module.
+ */
+public abstract class InstrumentationModule {
+  private static final Logger log = LoggerFactory.getLogger(InstrumentationModule.class);
+
+  private static final String[] EMPTY = new String[0];
+
+  // Added here instead of AgentInstaller's ignores because it's relatively
+  // expensive. https://github.com/DataDog/dd-trace-java/pull/1045
+  public static final ElementMatcher.Junction<AnnotationSource> NOT_DECORATOR_MATCHER =
+      not(isAnnotatedWith(named("javax.decorator.Decorator")));
+
+  private final Set<String> instrumentationNames;
+  protected final boolean enabled;
+
+  protected final String packageName =
+      getClass().getPackage() == null ? "" : getClass().getPackage().getName();
+
+  public InstrumentationModule(
+      String mainInstrumentationName, String... otherInstrumentationNames) {
+    this(toList(mainInstrumentationName, otherInstrumentationNames));
+  }
+
+  private static List<String> toList(String first, String[] rest) {
+    List<String> instrumentationNames = new ArrayList<>(rest.length + 1);
+    instrumentationNames.add(first);
+    instrumentationNames.addAll(asList(rest));
+    return instrumentationNames;
+  }
+
+  public InstrumentationModule(List<String> instrumentationNames) {
+    checkArgument(instrumentationNames.size() > 0, "InstrumentationModules must be named");
+    this.instrumentationNames = new LinkedHashSet<>(instrumentationNames);
+    enabled = Config.get().isInstrumentationEnabled(this.instrumentationNames, defaultEnabled());
+  }
+
+  /**
+   * Add this instrumentation to an AgentBuilder.
+   *
+   * @param parentAgentBuilder AgentBuilder to base instrumentation config off of.
+   * @return the original agentBuilder and this instrumentation
+   */
+  public final AgentBuilder instrument(AgentBuilder parentAgentBuilder) {
+    if (!enabled) {
+      log.debug("Instrumentation {} is disabled", instrumentationNames.iterator().next());
+      return parentAgentBuilder;
+    }
+
+    ElementMatcher<ClassLoader> classLoaderMatcher = classLoaderMatcher();
+    MuzzleMatcher muzzleMatcher = new MuzzleMatcher();
+    HelperInjector helperInjector =
+        new HelperInjector(
+            getClass().getSimpleName(), asList(helperClassNames()), asList(helperResourceNames()));
+    InstrumentationContextProvider contextProvider = getContextProvider();
+
+    AgentBuilder agentBuilder = parentAgentBuilder;
+    for (TypeInstrumentation typeInstrumentation : typeInstrumentations()) {
+      AgentBuilder.Identified.Extendable extendableAgentBuilder =
+          agentBuilder
+              .type(
+                  failSafe(
+                      typeInstrumentation.typeMatcher(),
+                      "Instrumentation type matcher unexpected exception: " + getClass().getName()),
+                  failSafe(
+                      classLoaderMatcher,
+                      "Instrumentation class loader matcher unexpected exception: "
+                          + getClass().getName()))
+              .and(NOT_DECORATOR_MATCHER)
+              .and(muzzleMatcher)
+              .transform(AgentTransformers.defaultTransformers())
+              .transform(helperInjector);
+      extendableAgentBuilder = contextProvider.instrumentationTransformer(extendableAgentBuilder);
+      extendableAgentBuilder =
+          applyInstrumentationTransformers(
+              typeInstrumentation.transformers(), extendableAgentBuilder);
+      extendableAgentBuilder = contextProvider.additionalInstrumentation(extendableAgentBuilder);
+
+      agentBuilder = extendableAgentBuilder;
+    }
+
+    return agentBuilder;
+  }
+
+  private AgentBuilder.Identified.Extendable applyInstrumentationTransformers(
+      Map<? extends ElementMatcher<? super MethodDescription>, String> transformers,
+      AgentBuilder.Identified.Extendable agentBuilder) {
+    for (Map.Entry<? extends ElementMatcher<? super MethodDescription>, String> entry :
+        transformers.entrySet()) {
+      agentBuilder =
+          agentBuilder.transform(
+              new AgentBuilder.Transformer.ForAdvice()
+                  .include(Utils.getBootstrapProxy(), Utils.getAgentClassLoader())
+                  .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
+                  .advice(entry.getKey(), entry.getValue()));
+    }
+    return agentBuilder;
+  }
+
+  private InstrumentationContextProvider getContextProvider() {
+    Map<String, String> contextStore = contextStore();
+    if (!contextStore.isEmpty()) {
+      return new FieldBackedProvider(getClass(), contextStore);
+    } else {
+      return NoopContextProvider.INSTANCE;
+    }
+  }
+
+  /**
+   * A ByteBuddy matcher that decides whether this instrumentation should be applied. Calls
+   * generated {@link ReferenceMatcher}: if any mismatch with the passed {@code classLoader} is
+   * found this instrumentation is skipped.
+   */
+  private class MuzzleMatcher implements AgentBuilder.RawMatcher {
+    @Override
+    public boolean matches(
+        TypeDescription typeDescription,
+        ClassLoader classLoader,
+        JavaModule module,
+        Class<?> classBeingRedefined,
+        ProtectionDomain protectionDomain) {
+      /* Optimization: calling getMuzzleReferenceMatcher() inside this method
+       * prevents unnecessary loading of muzzle references during agentBuilder
+       * setup.
+       */
+      ReferenceMatcher muzzle = getMuzzleReferenceMatcher();
+      if (muzzle != null) {
+        boolean isMatch = muzzle.matches(classLoader);
+
+        if (log.isDebugEnabled()) {
+          if (!isMatch) {
+            log.debug(
+                "Instrumentation skipped, mismatched references were found: {} -- {} on {}",
+                instrumentationNames.iterator().next(),
+                InstrumentationModule.this.getClass().getName(),
+                classLoader);
+            List<Mismatch> mismatches = muzzle.getMismatchedReferenceSources(classLoader);
+            for (Mismatch mismatch : mismatches) {
+              log.debug("-- {}", mismatch);
+            }
+          } else {
+            log.debug(
+                "Applying instrumentation: {} -- {} on {}",
+                instrumentationNames.iterator().next(),
+                InstrumentationModule.this.getClass().getName(),
+                classLoader);
+          }
+        }
+
+        return isMatch;
+      }
+      return true;
+    }
+  }
+
+  /**
+   * The actual implementation of this method is generated automatically during compilation by the
+   * {@link io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin}
+   * ByteBuddy plugin.
+   *
+   * <p><b>This method is generated automatically, do not override it.</b>
+   */
+  protected ReferenceMatcher getMuzzleReferenceMatcher() {
+    return null;
+  }
+
+  /**
+   * Order of adding instrumentation to ByteBuddy. For example instrumentation with order 1 runs
+   * after an instrumentation with order 0 (default) matched on the same API.
+   *
+   * @return the order of adding an instrumentation to ByteBuddy. Default value is 0 - no order.
+   */
+  public int getOrder() {
+    return 0;
+  }
+
+  /** @return Class names of helpers to inject into the user's classloader */
+  public String[] helperClassNames() {
+    return EMPTY;
+  }
+
+  /** @return Resource names to inject into the user's classloader */
+  public String[] helperResourceNames() {
+    return EMPTY;
+  }
+
+  /** @return A type matcher used to match the classloader under transform */
+  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return any();
+  }
+
+  public abstract List<TypeInstrumentation> typeInstrumentations();
+
+  /**
+   * Context stores to define for this instrumentation.
+   *
+   * <p>A map of {@code class-name to context-class-name}. Keys (and their subclasses) will be
+   * associated with a context of the value.
+   */
+  protected Map<String, String> contextStore() {
+    return Collections.emptyMap();
+  }
+
+  protected boolean defaultEnabled() {
+    return Config.get().getBooleanProperty("otel.instrumentations.enabled", true);
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Instrumenter.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Instrumenter.java
@@ -86,7 +86,7 @@ public interface Instrumenter {
       enabled = Config.get().isInstrumentationEnabled(instrumentationNames, defaultEnabled());
       Map<String, String> contextStore = contextStore();
       if (!contextStore.isEmpty()) {
-        contextProvider = new FieldBackedProvider(this, contextStore);
+        contextProvider = new FieldBackedProvider(getClass(), contextStore);
       } else {
         contextProvider = NoopContextProvider.INSTANCE;
       }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Instrumenter.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Instrumenter.java
@@ -41,7 +41,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>It is strongly recommended to extend {@link Default} rather than implement this interface
  * directly.
+ *
+ * @deprecated Use {@link InstrumentationModule} and {@link TypeInstrumentation} instead.
  */
+@Deprecated
 public interface Instrumenter {
   /**
    * Add this instrumentation to an AgentBuilder.
@@ -59,6 +62,8 @@ public interface Instrumenter {
    */
   int getOrder();
 
+  /** @deprecated Use {@link InstrumentationModule} and {@link TypeInstrumentation} instead. */
+  @Deprecated
   abstract class Default implements Instrumenter {
 
     private static final Logger log = LoggerFactory.getLogger(Default.class);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TypeInstrumentation.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TypeInstrumentation.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.tooling;
 
+import static net.bytebuddy.matcher.ElementMatchers.any;
+
+import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers;
 import java.util.Map;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -14,6 +17,17 @@ import net.bytebuddy.matcher.ElementMatcher;
  * Interface representing a single type instrumentation. Part of an {@link InstrumentationModule}.
  */
 public interface TypeInstrumentation {
+  /**
+   * A type instrumentation can implement this method to optimize an expensive {@link
+   * #typeMatcher()} - usually {@link AgentElementMatchers#implementsInterface(ElementMatcher)} or
+   * {@link AgentElementMatchers#extendsClass(ElementMatcher)}. In that case it's useful to check
+   * that the classloader contains the class/interface that is being extended.
+   *
+   * @return A type matcher used to match the classloader under transform
+   */
+  default ElementMatcher<ClassLoader> classLoaderMatcher() {
+    return any();
+  }
 
   /**
    * @return A type matcher defining which classes should undergo transformations defined by advices

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TypeInstrumentation.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TypeInstrumentation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling;
+
+import java.util.Map;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Interface representing a single type instrumentation. Part of an {@link InstrumentationModule}.
+ */
+public interface TypeInstrumentation {
+
+  /**
+   * @return A type matcher defining which classes should undergo transformations defined by advices
+   *     returned by {@link #transformers()}.
+   */
+  ElementMatcher<? super TypeDescription> typeMatcher();
+
+  /**
+   * @return Keys of the returned map are method matchers, values are full names of advice classes
+   *     that will be applied onto methods that satisfy matcher (key).
+   */
+  Map<? extends ElementMatcher<? super MethodDescription>, String> transformers();
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/collector/MuzzleCodeGenerationPlugin.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/collector/MuzzleCodeGenerationPlugin.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.javaagent.tooling.muzzle.collector;
 
 import io.opentelemetry.javaagent.instrumentation.api.WeakMap;
+import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.Instrumenter;
-import io.opentelemetry.javaagent.tooling.Instrumenter.Default;
 import java.util.Collections;
 import java.util.WeakHashMap;
 import net.bytebuddy.build.Plugin;
@@ -18,7 +18,7 @@ import net.bytebuddy.dynamic.DynamicType;
 
 /**
  * This class is a ByteBuddy build plugin that is responsible for generating actual implementation
- * of the {@link Default#getMuzzleReferenceMatcher()} method.
+ * of the {@link InstrumentationModule#getMuzzleReferenceMatcher()} method.
  *
  * <p>This class is used in the gradle build scripts, referenced by each instrumentation module.
  */
@@ -34,8 +34,10 @@ public class MuzzleCodeGenerationPlugin implements Plugin {
         });
   }
 
-  private static final TypeDescription DefaultInstrumenterTypeDesc =
+  private static final TypeDescription defaultInstrumenterType =
       new TypeDescription.ForLoadedType(Instrumenter.Default.class);
+  private static final TypeDescription instrumentationModuleType =
+      new TypeDescription.ForLoadedType(InstrumentationModule.class);
 
   @Override
   public boolean matches(TypeDescription target) {
@@ -46,7 +48,8 @@ public class MuzzleCodeGenerationPlugin implements Plugin {
     boolean isInstrumenter = false;
     TypeDefinition instrumenter = target.getSuperClass();
     while (instrumenter != null) {
-      if (instrumenter.equals(DefaultInstrumenterTypeDesc)) {
+      if (instrumenter.equals(defaultInstrumenterType)
+          || instrumenter.equals(instrumentationModuleType)) {
         isInstrumenter = true;
         break;
       }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
@@ -71,8 +71,7 @@ public final class MuzzleGradlePluginUtil {
         ReferenceMatcher muzzle = (ReferenceMatcher) m.invoke(instrumenter);
         List<Mismatch> mismatches = muzzle.getMismatchedReferenceSources(userClassLoader);
 
-        Method getClassLoaderMatcher =
-            instrumenter.getClass().getMethod("classLoaderMatcher");
+        Method getClassLoaderMatcher = instrumenter.getClass().getMethod("classLoaderMatcher");
         boolean classLoaderMatch =
             ((ElementMatcher<ClassLoader>) getClassLoaderMatcher.invoke(instrumenter))
                 .matches(userClassLoader);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
@@ -64,14 +64,16 @@ public final class MuzzleGradlePluginUtil {
         // only default Instrumenters and modules use muzzle. Skip custom instrumenters.
         continue;
       }
-      Method m = null;
+      Method getMuzzleReferenceMatcher = null;
       try {
-        m = instrumenter.getClass().getDeclaredMethod("getMuzzleReferenceMatcher");
-        m.setAccessible(true);
-        ReferenceMatcher muzzle = (ReferenceMatcher) m.invoke(instrumenter);
+        getMuzzleReferenceMatcher =
+            instrumenter.getClass().getDeclaredMethod("getMuzzleReferenceMatcher");
+        getMuzzleReferenceMatcher.setAccessible(true);
+        ReferenceMatcher muzzle = (ReferenceMatcher) getMuzzleReferenceMatcher.invoke(instrumenter);
         List<Mismatch> mismatches = muzzle.getMismatchedReferenceSources(userClassLoader);
 
         Method getClassLoaderMatcher = instrumenter.getClass().getMethod("classLoaderMatcher");
+        getClassLoaderMatcher.setAccessible(true);
         boolean classLoaderMatch =
             ((ElementMatcher<ClassLoader>) getClassLoaderMatcher.invoke(instrumenter))
                 .matches(userClassLoader);
@@ -97,8 +99,8 @@ public final class MuzzleGradlePluginUtil {
           throw new RuntimeException("Instrumentation failed Muzzle validation");
         }
       } finally {
-        if (null != m) {
-          m.setAccessible(false);
+        if (null != getMuzzleReferenceMatcher) {
+          getMuzzleReferenceMatcher.setAccessible(false);
         }
       }
     }
@@ -121,8 +123,9 @@ public final class MuzzleGradlePluginUtil {
         }
         try {
           // verify helper injector works
-          Method m = instrumenter.getClass().getMethod("helperClassNames");
-          String[] helperClassNames = (String[]) m.invoke(instrumenter);
+          Method getHelperClassNames = instrumenter.getClass().getMethod("helperClassNames");
+          getHelperClassNames.setAccessible(true);
+          String[] helperClassNames = (String[]) getHelperClassNames.invoke(instrumenter);
           if (helperClassNames.length > 0) {
             new HelperInjector(
                     MuzzleGradlePluginUtil.class.getSimpleName(),

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/InstrumentationModuleTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/InstrumentationModuleTest.groovy
@@ -1,0 +1,151 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling
+
+import io.opentelemetry.instrumentation.test.utils.ConfigUtils
+import net.bytebuddy.agent.builder.AgentBuilder
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.contrib.java.lang.system.RestoreSystemProperties
+import spock.lang.Specification
+
+class InstrumentationModuleTest extends Specification {
+
+  @Rule
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
+  @Rule
+  public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+  def setup() {
+    assert System.getenv().findAll { it.key.startsWith("OTEL_") }.isEmpty()
+    assert System.getProperties().findAll { it.key.toString().startsWith("otel.") }.isEmpty()
+  }
+
+  def "default enabled"() {
+    setup:
+    def target = new TestInstrumentationModule(["test"])
+    target.instrument(new AgentBuilder.Default())
+
+    expect:
+    target.enabled
+    target.applyCalled
+  }
+
+  def "default enabled override"() {
+    setup:
+    target.instrument(new AgentBuilder.Default())
+
+    expect:
+    target.enabled == enabled
+    target.applyCalled == enabled
+
+    where:
+    enabled | target
+    true    | new TestInstrumentationModule(["test"]) {
+      @Override
+      protected boolean defaultEnabled() {
+        return true
+      }
+    }
+    false   | new TestInstrumentationModule(["test"]) {
+      @Override
+      protected boolean defaultEnabled() {
+        return false
+      }
+    }
+  }
+
+  def "default disabled can override to enabled"() {
+    setup:
+    def previousConfig = ConfigUtils.updateConfig {
+      it.setProperty("otel.instrumentation.test.enabled", "$enabled")
+    }
+    def target = new TestInstrumentationModule(["test"]) {
+      @Override
+      protected boolean defaultEnabled() {
+        return false
+      }
+    }
+    target.instrument(new AgentBuilder.Default())
+
+    expect:
+    target.enabled == enabled
+    target.applyCalled == enabled
+
+    cleanup:
+    ConfigUtils.setConfig(previousConfig)
+
+    where:
+    enabled << [true, false]
+  }
+
+  def "configure default sys prop as #value"() {
+    setup:
+    def previousConfig = ConfigUtils.updateConfig {
+      it.setProperty("otel.instrumentations.enabled", value)
+    }
+    def target = new TestInstrumentationModule(["test"])
+    target.instrument(new AgentBuilder.Default())
+
+    expect:
+    target.enabled == enabled
+    target.applyCalled == enabled
+
+    cleanup:
+    ConfigUtils.setConfig(previousConfig)
+
+    where:
+    value   | enabled
+    "true"  | true
+    "false" | false
+    "asdf"  | false
+  }
+
+  def "configure sys prop enabled for #value when default is disabled"() {
+    setup:
+    def previousConfig = ConfigUtils.updateConfig {
+      it.setProperty("otel.instrumentations.enabled", "false")
+      it.setProperty("otel.instrumentation.${value}.enabled", "true")
+    }
+    def target = new TestInstrumentationModule([name, altName])
+    target.instrument(new AgentBuilder.Default())
+
+    expect:
+    target.enabled == enabled
+    target.applyCalled == enabled
+
+    cleanup:
+    ConfigUtils.setConfig(previousConfig)
+
+    where:
+    value             | enabled | name          | altName
+    "test"            | true    | "test"        | "asdf"
+    "duplicate"       | true    | "duplicate"   | "duplicate"
+    "bad"             | false   | "not"         | "valid"
+    "altTest"         | true    | "asdf"        | "altTest"
+    "dash-test"       | true    | "dash-test"   | "asdf"
+    "underscore_test" | true    | "asdf"        | "underscore_test"
+    "period.test"     | true    | "period.test" | "asdf"
+  }
+
+  class TestInstrumentationModule extends InstrumentationModule {
+    boolean applyCalled = false
+
+    TestInstrumentationModule(List<String> instrumentationNames) {
+      super(instrumentationNames)
+    }
+
+    def getEnabled() {
+      return super.enabled
+    }
+
+    @Override
+    List<TypeInstrumentation> typeInstrumentations() {
+      applyCalled = true
+      return []
+    }
+  }
+}


### PR DESCRIPTION
Implementation of this concept: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1274#issuecomment-707860035

Pros:
* shared muzzle matcher, result for CL is cached on the first run, so it's effectively run once for module;
* same with class loader matcher;
* and helper class injector. 

Spring MVC was chosen as the example because it's used in the smoke tests - this way you can see that modules work E2E.

I intentionally made it possible to have both `Instrumenter`s and `InstrumentationModule`s to avoid giant monster PR - if you like this concept I'll replace all `Instrumenter`s in batches.