### PR TITLE
fix master build fail due to latestDepTest

### DIFF
--- a/instrumentation/apache-camel-2.20/apache-camel-2.20.gradle
+++ b/instrumentation/apache-camel-2.20/apache-camel-2.20.gradle
@@ -15,6 +15,12 @@ muzzle {
 dependencies {
   library group: 'org.apache.camel', name: 'camel-core', version: '2.20.1'
 
+  testLibrary group: 'org.apache.camel', name: 'camel-spring-boot-starter', version: '2.20.1'
+  testLibrary group: 'org.apache.camel', name: 'camel-jetty-starter', version: '2.20.1'
+  testLibrary group: 'org.apache.camel', name: 'camel-http-starter', version: '2.20.1'
+  testLibrary group: 'org.apache.camel', name: 'camel-jaxb-starter', version: '2.20.1'
+  testLibrary group: 'org.apache.camel', name: 'camel-undertow', version: '2.20.1'
+
   testImplementation project(':instrumentation:apache-httpclient:apache-httpclient-2.0')
   testImplementation project(':instrumentation:servlet:servlet-3.0')
 
@@ -23,13 +29,12 @@ dependencies {
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '1.5.17.RELEASE'
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter', version: '1.5.17.RELEASE'
 
-  testImplementation group: 'org.apache.camel', name: 'camel-spring-boot-starter', version: '2.20.1'
-  testImplementation group: 'org.apache.camel', name: 'camel-jetty-starter', version: '2.20.1'
-  testImplementation group: 'org.apache.camel', name: 'camel-http-starter', version: '2.20.1'
-  testImplementation group: 'org.apache.camel', name: 'camel-jaxb-starter', version: '2.20.1'
-  testImplementation group: 'org.apache.camel', name: 'camel-undertow', version: '2.20.1'
-
   testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
 
   latestDepTestLibrary group: 'org.apache.camel', name: 'camel-core', version: '2.+'
+  latestDepTestLibrary group: 'org.apache.camel', name: 'camel-spring-boot-starter', version: '2.+'
+  latestDepTestLibrary group: 'org.apache.camel', name: 'camel-jetty-starter', version: '2.+'
+  latestDepTestLibrary group: 'org.apache.camel', name: 'camel-http-starter', version: '2.+'
+  latestDepTestLibrary group: 'org.apache.camel', name: 'camel-jaxb-starter', version: '2.+'
+  latestDepTestLibrary group: 'org.apache.camel', name: 'camel-undertow', version: '2.+'
 }

--- a/instrumentation/apache-camel-2.20/src/test/groovy/test/RestCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/src/test/groovy/test/RestCamelTest.groovy
@@ -88,7 +88,7 @@ class RestCamelTest extends AgentTestRunner {
             "$SemanticAttributes.HTTP_URL.key" "http://localhost:$port/api/firstModule/unit/unitOne"
             "$SemanticAttributes.HTTP_STATUS_CODE.key" 200
             "$SemanticAttributes.HTTP_CLIENT_IP.key" "127.0.0.1"
-            "$SemanticAttributes.HTTP_USER_AGENT.key" "Jetty/9.3.21.v20170918"
+            "$SemanticAttributes.HTTP_USER_AGENT.key" String
             "$SemanticAttributes.HTTP_FLAVOR.key" "HTTP/1.1"
             "$SemanticAttributes.HTTP_METHOD.key" "GET"
             "$SemanticAttributes.NET_PEER_IP.key" "127.0.0.1"


### PR DESCRIPTION
Fixes #1548

Fixing nightly build failure, due to incompatibility between latest used camel-core (2.25.3) and test helper dependencies (spring boot starter etc.).