### PR TITLE
Use correct name for bintray api key

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -77,6 +77,6 @@ jobs:
           arguments: final --stacktrace -Prelease.version=${{ github.event.inputs.version }}
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
+          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRGIT_USER: ${{ github.actor }}
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,6 +25,6 @@ jobs:
         run: ./gradlew final --stacktrace -Prelease.version=${{ github.event.inputs.version }} --info
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
+          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRGIT_USER: ${{ github.actor }}
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When copying from -java repo, didn't notice this drift sillily enough