### PR TITLE
Instrument java.servlet.Filter directly

### DIFF
--- a/instrumentation/servlet/servlet-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2InstrumentationModule.java
+++ b/instrumentation/servlet/servlet-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2InstrumentationModule.java
@@ -42,7 +42,7 @@ public class Servlet2InstrumentationModule extends InstrumentationModule {
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return Arrays.asList(
-        new HttpServletResponseInstrumentation(), new ServletAndFilterChainInstrumentation());
+        new HttpServletResponseInstrumentation(), new ServletAndFilterInstrumentation());
   }
 
   @Override

--- a/instrumentation/servlet/servlet-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/ServletAndFilterInstrumentation.java
+++ b/instrumentation/servlet/servlet-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/ServletAndFilterInstrumentation.java
@@ -19,7 +19,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ServletAndFilterChainInstrumentation implements TypeInstrumentation {
+final class ServletAndFilterInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
@@ -29,8 +29,7 @@ final class ServletAndFilterChainInstrumentation implements TypeInstrumentation 
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return safeHasSuperType(
-        namedOneOf("javax.servlet.FilterChain", "javax.servlet.http.HttpServlet"));
+    return safeHasSuperType(namedOneOf("javax.servlet.Filter", "javax.servlet.http.HttpServlet"));
   }
 
   /**

--- a/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3InstrumentationModule.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3InstrumentationModule.java
@@ -31,6 +31,6 @@ public class Servlet3InstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(new AsyncContextInstrumentation(), new ServletAndFilterChainInstrumentation());
+    return asList(new AsyncContextInstrumentation(), new ServletAndFilterInstrumentation());
   }
 }

--- a/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/ServletAndFilterInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/ServletAndFilterInstrumentation.java
@@ -19,7 +19,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ServletAndFilterChainInstrumentation implements TypeInstrumentation {
+final class ServletAndFilterInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.
@@ -28,8 +28,7 @@ final class ServletAndFilterChainInstrumentation implements TypeInstrumentation 
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return safeHasSuperType(
-        namedOneOf("javax.servlet.FilterChain", "javax.servlet.http.HttpServlet"));
+    return safeHasSuperType(namedOneOf("javax.servlet.Filter", "javax.servlet.http.HttpServlet"));
   }
 
   /**

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -167,6 +167,7 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
 
       if (name.startsWith("org.springframework.web.")) {
         if (name.startsWith("org.springframework.web.servlet.")
+            || name.startsWith("org.springframework.web.filter.")
             || name.startsWith("org.springframework.web.reactive.")
             || name.startsWith("org.springframework.web.context.request.async.")
             || name.equals(
@@ -306,7 +307,7 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
     return false;
   }
 
-  private static Set<String> INSTRUMENTED_SPRING_BOOT_CLASSES =
+  private static final Set<String> INSTRUMENTED_SPRING_BOOT_CLASSES =
       Sets.newHashSet(
           "org.springframework.boot.autoconfigure.BackgroundPreinitializer$",
           "org.springframework.boot.autoconfigure.condition.OnClassCondition$",
@@ -319,7 +320,12 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
           "org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext",
           "org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext",
           "org.springframework.boot.web.embedded.tomcat.TomcatWebServer$",
-          "org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLoader");
+          "org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLoader",
+          "org.springframework.boot.web.servlet.DelegatingFilterProxyRegistrationBean$",
+          "org.springframework.boot.web.filter.OrderedCharacterEncodingFilter",
+          "org.springframework.boot.web.filter.OrderedHiddenHttpMethodFilter",
+          "org.springframework.boot.web.filter.OrderedHttpPutFormContentFilter",
+          "org.springframework.boot.web.filter.OrderedRequestContextFilter");
 
   private static String outerClassName(final String name) {
     int separator = name.indexOf('$');


### PR DESCRIPTION
I'm not sure why we instrument `java.servlet.FilterChain.doFilter()` instead of the more general `java.servlet.Filter.doFilter()`.

Let's see if any tests fail with this change 😂.

See #1578