### PR TITLE
Collect WebLogic-specific span attributes

### DIFF
--- a/instrumentation/weblogic/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/weblogic/WebLogicEntity.java
+++ b/instrumentation/weblogic/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/weblogic/WebLogicEntity.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.servlet.weblogic;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRequest;
+
+/**
+ * Provides wrappers around WebLogic internal class instances.
+ */
+public class WebLogicEntity {
+  private static final MethodHandle REQUEST_GET_CONTEXT;
+  private static final MethodHandle CONTEXT_GET_MBEAN;
+  private static final MethodHandle CONTEXT_GET_SERVER;
+  private static final MethodHandle SERVER_GET_MBEAN;
+  private static final MethodHandle MBEAN_GET_PARENT;
+  private static final MethodHandle MBEAN_GET_KEY;
+  private static final Class<?> MBEAN_CLASS;
+  private static final MethodHandle MBEAN_GET_ATTRIBUTE;
+
+  static {
+    MethodHandle requestGetContext;
+    MethodHandle contextGetMBean;
+    MethodHandle contextGetServer;
+    MethodHandle serverGetMBean;
+    MethodHandle mbeanGetParent;
+    MethodHandle mbeanGetKey;
+    MethodHandle mbeanGetAttribute;
+    Class<?> mbeanClass;
+
+    try {
+      requestGetContext =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.servlet.internal.ServletRequestImpl"),
+                  "getContext",
+                  MethodType.methodType(
+                      Class.forName("weblogic.servlet.internal.WebAppServletContext")));
+    } catch (Exception e) {
+      requestGetContext = null;
+    }
+
+    REQUEST_GET_CONTEXT = requestGetContext;
+
+    try {
+      contextGetMBean =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.servlet.internal.WebAppServletContext"),
+                  "getMBean",
+                  MethodType.methodType(
+                      Class.forName("weblogic.management.configuration.WebAppComponentMBean")));
+    } catch (Exception e) {
+      contextGetMBean = null;
+    }
+
+    CONTEXT_GET_MBEAN = contextGetMBean;
+
+    try {
+      contextGetServer =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.servlet.internal.WebAppServletContext"),
+                  "getServer",
+                  MethodType.methodType(Class.forName("weblogic.servlet.internal.HttpServer")));
+    } catch (Exception e) {
+      contextGetServer = null;
+    }
+
+    CONTEXT_GET_SERVER = contextGetServer;
+
+    try {
+      serverGetMBean =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.servlet.internal.HttpServer"),
+                  "getMBean",
+                  MethodType.methodType(
+                      Class.forName("weblogic.management.configuration.WebServerMBean")));
+    } catch (Exception e) {
+      serverGetMBean = null;
+    }
+
+    SERVER_GET_MBEAN = serverGetMBean;
+
+    try {
+      mbeanGetParent =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.descriptor.DescriptorBean"),
+                  "getParentBean",
+                  MethodType.methodType(Class.forName("weblogic.descriptor.DescriptorBean")));
+    } catch (Exception e) {
+      mbeanGetParent = null;
+    }
+
+    MBEAN_GET_PARENT = mbeanGetParent;
+
+    try {
+      mbeanGetKey =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("weblogic.descriptor.internal.AbstractDescriptorBean"),
+                  "_getKey",
+                  MethodType.methodType(Object.class));
+    } catch (Exception e) {
+      mbeanGetKey = null;
+    }
+
+    MBEAN_GET_KEY = mbeanGetKey;
+
+    try {
+      mbeanGetAttribute =
+          MethodHandles.publicLookup()
+              .findVirtual(
+                  Class.forName("javax.management.DynamicMBean"),
+                  "getAttribute",
+                  MethodType.methodType(Object.class, String.class));
+    } catch (Exception e) {
+      mbeanGetAttribute = null;
+    }
+
+    MBEAN_GET_ATTRIBUTE = mbeanGetAttribute;
+
+    try {
+      mbeanClass = Class.forName("weblogic.management.WebLogicMBean");
+    } catch (Exception e) {
+      mbeanClass = null;
+    }
+
+    MBEAN_CLASS = mbeanClass;
+  }
+
+  public static class Request {
+    private static final Request NULL = new Request(null);
+
+    public final ServletRequest instance;
+
+    private Request(ServletRequest instance) {
+      this.instance = instance;
+    }
+
+    public static Request wrap(ServletRequest instance) {
+      return instance != null ? new Request(instance) : NULL;
+    }
+
+    public Context getContext() {
+      try {
+        return Context.wrap(
+            REQUEST_GET_CONTEXT != null ? REQUEST_GET_CONTEXT.invoke(instance) : null);
+      } catch (Throwable throwable) {
+        return Context.NULL;
+      }
+    }
+  }
+
+  public static class Context {
+    private static final Context NULL = new Context(null);
+
+    public final ServletContext instance;
+
+    private Context(ServletContext instance) {
+      this.instance = instance;
+    }
+
+    public static Context wrap(Object instance) {
+      return instance instanceof ServletContext ? new Context((ServletContext) instance) : NULL;
+    }
+
+    public Bean getBean() {
+      try {
+        return Bean.wrap(CONTEXT_GET_MBEAN != null ? CONTEXT_GET_MBEAN.invoke(instance) : null);
+      } catch (Throwable throwable) {
+        return Bean.NULL;
+      }
+    }
+
+    public Server getServer() {
+      try {
+        return Server.wrap(CONTEXT_GET_SERVER != null ? CONTEXT_GET_SERVER.invoke(instance) : null);
+      } catch (Throwable throwable) {
+        return Server.NULL;
+      }
+    }
+  }
+
+  public static class Server {
+    private static final Server NULL = new Server(null);
+
+    public final Object instance;
+
+    private Server(Object instance) {
+      this.instance = instance;
+    }
+
+    public static Server wrap(Object instance) {
+      return instance != null ? new Server(instance) : NULL;
+    }
+
+    public Bean getBean() {
+      try {
+        return Bean.wrap(SERVER_GET_MBEAN != null ? SERVER_GET_MBEAN.invoke(instance) : null);
+      } catch (Throwable throwable) {
+        return Bean.NULL;
+      }
+    }
+  }
+
+  public static class Bean {
+    private static final Bean NULL = new Bean(null);
+
+    public final Object instance;
+
+    private Bean(Object instance) {
+      this.instance = instance;
+    }
+
+    public static Bean wrap(Object instance) {
+      return instance != null
+              && MBEAN_CLASS != null
+              && MBEAN_CLASS.isAssignableFrom(instance.getClass())
+          ? new Bean(instance)
+          : NULL;
+    }
+
+    public String getName() {
+      try {
+        Object key = MBEAN_GET_KEY != null ? MBEAN_GET_KEY.invoke(instance) : null;
+        return key != null ? key.toString() : null;
+      } catch (Throwable throwable) {
+        return null;
+      }
+    }
+
+    public Bean getParent() {
+      try {
+        return Bean.wrap(MBEAN_GET_PARENT != null ? MBEAN_GET_PARENT.invoke(instance) : null);
+      } catch (Throwable throwable) {
+        return Bean.NULL;
+      }
+    }
+
+    public Object getAttribute(String name) {
+      try {
+        return MBEAN_GET_ATTRIBUTE != null ? MBEAN_GET_ATTRIBUTE.invoke(instance, name) : null;
+      } catch (Throwable throwable) {
+        return null;
+      }
+    }
+  }
+}

