### PR TITLE
ByteBuddy tasks no longer resolve dependencies at config time (#1692).

### DIFF
--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ByteBuddyPluginConfigurator.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ByteBuddyPluginConfigurator.java
@@ -6,12 +6,9 @@
 package io.opentelemetry.instrumentation.gradle.bytebuddy;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import net.bytebuddy.build.gradle.ByteBuddySimpleTask;
-import net.bytebuddy.build.gradle.PluginArgument;
 import net.bytebuddy.build.gradle.Transformation;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -42,13 +39,10 @@ public class ByteBuddyPluginConfigurator {
   private final Project project;
   private final SourceSet sourceSet;
   private final String pluginClassName;
-  private final List<Iterable<File>> inputClasspath;
+  private final Iterable<File> inputClasspath;
 
   public ByteBuddyPluginConfigurator(
-      Project project,
-      SourceSet sourceSet,
-      String pluginClassName,
-      List<Iterable<File>> inputClasspath) {
+      Project project, SourceSet sourceSet, String pluginClassName, Iterable<File> inputClasspath) {
     this.project = project;
     this.sourceSet = sourceSet;
     this.pluginClassName = pluginClassName;
@@ -87,13 +81,9 @@ public class ByteBuddyPluginConfigurator {
     task.setTarget(classesDirectory);
     task.setClassPath(compileTask.getClasspath());
 
-    List<Iterable<File>> classPath = new ArrayList<>();
-    classPath.add(Collections.singletonList(rawClassesDirectory));
-    classPath.addAll(inputClasspath);
-
     task.dependsOn(compileTask);
 
-    task.getTransformations().add(createTransformation(classPath, pluginClassName));
+    task.getTransformations().add(createTransformation(inputClasspath, pluginClassName));
     return task;
   }
 
@@ -120,19 +110,9 @@ public class ByteBuddyPluginConfigurator {
   }
 
   private static Transformation createTransformation(
-      List<Iterable<File>> classPath, String pluginClassName) {
-    Transformation transformation = new Transformation();
+      Iterable<File> classPath, String pluginClassName) {
+    Transformation transformation = new ClasspathTransformation(classPath, pluginClassName);
     transformation.setPlugin(ClasspathByteBuddyPlugin.class);
-    addArgument(transformation, classPath);
-    addArgument(transformation, pluginClassName);
     return transformation;
-  }
-
-  private static void addArgument(Transformation transformation, Object value) {
-    List<PluginArgument> arguments = transformation.getArguments();
-    PluginArgument argument = new PluginArgument();
-    argument.setIndex(arguments.size());
-    argument.setValue(value);
-    arguments.add(argument);
   }
 }

--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ClasspathTransformation.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ClasspathTransformation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.gradle.bytebuddy;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import net.bytebuddy.build.Plugin.Factory.UsingReflection.ArgumentResolver;
+import net.bytebuddy.build.gradle.Transformation;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+
+/**
+ * Special implementation of {@link Transformation} is required as classpath argument must be
+ * exposed to Gradle via {@link Classpath} annotation, which cannot be done if it is returned by
+ * {@link Transformation#getArguments()}.
+ */
+public class ClasspathTransformation extends Transformation {
+  private final Iterable<File> classpath;
+  private final String pluginClassName;
+
+  public ClasspathTransformation(Iterable<File> classpath, String pluginClassName) {
+    this.classpath = classpath;
+    this.pluginClassName = pluginClassName;
+  }
+
+  @Classpath
+  public Iterable<? extends File> getClasspath() {
+    return classpath;
+  }
+
+  @Input
+  public String getPluginClassName() {
+    return pluginClassName;
+  }
+
+  protected List<ArgumentResolver> makeArgumentResolvers() {
+    return Arrays.asList(
+        new ArgumentResolver.ForIndex(0, classpath),
+        new ArgumentResolver.ForIndex(2, pluginClassName));
+  }
+}

--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -51,9 +51,7 @@ afterEvaluate {
   }
 
   def pluginName = 'io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin'
-  new ByteBuddyPluginConfigurator(project, sourceSets.main, pluginName, [
-    project(':javaagent-tooling').configurations.instrumentationMuzzle.files,
-    configurations.runtimeClasspath.files,
-    sourceSets.main.output.files
-  ]).configure()
+  new ByteBuddyPluginConfigurator(project, sourceSets.main, pluginName,
+    project(':javaagent-tooling').configurations.instrumentationMuzzle + configurations.runtimeClasspath
+  ).configure()
 }


### PR DESCRIPTION
This fixes issue #1692 that caused `byteBuddy` task configuration to resolve dependencies. This was originally done to make it possible to store the classpath for that task in a task field with `Input` annotation as that requires serializable value, which an unresolved classpath is not.

Added a special implementation of `net.bytebuddy.build.gradle.Transformation` which resolves arguments for creating a `ClasspathByteBuddyPlugin`. This exposes the classpath to Gradle with `Classpath` annotation instead of `Input`, meaning that its value can be an unresolved classpath.