### PR TITLE
Enable checkstyle overload method ordering rule for Google Java Style

### DIFF
--- a/gradle/enforcement/checkstyle.xml
+++ b/gradle/enforcement/checkstyle.xml
@@ -270,9 +270,7 @@
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
                     RECORD_COMPONENT_DEF"/>
     </module>
-    <!--
     <module name="OverloadMethodsDeclarationOrder"/>
-    -->
     <!-- there are only a few violations of this, and they all appear to be for good reasons
     <module name="VariableDeclarationUsageDistance"/>
     -->

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
@@ -64,7 +64,7 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
   }
 
   public Span startSpan(REQUEST request, long startTimeNanos) {
-    return startSpan(request, spanNameForRequest(request), startTimeNanos);
+    return internalStartSpan(request, spanNameForRequest(request), startTimeNanos);
   }
 
   public Scope startScope(Span span, CARRIER carrier) {
@@ -103,7 +103,7 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
    * Returns a new client {@link Span} if there is no client {@link Span} in the current {@link
    * Context}, or an invalid {@link Span} otherwise.
    */
-  private Span startSpan(REQUEST request, String name, long startTimeNanos) {
+  private Span internalStartSpan(REQUEST request, String name, long startTimeNanos) {
     Context context = Context.current();
     Span clientSpan = context.get(CONTEXT_CLIENT_SPAN_KEY);
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamHandler.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamHandler.java
@@ -89,6 +89,11 @@ public abstract class TracingRequestStreamHandler implements RequestStreamHandle
     }
 
     @Override
+    public void write(int b) throws IOException {
+      delegate.write(b);
+    }
+
+    @Override
     public void flush() throws IOException {
       delegate.flush();
     }
@@ -98,11 +103,6 @@ public abstract class TracingRequestStreamHandler implements RequestStreamHandle
       delegate.close();
       tracer.end(span);
       OpenTelemetrySdk.getGlobalTracerManagement().forceFlush().join(1, TimeUnit.SECONDS);
-    }
-
-    @Override
-    public void write(int b) throws IOException {
-      delegate.write(b);
     }
   }
 }

--- a/instrumentation/cassandra/cassandra-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/TracingCqlSession.java
+++ b/instrumentation/cassandra/cassandra-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/TracingCqlSession.java
@@ -136,13 +136,6 @@ public class TracingCqlSession implements CqlSession {
   }
 
   @Override
