### PR TITLE
Add http4k to list of supported libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Because the automatic instrumentation runs in a different classpath than the ins
 | [gRPC](https://github.com/grpc/grpc-java)                                                                                             | 1.5+                           |
 | [Hibernate](https://github.com/hibernate/hibernate-orm)                                                                               | 3.3+                           |
 | [HttpURLConnection](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/HttpURLConnection.html)                     | Java 7+                        |
+| [http4k](https://http4k.org)                                                                                                          | 3.270.0+                 |
 | [Hystrix](https://github.com/Netflix/Hystrix)                                                                                         | 1.4+                           |
 | [JAX-RS](https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/package-summary.html)                                              | 0.5+                           |
 | [JAX-RS Client](https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/client/package-summary.html)                                | 2.0+                           |

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Because the automatic instrumentation runs in a different classpath than the ins
 | [gRPC](https://github.com/grpc/grpc-java)                                                                                             | 1.5+                           |
 | [Hibernate](https://github.com/hibernate/hibernate-orm)                                                                               | 3.3+                           |
 | [HttpURLConnection](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/HttpURLConnection.html)                     | Java 7+                        |
-| [http4k](https://http4k.org)                                                                                                          | 3.270.0+                 |
+| [http4k <sup>&dagger;</sup>](https://www.http4k.org/guide/modules/opentelemetry/)                                                      | 3.270.0+                                                                                                                              |
 | [Hystrix](https://github.com/Netflix/Hystrix)                                                                                         | 1.4+                           |
 | [JAX-RS](https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/package-summary.html)                                              | 0.5+                           |
 | [JAX-RS Client](https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/client/package-summary.html)                                | 2.0+                           |
@@ -274,6 +274,8 @@ Because the automatic instrumentation runs in a different classpath than the ins
 | [Twilio](https://github.com/twilio/twilio-java)                                                                                       | 6.6+ (not including 8.x yet)   |
 | [Vert.x](https://vertx.io)                                                                                                            | 3.0+                           |
 | [Vert.x RxJava2](https://vertx.io/docs/vertx-rx/java2/)                                                                               | 3.5+                           |
+
+<sup>&dagger;</sup> OpenTelemetry support provided by the library
 
 ### Disabled instrumentations
 


### PR DESCRIPTION
We've recently added OTEL support as an optional module to [http4k](http://http4k.org) and would love to get it listed here. The module provides simple way of instrumenting http4k apps so that both Metrics and Tracing are available.

You can see how the integration works [here](https://www.http4k.org/guide/modules/opentelemetry/). Happy to field questions, and keep up the great work!