### PR TITLE
Update instrumentation names to be consistent

### DIFF
--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpClientTracer.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpClientTracer.java
@@ -68,6 +68,6 @@ public class AkkaHttpClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.akka-http";
+    return "io.opentelemetry.javaagent.akka-http";
   }
 }

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpServerTracer.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpServerTracer.java
@@ -65,7 +65,7 @@ public class AkkaHttpServerTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.akka-http";
+    return "io.opentelemetry.javaagent.akka-http";
   }
 
   @Override

--- a/instrumentation/apache-camel-2.20/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelTracer.java
+++ b/instrumentation/apache-camel-2.20/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelTracer.java
@@ -37,7 +37,7 @@ class CamelTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.apache-camel-2.20";
+    return "io.opentelemetry.javaagent.apache-camel";
   }
 
   public Span.Builder spanBuilder(String name) {

--- a/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientTracer.java
+++ b/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientTracer.java
@@ -88,7 +88,7 @@ public class ApacheHttpAsyncClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.apache-httpasyncclient";
+    return "io.opentelemetry.javaagent.apache-httpasyncclient";
   }
 
   @Override

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/CommonsHttpClientTracer.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/CommonsHttpClientTracer.java
@@ -26,7 +26,7 @@ public class CommonsHttpClientTracer extends HttpClientTracer<HttpMethod, HttpMe
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.apache-httpclient";
+    return "io.opentelemetry.javaagent.apache-httpclient";
   }
 
   public Depth getCallDepth() {

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientTracer.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientTracer.java
@@ -68,7 +68,7 @@ class ApacheHttpClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.apache-httpclient";
+    return "io.opentelemetry.javaagent.apache-httpclient";
   }
 
   /** This method is overridden to allow other classes in this package to call it. */

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkClientTracer.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkClientTracer.java
@@ -126,7 +126,7 @@ public class AwsSdkClientTracer extends HttpClientTracer<Request<?>, Request<?>,
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.aws-sdk";
+    return "io.opentelemetry.javaagent.aws-sdk";
   }
 
   static final class NamesCache extends ClassValue<ConcurrentHashMap<String, String>> {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpClientTracer.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpClientTracer.java
@@ -68,7 +68,7 @@ final class AwsSdkHttpClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.aws-sdk";
+    return "io.opentelemetry.javaagent.aws-sdk";
   }
 
   /** This method is overridden to allow other classes in this package to call it. */

--- a/instrumentation/cassandra/cassandra-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraDatabaseClientTracer.java
+++ b/instrumentation/cassandra/cassandra-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraDatabaseClientTracer.java
@@ -24,7 +24,7 @@ public class CassandraDatabaseClientTracer extends DatabaseClientTracer<Session,
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.cassandra";
+    return "io.opentelemetry.javaagent.cassandra";
   }
 
   @Override

--- a/instrumentation/cassandra/cassandra-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraDatabaseClientTracer.java
+++ b/instrumentation/cassandra/cassandra-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraDatabaseClientTracer.java
@@ -25,7 +25,7 @@ public class CassandraDatabaseClientTracer extends DatabaseClientTracer<CqlSessi
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.cassandra";
+    return "io.opentelemetry.javaagent.cassandra";
   }
 
   @Override

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseClientTracer.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseClientTracer.java
@@ -37,6 +37,6 @@ public class CouchbaseClientTracer extends DatabaseClientTracer<Void, Method> {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.couchbase";
+    return "io.opentelemetry.javaagent.couchbase";
   }
 }

--- a/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/DropwizardTracer.java
+++ b/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/DropwizardTracer.java
@@ -21,6 +21,6 @@ public class DropwizardTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.dropwizard-views-0.7";
+    return "io.opentelemetry.javaagent.dropwizard-views";
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestClientTracer.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestClientTracer.java
@@ -55,6 +55,6 @@ public class ElasticsearchRestClientTracer extends DatabaseClientTracer<Void, St
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.elasticsearch";
+    return "io.opentelemetry.javaagent.elasticsearch";
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportClientTracer.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportClientTracer.java
@@ -48,6 +48,6 @@ public class ElasticsearchTransportClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.elasticsearch";
+    return "io.opentelemetry.javaagent.elasticsearch";
   }
 }

