### PR TITLE
Add manual dispatch trigger to smoke dist builds.

### DIFF
--- a/.github/workflows/build-grpc-smoke-dist.yaml
+++ b/.github/workflows/build-grpc-smoke-dist.yaml
@@ -6,6 +6,7 @@ on:
       - 'smoke-tests/grpc/**'
       - '.github/workflows/build-grpc-smoke-dist.yaml'
     branches: 'master'
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/build-play-smoke-dist.yaml
+++ b/.github/workflows/build-play-smoke-dist.yaml
@@ -6,6 +6,7 @@ on:
       - 'smoke-tests/play/**'
       - '.github/workflows/build-play-smoke-dist.yaml'
     branches: 'master'
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/build-smoke-dist-fakebackend.yaml
+++ b/.github/workflows/build-smoke-dist-fakebackend.yaml
@@ -6,6 +6,7 @@ on:
       - 'smoke-tests/fake-backend/**'
       - '.github/workflows/build-smoke-dist-fakebackend.yaml'
     branches: 'master'
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/build-springboot-smoke-dist.yaml
+++ b/.github/workflows/build-springboot-smoke-dist.yaml
@@ -6,6 +6,7 @@ on:
       - 'smoke-tests/springboot/**'
       - '.github/workflows/build-springboot-smoke-dist.yaml'
     branches: 'master'
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
In case it didn't run, and it doesn't hurt to have a button.