### PR TITLE
Generate opentelemetry-javaagent "-all" artifact during "assemble"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,6 @@ java -version
 ./gradlew assemble
 ```
 
-and then generate the -all artifact
-
-```bash
-./gradlew :javaagent:shadowJar
-```
-
 and then you can find the java agent artifact at
 
 `javaagent/build/lib/opentelemetry-javaagent-<version>-all.jar`.

--- a/javaagent/javaagent.gradle
+++ b/javaagent/javaagent.gradle
@@ -123,3 +123,5 @@ tasks.withType(Test).configureEach {
 
   dependsOn shadowJar
 }
+
+assemble.dependsOn shadowJar

--- a/javaagent/javaagent.gradle
+++ b/javaagent/javaagent.gradle
@@ -123,5 +123,5 @@ tasks.withType(Test).configureEach {
 
   dependsOn shadowJar
 }
-
+assemble.dependsOn lightShadow
 assemble.dependsOn shadowJar


### PR DESCRIPTION
Fixes #708

```
./gradlew clean assemble
ls -l javaagent/build/libs 

total 62344
-rw-r--r--  1 nikem  staff    29M Nov 16 14:36 opentelemetry-javaagent-0.11.0-SNAPSHOT-all.jar
-rw-r--r--  1 nikem  staff   389K Nov 16 14:35 opentelemetry-javaagent-0.11.0-SNAPSHOT-javadoc.jar
-rw-r--r--  1 nikem  staff   3.4K Nov 16 14:35 opentelemetry-javaagent-0.11.0-SNAPSHOT-sources.jar
-rw-r--r--  1 nikem  staff   4.9K Nov 16 14:35 opentelemetry-javaagent-0.11.0-SNAPSHOT.jar
```