### PR TITLE
Update publish.gradle

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -87,7 +87,7 @@ bintray {
   user = System.getenv('BINTRAY_USER')
   key = System.getenv('BINTRAY_API_KEY')
   publications = ['maven']
-  publish = true
+  publish = false
   pkg {
     repo = 'maven'
     name = 'opentelemetry-java-instrumentation'


### PR DESCRIPTION
Do not automatically publish to Bintray after upload.

Recent releases showed that `bintrayPublish` often times silently fails. Let us disable it and resort to manually clicking "Publish" link in Bintray UI.

Closes #1608