--- a/instrumentation/external-annotations/src/main/java/io/opentelemetry/javaagent/instrumentation/traceannotation/TraceAnnotationTracer.java
+++ b/instrumentation/external-annotations/src/main/java/io/opentelemetry/javaagent/instrumentation/traceannotation/TraceAnnotationTracer.java
@@ -16,6 +16,6 @@ public class TraceAnnotationTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.trace-annotation";
+    return "io.opentelemetry.javaagent.external-annotation";
   }
 }

--- a/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/javaagent/instrumentation/finatra/FinatraTracer.java
+++ b/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/javaagent/instrumentation/finatra/FinatraTracer.java
@@ -16,6 +16,6 @@ public class FinatraTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.finatra";
+    return "io.opentelemetry.javaagent.finatra";
   }
 }

--- a/instrumentation/geode-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeTracer.java
+++ b/instrumentation/geode-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeTracer.java
@@ -61,6 +61,6 @@ public class GeodeTracer extends DatabaseClientTracer<Region<?, ?>, String> {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.geode";
+    return "io.opentelemetry.javaagent.geode";
   }
 }

--- a/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientTracer.java
+++ b/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientTracer.java
@@ -23,7 +23,7 @@ public class GoogleHttpClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.google-http-client";
+    return "io.opentelemetry.javaagent.google-http-client";
   }
 
   @Override

--- a/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpServerTracer.java
+++ b/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpServerTracer.java
@@ -90,7 +90,7 @@ public class GrizzlyHttpServerTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.grizzly";
+    return "io.opentelemetry.javaagent.grizzly";
   }
 
   @Override

--- a/instrumentation/grizzly-client-1.9/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/client/GrizzlyClientTracer.java
+++ b/instrumentation/grizzly-client-1.9/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/client/GrizzlyClientTracer.java
@@ -52,6 +52,6 @@ public class GrizzlyClientTracer extends HttpClientTracer<Request, Request, Resp
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.grizzly-client";
+    return "io.opentelemetry.javaagent.grizzly-client";
   }
 }

--- a/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/client/GrpcClientTracer.java
+++ b/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/client/GrpcClientTracer.java
@@ -42,6 +42,6 @@ public class GrpcClientTracer extends RpcClientTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.grpc";
+    return "io.opentelemetry.javaagent.grpc";
   }
 }

--- a/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/server/GrpcServerTracer.java
+++ b/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/server/GrpcServerTracer.java
@@ -47,7 +47,7 @@ public class GrpcServerTracer extends RpcServerTracer<Metadata> {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.grpc";
+    return "io.opentelemetry.javaagent.grpc";
   }
 
   @Override

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionTracer.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionTracer.java
@@ -54,6 +54,6 @@ public class HttpUrlConnectionTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.http-url-connection";
+    return "io.opentelemetry.javaagent.http-url-connection";
   }
 }

--- a/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixTracer.java
+++ b/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixTracer.java
@@ -25,7 +25,7 @@ public class HystrixTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.hystrix";
+    return "io.opentelemetry.javaagent.hystrix";
   }
 
   public void onCommand(Span span, HystrixInvokableInfo<?> command, String methodName) {

--- a/instrumentation/java-httpclient/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpClientTracer.java
+++ b/instrumentation/java-httpclient/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpClientTracer.java
@@ -39,7 +39,7 @@ public class JdkHttpClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.java-httpclient";
+    return "io.opentelemetry.javaagent.java-httpclient";
   }
 
   @Override

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Tracer.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Tracer.java
@@ -54,6 +54,6 @@ public class JaxRsClientV1Tracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jaxrs-client";
+    return "io.opentelemetry.javaagent.jaxrs-client";
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientTracer.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientTracer.java
@@ -53,6 +53,6 @@ public class ResteasyClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jaxrs-client-2.0";
+    return "io.opentelemetry.javaagent.jaxrs-client";
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientTracer.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientTracer.java
@@ -53,6 +53,6 @@ public class JaxRsClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jaxrs-client";
+    return "io.opentelemetry.javaagent.jaxrs-client";
   }
 }

--- a/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotationsTracer.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotationsTracer.java
@@ -184,6 +184,6 @@ public class JaxRsAnnotationsTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jaxrs";
+    return "io.opentelemetry.javaagent.jaxrs";
   }
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAnnotationsTracer.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAnnotationsTracer.java
@@ -194,6 +194,6 @@ public class JaxRsAnnotationsTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jaxrs";
+    return "io.opentelemetry.javaagent.jaxrs";
   }
 }

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/DataSourceTracer.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/DataSourceTracer.java
@@ -16,6 +16,6 @@ public class DataSourceTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jdbc";
+    return "io.opentelemetry.javaagent.jdbc";
   }
 }

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcTracer.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcTracer.java
@@ -29,7 +29,7 @@ public class JdbcTracer extends DatabaseClientTracer<DbInfo, SqlStatementInfo> {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jdbc";
+    return "io.opentelemetry.javaagent.jdbc";
   }
 
   @Override