--- a/instrumentation/weblogic/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/weblogic/WebLogicEntity.java
+++ b/instrumentation/weblogic/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/weblogic/WebLogicEntity.java
@@ -11,9 +11,7 @@ import java.lang.invoke.MethodType;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRequest;
 
-/**
- * Provides wrappers around WebLogic internal class instances.
- */
+/** Provides wrappers around WebLogic internal class instances. */
 public class WebLogicEntity {
   private static final MethodHandle REQUEST_GET_CONTEXT;
   private static final MethodHandle CONTEXT_GET_MBEAN;

--- a/instrumentation/weblogic/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/weblogic/WebLogicInstrumentationModule.java
+++ b/instrumentation/weblogic/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/weblogic/WebLogicInstrumentationModule.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.servlet.weblogic;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isPrivate;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.tooling.InstrumentationModule;
+import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
+import java.util.List;
+import java.util.Map;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Adds an instrumentation to collect middleware attributes for WebLogic Server 12 and 14. As span
+ * detection on WebLogic does not require and special logic, this does not initiate servlet spans
+ * by itself, but saves the special attributes as a map to a servlet request attribute, which is
+ * then later read when span is started by generic servlet instrumentation.
+ */
+@AutoService(InstrumentationModule.class)
+public class WebLogicInstrumentationModule extends InstrumentationModule {
+  public WebLogicInstrumentationModule() {
+    super("weblogic");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new MiddlewareInstrumentation());
+  }
+
+  private static class MiddlewareInstrumentation implements TypeInstrumentation {
+    @Override
+    public ElementMatcher<? super TypeDescription> typeMatcher() {
+      return named("weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction");
+    }
+
+    @Override
+    public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+      return singletonMap(
+          named("wrapRun")
+              .and(takesArgument(1, named("javax.servlet.http.HttpServletRequest")))
+              .and(isPrivate()),
+          WebLogicInstrumentationModule.class.getPackage().getName() + ".WebLogicMiddlewareAdvice");
+    }
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".WebLogicMiddlewareAdvice",
+      packageName + ".WebLogicEntity",
+      packageName + ".WebLogicEntity$Request",
+      packageName + ".WebLogicEntity$Context",
+      packageName + ".WebLogicEntity$Server",
+      packageName + ".WebLogicEntity$Bean"
+    };
+  }
+}

