### PR TITLE
Enable type var naming rule for Google Style

### DIFF
--- a/gradle/enforcement/checkstyle.xml
+++ b/gradle/enforcement/checkstyle.xml
@@ -216,25 +216,21 @@
       <message key="name.invalidPattern"
         value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
-    <!--
     <module name="ClassTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
         value="Class type name ''{0}'' must match pattern ''{1}''."/>
     </module>
-    -->
     <module name="RecordTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
         value="Record type name ''{0}'' must match pattern ''{1}''."/>
     </module>
-    <!--
     <module name="MethodTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
         value="Method type name ''{0}'' must match pattern ''{1}''."/>
     </module>
-    -->
     <module name="InterfaceTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
@@ -18,7 +18,7 @@ import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
 
-public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer {
+public abstract class DatabaseClientTracer<C, Q> extends BaseTracer {
 
   protected static final String DB_QUERY = "DB Query";
 
@@ -28,7 +28,7 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
     tracer = OpenTelemetry.getGlobalTracer(getInstrumentationName(), getVersion());
   }
 
-  public Span startSpan(CONNECTION connection, QUERY query) {
+  public Span startSpan(C connection, Q query) {
     String normalizedQuery = normalizeQuery(query);
 
     Span span =
@@ -82,7 +82,7 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
   }
 
   /** This should be called when the connection is being used, not when it's created. */
-  protected Span onConnection(Span span, CONNECTION connection) {
+  protected Span onConnection(Span span, C connection) {
     span.setAttribute(SemanticAttributes.DB_USER, dbUser(connection));
     span.setAttribute(SemanticAttributes.DB_NAME, dbName(connection));
     span.setAttribute(SemanticAttributes.DB_CONNECTION_STRING, dbConnectionString(connection));
@@ -98,7 +98,7 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
     }
   }
 
-  protected void setNetSemanticConvention(Span span, CONNECTION connection) {
+  protected void setNetSemanticConvention(Span span, C connection) {
     NetPeerUtils.setNetPeer(span, peerAddress(connection));
   }
 
@@ -106,25 +106,25 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
     span.setAttribute(SemanticAttributes.DB_STATEMENT, statement);
   }
 
-  protected abstract String normalizeQuery(QUERY query);
+  protected abstract String normalizeQuery(Q query);
 
-  protected abstract String dbSystem(CONNECTION connection);
+  protected abstract String dbSystem(C connection);
 
-  protected String dbUser(CONNECTION connection) {
+  protected String dbUser(C connection) {
     return null;
   }
 
-  protected String dbName(CONNECTION connection) {
+  protected String dbName(C connection) {
     return null;
   }
 
-  protected String dbConnectionString(CONNECTION connection) {
+  protected String dbConnectionString(C connection) {
     return null;
   }
 
-  protected abstract InetSocketAddress peerAddress(CONNECTION connection);
+  protected abstract InetSocketAddress peerAddress(C connection);
 
-  protected String spanName(CONNECTION connection, QUERY query, String normalizedQuery) {
+  protected String spanName(C connection, Q query, String normalizedQuery) {
     if (normalizedQuery != null) {
       return normalizedQuery;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
@@ -22,7 +22,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseTracer {
+public abstract class HttpClientTracer<ReqT, CarT, ResT> extends BaseTracer {
 
   private static final Logger log = LoggerFactory.getLogger(HttpClientTracer.class);
 
@@ -30,26 +30,26 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
 
   protected static final String USER_AGENT = "User-Agent";
 
-  protected abstract String method(REQUEST request);
+  protected abstract String method(ReqT request);
 
   @Nullable
-  protected abstract URI url(REQUEST request) throws URISyntaxException;
+  protected abstract URI url(ReqT request) throws URISyntaxException;
 
   @Nullable
-  protected String flavor(REQUEST request) {
+  protected String flavor(ReqT request) {
     // This is de facto standard nowadays, so let us use it, unless overridden
     return "1.1";
   }
 
-  protected abstract Integer status(RESPONSE response);
+  protected abstract Integer status(ResT response);
 
   @Nullable
-  protected abstract String requestHeader(REQUEST request, String name);
+  protected abstract String requestHeader(ReqT request, String name);
 
   @Nullable
-  protected abstract String responseHeader(RESPONSE response, String name);
+  protected abstract String responseHeader(ResT response, String name);
 
-  protected abstract TextMapPropagator.Setter<CARRIER> getSetter();
+  protected abstract TextMapPropagator.Setter<CarT> getSetter();
 
   protected HttpClientTracer() {
     super();
@@ -59,18 +59,18 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     super(tracer);
   }
 
-  public Span startSpan(REQUEST request) {
+  public Span startSpan(ReqT request) {
     return startSpan(request, -1);
   }
 
-  public Span startSpan(REQUEST request, long startTimeNanos) {
+  public Span startSpan(ReqT request, long startTimeNanos) {
     return startSpan(request, spanNameForRequest(request), startTimeNanos);
   }
 
-  public Scope startScope(Span span, CARRIER carrier) {
+  public Scope startScope(Span span, CarT carrier) {
     Context context = Context.current().with(span);
 
-    Setter<CARRIER> setter = getSetter();
+    Setter<CarT> setter = getSetter();
     if (setter == null) {
       throw new IllegalStateException(
           "getSetter() not defined but calling startScope(), either getSetter must be implemented or the scope should be setup manually");
@@ -80,21 +80,20 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     return context.makeCurrent();
   }
 
-  public void end(Span span, RESPONSE response) {
+  public void end(Span span, ResT response) {
     end(span, response, -1);
   }
 
-  public void end(Span span, RESPONSE response, long endTimeNanos) {
+  public void end(Span span, ResT response, long endTimeNanos) {
     onResponse(span, response);
     super.end(span, endTimeNanos);
   }
 
-  public void endExceptionally(Span span, RESPONSE response, Throwable throwable) {
+  public void endExceptionally(Span span, ResT response, Throwable throwable) {
     endExceptionally(span, response, throwable, -1);
   }
 
-  public void endExceptionally(
-      Span span, RESPONSE response, Throwable throwable, long endTimeNanos) {
+  public void endExceptionally(Span span, ResT response, Throwable throwable, long endTimeNanos) {
     onResponse(span, response);
     super.endExceptionally(span, throwable, endTimeNanos);
   }
@@ -103,7 +102,7 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
    * Returns a new client {@link Span} if there is no client {@link Span} in the current {@link
    * Context}, or an invalid {@link Span} otherwise.
    */
-  private Span startSpan(REQUEST request, String name, long startTimeNanos) {
+  private Span startSpan(ReqT request, String name, long startTimeNanos) {
     Context context = Context.current();
     Span clientSpan = context.get(CONTEXT_CLIENT_SPAN_KEY);
 
@@ -121,7 +120,7 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     return span;
   }
 
-  protected Span onRequest(Span span, REQUEST request) {
+  protected Span onRequest(Span span, ReqT request) {
     assert span != null;
     if (request != null) {
       span.setAttribute(SemanticAttributes.NET_TRANSPORT, "IP.TCP");
@@ -134,7 +133,7 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     return span;
   }
 
-  private void setFlavor(Span span, REQUEST request) {
+  private void setFlavor(Span span, ReqT request) {
     String flavor = flavor(request);
     if (flavor == null) {
       return;
@@ -148,7 +147,7 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     span.setAttribute(SemanticAttributes.HTTP_FLAVOR, flavor);
   }
 
-  private void setUrl(Span span, REQUEST request) {
+  private void setUrl(Span span, ReqT request) {
     try {
       URI url = url(request);
       if (url != null) {
@@ -160,7 +159,7 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     }
   }
 
-  protected Span onResponse(Span span, RESPONSE response) {
+  protected Span onResponse(Span span, ResT response) {
     assert span != null;
     if (response != null) {
       Integer status = status(response);
@@ -172,7 +171,7 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     return span;
   }
 
-  protected String spanNameForRequest(REQUEST request) {
+  protected String spanNameForRequest(ReqT request) {
     if (request == null) {
       return DEFAULT_SPAN_NAME;
     }

--- a/instrumentation-core/servlet-2.2/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
+++ b/instrumentation-core/servlet-2.2/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
@@ -20,8 +20,8 @@ import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class ServletHttpServerTracer<RESPONSE>
-    extends HttpServerTracer<HttpServletRequest, RESPONSE, HttpServletRequest, HttpServletRequest> {
+public abstract class ServletHttpServerTracer<ResT>
+    extends HttpServerTracer<HttpServletRequest, ResT, HttpServletRequest, HttpServletRequest> {
 
   private static final Logger log = LoggerFactory.getLogger(ServletHttpServerTracer.class);
 

--- a/instrumentation/hibernate/hibernate-common/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/SessionMethodUtils.java
+++ b/instrumentation/hibernate/hibernate-common/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/SessionMethodUtils.java
@@ -24,11 +24,11 @@ public class SessionMethodUtils {
 
   // Starts a scope as a child from a Span, where the Span is attached to the given spanKey using
   // the given contextStore.
-  public static <TARGET, ENTITY> SpanWithScope startScopeFrom(
-      ContextStore<TARGET, Context> contextStore,
-      TARGET spanKey,
+  public static <K> SpanWithScope startScopeFrom(
+      ContextStore<K, Context> contextStore,
+      K spanKey,
       String operationName,
-      ENTITY entity,
+      Object entity,
       boolean createSpan) {
 
     Context sessionContext = contextStore.get(spanKey);

--- a/instrumentation/lettuce/lettuce-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAbstractDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAbstractDatabaseClientTracer.java
@@ -12,8 +12,8 @@ import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import io.opentelemetry.javaagent.instrumentation.api.db.DbSystem;
 import java.net.InetSocketAddress;
 
-public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
-    extends DatabaseClientTracer<RedisURI, QUERY> {
+public abstract class LettuceAbstractDatabaseClientTracer<Q>
+    extends DatabaseClientTracer<RedisURI, Q> {
 
   @Override
   protected String dbSystem(RedisURI connection) {

--- a/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAbstractDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAbstractDatabaseClientTracer.java
@@ -12,8 +12,8 @@ import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import io.opentelemetry.javaagent.instrumentation.api.db.DbSystem;
 import java.net.InetSocketAddress;
 
-public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
-    extends DatabaseClientTracer<RedisURI, QUERY> {
+public abstract class LettuceAbstractDatabaseClientTracer<Q>
+    extends DatabaseClientTracer<RedisURI, Q> {
   @Override
   protected String getInstrumentationName() {
     return "io.opentelemetry.auto.lettuce";

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/util/CombinedSimpleChannelHandler.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/util/CombinedSimpleChannelHandler.java
@@ -17,14 +17,13 @@ import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 import org.jboss.netty.channel.WriteCompletionEvent;
 
 public class CombinedSimpleChannelHandler<
-        Upstream extends SimpleChannelUpstreamHandler,
-        Downstream extends SimpleChannelDownstreamHandler>
+        U extends SimpleChannelUpstreamHandler, D extends SimpleChannelDownstreamHandler>
     extends SimpleChannelHandler {
 
-  private final Upstream upstream;
-  private final Downstream downstream;
+  private final U upstream;
+  private final D downstream;
 
-  public CombinedSimpleChannelHandler(Upstream upstream, Downstream downstream) {
+  public CombinedSimpleChannelHandler(U upstream, D downstream) {
     this.upstream = upstream;
     this.downstream = downstream;
   }


### PR DESCRIPTION
Enables checkstyle rule for https://google.github.io/styleguide/javaguide.html#s5.2.8-type-variable-names

> Each type variable is named in one of two styles:
> * A single capital letter, optionally followed by a single numeral (such as E, T, X, T2)
> * A name in the form used for classes (see Section 5.2.2, Class names), followed by the capital letter T (examples: RequestT, FooBarT).

Just trying this out, please provide feedback.

`Q` = query
`C` = connection
`S` = storage
`ReqT` = request (could also use `RequestT`)
`ResT` = response (could also use  `RespT` or `ResponseT`)
`CarT` = carrier (could also use `CarrierT`)