### PR TITLE
Remove bootstrap jar from Test inputs

### DIFF
--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/AutoInstrumentationPlugin.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/AutoInstrumentationPlugin.java
@@ -34,8 +34,6 @@ public class AutoInstrumentationPlugin implements Plugin<Project> {
                   new File(
                       project.project(":testing-bootstrap").getBuildDir(),
                       "libs/testing-bootstrap.jar");
-              // Make sure tests get rerun if the contents of the testing-bootstrap.jar change
-              task.getInputs().property("testing-bootstrap-jar", testingBootstrapJar);
               task.getJvmArgumentProviders().add(new InstrumentationTestArgs(testingBootstrapJar));
             });
   }


### PR DESCRIPTION
I had issues while developing where updates to bootstrap jar didn't rerun tasks. But perhaps this input is too strict (maybe bootstrap jar has some minor change like a timestamp change). Since it changes so rarely it's probably ok not to add it as an input if it's not working correctly.

Just hypothesis, haven't confirmed in build scans or anything.