### PR TITLE
Improve consistency of struts with existing tests

### DIFF
--- a/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
+++ b/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 

--- a/instrumentation/struts-2.3/javaagent/src/test/java/io/opentelemetry/struts/GreetingAction.java
+++ b/instrumentation/struts-2.3/javaagent/src/test/java/io/opentelemetry/struts/GreetingAction.java
@@ -20,7 +20,15 @@ public class GreetingAction extends ActionSupport {
     return "greeting";
   }
 
-  public String query() {
+  public String redirect() {
+    responseBody =
+        HttpServerTest.controller(
+            HttpServerTest.ServerEndpoint.REDIRECT,
+            HttpServerTest.ServerEndpoint.REDIRECT::getBody);
+    return "redirect";
+  }
+
+  public String query_param() {
     responseBody =
         HttpServerTest.controller(
             HttpServerTest.ServerEndpoint.QUERY_PARAM,
@@ -28,17 +36,22 @@ public class GreetingAction extends ActionSupport {
     return "greeting";
   }
 
-  public String exception() {
-    responseBody =
-        HttpServerTest.controller(
-            HttpServerTest.ServerEndpoint.EXCEPTION,
-            () -> {
-              throw new Exception(HttpServerTest.ServerEndpoint.EXCEPTION.getBody());
-            });
-    return "exception";
+  public String error() {
+    HttpServerTest.controller(
+        HttpServerTest.ServerEndpoint.ERROR, HttpServerTest.ServerEndpoint.ERROR::getBody);
+    return "error";
   }
 
-  public String pathParam() {
+  public String exception() {
+    HttpServerTest.controller(
+        HttpServerTest.ServerEndpoint.EXCEPTION,
+        () -> {
+          throw new Exception(HttpServerTest.ServerEndpoint.EXCEPTION.getBody());
+        });
+    throw new AssertionError(); // should not reach here
+  }
+
+  public String path_param() {
     HttpServerTest.controller(
         HttpServerTest.ServerEndpoint.PATH_PARAM,
         () ->
@@ -48,11 +61,6 @@ public class GreetingAction extends ActionSupport {
 
   public void setId(String id) {
     responseBody = id;
-  }
-
-  public void setSome(String some) {
-    responseBody = "some=" + some;
-    System.out.println("Setting query param some to " + some);
   }
 
   public String getResponseBody() {

--- a/instrumentation/struts-2.3/javaagent/src/test/resources/struts.xml
+++ b/instrumentation/struts-2.3/javaagent/src/test/resources/struts.xml
@@ -5,27 +5,32 @@
 
 <struts>
 
-  <constant name="struts.devMode" value="true" />
   <constant name="struts.enable.SlashesInActionNames" value="true"/>
-  <constant name="struts.mapper.alwaysSelectFullNamespace" value="false"/>
-  <constant name="struts.patternMatcher" value="namedVariable" />
+  <constant name="struts.patternMatcher" value="namedVariable"/>
 
   <package name="basic-struts2" extends="struts-default">
     <global-results>
-      <result name="exception" type="httpheader">
+      <result name="redirect" type="redirect">
+        <param name="location">/redirected</param>
+        <param name="prependServletContext">false</param>
+      </result>
+      <result name="error" type="httpheader">
         <param name="error">500</param>
       </result>
-      <result type="freemarker" name="greeting">greeting.ftl</result>
+      <result type="freemarker" name="greeting">/greeting.ftl</result>
     </global-results>
 
     <global-exception-mappings>
-      <exception-mapping exception="java.lang.Exception" result="exception" />
+      <exception-mapping exception="java.lang.Exception" result="error"/>
     </global-exception-mappings>
 
     <action name="success" class="io.opentelemetry.struts.GreetingAction" method="success"/>
-    <action name="query" class="io.opentelemetry.struts.GreetingAction" method="query"/>
+    <action name="redirect" class="io.opentelemetry.struts.GreetingAction" method="redirect"/>
+    <action name="query" class="io.opentelemetry.struts.GreetingAction" method="query_param"/>
+    <action name="error-status" class="io.opentelemetry.struts.GreetingAction" method="error"/>
     <action name="exception" class="io.opentelemetry.struts.GreetingAction" method="exception"/>
-    <action name="/path/{id}/param" class="io.opentelemetry.struts.GreetingAction" method="pathParam"/>
+    <action name="/path/{id}/param" class="io.opentelemetry.struts.GreetingAction"
+      method="path_param"/>
   </package>
 
 

--- a/instrumentation/struts-2.3/javaagent/struts-2.3-javaagent.gradle
+++ b/instrumentation/struts-2.3/javaagent/struts-2.3-javaagent.gradle
@@ -4,12 +4,12 @@ muzzle {
   pass {
     group = "org.apache.struts"
     module = "struts2-core"
-    versions = "[2.3.20,)"
+    versions = "[2.3.1,)"
   }
 }
 
 dependencies {
-  library group: 'org.apache.struts', name: 'struts2-core', version: '2.3.20'
+  library group: 'org.apache.struts', name: 'struts2-core', version: '2.3.1'
 
   testImplementation(project(':testing-common')) {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'


### PR DESCRIPTION
cc: @vovencij

* add tests for redirect and error endpoints
* sets struts version to first 2.3 version in maven central (2.3.1)
* a couple other minor updates to be more consistent with other mvc framework tests

I had sent these updates as a [PR to #1628](https://github.com/vovencij/opentelemetry-java-instrumentation/pull/1), but I forgot to mention it in the PR, and then I accidentally deleted the branch which closed my PR 😅 