### PR TITLE
Remove scala from runtime dependencies

### DIFF
--- a/gradle/test-with-scala.gradle
+++ b/gradle/test-with-scala.gradle
@@ -3,7 +3,6 @@
 apply plugin: 'scala'
 
 dependencies {
-  implementation deps.scala
   testImplementation deps.scala
 }
 


### PR DESCRIPTION
As a side effect of this, we had a whole scala language in our javaagent jar file.