### PR TITLE
Push cherrypick commits before building / publishing for patch release.

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -64,6 +64,7 @@ jobs:
               # Trim whitespaces and cherrypick
               echo $word | sed 's/ *$//g' | sed 's/^ *//g' | git cherry-pick --stdin
           done
+          git push
       - uses: burrunan/gradle-cache-action@v1.5
         with:
           job-id: jdk11


### PR DESCRIPTION
We currently often have to manually publish from bintray due to freezing of our release job. For the patch, this is particularly a problem since currently we only push after publishing succeeds, because we don't want to tag an unreleased version if possible. But in the case we do manually push, we also don't have the cherrypicks anywhere in our repo which makes it not a good idea if we have to reproduce those manually as well to set the tag. At least by pushing the cherrypicks before publishing, this would not be the case. It means we wouldn't be able to change what we cherrypick in between failures of the job, but I think this is at least as good as the alternative on further thinking.