### PR TITLE
Build and publish artifacts as a single step

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -63,17 +63,12 @@ jobs:
               # Trim whitespaces and cherrypick
               echo $word | sed 's/ *$//g' | sed 's/^ *//g' | git cherry-pick --stdin
           done
-      - uses: burrunan/gradle-cache-action@v1.5
-        with:
-          job-id: jdk11
-          remote-build-cache-proxy-enabled: false
-          arguments: build --stacktrace -Prelease.version=${{ github.event.inputs.version }}
-      - name: Publish artifacts
+      - name: Build and publish artifacts
         uses: burrunan/gradle-cache-action@v1.5
         with:
           job-id: jdk11
           remote-build-cache-proxy-enabled: false
-          arguments: final --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+          arguments: build final --stacktrace -Prelease.version=${{ github.event.inputs.version }}
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,13 +16,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - uses: burrunan/gradle-cache-action@v1.5
+      - name: Build and publish artifacts
+        uses: burrunan/gradle-cache-action@v1.5
         with:
           job-id: jdk11
           remote-build-cache-proxy-enabled: false
-          arguments: build --stacktrace -Prelease.version=${{ github.event.inputs.version }}
-      - name: Publish artifacts
-        run: ./gradlew final --stacktrace -Prelease.version=${{ github.event.inputs.version }} --info
+          arguments: build final --stacktrace -Prelease.version=${{ github.event.inputs.version }}
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}


### PR DESCRIPTION
This avoids restoring gradle cache twice, thus speeding up the workflow