### PR TITLE
Don't apply unnecessary plugins at top level.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,15 +9,15 @@ plugins {
 
   id 'org.gradle.test-retry' version '1.1.8' apply false
 
-  id 'org.unbroken-dome.test-sets' version '3.0.1'
+  id 'org.unbroken-dome.test-sets' version '3.0.1' apply false
   id 'com.github.ben-manes.versions' version '0.27.0'
 
   id 'com.dorongold.task-tree' version '1.5'
 
-  id "com.github.johnrengelman.shadow" version "6.1.0"
+  id "com.github.johnrengelman.shadow" version "6.1.0" apply false
 
   id "com.diffplug.spotless" version "5.6.1"
-  id "com.github.spotbugs" version "4.5.1"
+  id "com.github.spotbugs" version "4.5.1" apply false
 
   id "net.ltgt.errorprone" version "1.2.1" apply false
 }


### PR DESCRIPTION
No clue how applying shadow plugin could cause a bug in nebula but they do seem incompatible right now. No worries though since we don't need shadow (and some other plugins) at the top level anyways.

There's non-zero chance this may fix our recent build slowness problem if that jar name was leaking into our up-to-date checks somehow :O

Fixes #1693