--- a/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisClientTracer.java
+++ b/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisClientTracer.java
@@ -52,7 +52,7 @@ public class JedisClientTracer extends DatabaseClientTracer<Connection, CommandW
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jedis";
+    return "io.opentelemetry.javaagent.jedis";
   }
 
   public static final class CommandWithArgs {

--- a/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisClientTracer.java
+++ b/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisClientTracer.java
@@ -54,7 +54,7 @@ public class JedisClientTracer extends DatabaseClientTracer<Connection, CommandW
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jedis";
+    return "io.opentelemetry.javaagent.jedis";
   }
 
   public static final class CommandWithArgs {

--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/JettyHttpServerTracer.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/JettyHttpServerTracer.java
@@ -16,6 +16,6 @@ public class JettyHttpServerTracer extends Servlet3HttpServerTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jetty";
+    return "io.opentelemetry.javaagent.jetty";
   }
 }

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsTracer.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsTracer.java
@@ -164,6 +164,6 @@ public class JmsTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jms";
+    return "io.opentelemetry.javaagent.jms";
   }
 }

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/JspTracer.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/JspTracer.java
@@ -76,6 +76,6 @@ public class JspTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.jsp";
+    return "io.opentelemetry.javaagent.jsp";
   }
 }

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaConsumerTracer.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaConsumerTracer.java
@@ -78,6 +78,6 @@ public class KafkaConsumerTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.kafka-clients";
+    return "io.opentelemetry.javaagent.kafka-clients";
   }
 }

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerTracer.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerTracer.java
@@ -59,6 +59,6 @@ public class KafkaProducerTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.kafka-clients-0.11";
+    return "io.opentelemetry.javaagent.kafka-clients";
   }
 }

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsTracer.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsTracer.java
@@ -52,6 +52,6 @@ public class KafkaStreamsTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.kafka-streams";
+    return "io.opentelemetry.javaagent.kafka-streams";
   }
 }

--- a/instrumentation/khttp-0.1/src/main/java/io/opentelemetry/javaagent/instrumentation/khttp/KHttpTracer.java
+++ b/instrumentation/khttp-0.1/src/main/java/io/opentelemetry/javaagent/instrumentation/khttp/KHttpTracer.java
@@ -60,6 +60,6 @@ public class KHttpTracer extends HttpClientTracer<RequestWrapper, Map<String, St
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.khttp";
+    return "io.opentelemetry.javaagent.khttp";
   }
 }

--- a/instrumentation/kubernetes-client-7.0/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientTracer.java
+++ b/instrumentation/kubernetes-client-7.0/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientTracer.java
@@ -54,7 +54,7 @@ public class KubernetesClientTracer extends HttpClientTracer<Request, Request, R
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.kubernetes-client";
+    return "io.opentelemetry.javaagent.kubernetes-client";
   }
 
   /** This method is overridden to allow other classes in this package to call it. */

--- a/instrumentation/lettuce/lettuce-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAbstractDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAbstractDatabaseClientTracer.java
@@ -35,6 +35,6 @@ public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.lettuce";
+    return "io.opentelemetry.javaagent.lettuce";
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAbstractDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAbstractDatabaseClientTracer.java
@@ -16,7 +16,7 @@ public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
     extends DatabaseClientTracer<RedisURI, QUERY> {
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.lettuce";
+    return "io.opentelemetry.javaagent.lettuce";
   }
 
   @Override

