### PR TITLE
Update ByteBuddy to 1.10.18, adjust to new ByteBuddy gradle plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -46,6 +46,7 @@ dependencies {
   implementation group: "org.ow2.asm", name: "asm", version: "7.0-beta"
   implementation group: "org.ow2.asm", name: "asm-tree", version: "7.0-beta"
   implementation group: "org.apache.httpcomponents", name: "httpclient", version: "4.5.10"
+  implementation group: "net.bytebuddy", name: "byte-buddy-gradle-plugin", version: "1.10.18"
 
   testImplementation group: "org.spockframework", name: "spock-core", version: "1.3-groovy-2.5"
   testImplementation group: "org.codehaus.groovy", name: "groovy-all", version: "2.5.8"

--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ByteBuddyPluginConfigurator.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ByteBuddyPluginConfigurator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.gradle.bytebuddy;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.bytebuddy.build.gradle.ByteBuddySimpleTask;
+import net.bytebuddy.build.gradle.PluginArgument;
+import net.bytebuddy.build.gradle.Transformation;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.AbstractCompile;
+
+/**
+ * Starting from version 1.10.15, ByteBuddy gradle plugin transformation task autoconfiguration is
+ * hardcoded to be applied to javaCompile task. This causes the dependencies to be resolved during
+ * an afterEvaluate that runs before any afterEvaluate specified in the build script, which in turn
+ * makes it impossible to add dependencies in afterEvaluate. Additionally the autoconfiguration will
+ * attempt to scan the entire project for tasks which depend on the compile task, to make each task
+ * that depends on compile also depend on the transformation task. This is an extremely inefficient
+ * operation in this project to the point of causing a stack overflow in some environments.
+ *
+ * <p>To avoid all the issues with autoconfiguration, this class manually configures the ByteBuddy
+ * transformation task. This also allows it to be applied to source languages other than Java. The
+ * transformation task is configured to run between the compile and the classes tasks, assuming no
+ * other task depends directly on the compile task, but instead other tasks depend on classes task.
+ * Contrary to how the ByteBuddy plugin worked in versions up to 1.10.14, this changes the compile
+ * task output directory, as starting from 1.10.15, the plugin does not allow the source and target
+ * directories to be the same. The transformation task then writes to the original output directory
+ * of the compile task.
+ */
+public class ByteBuddyPluginConfigurator {
+  private static final List<String> LANGUAGES = Arrays.asList("java", "groovy", "kotlin");
+
+  private final Project project;
+  private final SourceSet sourceSet;
+  private final String pluginClassName;
+  private final List<Iterable<File>> inputClasspath;
+
+  public ByteBuddyPluginConfigurator(
+      Project project,
+      SourceSet sourceSet,
+      String pluginClassName,
+      List<Iterable<File>> inputClasspath) {
+    this.project = project;
+    this.sourceSet = sourceSet;
+    this.pluginClassName = pluginClassName;
+    this.inputClasspath = inputClasspath;
+  }
+
+  public void configure() {
+    String taskName = getTaskName();
+    Task byteBuddyTask = project.getTasks().create(taskName);
+
+    for (String language : LANGUAGES) {
+      AbstractCompile compile = getCompileTask(language);
+
+      if (compile != null) {
+        Task languageTask = createLanguageTask(compile, taskName + language);
+        byteBuddyTask.dependsOn(languageTask);
+      }
+    }
+
+    project.getTasks().getByName(sourceSet.getClassesTaskName()).dependsOn(byteBuddyTask);
+  }
+
+  private Task createLanguageTask(AbstractCompile compileTask, String name) {
+    ByteBuddySimpleTask task = project.getTasks().create(name, ByteBuddySimpleTask.class);
+    task.setGroup("Byte Buddy");
+
+    File classesDirectory = compileTask.getDestinationDir();
+    File rawClassesDirectory =
+        new File(classesDirectory.getParent(), classesDirectory.getName() + "raw")
+            .getAbsoluteFile();
+
+    task.dependsOn(compileTask);
+    compileTask.setDestinationDir(rawClassesDirectory);
+
+    task.setSource(rawClassesDirectory);
+    task.setTarget(classesDirectory);
+    task.setClassPath(compileTask.getClasspath());
+
+    List<Iterable<File>> classPath = new ArrayList<>();
+    classPath.add(Collections.singletonList(rawClassesDirectory));
+    classPath.addAll(inputClasspath);
+
+    task.dependsOn(compileTask);
+
+    task.getTransformations().add(createTransformation(classPath, pluginClassName));
+    return task;
+  }
+
+  private AbstractCompile getCompileTask(String language) {
+    Task task = project.getTasks().findByName(sourceSet.getCompileTaskName(language));
+
+    if (task instanceof AbstractCompile) {
+      AbstractCompile compile = (AbstractCompile) task;
+
+      if (!compile.getSource().isEmpty()) {
+        return compile;
+      }
+    }
+
+    return null;
+  }
+
+  private String getTaskName() {
+    if (SourceSet.MAIN_SOURCE_SET_NAME.equals(sourceSet.getName())) {
+      return "byteBuddy";
+    } else {
+      return sourceSet.getName() + "ByteBuddy";
+    }
+  }
+
+  private static Transformation createTransformation(
+      List<Iterable<File>> classPath, String pluginClassName) {
+    Transformation transformation = new Transformation();
+    transformation.setPlugin(ClasspathByteBuddyPlugin.class);
+    addArgument(transformation, classPath);
+    addArgument(transformation, pluginClassName);
+    return transformation;
+  }
+
+  private static void addArgument(Transformation transformation, Object value) {
+    List<PluginArgument> arguments = transformation.getArguments();
+    PluginArgument argument = new PluginArgument();
+    argument.setIndex(arguments.size());
+    argument.setValue(value);
+    arguments.add(argument);
+  }
+}

--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ByteBuddyPluginConfigurator.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ByteBuddyPluginConfigurator.java
@@ -37,7 +37,7 @@ import org.gradle.api.tasks.compile.AbstractCompile;
  * of the compile task.
  */
 public class ByteBuddyPluginConfigurator {
-  private static final List<String> LANGUAGES = Arrays.asList("java", "groovy", "kotlin");
+  private static final List<String> LANGUAGES = Arrays.asList("java", "scala", "kotlin");
 
   private final Project project;
   private final SourceSet sourceSet;

--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ClasspathByteBuddyPlugin.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ClasspathByteBuddyPlugin.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.gradle.bytebuddy;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.build.Plugin;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.DynamicType;
+
+/**
+ * Starting from version 1.10.15, ByteBuddy gradle plugin transformations require that plugin
+ * classes are given as class instances instead of a class name string. To be able to still use a
+ * plugin implementation that is not a buildscript dependency, this reimplements the previous logic
+ * by taking a delegate class name and class path as arguments and loading the plugin class from the
+ * provided classloader when the plugin is instantiated.
+ */
+public class ClasspathByteBuddyPlugin implements Plugin {
+  private final Plugin delegate;
+
+  public ClasspathByteBuddyPlugin(List<Iterable<File>> classPath, String className) {
+    this.delegate = pluginFromClassPath(classPath, className);
+  }
+
+  @Override
+  public DynamicType.Builder<?> apply(
+      DynamicType.Builder<?> builder,
+      TypeDescription typeDescription,
+      ClassFileLocator classFileLocator) {
+
+    return delegate.apply(builder, typeDescription, classFileLocator);
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+
+  @Override
+  public boolean matches(TypeDescription typeDefinitions) {
+    return delegate.matches(typeDefinitions);
+  }
+
+  private static Plugin pluginFromClassPath(List<Iterable<File>> classPath, String className) {
+    try {
+      ClassLoader classLoader = classLoaderFromClassPath(classPath);
+      Class<?> clazz = Class.forName(className, false, classLoader);
+      return (Plugin) clazz.getDeclaredConstructor().newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create ByteBuddy plugin instance", e);
+    }
+  }
+
+  private static ClassLoader classLoaderFromClassPath(List<Iterable<File>> classPath) {
+    List<URL> urls = new ArrayList<>();
+
+    for (Iterable<File> fileList : classPath) {
+      for (File file : fileList) {
+        try {
+          URL url = file.toURI().toURL();
+          urls.add(url);
+        } catch (MalformedURLException e) {
+          throw new RuntimeException("Cannot resolve " + file + " as URL", e);
+        }
+      }
+    }
+
+    return new URLClassLoader(urls.toArray(new URL[0]), ByteBuddy.class.getClassLoader());
+  }
+}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ ext {
     spock               : "1.3-groovy-$spockGroovyVer",
     groovy              : groovyVer,
     logback             : "1.2.3",
-    bytebuddy           : "1.10.10",
+    bytebuddy           : "1.10.18", // Also explicitly specified in buildSrc
     scala               : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     kotlin              : "1.4.0",
     coroutines          : "1.3.0",

--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -1,4 +1,5 @@
 // common gradle file for instrumentation
+import io.opentelemetry.instrumentation.gradle.bytebuddy.ByteBuddyPluginConfigurator
 
 apply plugin: 'io.opentelemetry.javaagent.instrumentation-instrumentation'
 apply plugin: 'net.bytebuddy.byte-buddy'
@@ -7,14 +8,6 @@ apply plugin: 'muzzle'
 ext {
   packageInAgentBundle = true
   mavenGroupId = 'io.opentelemetry.javaagent.instrumentation'
-}
-
-byteBuddy {
-  transformation {
-    // Applying NoOp optimizes build by applying bytebuddy plugin to only compileJava task
-    tasks = ['compileJava', 'compileScala', 'compileKotlin']
-    plugin = 'io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin$NoOp'
-  }
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -29,14 +22,6 @@ if (projectDir.name == 'javaagent') {
 }
 
 afterEvaluate {
-  byteBuddy {
-    transformation {
-      tasks = ['compileJava', 'compileScala', 'compileKotlin']
-      plugin = 'io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin'
-      classPath = project(':javaagent-tooling').configurations.instrumentationMuzzle + configurations.runtimeClasspath + sourceSets.main.output
-    }
-  }
-
   dependencies {
     implementation project(':instrumentation-api')
     implementation project(':javaagent-api')
@@ -64,4 +49,11 @@ afterEvaluate {
 
     testImplementation deps.testcontainers
   }
+
+  def pluginName = 'io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin'
+  new ByteBuddyPluginConfigurator(project, sourceSets.main, pluginName, [
+    project(':javaagent-tooling').configurations.instrumentationMuzzle.files,
+    configurations.runtimeClasspath.files,
+    sourceSets.main.output.files
+  ]).configure()
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/collector/MuzzleCodeGenerationPlugin.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/collector/MuzzleCodeGenerationPlugin.java
@@ -65,23 +65,4 @@ public class MuzzleCodeGenerationPlugin implements Plugin {
 
   @Override
   public void close() {}
-
-  /** Compile-time Optimization used by gradle buildscripts. */
-  public static class NoOp implements Plugin {
-    @Override
-    public boolean matches(TypeDescription target) {
-      return false;
-    }
-
-    @Override
-    public DynamicType.Builder<?> apply(
-        DynamicType.Builder<?> builder,
-        TypeDescription typeDescription,
-        ClassFileLocator classFileLocator) {
-      return builder;
-    }
-
-    @Override
-    public void close() {}
-  }
 }


### PR DESCRIPTION
Updating to ByteBuddy 1.10.18. The motivation is to include the following fix for WebLogic Server:
https://github.com/raphw/byte-buddy/pull/965

In version 1.10.15, ByteBuddy changed how the Gradle plugin works. It is now automatically configured in a way which is incompatible with the current use case, therefore I configure the transformation task from the plugin manually. The specifics are included as comments for the new buildSrc classes, but I will include them in the decription as well:

`ByteBuddyPluginConfigurator`:
Starting from version 1.10.15, ByteBuddy gradle plugin transformation task autoconfiguration is hardcoded to be applied to javaCompile task. This causes the dependencies to be resolved during an afterEvaluate that runs before any afterEvaluate specified in the build script, which in turn makes it impossible to add dependencies in afterEvaluate. Additionally the autoconfiguration will attempt to scan the entire project for tasks which depend on the compile task, to make each task that depends on compile also depend on the transformation task. This is an extremely inefficient operation in this project to the point of causing a stack overflow in some environments.

To avoid all the issues with autoconfiguration, this class manually configures the ByteBuddy transformation task. This also allows it to be applied to source languages other than Java. The transformation task is configured to run between the compile and the classes tasks, assuming no other task depends directly on the compile task, but instead other tasks depend on classes task. Contrary to how the ByteBuddy plugin worked in versions up to 1.10.14, this changes the compile task output directory, as starting from 1.10.15, the plugin does not allow the source and target directories to be the same. The transformation task then writes to the original output directory of the compile task.

`ClasspathByteBuddyPlugin`:
Starting from version 1.10.15, ByteBuddy gradle plugin transformations require that plugin classes are given as class instances instead of a class name string. To be able to still use a plugin implementation that is not a buildscript dependency, this reimplements the previous logic by taking a delegate class name and class path as arguments and loading the plugin class from the provided classloader when the plugin is instantiated.


Manually verified that the shadowJar that is built includes the transformed classes.