--- a/instrumentation/weblogic/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/weblogic/WebLogicInstrumentationModule.java
+++ b/instrumentation/weblogic/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/weblogic/WebLogicInstrumentationModule.java
@@ -22,9 +22,9 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 /**
  * Adds an instrumentation to collect middleware attributes for WebLogic Server 12 and 14. As span
- * detection on WebLogic does not require and special logic, this does not initiate servlet spans
- * by itself, but saves the special attributes as a map to a servlet request attribute, which is
- * then later read when span is started by generic servlet instrumentation.
+ * detection on WebLogic does not require any special logic, this does not initiate servlet spans by
+ * itself, but saves the special attributes as a map to a servlet request attribute, which is then
+ * later read when span is started by generic servlet instrumentation.
  */
 @AutoService(InstrumentationModule.class)
 public class WebLogicInstrumentationModule extends InstrumentationModule {

--- a/instrumentation/weblogic/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/weblogic/WebLogicMiddlewareAdvice.java
+++ b/instrumentation/weblogic/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/weblogic/WebLogicMiddlewareAdvice.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.servlet.weblogic;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import net.bytebuddy.asm.Advice;
+
+public class WebLogicMiddlewareAdvice {
+  private static final String CONTEXT_ATTRIBUTE_NAME = "otel.weblogic.attributes";
+  public static final String REQUEST_ATTRIBUTE_NAME = "otel.middleware";
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void start(@Advice.Argument(1) HttpServletRequest servletRequest) {
+    WebLogicEntity.Request request = WebLogicEntity.Request.wrap(servletRequest);
+
+    Map<?, ?> attributes = getMiddlewareAttributes(request.getContext());
+    request.instance.setAttribute(REQUEST_ATTRIBUTE_NAME, attributes);
+  }
+
+  public static Map<?, ?> getMiddlewareAttributes(WebLogicEntity.Context context) {
+    if (context.instance == null) {
+      return null;
+    }
+
+    Object value = context.instance.getAttribute(CONTEXT_ATTRIBUTE_NAME);
+
+    if (value instanceof Map<?, ?>) {
+      return (Map<?, ?>) value;
+    }
+
+    Map<String, String> middleware = collectMiddlewareAttributes(context);
+    context.instance.setAttribute(CONTEXT_ATTRIBUTE_NAME, middleware);
+    return middleware;
+  }
+
+  private static Map<String, String> collectMiddlewareAttributes(WebLogicEntity.Context context) {
+    WebLogicEntity.Bean applicationBean = context.getBean();
+    WebLogicEntity.Bean webServerBean = context.getServer().getBean();
+    WebLogicEntity.Bean serverBean = webServerBean.getParent();
+    WebLogicEntity.Bean clusterBean = WebLogicEntity.Bean.wrap(serverBean.getAttribute("Cluster"));
+    WebLogicEntity.Bean domainBean = serverBean.getParent();
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("middleware.name", "WebLogic Server");
+    attributes.put("middleware.version", detectVersion(context));
+    attributes.put("middleware.weblogic.domain", domainBean.getName());
+    attributes.put("middleware.weblogic.cluster", clusterBean.getName());
+    attributes.put("middleware.weblogic.server", webServerBean.getName());
+    attributes.put("middleware.weblogic.application", applicationBean.getName());
+
+    return attributes;
+  }
+
+  private static String detectVersion(WebLogicEntity.Context context) {
+    String serverInfo = context.instance.getServerInfo();
+
+    if (serverInfo != null) {
+      for (String token : serverInfo.split(" ")) {
+        if (token.length() > 0 && Character.isDigit(token.charAt(0))) {
+          return token;
+        }
+      }
+    }
+
+    return "";
+  }
+}

--- a/instrumentation/weblogic/weblogic.gradle
+++ b/instrumentation/weblogic/weblogic.gradle
@@ -1,0 +1,5 @@
+apply from: "$rootDir/gradle/instrumentation.gradle"
+
+dependencies {
+  compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.2'
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -190,6 +190,7 @@ include ':instrumentation:spymemcached-2.12'
 include ':instrumentation:twilio-6.6'
 include ':instrumentation:vertx-3.0'
 include ':instrumentation:vertx-reactive-3.5'
+include ':instrumentation:weblogic'
 
 include ':instrumentation-core:reactor-3.1'
 include ':instrumentation-core:servlet-2.2'


### PR DESCRIPTION
This adds collection of WebLogic-specific attributes to servlet spans, along with `middleware.name` and `middleware.version` attributes that can be used for other application servers or servlet containers as well.

Sample output from the logging collector:
```
Attributes:
     -> middleware.name: STRING(WebLogic Server)
     -> middleware.version: STRING(12.2.1.4.0)
     -> middleware.weblogic.server: STRING(admin-server)
     -> middleware.weblogic.application: STRING(weblogic)
     -> middleware.weblogic.domain: STRING(domain1)
```

As there is no reason to create the spans at WebLogic instrumentation level (no custom logic required), this adds an instrumentation that only collects the attribute values, stores them as a map into `otel.middleware` `ServletRequest` attribute. The map contents are copied over to the span by `ServletHttpServerTracer` later when the generic servlet instrumentation is triggered.

WebLogic classes are not published as a public dependency, therefore its classes are accessed with `Class.forName` and `MethodHandle` instead of compiling against its classes directly. These are resolved by `WebLogicEntity` during its static initialization, which also provides wrapper classes for WebLogic classes. As an optimization, the full set of attributes is not collected on every request, but they are cached to a servlet context attribute.