-  @Nullable
-  public <RequestT extends Request, ResultT> ResultT execute(
-      @NonNull RequestT request, @NonNull GenericType<ResultT> resultType) {
-    return session.execute(request, resultType);
-  }
-
-  @Override
   @NonNull
   public CompletionStage<Void> closeFuture() {
     return session.closeFuture();
@@ -171,14 +164,20 @@ public class TracingCqlSession implements CqlSession {
   }
 
   @Override
+  @Nullable
+  public <RequestT extends Request, ResultT> ResultT execute(
+      @NonNull RequestT request, @NonNull GenericType<ResultT> resultType) {
+    return session.execute(request, resultType);
+  }
+
+  @Override
   @NonNull
-  public ResultSet execute(@NonNull Statement<?> statement) {
-    String query = getQuery(statement);
+  public ResultSet execute(@NonNull String query) {
 
     Span span = tracer().startSpan(session, query);
     try (Scope ignored = tracer().startScope(span)) {
       try {
-        ResultSet resultSet = session.execute(statement);
+        ResultSet resultSet = session.execute(query);
         tracer().onResponse(span, resultSet.getExecutionInfo());
         return resultSet;
       } catch (RuntimeException e) {
@@ -192,12 +191,13 @@ public class TracingCqlSession implements CqlSession {
 
   @Override
   @NonNull
-  public ResultSet execute(@NonNull String query) {
+  public ResultSet execute(@NonNull Statement<?> statement) {
+    String query = getQuery(statement);
 
     Span span = tracer().startSpan(session, query);
     try (Scope ignored = tracer().startScope(span)) {
       try {
-        ResultSet resultSet = session.execute(query);
+        ResultSet resultSet = session.execute(statement);
         tracer().onResponse(span, resultSet.getExecutionInfo());
         return resultSet;
       } catch (RuntimeException e) {

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/TracingList.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/TracingList.java
@@ -49,8 +49,18 @@ public class TracingList extends TracingIterable implements List<ConsumerRecord<
   }
 
   @Override
+  public void add(int index, ConsumerRecord element) {
+    delegate.add(index, element);
+  }
+
+  @Override
   public boolean remove(Object o) {
     return delegate.remove(o);
+  }
+
+  @Override
+  public ConsumerRecord<?, ?> remove(int index) {
+    return delegate.remove(index);
   }
 
   @Override
@@ -92,16 +102,6 @@ public class TracingList extends TracingIterable implements List<ConsumerRecord<
   @Override
   public ConsumerRecord<?, ?> set(int index, ConsumerRecord element) {
     return delegate.set(index, element);
-  }
-
-  @Override
-  public void add(int index, ConsumerRecord element) {
-    delegate.add(index, element);
-  }
-
-  @Override
-  public ConsumerRecord<?, ?> remove(int index) {
-    return delegate.remove(index);
   }
 
   @Override

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/AdviceUtils.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/AdviceUtils.java
@@ -68,14 +68,6 @@ public class AdviceUtils {
     }
   }
 
-  private static void finishSpanIfPresentInAttributes(
-      Map<String, Object> attributes, Throwable throwable) {
-
-    io.opentelemetry.context.Context context =
-        (io.opentelemetry.context.Context) attributes.remove(CONTEXT_ATTRIBUTE);
-    finishSpanIfPresent(context, throwable);
-  }
-
   static void finishSpanIfPresent(io.opentelemetry.context.Context context, Throwable throwable) {
     if (context != null) {
       Span span = Span.fromContext(context);
@@ -85,6 +77,14 @@ public class AdviceUtils {
       }
       span.end();
     }
+  }
+
+  private static void finishSpanIfPresentInAttributes(
+      Map<String, Object> attributes, Throwable throwable) {
+
+    io.opentelemetry.context.Context context =
+        (io.opentelemetry.context.Context) attributes.remove(CONTEXT_ATTRIBUTE);
+    finishSpanIfPresent(context, throwable);
   }
 
   public static class SpanFinishingSubscriber<T> implements CoreSubscriber<T> {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
@@ -143,50 +143,6 @@ public final class ReferenceMatcher {
     }
   }
 
-  // for helper classes we make sure that all abstract methods from super classes and interfaces are
-  // implemented
-  private List<Mismatch> checkHelperClassMatch(Reference helperClass, TypePool typePool) {
-    List<Mismatch> mismatches = Collections.emptyList();
-
-    HelperReferenceWrapper helperWrapper = new Factory(typePool, references).create(helperClass);
-
-    if (!helperWrapper.hasSuperTypes() || helperWrapper.isAbstract()) {
-      return mismatches;
-    }
-
-    // treat the helper type as a bag of methods: collect all methods defined in the helper class,
-    // all superclasses and interfaces and check if all abstract methods are implemented somewhere
-    Set<HelperReferenceWrapper.Method> abstractMethods = new HashSet<>();
-    Set<HelperReferenceWrapper.Method> plainMethods = new HashSet<>();
-    collectMethodsFromTypeHierarchy(helperWrapper, abstractMethods, plainMethods);
-
-    Set<HelperReferenceWrapper.Method> unimplementedMethods =
-        Sets.difference(abstractMethods, plainMethods);
-    for (HelperReferenceWrapper.Method unimplementedMethod : unimplementedMethods) {
-      mismatches =
-          lazyAdd(
-              mismatches,
-              new Mismatch.MissingMethod(
-                  helperClass.getSources().toArray(new Reference.Source[0]),
-                  unimplementedMethod.getDeclaringClass(),
-                  unimplementedMethod.getName(),
-                  unimplementedMethod.getDescriptor()));
-    }
-
-    return mismatches;
-  }
-
-  private static void collectMethodsFromTypeHierarchy(
-      HelperReferenceWrapper type, Set<Method> abstractMethods, Set<Method> plainMethods) {
-
-    type.getMethods()
-        .forEach(method -> (method.isAbstract() ? abstractMethods : plainMethods).add(method));
-
-    type.getSuperTypes()
-        .forEach(
-            superType -> collectMethodsFromTypeHierarchy(superType, abstractMethods, plainMethods));
-  }
-
   private static List<Mismatch> checkMatch(Reference reference, TypeDescription typeOnClasspath) {
     List<Mismatch> mismatches = Collections.emptyList();
 
@@ -265,6 +221,50 @@ public final class ReferenceMatcher {
       }
     }
     return mismatches;
+  }
+
+  // for helper classes we make sure that all abstract methods from super classes and interfaces are
+  // implemented
+  private List<Mismatch> checkHelperClassMatch(Reference helperClass, TypePool typePool) {
+    List<Mismatch> mismatches = Collections.emptyList();
+
+    HelperReferenceWrapper helperWrapper = new Factory(typePool, references).create(helperClass);
+
+    if (!helperWrapper.hasSuperTypes() || helperWrapper.isAbstract()) {
+      return mismatches;
+    }
+
+    // treat the helper type as a bag of methods: collect all methods defined in the helper class,
+    // all superclasses and interfaces and check if all abstract methods are implemented somewhere
+    Set<HelperReferenceWrapper.Method> abstractMethods = new HashSet<>();
+    Set<HelperReferenceWrapper.Method> plainMethods = new HashSet<>();
+    collectMethodsFromTypeHierarchy(helperWrapper, abstractMethods, plainMethods);
+
+    Set<HelperReferenceWrapper.Method> unimplementedMethods =
+        Sets.difference(abstractMethods, plainMethods);
+    for (HelperReferenceWrapper.Method unimplementedMethod : unimplementedMethods) {
+      mismatches =
+          lazyAdd(
+              mismatches,
+              new Mismatch.MissingMethod(
+                  helperClass.getSources().toArray(new Reference.Source[0]),
+                  unimplementedMethod.getDeclaringClass(),
+                  unimplementedMethod.getName(),
+                  unimplementedMethod.getDescriptor()));
+    }
+
+    return mismatches;
+  }
+
+  private static void collectMethodsFromTypeHierarchy(
+      HelperReferenceWrapper type, Set<Method> abstractMethods, Set<Method> plainMethods) {
+
+    type.getMethods()
+        .forEach(method -> (method.isAbstract() ? abstractMethods : plainMethods).add(method));
+
+    type.getSuperTypes()
+        .forEach(
+            superType -> collectMethodsFromTypeHierarchy(superType, abstractMethods, plainMethods));
   }
 
   private static boolean matchesPrimitive(String longName, String shortName) {


### PR DESCRIPTION
Enables checkstyle rule for https://google.github.io/styleguide/javaguide.html#s3.4.2-ordering-class-contents

> 3.4.2.1 Overloads: never split
When a class has multiple constructors, or multiple methods with the same name, these appear sequentially, with no other code in between (not even private members).

I don't feel strongly either way about this rule.