### PR TITLE
Rename otel.trace.classes.excludes to otel.javaagent.exclude-classes

### DIFF
--- a/docs/suppressing-instrumentation.md
+++ b/docs/suppressing-instrumentation.md
@@ -26,6 +26,6 @@ which could have unknown side-effects.
 If you find yourself needing to use this, it would be great if you could drop us an issue explaining why,
 so that we can try to come up with a better solution to address your need.
 
-| System property       | Environment variable  | Purpose                                                                                           |
-|-----------------------|-----------------------|---------------------------------------------------------------------------------------------------|
-| otel.trace.classes.exclude | OTEL_TRACE_CLASSES_EXCLUDE | Suppresses all instrumentation for specific classes, format is "my.package.MyClass,my.package2.*" |
+| System property                | Environment variable           | Purpose                                                                                           |
+|--------------------------------|--------------------------------|---------------------------------------------------------------------------------------------------|
+| otel.javaagent.exclude-classes | OTEL_JAVAAGENT_EXCLUDE_CLASSES | Suppresses all instrumentation for specific classes, format is "my.package.MyClass,my.package2.*" |

--- a/instrumentation/external-annotations/src/test/groovy/TraceProvidersTest.groovy
+++ b/instrumentation/external-annotations/src/test/groovy/TraceProvidersTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import io.opentelemetry.test.annotation.SayTracedHello
 

--- a/instrumentation/external-annotations/src/test/groovy/TraceProvidersTest.groovy
+++ b/instrumentation/external-annotations/src/test/groovy/TraceProvidersTest.groovy
@@ -3,23 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentTestRunner
-import io.opentelemetry.instrumentation.test.utils.ConfigUtils
 import io.opentelemetry.test.annotation.SayTracedHello
 
 /**
  * This test verifies that Otel supports various 3rd-party trace annotations
  */
 class TraceProvidersTest extends AgentTestRunner {
-  //Don't bother to instrument inner closures of this test class
-  static final PREVIOUS_CONFIG = ConfigUtils.updateConfigAndResetInstrumentation {
-    it.remove("otel.trace.annotations")
-    it.setProperty("otel.trace.classes.exclude", TraceProvidersTest.name + "*")
-  }
-
-  def cleanupSpec() {
-    ConfigUtils.setConfig(PREVIOUS_CONFIG)
-  }
 
   def "should support #provider"(String provider) {
     setup:

--- a/instrumentation/external-annotations/src/test/groovy/TracedMethodsExclusionTest.groovy
+++ b/instrumentation/external-annotations/src/test/groovy/TracedMethodsExclusionTest.groovy
@@ -9,8 +9,6 @@ import io.opentracing.contrib.dropwizard.Trace
 
 class TracedMethodsExclusionTest extends AgentTestRunner {
   static final PREVIOUS_CONFIG = ConfigUtils.updateConfigAndResetInstrumentation {
-    // remove trace annotations in case previous tests have set it
-    it.remove("otel.trace.annotations")
     it.setProperty("otel.trace.methods", "${TestClass.name}[included,excluded]")
     it.setProperty("otel.trace.annotated.methods.exclude", "${TestClass.name}[excluded,annotatedButExcluded]")
   }

--- a/instrumentation/opentelemetry-api-1.0/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/opentelemetry-api-1.0/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -13,7 +13,6 @@ import io.opentelemetry.test.annotation.TracedWithSpan
  */
 class WithSpanInstrumentationTest extends AgentTestRunner {
   static final PREVIOUS_CONFIG = ConfigUtils.updateConfigAndResetInstrumentation {
-    it.setProperty("otel.trace.classes.exclude", WithSpanInstrumentationTest.name + "*")
     it.setProperty("otel.trace.annotated.methods.exclude", "${TracedWithSpan.name}[ignored]")
   }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -46,7 +46,7 @@ public class AgentInstaller {
   private static final Logger log = LoggerFactory.getLogger(AgentInstaller.class);
 
   private static final String JAVAAGENT_ENABLED_CONFIG = "otel.javaagent.enabled";
-  private static final String EXCLUDED_CLASSES_CONFIG = "otel.trace.classes.exclude";
+  private static final String EXCLUDED_CLASSES_CONFIG = "otel.javaagent.exclude-classes";
 
   private static final Map<String, List<Runnable>> CLASS_LOAD_CALLBACKS = new HashMap<>();
   private static volatile Instrumentation INSTRUMENTATION;

--- a/testing-common/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/testing-common/src/test/groovy/AgentTestRunnerTest.groovy
@@ -18,7 +18,7 @@ class AgentTestRunnerTest extends AgentTestRunner {
   private static final boolean AGENT_INSTALLED_IN_CLINIT
 
   static final PREVIOUS_CONFIG = ConfigUtils.updateConfig {
-    it.setProperty("otel.trace.classes.exclude",
+    it.setProperty("otel.javaagent.exclude-classes",
       "config.exclude.packagename.*, config.exclude.SomeClass,config.exclude.SomeClass\$NestedClass")
   }
 


### PR DESCRIPTION
Missed this in #1740.

See latest note about `exclude-classes` vs `excludeClasses`: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1414#issuecomment-732632618, though happy to change to something else either in this PR or later on