### PR TITLE
Update nebula same version as opentelemetry-java repository.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
   id "com.jfrog.artifactory" version "4.15.2" apply false
   id 'com.jfrog.bintray' version '1.8.5' apply false
-  id "nebula.release" version "15.0.1"
+  id "nebula.release" version "15.1.0"
 
   id 'org.gradle.test-retry' version '1.1.8' apply false
 


### PR DESCRIPTION
A bit worried our old version doesn't support GRGIT env variables which may (didn't dig deeply) have come in https://github.com/nebula-plugins/nebula-release-plugin/releases/tag/v15.0.2