### PR TITLE
Add AgentInstaller extensions SPI

### DIFF
--- a/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerExtension.java
+++ b/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerExtension.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.spi;
+
+/**
+ * {@link AgentInstallerExtension} runs at the beginning of {@code AgentInstaller} in agent's
+ * classloader. It can be used to load resources available in agent's classloader. For instance
+ * instrumentation classes might use an API that is backed by dynamically loaded implementation
+ * (e.g. via service loader) available in agent classloader.
+ *
+ * <p>Before using service loader set the context classloader to agent's classloader e.g. {@code
+ * Thread.currentThread().setContextClassLoader(AgentInstaller.class.getClassLoader())}.
+ */
+public interface AgentInstallerExtension {
+
+  /** Run the provider in agent's classloader. The method must not throw any exception. */
+  void run();
+}

--- a/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerExtension.java
+++ b/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerExtension.java
@@ -7,12 +7,12 @@ package io.opentelemetry.javaagent.spi;
 
 /**
  * {@link AgentInstallerExtension} runs at the beginning of {@code AgentInstaller} in agent's
- * classloader. It can be used to load resources available in agent's classloader. For instance
- * instrumentation classes might use an API that is backed by dynamically loaded implementation
- * (e.g. via service loader) available in agent classloader.
+ * classloader. This SPI can be used to load resources available in agent's classloader. For instance
+ * instrumentations added by vendor might use an API (in bootstrap classloader)
+ * that is backed by dynamically loaded implementation (e.g. via service loader) available in agent classloader.
  *
  * <p>Before using service loader set the context classloader to agent's classloader e.g. {@code
- * Thread.currentThread().setContextClassLoader(AgentInstaller.class.getClassLoader())}.
+ * Thread.currentThread().setContextClassLoader(AgentInstallerExtension.class.getClassLoader())}.
  *
  * <p>This is a service provider interface that requires implementations to be registered in {@code
  * META-INF/services} folder.

--- a/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerExtension.java
+++ b/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerExtension.java
@@ -13,6 +13,9 @@ package io.opentelemetry.javaagent.spi;
  *
  * <p>Before using service loader set the context classloader to agent's classloader e.g. {@code
  * Thread.currentThread().setContextClassLoader(AgentInstaller.class.getClassLoader())}.
+ *
+ * <p>This is a service provider interface that requires implementations to be registered in
+ * `META-INF/services` folder.
  */
 public interface AgentInstallerExtension {
 

--- a/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerExtension.java
+++ b/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerExtension.java
@@ -14,8 +14,8 @@ package io.opentelemetry.javaagent.spi;
  * <p>Before using service loader set the context classloader to agent's classloader e.g. {@code
  * Thread.currentThread().setContextClassLoader(AgentInstaller.class.getClassLoader())}.
  *
- * <p>This is a service provider interface that requires implementations to be registered in
- * `META-INF/services` folder.
+ * <p>This is a service provider interface that requires implementations to be registered in {@code
+ * META-INF/services} folder.
  */
 public interface AgentInstallerExtension {
 

--- a/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerSPI.java
+++ b/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerSPI.java
@@ -1,6 +1,0 @@
-package io.opentelemetry.javaagent.spi;
-
-public interface AgentInstallerSPI {
-
-  void run();
-}

--- a/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerSPI.java
+++ b/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/AgentInstallerSPI.java
@@ -1,0 +1,6 @@
+package io.opentelemetry.javaagent.spi;
+
+public interface AgentInstallerSPI {
+
+  void run();
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -62,6 +62,8 @@ public class AgentInstaller {
   }
 
   public static void installBytebuddyAgent(Instrumentation inst) {
+    
+
     if (Config.get().getBooleanProperty(TRACE_ENABLED_CONFIG, true)) {
       installBytebuddyAgent(inst, false);
     } else {


### PR DESCRIPTION
This SPI allows to run any code in the agent's classloader. This is useful for loading (SPI) implementations (in agent classloader) of API (in bootstrap classloader) that is commonly used by instrumentation. In our case we the API is for filtering/blocking requests. 