### PR TITLE
Rename otel trace properties

### DIFF
--- a/docs/suppressing-instrumentation.md
+++ b/docs/suppressing-instrumentation.md
@@ -1,6 +1,11 @@
-## Suppressing specific auto-instrumentation
+## Disabling the agent entirely
 
-You can suppress auto-instrumentation of specific libraries by using
+You can disable the agent using `-Dotel.javaagent.enabled=false`
+(or using the equivalent environment variable `OTEL_JAVAAGENT_ENABLED=false`).
+
+## Suppressing specific agent instrumentation
+
+You can suppress agent instrumentation of specific libraries by using
 `-Dotel.instrumentation.[id].enabled=false`.
 
 where `id` is the instrumentation `id`:

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
@@ -220,12 +220,12 @@ public class AgentInitializer {
   }
 
   /**
-   * Determine if we should log in debug level according to otel.trace.debug
+   * Determine if we should log in debug level according to otel.javaagent.debug
    *
    * @return true if we should
    */
   private static boolean isDebugMode() {
-    String tracerDebugLevelSysprop = "otel.trace.debug";
+    String tracerDebugLevelSysprop = "otel.javaagent.debug";
     String tracerDebugLevelProp = System.getProperty(tracerDebugLevelSysprop);
 
     if (tracerDebugLevelProp != null) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 public class AgentInstaller {
   private static final Logger log = LoggerFactory.getLogger(AgentInstaller.class);
 
-  private static final String TRACE_ENABLED_CONFIG = "otel.trace.enabled";
+  private static final String JAVAAGENT_ENABLED_CONFIG = "otel.javaagent.enabled";
   private static final String EXCLUDED_CLASSES_CONFIG = "otel.trace.classes.exclude";
 
   private static final Map<String, List<Runnable>> CLASS_LOAD_CALLBACKS = new HashMap<>();
@@ -64,7 +64,7 @@ public class AgentInstaller {
   }
 
   public static void installBytebuddyAgent(Instrumentation inst) {
-    if (Config.get().getBooleanProperty(TRACE_ENABLED_CONFIG, true)) {
+    if (Config.get().getBooleanProperty(JAVAAGENT_ENABLED_CONFIG, true)) {
       installBytebuddyAgent(inst, false);
     } else {
       log.debug("Tracing is disabled, not installing instrumentations.");

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InstrumentationModule.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InstrumentationModule.java
@@ -295,6 +295,6 @@ public abstract class InstrumentationModule {
   }
 
   protected boolean defaultEnabled() {
-    return Config.get().getBooleanProperty("otel.instrumentations.enabled", true);
+    return Config.get().getBooleanProperty("otel.instrumentation.defaultEnabled", true);
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TracerInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TracerInstaller.java
@@ -35,13 +35,13 @@ public class TracerInstaller {
   private static final String EXPORTER_JAR_CONFIG = "otel.exporter.jar";
   private static final String EXPORTERS_CONFIG = "otel.exporter";
   private static final String PROPAGATORS_CONFIG = "otel.propagators";
-  private static final String TRACE_ENABLED_CONFIG = "otel.trace.enabled";
+  private static final String JAVAAGENT_ENABLED_CONFIG = "otel.javaagent.enabled";
   private static final List<String> DEFAULT_EXPORTERS = Collections.singletonList("otlp");
 
   /** Register agent tracer if no agent tracer is already registered. */
   @SuppressWarnings("unused")
   public static synchronized void installAgentTracer() {
-    if (Config.get().getBooleanProperty(TRACE_ENABLED_CONFIG, true)) {
+    if (Config.get().getBooleanProperty(JAVAAGENT_ENABLED_CONFIG, true)) {
       Properties config = Config.get().asJavaProperties();
 
       configure(config);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigInitializer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigInitializer.java
@@ -22,8 +22,8 @@ import org.slf4j.LoggerFactory;
 public final class ConfigInitializer {
   private static final Logger log = LoggerFactory.getLogger(ConfigInitializer.class);
 
-  private static final String CONFIGURATION_FILE_PROPERTY = "otel.trace.config";
-  private static final String CONFIGURATION_FILE_ENV_VAR = "OTEL_TRACE_CONFIG";
+  private static final String CONFIGURATION_FILE_PROPERTY = "otel.javaagent.config";
+  private static final String CONFIGURATION_FILE_ENV_VAR = "OTEL_JAVAAGENT_CONFIG";
 
   public static void initialize() {
     Config.internalInitializeConfig(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/context/FieldBackedProvider.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/context/FieldBackedProvider.java
@@ -104,7 +104,7 @@ public class FieldBackedProvider implements InstrumentationContextProvider {
   }
 
   private static final boolean FIELD_INJECTION_ENABLED =
-      Config.get().getBooleanProperty("otel.trace.runtime.context.field.injection", true);
+      Config.get().getBooleanProperty("otel.javaagent.runtime.context.field.injection", true);
 
   private final Class<?> instrumenterClass;
   private final ByteBuddy byteBuddy;

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/InstrumentationModuleTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/InstrumentationModuleTest.groovy
@@ -85,7 +85,7 @@ class InstrumentationModuleTest extends Specification {
   def "configure default sys prop as #value"() {
     setup:
     def previousConfig = ConfigUtils.updateConfig {
-      it.setProperty("otel.instrumentations.enabled", value)
+      it.setProperty("otel.instrumentation.defaultEnabled", value)
     }
     def target = new TestInstrumentationModule(["test"])
     target.instrument(new AgentBuilder.Default())
@@ -107,7 +107,7 @@ class InstrumentationModuleTest extends Specification {
   def "configure sys prop enabled for #value when default is disabled"() {
     setup:
     def previousConfig = ConfigUtils.updateConfig {
-      it.setProperty("otel.instrumentations.enabled", "false")
+      it.setProperty("otel.instrumentation.defaultEnabled", "false")
       it.setProperty("otel.instrumentation.${value}.enabled", "true")
     }
     def target = new TestInstrumentationModule([name, altName])

--- a/javaagent/src/test/groovy/io/opentelemetry/javaagent/LogLevelTest.groovy
+++ b/javaagent/src/test/groovy/io/opentelemetry/javaagent/LogLevelTest.groovy
@@ -13,82 +13,82 @@ import spock.lang.Timeout
 class LogLevelTest extends Specification {
 
 
-  /* Priority: io.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel > opentelemetry.auto.trace.debug > OTEL_TRACE_DEBUG
+  /* Priority: io.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel > opentelemetry.javaagent.debug > OTEL_JAVAAGENT_DEBUG
   1: INFO LOGS
   0: DEBUG Logs
    */
 
-  def "otel.trace.debug false"() {
+  def "otel.javaagent.debug false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.debug=false", "-Dotel.javaagent.enabled=false"] as String[]
+      , ["-Dotel.javaagent.debug=false", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , [:]
       , true) == 1
   }
 
-  def "SLF4J DEBUG && otel.trace.debug is false"() {
+  def "SLF4J DEBUG && otel.javaagent.debug is false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.debug=false", "-Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=debug", "-Dotel.javaagent.enabled=false"] as String[]
+      , ["-Dotel.javaagent.debug=false", "-Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=debug", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , [:]
       , true) == 0
   }
 
-  def "otel.trace.debug is false && OTEL_TRACE_DEBUG is true"() {
+  def "otel.javaagent.debug is false && OTEL_JAVAAGENT_DEBUG is true"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.debug=false", "-Dotel.javaagent.enabled=false"] as String[]
+      , ["-Dotel.javaagent.debug=false", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
-      , ["OTEL_TRACE_DEBUG": "true"]
+      , ["OTEL_JAVAAGENT_DEBUG": "true"]
       , true) == 1
   }
 
-  def "otel.trace.debug is true"() {
+  def "otel.javaagent.debug is true"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.debug=true", "-Dotel.javaagent.enabled=false"] as String[]
+      , ["-Dotel.javaagent.debug=true", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , [:]
       , true) == 0
   }
 
 
-  def "OTEL_TRACE_DEBUG is true"() {
+  def "OTEL_JAVAAGENT_DEBUG is true"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
       , ["-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
-      , ["OTEL_TRACE_DEBUG": "true"]
+      , ["OTEL_JAVAAGENT_DEBUG": "true"]
       , true) == 0
   }
 
-  def "otel.trace.debug is true && OTEL_TRACE_DEBUG is false"() {
+  def "otel.javaagent.debug is true && OTEL_JAVAAGENT_DEBUG is false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.debug=true", "-Dotel.javaagent.enabled=false"] as String[]
+      , ["-Dotel.javaagent.debug=true", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
-      , ["OTEL_TRACE_DEBUG": "false"]
+      , ["OTEL_JAVAAGENT_DEBUG": "false"]
       , true) == 0
   }
 
 
-  def "SLF4J DEBUG && OTEL_TRACE_DEBUG is false"() {
+  def "SLF4J DEBUG && OTEL_JAVAAGENT_DEBUG is false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
       , ["-Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=debug", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
-      , ["OTEL_TRACE_DEBUG": "false"]
+      , ["OTEL_JAVAAGENT_DEBUG": "false"]
       , true) == 0
   }
 
-  def "SLF4J INFO && OTEL_TRACE_DEBUG is true"() {
+  def "SLF4J INFO && OTEL_JAVAAGENT_DEBUG is true"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
       , ["-Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=info", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
-      , ["OTEL_TRACE_DEBUG": "true"]
+      , ["OTEL_JAVAAGENT_DEBUG": "true"]
       , true) == 1
   }
 

--- a/javaagent/src/test/groovy/io/opentelemetry/javaagent/LogLevelTest.groovy
+++ b/javaagent/src/test/groovy/io/opentelemetry/javaagent/LogLevelTest.groovy
@@ -21,7 +21,7 @@ class LogLevelTest extends Specification {
   def "otel.trace.debug false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.debug=false", "-Dotel.trace.enabled=false"] as String[]
+      , ["-Dotel.trace.debug=false", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , [:]
       , true) == 1
@@ -30,7 +30,7 @@ class LogLevelTest extends Specification {
   def "SLF4J DEBUG && otel.trace.debug is false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.debug=false", "-Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=debug", "-Dotel.trace.enabled=false"] as String[]
+      , ["-Dotel.trace.debug=false", "-Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=debug", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , [:]
       , true) == 0
@@ -39,7 +39,7 @@ class LogLevelTest extends Specification {
   def "otel.trace.debug is false && OTEL_TRACE_DEBUG is true"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.debug=false", "-Dotel.trace.enabled=false"] as String[]
+      , ["-Dotel.trace.debug=false", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , ["OTEL_TRACE_DEBUG": "true"]
       , true) == 1
@@ -48,7 +48,7 @@ class LogLevelTest extends Specification {
   def "otel.trace.debug is true"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.debug=true", "-Dotel.trace.enabled=false"] as String[]
+      , ["-Dotel.trace.debug=true", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , [:]
       , true) == 0
@@ -58,7 +58,7 @@ class LogLevelTest extends Specification {
   def "OTEL_TRACE_DEBUG is true"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.enabled=false"] as String[]
+      , ["-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , ["OTEL_TRACE_DEBUG": "true"]
       , true) == 0
@@ -67,7 +67,7 @@ class LogLevelTest extends Specification {
   def "otel.trace.debug is true && OTEL_TRACE_DEBUG is false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dotel.trace.debug=true", "-Dotel.trace.enabled=false"] as String[]
+      , ["-Dotel.trace.debug=true", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , ["OTEL_TRACE_DEBUG": "false"]
       , true) == 0
@@ -77,7 +77,7 @@ class LogLevelTest extends Specification {
   def "SLF4J DEBUG && OTEL_TRACE_DEBUG is false"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=debug", "-Dotel.trace.enabled=false"] as String[]
+      , ["-Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=debug", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , ["OTEL_TRACE_DEBUG": "false"]
       , true) == 0
@@ -86,7 +86,7 @@ class LogLevelTest extends Specification {
   def "SLF4J INFO && OTEL_TRACE_DEBUG is true"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogLevelChecker.getName()
-      , ["-Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=info", "-Dotel.trace.enabled=false"] as String[]
+      , ["-Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=info", "-Dotel.javaagent.enabled=false"] as String[]
       , "" as String[]
       , ["OTEL_TRACE_DEBUG": "true"]
       , true) == 1

--- a/testing-common/src/test/groovy/context/FieldBackedProviderTest.groovy
+++ b/testing-common/src/test/groovy/context/FieldBackedProviderTest.groovy
@@ -217,7 +217,7 @@ class FieldBackedProviderTest extends AgentTestRunner {
  * Unfortunately we cannot set system properties here early enough for AgentTestRunner to see.
  * Instead we have to configure this via Gradle. Ideally we should not have to do this.
  */
-@Requires({ "false" == System.getProperty("otel.trace.runtime.context.field.injection") })
+@Requires({ "false" == System.getProperty("otel.javaagent.runtime.context.field.injection") })
 class FieldBackedProviderFieldInjectionDisabledTest extends AgentTestRunner {
 
   static {

--- a/testing-common/testing-common.gradle
+++ b/testing-common/testing-common.gradle
@@ -62,7 +62,7 @@ dependencies {
 
 // See comment for FieldBackedProviderFieldInjectionDisabledTest about why this hack is here
 tasks.register("testDisabledFieldInjection", Test) {
-  systemProperties "otel.trace.runtime.context.field.injection": "false"
+  systemProperties "otel.javaagent.runtime.context.field.injection": "false"
   includes = ["context/FieldBackedProviderFieldInjectionDisabledTest.class"]
 }
 test.dependsOn(testDisabledFieldInjection)


### PR DESCRIPTION
Closes #1697

* `otel.trace.enabled` --> `otel.javaagent.enabled`
* `otel.trace.debug` --> `otel.javaagent.debug`
* `otel.trace.config` --> `otel.javaagent.config`
* `otel.trace.runtime.context.field.injection` --> `otel.javaagent.runtime.context.field.injection` (this is surely not the last rename for this property)
* `otel.instrumentations.enabled` --> `otel.instrumentations.defaultEnabled`