### PR TITLE
Remove default aws credentials lookup

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,6 @@ buildCache {
     region = 'us-west-2'
     bucket = 'opentelemetry-java-instrumentation-gradle-cache'
     push = isCI && awsAccessKeyId != null && !awsAccessKeyId.isEmpty()
-    lookupDefaultAwsCredentials = true
   }
 }
 


### PR DESCRIPTION
It leads to a lot of warnings on any developer machine without AWS credentials configured. And CI, where AWS credentials actually matter, uses explicit env variables anyway.