--- a/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/MongoClientTracer.java
+++ b/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/MongoClientTracer.java
@@ -30,7 +30,7 @@ public class MongoClientTracer extends DatabaseClientTracer<CommandStartedEvent,
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.mongo";
+    return "io.opentelemetry.javaagent.mongo";
   }
 
   @Override

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientTracer.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientTracer.java
@@ -84,6 +84,6 @@ public class NettyHttpClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.netty";
+    return "io.opentelemetry.javaagent.netty";
   }
 }

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerTracer.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerTracer.java
@@ -81,7 +81,7 @@ public class NettyHttpServerTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.netty";
+    return "io.opentelemetry.javaagent.netty";
   }
 
   @Override

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/NettyHttpClientTracer.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/NettyHttpClientTracer.java
@@ -84,6 +84,6 @@ public class NettyHttpClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.netty";
+    return "io.opentelemetry.javaagent.netty";
   }
 }

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/NettyHttpServerTracer.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/NettyHttpServerTracer.java
@@ -52,7 +52,7 @@ public class NettyHttpServerTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.netty";
+    return "io.opentelemetry.javaagent.netty";
   }
 
   @Override

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/NettyHttpClientTracer.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/NettyHttpClientTracer.java
@@ -67,6 +67,6 @@ public class NettyHttpClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.netty";
+    return "io.opentelemetry.javaagent.netty";
   }
 }

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/NettyHttpServerTracer.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/NettyHttpServerTracer.java
@@ -52,7 +52,7 @@ public class NettyHttpServerTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.netty";
+    return "io.opentelemetry.javaagent.netty";
   }
 
   @Override

--- a/instrumentation/okhttp/okhttp-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttpClientTracer.java
+++ b/instrumentation/okhttp/okhttp-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttpClientTracer.java
@@ -53,6 +53,6 @@ public class OkHttpClientTracer extends HttpClientTracer<Request, Request.Builde
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.okhttp";
+    return "io.opentelemetry.javaagent.okhttp";
   }
 }

--- a/instrumentation/okhttp/okhttp-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttpClientTracer.java
+++ b/instrumentation/okhttp/okhttp-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttpClientTracer.java
@@ -52,6 +52,6 @@ public class OkHttpClientTracer extends HttpClientTracer<Request, Request.Builde
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.okhttp";
+    return "io.opentelemetry.javaagent.okhttp";
   }
 }

--- a/instrumentation/opentelemetry-api-beta/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/anotations/TraceAnnotationTracer.java
+++ b/instrumentation/opentelemetry-api-beta/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/anotations/TraceAnnotationTracer.java
@@ -52,6 +52,6 @@ public class TraceAnnotationTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.trace-annotation";
+    return "io.opentelemetry.javaagent.opentelemetry-api-beta";
   }
 }

--- a/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientTracer.java
+++ b/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientTracer.java
@@ -54,6 +54,6 @@ public class PlayWsClientTracer extends HttpClientTracer<Request, HttpHeaders, R
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.play-ws";
+    return "io.opentelemetry.javaagent.play-ws";
   }
 }

--- a/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_3/PlayTracer.java
+++ b/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_3/PlayTracer.java
@@ -30,7 +30,7 @@ public class PlayTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.play";
+    return "io.opentelemetry.javaagent.play";
   }
 
   @Override

--- a/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/PlayTracer.java
+++ b/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/PlayTracer.java
@@ -31,7 +31,7 @@ public class PlayTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.play";
+    return "io.opentelemetry.javaagent.play";
   }
 
   @Override

--- a/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/PlayTracer.java
+++ b/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/PlayTracer.java
@@ -67,7 +67,7 @@ public class PlayTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.play";
+    return "io.opentelemetry.javaagent.play";
   }
 
   @Override

--- a/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelInstrumentation.java
+++ b/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelInstrumentation.java
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp;
+package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
-import static io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp.RabbitCommandInstrumentation.SpanHolder.CURRENT_RABBIT_SPAN;
-import static io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp.RabbitTracer.tracer;
-import static io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp.TextMapInjectAdapter.SETTER;
+import static io.opentelemetry.javaagent.instrumentation.rabbitmq.RabbitCommandInstrumentation.SpanHolder.CURRENT_RABBIT_SPAN;
+import static io.opentelemetry.javaagent.instrumentation.rabbitmq.RabbitTracer.tracer;
 import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
 import static io.opentelemetry.javaagent.tooling.matcher.NameMatchers.namedOneOf;
