### PR TITLE
Fix dropwizard instrumentation

### DIFF
--- a/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/DropwizardTracer.java
+++ b/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/DropwizardTracer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.dropwizardviews;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
+
+public class DropwizardTracer extends BaseTracer {
+  private static final DropwizardTracer TRACER = new DropwizardTracer();
+
+  public static DropwizardTracer tracer() {
+    return TRACER;
+  }
+
+  public Span startSpan(String spanName) {
+    return super.startSpan(spanName, Span.Kind.INTERNAL);
+  }
+
+  @Override
+  protected String getInstrumentationName() {
+    return "io.opentelemetry.auto.dropwizard-views-0.7";
+  }
+}

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/HibernateInstrumentationModule.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/HibernateInstrumentationModule.java
@@ -28,6 +28,7 @@ public class HibernateInstrumentationModule extends InstrumentationModule {
     return new String[] {
       "io.opentelemetry.javaagent.instrumentation.hibernate.SessionMethodUtils",
       "io.opentelemetry.javaagent.instrumentation.hibernate.HibernateDecorator",
+      packageName + ".V3Advice",
     };
   }
 

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/HibernateInstrumentationModule.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/HibernateInstrumentationModule.java
@@ -28,6 +28,7 @@ public class HibernateInstrumentationModule extends InstrumentationModule {
     return new String[] {
       "io.opentelemetry.javaagent.instrumentation.hibernate.SessionMethodUtils",
       "io.opentelemetry.javaagent.instrumentation.hibernate.HibernateDecorator",
+      packageName + ".V4Advice",
     };
   }
 

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/NettyInstrumentationModule.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/NettyInstrumentationModule.java
@@ -39,7 +39,8 @@ public class NettyInstrumentationModule extends InstrumentationModule {
       packageName + ".server.NettyRequestExtractAdapter",
       packageName + ".server.HttpServerRequestTracingHandler",
       packageName + ".server.HttpServerResponseTracingHandler",
-      packageName + ".server.HttpServerTracingHandler"
+      packageName + ".server.HttpServerTracingHandler",
+      packageName + ".AbstractNettyAdvice"
     };
   }
 


### PR DESCRIPTION
This broke in #1557 due to removing the `helperClassNames` which (oddly but usefully) pointed to the Advice class.

But the tests didn't catch it because of #1585.

And so after both of those got merged, now master is failing (which is good).