### PR TITLE
Try using low Gradle priority instead of capping workers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,7 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 
-# limiting the number of parallel workers helps to keep your machine responsive during builds
-# see https://github.com/gradle/gradle/issues/14224
-org.gradle.workers.max=2
+org.gradle.priority=low
 
 # Gradle default is 256m which causes issues with our build - https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
Gradle team recommended trying this setting - can anyone else check if it helps with their builds? Even so, I'm worried it will still be too much for CI but let's see what happens. For me locally, build seems to be going reasonably fast without bogging down computer.