@@ -158,7 +157,7 @@ final class RabbitChannelInstrumentation implements TypeInstrumentation {
 
         Java8BytecodeBridge.getGlobalPropagators()
             .getTextMapPropagator()
-            .inject(context, headers, SETTER);
+            .inject(context, headers, TextMapInjectAdapter.SETTER);
 
         props =
             new AMQP.BasicProperties(

--- a/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitCommandInstrumentation.java
+++ b/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitCommandInstrumentation.java
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp;
+package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
-import static io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp.RabbitCommandInstrumentation.SpanHolder.CURRENT_RABBIT_SPAN;
-import static io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp.RabbitTracer.tracer;
+import static io.opentelemetry.javaagent.instrumentation.rabbitmq.RabbitCommandInstrumentation.SpanHolder.CURRENT_RABBIT_SPAN;
+import static io.opentelemetry.javaagent.instrumentation.rabbitmq.RabbitTracer.tracer;
 import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
 import static java.util.Collections.singletonMap;

--- a/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitMqInstrumentationModule.java
+++ b/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitMqInstrumentationModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp;
+package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
 import static java.util.Arrays.asList;
 

--- a/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitTracer.java
+++ b/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitTracer.java
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp;
+package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT;
 import static io.opentelemetry.api.trace.Span.Kind.CONSUMER;
 import static io.opentelemetry.api.trace.Span.Kind.PRODUCER;
 import static io.opentelemetry.instrumentation.api.decorator.BaseDecorator.extract;
-import static io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp.TextMapExtractAdapter.GETTER;
+import static io.opentelemetry.javaagent.instrumentation.rabbitmq.TextMapExtractAdapter.GETTER;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import com.rabbitmq.client.AMQP;

--- a/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TextMapExtractAdapter.java
+++ b/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TextMapExtractAdapter.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp;
+package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import java.util.Map;

--- a/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TextMapInjectAdapter.java
+++ b/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TextMapInjectAdapter.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp;
+package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import java.util.Map;

--- a/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TracedDelegatingConsumer.java
+++ b/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TracedDelegatingConsumer.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp;
+package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
-import static io.opentelemetry.javaagent.instrumentation.rabbitmq.amqp.RabbitTracer.tracer;
+import static io.opentelemetry.javaagent.instrumentation.rabbitmq.RabbitTracer.tracer;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Consumer;

--- a/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/amqp/RabbitTracer.java
+++ b/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/amqp/RabbitTracer.java
@@ -163,6 +163,6 @@ public class RabbitTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.rabbitmq-amqp";
+    return "io.opentelemetry.javaagent.rabbitmq";
   }
 }

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/RatpackTracer.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/RatpackTracer.java
@@ -31,7 +31,7 @@ public class RatpackTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.ratpack";
+    return "io.opentelemetry.javaagent.ratpack";
   }
 
   @Override

--- a/instrumentation/rediscala-1.8/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaClientTracer.java
+++ b/instrumentation/rediscala-1.8/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaClientTracer.java
@@ -36,6 +36,6 @@ public class RediscalaClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.rediscala";
+    return "io.opentelemetry.javaagent.rediscala";
   }
 }

--- a/instrumentation/redisson-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonClientTracer.java
+++ b/instrumentation/redisson-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonClientTracer.java
@@ -50,7 +50,7 @@ public class RedissonClientTracer extends DatabaseClientTracer<RedisConnection, 
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.redisson";
+    return "io.opentelemetry.javaagent.redisson";
   }
 
   @Override

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientTracer.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientTracer.java
@@ -19,6 +19,7 @@ public class RmiClientTracer extends RpcClientTracer {
     return TRACER;
   }
 
+  @Override
   public Span startSpan(Method method) {
     String serviceName = method.getDeclaringClass().getName();
     String methodName = method.getName();
@@ -34,6 +35,6 @@ public class RmiClientTracer extends RpcClientTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.rmi";
+    return "io.opentelemetry.javaagent.rmi";
   }
 }

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerTracer.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerTracer.java
@@ -41,6 +41,6 @@ public class RmiServerTracer extends RpcServerTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.rmi";
+    return "io.opentelemetry.javaagent.rmi";
   }
 }

--- a/instrumentation/servlet/servlet-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2HttpServerTracer.java
+++ b/instrumentation/servlet/servlet-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2HttpServerTracer.java
@@ -14,8 +14,9 @@ public class Servlet2HttpServerTracer extends ServletHttpServerTracer<ResponseWi
     return TRACER;
   }
 
+  @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.servlet";
+    return "io.opentelemetry.javaagent.servlet";
   }
 
   @Override

--- a/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3HttpServerTracer.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3HttpServerTracer.java
@@ -22,7 +22,7 @@ public class Servlet3HttpServerTracer extends ServletHttpServerTracer<HttpServle
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.servlet";
+    return "io.opentelemetry.javaagent.servlet";
   }
 
   @Override

--- a/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/dispatcher/RequestDispatcherTracer.java
+++ b/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/dispatcher/RequestDispatcherTracer.java
@@ -16,6 +16,6 @@ public class RequestDispatcherTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.servlet";
+    return "io.opentelemetry.javaagent.servlet";
   }
 }

--- a/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/filter/FilterTracer.java
+++ b/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/filter/FilterTracer.java
@@ -16,6 +16,6 @@ public class FilterTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.servlet";
+    return "io.opentelemetry.javaagent.servlet";
   }
 }

--- a/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/http/HttpServletResponseTracer.java
+++ b/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/http/HttpServletResponseTracer.java
@@ -16,6 +16,6 @@ public class HttpServletResponseTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.servlet";
+    return "io.opentelemetry.javaagent.servlet";
   }
 }

--- a/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/http/HttpServletTracer.java
+++ b/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/http/HttpServletTracer.java
@@ -16,6 +16,6 @@ public class HttpServletTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.servlet";
+    return "io.opentelemetry.javaagent.servlet";
   }
 }

--- a/instrumentation/spring/spring-data-1.8/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataTracer.java
+++ b/instrumentation/spring/spring-data-1.8/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataTracer.java
@@ -18,6 +18,6 @@ public final class SpringDataTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.spring-data";
+    return "io.opentelemetry.javaagent.spring-data";
   }
 }

--- a/instrumentation/spring/spring-scheduling-3.1/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingTracer.java
+++ b/instrumentation/spring/spring-scheduling-3.1/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingTracer.java
@@ -17,7 +17,7 @@ public class SpringSchedulingTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.spring-scheduling";
+    return "io.opentelemetry.javaagent.spring-scheduling";
   }
 
   public String spanNameOnRun(Runnable runnable) {

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/httpclients/RestTemplateTracer.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/httpclients/RestTemplateTracer.java
@@ -60,6 +60,6 @@ class RestTemplateTracer extends HttpClientTracer<HttpRequest, HttpHeaders, Clie
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.spring-web";
+    return "io.opentelemetry.javaagent.spring-web";
   }
 }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/SpringWebfluxHttpServerTracer.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/SpringWebfluxHttpServerTracer.java
@@ -16,6 +16,6 @@ public class SpringWebfluxHttpServerTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.spring-webflux";
+    return "io.opentelemetry.javaagent.spring-webflux";
   }
 }

--- a/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxHttpClientTracer.java
+++ b/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxHttpClientTracer.java
@@ -77,7 +77,7 @@ public class SpringWebfluxHttpClientTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.spring-webflux";
+    return "io.opentelemetry.javaagent.spring-webflux";
   }
 
   public Tracer getTracer() {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcTracer.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcTracer.java
@@ -100,6 +100,6 @@ public class SpringWebMvcTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.spring-webmvc";
+    return "io.opentelemetry.javaagent.spring-webmvc";
   }
 }

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcServerTracer.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcServerTracer.java
@@ -74,6 +74,6 @@ class SpringWebMvcServerTracer
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.spring-web";
+    return "io.opentelemetry.javaagent.spring-webmvc";
   }
 }

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/MemcacheClientTracer.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/MemcacheClientTracer.java
@@ -50,6 +50,6 @@ public class MemcacheClientTracer extends DatabaseClientTracer<MemcachedConnecti
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.spymemcached";
+    return "io.opentelemetry.javaagent.spymemcached";
   }
 }

--- a/instrumentation/struts-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/struts2/Struts2Tracer.java
+++ b/instrumentation/struts-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/struts2/Struts2Tracer.java
@@ -75,6 +75,6 @@ public class Struts2Tracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.struts-2.3";
+    return "io.opentelemetry.javaagent.struts";
   }
 }

--- a/instrumentation/vertx-web-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/VertxTracer.java
+++ b/instrumentation/vertx-web-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/VertxTracer.java
@@ -16,6 +16,6 @@ public class VertxTracer extends BaseTracer {
 
   @Override
   protected String getInstrumentationName() {
-    return "io.opentelemetry.auto.vertx";
+    return "io.opentelemetry.javaagent.vertx-web";
   }
 }


### PR DESCRIPTION
* `auto` -> `javaagent` in instrumentation names
* removes version from instrumentation names where it snuck back - https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1260#issuecomment-699637803
* removes `amqp` package name from rabbitmq instrumentation

Still need to do #1436...