### PR TITLE
Make instrumentations non final

### DIFF
--- a/instrumentation/akka-actor-2.5/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaForkJoinPoolInstrumentation.java
+++ b/instrumentation/akka-actor-2.5/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaForkJoinPoolInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class AkkaForkJoinPoolInstrumentation implements TypeInstrumentation {
+public class AkkaForkJoinPoolInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/akka-actor-2.5/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaForkJoinTaskInstrumentation.java
+++ b/instrumentation/akka-actor-2.5/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaForkJoinTaskInstrumentation.java
@@ -34,7 +34,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * <p>Note: There are quite a few separate implementations of {@code ForkJoinTask}/{@code
  * ForkJoinPool}: JVM, Akka, Scala, Netty to name a few. This class handles Akka version.
  */
-final class AkkaForkJoinTaskInstrumentation implements TypeInstrumentation {
+public class AkkaForkJoinTaskInstrumentation implements TypeInstrumentation {
   static final String TASK_CLASS_NAME = "akka.dispatch.forkjoin.ForkJoinTask";
 
   @Override

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpClientInstrumentationModule.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpClientInstrumentationModule.java
@@ -33,7 +33,7 @@ import scala.runtime.AbstractFunction1;
 import scala.util.Try;
 
 @AutoService(InstrumentationModule.class)
-public final class AkkaHttpClientInstrumentationModule extends InstrumentationModule {
+public class AkkaHttpClientInstrumentationModule extends InstrumentationModule {
   public AkkaHttpClientInstrumentationModule() {
     super("akka-http", "akka-http-client");
   }
@@ -43,7 +43,7 @@ public final class AkkaHttpClientInstrumentationModule extends InstrumentationMo
     return Collections.singletonList(new HttpExtInstrumentation());
   }
 
-  private static final class HttpExtInstrumentation implements TypeInstrumentation {
+  public static class HttpExtInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("akka.http.scaladsl.HttpExt");

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpServerInstrumentationModule.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpServerInstrumentationModule.java
@@ -33,7 +33,7 @@ import scala.concurrent.Future;
 import scala.runtime.AbstractFunction1;
 
 @AutoService(InstrumentationModule.class)
-public final class AkkaHttpServerInstrumentationModule extends InstrumentationModule {
+public class AkkaHttpServerInstrumentationModule extends InstrumentationModule {
   public AkkaHttpServerInstrumentationModule() {
     super("akka-http", "akka-http-server");
   }
@@ -43,7 +43,7 @@ public final class AkkaHttpServerInstrumentationModule extends InstrumentationMo
     return singletonList(new HttpExtInstrumentation());
   }
 
-  private static final class HttpExtInstrumentation implements TypeInstrumentation {
+  public static class HttpExtInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("akka.http.scaladsl.HttpExt");

--- a/instrumentation/apache-camel-2.20/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/ApacheCamelInstrumentationModule.java
+++ b/instrumentation/apache-camel-2.20/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/ApacheCamelInstrumentationModule.java
@@ -38,7 +38,7 @@ public class ApacheCamelInstrumentationModule extends InstrumentationModule {
     return singletonList(new CamelContextInstrumentation());
   }
 
-  private static final class CamelContextInstrumentation implements TypeInstrumentation {
+  public static class CamelContextInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("org.apache.camel.CamelContext");

--- a/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -38,7 +38,7 @@ import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpCoreContext;
 
-final class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation {
+public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientInstrumentationModule.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientInstrumentationModule.java
@@ -41,7 +41,7 @@ public class ApacheHttpClientInstrumentationModule extends InstrumentationModule
     return singletonList(new HttpClientInstrumentation());
   }
 
-  private static final class HttpClientInstrumentation implements TypeInstrumentation {
+  public static class HttpClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("org.apache.commons.httpclient.HttpClient");

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentationModule.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentationModule.java
@@ -46,7 +46,7 @@ public class ApacheHttpClientInstrumentationModule extends InstrumentationModule
     return singletonList(new HttpClientInstrumentation());
   }
 
-  private static final class HttpClientInstrumentation implements TypeInstrumentation {
+  public static class HttpClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("org.apache.http.client.HttpClient");

--- a/instrumentation/armeria-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_0/ArmeriaServerBuilderInstrumentation.java
+++ b/instrumentation/armeria-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_0/ArmeriaServerBuilderInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ArmeriaServerBuilderInstrumentation implements TypeInstrumentation {
+public class ArmeriaServerBuilderInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/armeria-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_0/ArmeriaServerInstrumentation.java
+++ b/instrumentation/armeria-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_0/ArmeriaServerInstrumentation.java
@@ -19,7 +19,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ArmeriaServerInstrumentation implements TypeInstrumentation {
+public class ArmeriaServerInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
     return named("com.linecorp.armeria.server.Server");

--- a/instrumentation/armeria-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_0/ArmeriaWebClientBuilderInstrumentation.java
+++ b/instrumentation/armeria-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_0/ArmeriaWebClientBuilderInstrumentation.java
@@ -20,7 +20,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ArmeriaWebClientBuilderInstrumentation implements TypeInstrumentation {
+public class ArmeriaWebClientBuilderInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/async-http-client-1.9/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/RequestInstrumentation.java
+++ b/instrumentation/async-http-client-1.9/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/RequestInstrumentation.java
@@ -16,7 +16,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class RequestInstrumentation implements TypeInstrumentation {
+public class RequestInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/async-http-client-1.9/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/ResponseInstrumentation.java
+++ b/instrumentation/async-http-client-1.9/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/ResponseInstrumentation.java
@@ -18,7 +18,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ResponseInstrumentation implements TypeInstrumentation {
+public class ResponseInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/aws-lambda-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambda/v1_0/AwsLambdaRequestHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambda/v1_0/AwsLambdaRequestHandlerInstrumentation.java
@@ -30,7 +30,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.bytecode.assign.Assigner.Typing;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class AwsLambdaRequestHandlerInstrumentation implements TypeInstrumentation {
+public class AwsLambdaRequestHandlerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsClientInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * This instrumentation might work with versions before 1.11.0, but this was the first version that
  * is tested. It could possibly be extended earlier.
  */
-final class AwsClientInstrumentation implements TypeInstrumentation {
+public class AwsClientInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsHttpClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsHttpClientInstrumentation.java
@@ -29,7 +29,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * {@link AmazonClientException} (for example an error thrown by another handler). In these cases
  * {@link RequestHandler2#afterError} is not called.
  */
-final class AwsHttpClientInstrumentation implements TypeInstrumentation {
+public class AwsHttpClientInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/RequestExecutorInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/RequestExecutorInstrumentation.java
@@ -26,7 +26,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * Due to a change in the AmazonHttpClient class, this instrumentation is needed to support newer
  * versions. The {@link AwsHttpClientInstrumentation} class should cover older versions.
  */
-final class RequestExecutorInstrumentation implements TypeInstrumentation {
+public class RequestExecutorInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/RequestInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/RequestInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class RequestInstrumentation implements TypeInstrumentation {
+public class RequestInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsHttpClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsHttpClientInstrumentation.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.core.internal.http.pipeline.stages.MakeAsyncHttpRe
  * Separate instrumentation class to close aws request scope right after request has been submitted
  * for execution for Sync clients.
  */
-final class AwsHttpClientInstrumentation implements TypeInstrumentation {
+public class AwsHttpClientInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/cassandra/cassandra-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientInstrumentationModule.java
+++ b/instrumentation/cassandra/cassandra-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientInstrumentationModule.java
@@ -34,7 +34,7 @@ public class CassandraClientInstrumentationModule extends InstrumentationModule 
     return singletonList(new ClusterManagerInstrumentation());
   }
 
-  private static final class ClusterManagerInstrumentation implements TypeInstrumentation {
+  public static class ClusterManagerInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       // Note: Cassandra has a large driver and we instrument single class in it.

--- a/instrumentation/cassandra/cassandra-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraClientInstrumentationModule.java
+++ b/instrumentation/cassandra/cassandra-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraClientInstrumentationModule.java
@@ -32,7 +32,7 @@ public class CassandraClientInstrumentationModule extends InstrumentationModule 
     return singletonList(new SessionBuilderInstrumentation());
   }
 
-  private static final class SessionBuilderInstrumentation implements TypeInstrumentation {
+  public static class SessionBuilderInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       // Note: Cassandra has a large driver and we instrument single class in it.

--- a/instrumentation/classloaders/src/main/java/io/opentelemetry/javaagent/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
+++ b/instrumentation/classloaders/src/main/java/io/opentelemetry/javaagent/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
@@ -36,7 +36,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * This instrumentation forces all class loaders to delegate to the bootstrap class loader
  * for the classes that we have put in the bootstrap class loader.
  */
-final class ClassLoaderInstrumentation implements TypeInstrumentation {
+public class ClassLoaderInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/classloaders/src/main/java/io/opentelemetry/javaagent/instrumentation/javaclassloader/ResourceInjectionInstrumentation.java
+++ b/instrumentation/classloaders/src/main/java/io/opentelemetry/javaagent/instrumentation/javaclassloader/ResourceInjectionInstrumentation.java
@@ -29,7 +29,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * <p>We currently only intercept {@link ClassLoader#getResources(String)} because this is the case
  * we are currently always interested in, where it's used for service loading.
  */
-class ResourceInjectionInstrumentation implements TypeInstrumentation {
+public class ResourceInjectionInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseBucketInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseBucketInstrumentation.java
@@ -24,7 +24,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import rx.Observable;
 
-final class CouchbaseBucketInstrumentation implements TypeInstrumentation {
+public class CouchbaseBucketInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseClusterInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseClusterInstrumentation.java
@@ -24,7 +24,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import rx.Observable;
 
-final class CouchbaseClusterInstrumentation implements TypeInstrumentation {
+public class CouchbaseClusterInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/couchbase/couchbase-2.6/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseCoreInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.6/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseCoreInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class CouchbaseCoreInstrumentation implements TypeInstrumentation {
+public class CouchbaseCoreInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/couchbase/couchbase-2.6/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseNetworkInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.6/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseNetworkInstrumentation.java
@@ -27,7 +27,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class CouchbaseNetworkInstrumentation implements TypeInstrumentation {
+public class CouchbaseNetworkInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/DropwizardViewsInstrumentationModule.java
+++ b/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/DropwizardViewsInstrumentationModule.java
@@ -30,7 +30,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class DropwizardViewsInstrumentationModule extends InstrumentationModule {
+public class DropwizardViewsInstrumentationModule extends InstrumentationModule {
   public DropwizardViewsInstrumentationModule() {
     super("dropwizard-views");
   }
@@ -40,7 +40,7 @@ public final class DropwizardViewsInstrumentationModule extends InstrumentationM
     return singletonList(new ViewRendererInstrumentation());
   }
 
-  private static final class ViewRendererInstrumentation implements TypeInstrumentation {
+  public static class ViewRendererInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("io.dropwizard.views.ViewRenderer");

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/Elasticsearch5RestClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/Elasticsearch5RestClientInstrumentationModule.java
@@ -38,7 +38,7 @@ public class Elasticsearch5RestClientInstrumentationModule extends Instrumentati
     return singletonList(new RestClientInstrumentation());
   }
 
-  private static final class RestClientInstrumentation implements TypeInstrumentation {
+  public static class RestClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("org.elasticsearch.client.RestClient");

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/Elasticsearch6RestClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/Elasticsearch6RestClientInstrumentationModule.java
@@ -38,7 +38,7 @@ public class Elasticsearch6RestClientInstrumentationModule extends Instrumentati
     return singletonList(new RestClientInstrumentation());
   }
 
-  private static final class RestClientInstrumentation implements TypeInstrumentation {
+  public static class RestClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("org.elasticsearch.client.RestClient");

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientInstrumentationModule.java
@@ -51,7 +51,7 @@ public class Elasticsearch5TransportClientInstrumentationModule extends Instrume
     return singletonList(new AbstractClientInstrumentation());
   }
 
-  private static final class AbstractClientInstrumentation implements TypeInstrumentation {
+  public static class AbstractClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       // If we want to be more generic, we could instrument the interface instead:

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientInstrumentationModule.java
@@ -52,7 +52,7 @@ public class Elasticsearch53TransportClientInstrumentationModule extends Instrum
     return singletonList(new AbstractClientInstrumentation());
   }
 
-  private static final class AbstractClientInstrumentation implements TypeInstrumentation {
+  public static class AbstractClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       // If we want to be more generic, we could instrument the interface instead:

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportClientInstrumentationModule.java
@@ -55,7 +55,7 @@ public class Elasticsearch6TransportClientInstrumentationModule extends Instrume
     return singletonList(new AbstractClientInstrumentation());
   }
 
-  private static final class AbstractClientInstrumentation implements TypeInstrumentation {
+  public static class AbstractClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       // If we want to be more generic, we could instrument the interface instead:

--- a/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
+++ b/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-abstract class AbstractExecutorInstrumentation implements TypeInstrumentation {
+public abstract class AbstractExecutorInstrumentation implements TypeInstrumentation {
   private static final Logger log = LoggerFactory.getLogger(AbstractExecutorInstrumentation.class);
 
   private static final String EXECUTORS_INCLUDE_PROPERTY_NAME =
@@ -49,7 +49,7 @@ abstract class AbstractExecutorInstrumentation implements TypeInstrumentation {
    */
   private final Collection<String> includePrefixes;
 
-  AbstractExecutorInstrumentation() {
+  protected AbstractExecutorInstrumentation() {
     if (includeAll) {
       includeExecutors = Collections.emptyList();
       includePrefixes = Collections.emptyList();

--- a/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/CallableInstrumentation.java
+++ b/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/CallableInstrumentation.java
@@ -24,7 +24,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class CallableInstrumentation implements TypeInstrumentation {
+public class CallableInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
+++ b/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
@@ -27,7 +27,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class FutureInstrumentation implements TypeInstrumentation {
+public class FutureInstrumentation implements TypeInstrumentation {
   private static final Logger log = LoggerFactory.getLogger(FutureInstrumentation.class);
 
   /**

--- a/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaExecutorInstrumentation.java
+++ b/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaExecutorInstrumentation.java
@@ -28,7 +28,7 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation {
+public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation {
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {

--- a/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaForkJoinTaskInstrumentation.java
+++ b/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaForkJoinTaskInstrumentation.java
@@ -33,7 +33,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * <p>Note: There are quite a few separate implementations of {@code ForkJoinTask}/{@code
  * ForkJoinPool}: JVM, Akka, Scala, Netty to name a few. This class handles JVM version.
  */
-final class JavaForkJoinTaskInstrumentation implements TypeInstrumentation {
+public class JavaForkJoinTaskInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/NonStandardExecutorInstrumentationModule.java
+++ b/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/NonStandardExecutorInstrumentationModule.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class NonStandardExecutorInstrumentationModule extends InstrumentationModule {
+public class NonStandardExecutorInstrumentationModule extends InstrumentationModule {
 
   public NonStandardExecutorInstrumentationModule() {
     super("executor", "non-standard-executor");
@@ -38,7 +38,7 @@ public final class NonStandardExecutorInstrumentationModule extends Instrumentat
     return singletonMap(Runnable.class.getName(), State.class.getName());
   }
 
-  private static final class OtherExecutorsInstrumentation extends AbstractExecutorInstrumentation {
+  public static class OtherExecutorsInstrumentation extends AbstractExecutorInstrumentation {
     @Override
     public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
       Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();

--- a/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/RunnableInstrumentation.java
+++ b/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/RunnableInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class RunnableInstrumentation implements TypeInstrumentation {
+public class RunnableInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/external-annotations/src/main/java/io/opentelemetry/javaagent/instrumentation/traceannotation/TraceAnnotationsInstrumentationModule.java
+++ b/instrumentation/external-annotations/src/main/java/io/opentelemetry/javaagent/instrumentation/traceannotation/TraceAnnotationsInstrumentationModule.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @AutoService(InstrumentationModule.class)
-public final class TraceAnnotationsInstrumentationModule extends InstrumentationModule {
+public class TraceAnnotationsInstrumentationModule extends InstrumentationModule {
   private static final Logger log =
       LoggerFactory.getLogger(TraceAnnotationsInstrumentationModule.class);
 
@@ -75,7 +75,7 @@ public final class TraceAnnotationsInstrumentationModule extends Instrumentation
     return singletonList(new AnnotatedMethodsInstrumentation());
   }
 
-  private static final class AnnotatedMethodsInstrumentation implements TypeInstrumentation {
+  public static class AnnotatedMethodsInstrumentation implements TypeInstrumentation {
     private final Set<String> additionalTraceAnnotations;
     private final ElementMatcher.Junction<ClassLoader> classLoaderOptimization;
     private final ElementMatcher.Junction<NamedElement> traceAnnotationMatcher;

--- a/instrumentation/external-annotations/src/main/java/io/opentelemetry/javaagent/instrumentation/traceannotation/TraceConfigInstrumentationModule.java
+++ b/instrumentation/external-annotations/src/main/java/io/opentelemetry/javaagent/instrumentation/traceannotation/TraceConfigInstrumentationModule.java
@@ -69,7 +69,7 @@ public class TraceConfigInstrumentationModule extends InstrumentationModule {
     return typeInstrumentations;
   }
 
-  private static final class TracerClassInstrumentation implements TypeInstrumentation {
+  public static class TracerClassInstrumentation implements TypeInstrumentation {
     private final String className;
     private final Set<String> methodNames;
 

--- a/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/javaagent/instrumentation/finatra/FinatraInstrumentationModule.java
+++ b/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/javaagent/instrumentation/finatra/FinatraInstrumentationModule.java
@@ -45,7 +45,7 @@ public class FinatraInstrumentationModule extends InstrumentationModule {
     return singletonList(new RouteInstrumentation());
   }
 
-  private static final class RouteInstrumentation implements TypeInstrumentation {
+  public static class RouteInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("com.twitter.finatra.http.internal.routing.Route");

--- a/instrumentation/geode-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeInstrumentationModule.java
+++ b/instrumentation/geode-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeInstrumentationModule.java
@@ -41,7 +41,7 @@ public class GeodeInstrumentationModule extends InstrumentationModule {
     return singletonList(new RegionInstrumentation());
   }
 
-  private static final class RegionInstrumentation implements TypeInstrumentation {
+  public static class RegionInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("org.apache.geode.cache.Region");

--- a/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientInstrumentationModule.java
+++ b/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientInstrumentationModule.java
@@ -50,7 +50,7 @@ public class GoogleHttpClientInstrumentationModule extends InstrumentationModule
     return singletonList(new HttpRequestInstrumentation());
   }
 
-  private static final class HttpRequestInstrumentation implements TypeInstrumentation {
+  public static class HttpRequestInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<? super TypeDescription> typeMatcher() {
       // HttpRequest is a final class.  Only need to instrument it exactly

--- a/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/DefaultFilterChainInstrumentation.java
+++ b/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/DefaultFilterChainInstrumentation.java
@@ -17,7 +17,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class DefaultFilterChainInstrumentation implements TypeInstrumentation {
+public class DefaultFilterChainInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/FilterInstrumentation.java
+++ b/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/FilterInstrumentation.java
@@ -20,7 +20,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
-final class FilterInstrumentation implements TypeInstrumentation {
+public class FilterInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpCodecFilterInstrumentation.java
+++ b/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpCodecFilterInstrumentation.java
@@ -16,7 +16,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class HttpCodecFilterInstrumentation implements TypeInstrumentation {
+public class HttpCodecFilterInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpServerFilterInstrumentation.java
+++ b/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpServerFilterInstrumentation.java
@@ -16,7 +16,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class HttpServerFilterInstrumentation implements TypeInstrumentation {
+public class HttpServerFilterInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcClientBuilderBuildInstrumentation.java
+++ b/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcClientBuilderBuildInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class GrpcClientBuilderBuildInstrumentation implements TypeInstrumentation {
+public class GrpcClientBuilderBuildInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {
     return hasClassesNamed("io.grpc.ManagedChannelBuilder");

--- a/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcServerBuilderInstrumentation.java
+++ b/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcServerBuilderInstrumentation.java
@@ -19,7 +19,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class GrpcServerBuilderInstrumentation implements TypeInstrumentation {
+public class GrpcServerBuilderInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/guava-10.0/src/main/java/io/opentelemetry/javaagent/instrumentation/guava/GuavaInstrumentationModule.java
+++ b/instrumentation/guava-10.0/src/main/java/io/opentelemetry/javaagent/instrumentation/guava/GuavaInstrumentationModule.java
@@ -46,7 +46,7 @@ public class GuavaInstrumentationModule extends InstrumentationModule {
     return singletonMap(Runnable.class.getName(), State.class.getName());
   }
 
-  private static final class ListenableFutureInstrumentation implements TypeInstrumentation {
+  public static class ListenableFutureInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("com.google.common.util.concurrent.AbstractFuture");

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/CriteriaInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/CriteriaInstrumentation.java
@@ -26,7 +26,7 @@ import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.Criteria;
 
-final class CriteriaInstrumentation implements TypeInstrumentation {
+public class CriteriaInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/QueryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/QueryInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.Query;
 
-final class QueryInstrumentation implements TypeInstrumentation {
+public class QueryInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/SessionFactoryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/SessionFactoryInstrumentation.java
@@ -31,7 +31,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.Session;
 import org.hibernate.StatelessSession;
 
-final class SessionFactoryInstrumentation implements TypeInstrumentation {
+public class SessionFactoryInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/SessionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/SessionInstrumentation.java
@@ -38,7 +38,7 @@ import org.hibernate.Session;
 import org.hibernate.StatelessSession;
 import org.hibernate.Transaction;
 
-final class SessionInstrumentation implements TypeInstrumentation {
+public class SessionInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/TransactionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/TransactionInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.Transaction;
 
-final class TransactionInstrumentation implements TypeInstrumentation {
+public class TransactionInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/CriteriaInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/CriteriaInstrumentation.java
@@ -26,7 +26,7 @@ import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.Criteria;
 
-final class CriteriaInstrumentation implements TypeInstrumentation {
+public class CriteriaInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/QueryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/QueryInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.Query;
 
-final class QueryInstrumentation implements TypeInstrumentation {
+public class QueryInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionFactoryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionFactoryInstrumentation.java
@@ -29,7 +29,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.SharedSessionContract;
 
-final class SessionFactoryInstrumentation implements TypeInstrumentation {
+public class SessionFactoryInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionInstrumentation.java
@@ -37,7 +37,7 @@ import org.hibernate.Query;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.Transaction;
 
-final class SessionInstrumentation implements TypeInstrumentation {
+public class SessionInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/TransactionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/TransactionInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.Transaction;
 
-final class TransactionInstrumentation implements TypeInstrumentation {
+public class TransactionInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallInstrumentation.java
@@ -24,7 +24,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.procedure.ProcedureCall;
 
-final class ProcedureCallInstrumentation implements TypeInstrumentation {
+public class ProcedureCallInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/SessionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/SessionInstrumentation.java
@@ -26,7 +26,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.procedure.ProcedureCall;
 
-final class SessionInstrumentation implements TypeInstrumentation {
+public class SessionInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentationModule.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentationModule.java
@@ -50,7 +50,7 @@ public class HttpUrlConnectionInstrumentationModule extends InstrumentationModul
     return singletonMap("java.net.HttpURLConnection", getClass().getName() + "$HttpUrlState");
   }
 
-  private static final class HttpUrlConnectionInstrumentation implements TypeInstrumentation {
+  public static class HttpUrlConnectionInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return nameStartsWith("java.net.")

--- a/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixInstrumentationModule.java
+++ b/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixInstrumentationModule.java
@@ -50,7 +50,7 @@ public class HystrixInstrumentationModule extends InstrumentationModule {
     return singletonList(new HystrixCommandInstrumentation());
   }
 
-  private static final class HystrixCommandInstrumentation implements TypeInstrumentation {
+  public static class HystrixCommandInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed(

--- a/instrumentation/java-httpclient/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/HttpClientInstrumentation.java
+++ b/instrumentation/java-httpclient/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/HttpClientInstrumentation.java
@@ -30,7 +30,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class HttpClientInstrumentation implements TypeInstrumentation {
+public class HttpClientInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/java-httpclient/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/HttpHeadersInstrumentation.java
+++ b/instrumentation/java-httpclient/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/HttpHeadersInstrumentation.java
@@ -21,7 +21,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class HttpHeadersInstrumentation implements TypeInstrumentation {
+public class HttpHeadersInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientInstrumentationModule.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientInstrumentationModule.java
@@ -32,7 +32,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class JaxRsClientInstrumentationModule extends InstrumentationModule {
+public class JaxRsClientInstrumentationModule extends InstrumentationModule {
 
   public JaxRsClientInstrumentationModule() {
     super("jaxrs-client", "jaxrs-client-1.1");
@@ -43,7 +43,7 @@ public final class JaxRsClientInstrumentationModule extends InstrumentationModul
     return singletonList(new ClientHandlerInstrumentation());
   }
 
-  private static final class ClientHandlerInstrumentation implements TypeInstrumentation {
+  public static class ClientHandlerInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("com.sun.jersey.api.client.ClientHandler");

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientInstrumentationModule.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientInstrumentationModule.java
@@ -26,7 +26,7 @@ import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class JaxRsClientInstrumentationModule extends InstrumentationModule {
+public class JaxRsClientInstrumentationModule extends InstrumentationModule {
 
   public JaxRsClientInstrumentationModule() {
     super("jaxrs-client", "jaxrs-client-2.0");
@@ -37,7 +37,7 @@ public final class JaxRsClientInstrumentationModule extends InstrumentationModul
     return singletonList(new ClientBuilderInstrumentation());
   }
 
-  private static final class ClientBuilderInstrumentation implements TypeInstrumentation {
+  public static class ClientBuilderInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("javax.ws.rs.client.ClientBuilder");

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JerseyClientInstrumentationModule.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JerseyClientInstrumentationModule.java
@@ -34,7 +34,7 @@ import org.glassfish.jersey.client.ClientRequest;
  * handle these errors at the implementation level.
  */
 @AutoService(InstrumentationModule.class)
-public final class JerseyClientInstrumentationModule extends InstrumentationModule {
+public class JerseyClientInstrumentationModule extends InstrumentationModule {
 
   public JerseyClientInstrumentationModule() {
     super("jaxrs-client", "jaxrs-client-2.0", "jersey-client", "jersey-client-2.0");
@@ -45,8 +45,7 @@ public final class JerseyClientInstrumentationModule extends InstrumentationModu
     return Collections.singletonList(new JerseyClientConnectionErrorInstrumentation());
   }
 
-  private static final class JerseyClientConnectionErrorInstrumentation
-      implements TypeInstrumentation {
+  public static class JerseyClientConnectionErrorInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("org.glassfish.jersey.client.JerseyInvocation");

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientInstrumentationModule.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientInstrumentationModule.java
@@ -36,7 +36,7 @@ import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
  * because {@link JaxRsClientTracer} used by the latter checks against double client spans.
  */
 @AutoService(InstrumentationModule.class)
-public final class ResteasyClientInstrumentationModule extends InstrumentationModule {
+public class ResteasyClientInstrumentationModule extends InstrumentationModule {
 
   public ResteasyClientInstrumentationModule() {
     super("jaxrs-client", "jaxrs-client-2.0", "resteasy-client", "resteasy-client-2.0");

--- a/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotationsInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotationsInstrumentation.java
@@ -28,7 +28,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class JaxRsAnnotationsInstrumentation implements TypeInstrumentation {
+public class JaxRsAnnotationsInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/ContainerRequestFilterInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/ContainerRequestFilterInstrumentation.java
@@ -26,7 +26,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * This adds the filter class name to the request properties. The class name is used by <code>
  * DefaultRequestContextInstrumentation</code>
  */
-class ContainerRequestFilterInstrumentation implements TypeInstrumentation {
+public class ContainerRequestFilterInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/DefaultRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/DefaultRequestContextInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.asm.Advice.Local;
  * <p>This default instrumentation uses the class name of the filter to create the span. More
  * specific instrumentations may override this value.
  */
-final class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrumentation {
+public class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrumentation {
   @Override
   protected String abortAdviceName() {
     return ContainerRequestContextAdvice.class.getName();

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAnnotationsInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAnnotationsInstrumentation.java
@@ -33,7 +33,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.bytecode.assign.Assigner.Typing;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class JaxRsAnnotationsInstrumentation implements TypeInstrumentation {
+public class JaxRsAnnotationsInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {
     return hasClassesNamed("javax.ws.rs.Path");

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
@@ -24,7 +24,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class JaxRsAsyncResponseInstrumentation implements TypeInstrumentation {
+public class JaxRsAsyncResponseInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JerseyRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JerseyRequestContextInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.asm.Advice.Local;
  * <p>In the Jersey implementation, <code>UriInfo</code> implements <code>ResourceInfo</code>. The
  * matched resource method can be retrieved from that object
  */
-final class JerseyRequestContextInstrumentation extends AbstractRequestContextInstrumentation {
+public class JerseyRequestContextInstrumentation extends AbstractRequestContextInstrumentation {
   @Override
   protected String abortAdviceName() {
     return ContainerRequestContextAdvice.class.getName();

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/Resteasy30RequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/Resteasy30RequestContextInstrumentation.java
@@ -26,7 +26,7 @@ import org.jboss.resteasy.core.interception.PostMatchContainerRequestContext;
  * PostMatchContainerRequestContext</code>. This class provides a way to get the matched resource
  * method through <code>getResourceMethod()</code>.
  */
-final class Resteasy30RequestContextInstrumentation extends AbstractRequestContextInstrumentation {
+public class Resteasy30RequestContextInstrumentation extends AbstractRequestContextInstrumentation {
   @Override
   protected String abortAdviceName() {
     return ContainerRequestContextAdvice.class.getName();

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/Resteasy31RequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/Resteasy31RequestContextInstrumentation.java
@@ -26,7 +26,7 @@ import org.jboss.resteasy.core.interception.jaxrs.PostMatchContainerRequestConte
  * PostMatchContainerRequestContext</code>. This class provides a way to get the matched resource
  * method through <code>getResourceMethod()</code>.
  */
-final class Resteasy31RequestContextInstrumentation extends AbstractRequestContextInstrumentation {
+public class Resteasy31RequestContextInstrumentation extends AbstractRequestContextInstrumentation {
   @Override
   protected String abortAdviceName() {
     return ContainerRequestContextAdvice.class.getName();

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ConnectionInstrumentation implements TypeInstrumentation {
+public class ConnectionInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/DriverInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/DriverInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class DriverInstrumentation implements TypeInstrumentation {
+public class DriverInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcDataSourceInstrumentationModule.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcDataSourceInstrumentationModule.java
@@ -27,7 +27,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class JdbcDataSourceInstrumentationModule extends InstrumentationModule {
+public class JdbcDataSourceInstrumentationModule extends InstrumentationModule {
   public JdbcDataSourceInstrumentationModule() {
     super("jdbc-datasource");
   }
@@ -42,7 +42,7 @@ public final class JdbcDataSourceInstrumentationModule extends InstrumentationMo
     return false;
   }
 
-  private static final class DataSourceInstrumentation implements TypeInstrumentation {
+  public static class DataSourceInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return implementsInterface(named("javax.sql.DataSource"));

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class PreparedStatementInstrumentation implements TypeInstrumentation {
+public class PreparedStatementInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class StatementInstrumentation implements TypeInstrumentation {
+public class StatementInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisInstrumentationModule.java
@@ -33,7 +33,7 @@ import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol.Command;
 
 @AutoService(InstrumentationModule.class)
-public final class JedisInstrumentationModule extends InstrumentationModule {
+public class JedisInstrumentationModule extends InstrumentationModule {
 
   public JedisInstrumentationModule() {
     super("jedis", "jedis-1.4");
@@ -50,7 +50,7 @@ public final class JedisInstrumentationModule extends InstrumentationModule {
     return singletonList(new ConnectionInstrumentation());
   }
 
-  private static final class ConnectionInstrumentation implements TypeInstrumentation {
+  public static class ConnectionInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("redis.clients.jedis.Connection");

--- a/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisInstrumentationModule.java
@@ -30,7 +30,7 @@ import redis.clients.jedis.Connection;
 import redis.clients.jedis.commands.ProtocolCommand;
 
 @AutoService(InstrumentationModule.class)
-public final class JedisInstrumentationModule extends InstrumentationModule {
+public class JedisInstrumentationModule extends InstrumentationModule {
 
   public JedisInstrumentationModule() {
     super("jedis", "jedis-3.0");
@@ -41,7 +41,7 @@ public final class JedisInstrumentationModule extends InstrumentationModule {
     return singletonList(new ConnectionInstrumentation());
   }
 
-  private static final class ConnectionInstrumentation implements TypeInstrumentation {
+  public static class ConnectionInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("redis.clients.jedis.Connection");

--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/JettyInstrumentationModule.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/JettyInstrumentationModule.java
@@ -24,7 +24,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class JettyInstrumentationModule extends InstrumentationModule {
+public class JettyInstrumentationModule extends InstrumentationModule {
 
   public JettyInstrumentationModule() {
     super("jetty", "jetty-8.0");
@@ -35,7 +35,7 @@ public final class JettyInstrumentationModule extends InstrumentationModule {
     return singletonList(new HandlerInstrumentation());
   }
 
-  private static final class HandlerInstrumentation implements TypeInstrumentation {
+  public static class HandlerInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("org.eclipse.jetty.server.Handler");

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageConsumerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageConsumerInstrumentation.java
@@ -24,7 +24,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class JmsMessageConsumerInstrumentation implements TypeInstrumentation {
+public class JmsMessageConsumerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageListenerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageListenerInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class JmsMessageListenerInstrumentation implements TypeInstrumentation {
+public class JmsMessageListenerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageProducerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageProducerInstrumentation.java
@@ -27,7 +27,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class JmsMessageProducerInstrumentation implements TypeInstrumentation {
+public class JmsMessageProducerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSessionInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSessionInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class JmsSessionInstrumentation implements TypeInstrumentation {
+public class JmsSessionInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/HttpJspPageInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/HttpJspPageInstrumentation.java
@@ -24,7 +24,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class HttpJspPageInstrumentation implements TypeInstrumentation {
+public class HttpJspPageInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/JspCompilationContextInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/JspCompilationContextInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.jasper.JspCompilationContext;
 
-final class JspCompilationContextInstrumentation implements TypeInstrumentation {
+public class JspCompilationContextInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaConsumerInstrumentation.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaConsumerInstrumentation.java
@@ -24,7 +24,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-final class KafkaConsumerInstrumentation implements TypeInstrumentation {
+public class KafkaConsumerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerInstrumentation.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerInstrumentation.java
@@ -27,7 +27,7 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
-final class KafkaProducerInstrumentation implements TypeInstrumentation {
+public class KafkaProducerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsSourceNodeRecordDeserializerInstrumentation.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsSourceNodeRecordDeserializerInstrumentation.java
@@ -22,7 +22,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.record.TimestampType;
 
 // This is necessary because SourceNodeRecordDeserializer drops the headers.  :-(
-final class KafkaStreamsSourceNodeRecordDeserializerInstrumentation implements TypeInstrumentation {
+public class KafkaStreamsSourceNodeRecordDeserializerInstrumentation
+    implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/StreamTaskStartInstrumentation.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/StreamTaskStartInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.kafka.streams.processor.internals.StampedRecord;
 
-final class StreamTaskStartInstrumentation implements TypeInstrumentation {
+public class StreamTaskStartInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/StreamTaskStopInstrumentation.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/StreamTaskStopInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class StreamTaskStopInstrumentation implements TypeInstrumentation {
+public class StreamTaskStopInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/khttp-0.1/src/main/java/io/opentelemetry/javaagent/instrumentation/khttp/KHttpInstrumentationModule.java
+++ b/instrumentation/khttp-0.1/src/main/java/io/opentelemetry/javaagent/instrumentation/khttp/KHttpInstrumentationModule.java
@@ -37,7 +37,7 @@ public class KHttpInstrumentationModule extends InstrumentationModule {
     return singletonList(new KHttpInstrumentation());
   }
 
-  private static final class KHttpInstrumentation implements TypeInstrumentation {
+  public static class KHttpInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("khttp.KHttp");

--- a/instrumentation/kotlinx-coroutines/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/KotlinCoroutinesInstrumentationModule.java
+++ b/instrumentation/kotlinx-coroutines/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/KotlinCoroutinesInstrumentationModule.java
@@ -61,7 +61,7 @@ public class KotlinCoroutinesInstrumentationModule extends InstrumentationModule
     return singletonList(new KotlinDebugProbeInstrumentation());
   }
 
-  private static final class KotlinDebugProbeInstrumentation implements TypeInstrumentation {
+  public static class KotlinDebugProbeInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<? super TypeDescription> typeMatcher() {
       return named("kotlin.coroutines.jvm.internal.DebugProbesKt");

--- a/instrumentation/kubernetes-client-7.0/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientInstrumentationModule.java
+++ b/instrumentation/kubernetes-client-7.0/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientInstrumentationModule.java
@@ -43,7 +43,7 @@ public class KubernetesClientInstrumentationModule extends InstrumentationModule
     return singletonList(new ApiClientInstrumentation());
   }
 
-  private static final class ApiClientInstrumentation implements TypeInstrumentation {
+  public static class ApiClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("io.kubernetes.client.openapi.ApiClient");

--- a/instrumentation/lettuce/lettuce-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncCommandsInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncCommandsInstrumentation.java
@@ -16,7 +16,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
+public class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/lettuce/lettuce-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClientInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClientInstrumentation.java
@@ -15,7 +15,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class LettuceClientInstrumentation implements TypeInstrumentation {
+public class LettuceClientInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncCommandsInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncCommandsInstrumentation.java
@@ -16,7 +16,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
+public class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceClientInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceClientInstrumentation.java
@@ -20,7 +20,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class LettuceClientInstrumentation implements TypeInstrumentation {
+public class LettuceClientInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceReactiveCommandsInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-5.0/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceReactiveCommandsInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class LettuceReactiveCommandsInstrumentation implements TypeInstrumentation {
+public class LettuceReactiveCommandsInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/lettuce/lettuce-5.1/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceInstrumentationModule.java
+++ b/instrumentation/lettuce/lettuce-5.1/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceInstrumentationModule.java
@@ -41,7 +41,7 @@ public class LettuceInstrumentationModule extends InstrumentationModule {
     return singletonList(new DefaultClientResourcesInstrumentation());
   }
 
-  private static final class DefaultClientResourcesInstrumentation implements TypeInstrumentation {
+  public static class DefaultClientResourcesInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<? super TypeDescription> typeMatcher() {
       return named("io.lettuce.core.resource.DefaultClientResources");

--- a/instrumentation/log4j/log4j-1.2/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v1_2/CategoryInstrumentation.java
+++ b/instrumentation/log4j/log4j-1.2/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v1_2/CategoryInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.log4j.spi.LoggingEvent;
 
-final class CategoryInstrumentation implements TypeInstrumentation {
+public class CategoryInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
     return named("org.apache.log4j.Category");

--- a/instrumentation/log4j/log4j-1.2/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v1_2/LoggingEventInstrumentation.java
+++ b/instrumentation/log4j/log4j-1.2/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v1_2/LoggingEventInstrumentation.java
@@ -28,7 +28,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.log4j.MDC;
 import org.apache.log4j.spi.LoggingEvent;
 
-final class LoggingEventInstrumentation implements TypeInstrumentation {
+public class LoggingEventInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
     return named("org.apache.log4j.spi.LoggingEvent");

--- a/instrumentation/log4j/log4j-2.13.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v2_13_2/Log4j2InstrumentationModule.java
+++ b/instrumentation/log4j/log4j-2.13.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v2_13_2/Log4j2InstrumentationModule.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class Log4j2InstrumentationModule extends InstrumentationModule {
+public class Log4j2InstrumentationModule extends InstrumentationModule {
   public Log4j2InstrumentationModule() {
     super("log4j", "log4j-2.13.2");
   }
@@ -46,7 +46,7 @@ public final class Log4j2InstrumentationModule extends InstrumentationModule {
     return singletonList(new EmptyTypeInstrumentation());
   }
 
-  private static final class EmptyTypeInstrumentation implements TypeInstrumentation {
+  public static class EmptyTypeInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<? super TypeDescription> typeMatcher() {
       // we cannot use ContextDataProvider here because one of the classes that we inject implements

--- a/instrumentation/log4j/log4j-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v2_7/Log4j27InstrumentationModule.java
+++ b/instrumentation/log4j/log4j-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v2_7/Log4j27InstrumentationModule.java
@@ -44,8 +44,7 @@ public class Log4j27InstrumentationModule extends InstrumentationModule {
     return singletonList(new ContextDataInjectorFactoryInstrumentation());
   }
 
-  private static final class ContextDataInjectorFactoryInstrumentation
-      implements TypeInstrumentation {
+  public static class ContextDataInjectorFactoryInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<? super TypeDescription> typeMatcher() {
       return named("org.apache.logging.log4j.core.impl.ContextDataInjectorFactory");

--- a/instrumentation/logback/logback-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/v1_0/LoggerInstrumentation.java
+++ b/instrumentation/logback/logback-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/v1_0/LoggerInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class LoggerInstrumentation implements TypeInstrumentation {
+public class LoggerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/logback/logback-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/v1_0/LoggingEventInstrumentation.java
+++ b/instrumentation/logback/logback-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/v1_0/LoggingEventInstrumentation.java
@@ -29,7 +29,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.bytecode.assign.Assigner.Typing;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class LoggingEventInstrumentation implements TypeInstrumentation {
+public class LoggingEventInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
     return implementsInterface(named("ch.qos.logback.classic.spi.ILoggingEvent"));

--- a/instrumentation/mongo/mongo-3.1/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v3_1/MongoClientInstrumentationModule.java
+++ b/instrumentation/mongo/mongo-3.1/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v3_1/MongoClientInstrumentationModule.java
@@ -29,7 +29,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class MongoClientInstrumentationModule extends InstrumentationModule {
+public class MongoClientInstrumentationModule extends InstrumentationModule {
 
   public MongoClientInstrumentationModule() {
     super("mongo", "mongo-3.1");

--- a/instrumentation/mongo/mongo-3.7/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v3_7/MongoClientInstrumentationModule.java
+++ b/instrumentation/mongo/mongo-3.7/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v3_7/MongoClientInstrumentationModule.java
@@ -29,7 +29,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class MongoClientInstrumentationModule extends InstrumentationModule {
+public class MongoClientInstrumentationModule extends InstrumentationModule {
 
   public MongoClientInstrumentationModule() {
     super("mongo", "mongo-3.7");

--- a/instrumentation/mongo/mongo-async-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/mongoasync/v3_3/MongoAsyncClientInstrumentationModule.java
+++ b/instrumentation/mongo/mongo-async-3.3/src/main/java/io/opentelemetry/javaagent/instrumentation/mongoasync/v3_3/MongoAsyncClientInstrumentationModule.java
@@ -30,7 +30,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class MongoAsyncClientInstrumentationModule extends InstrumentationModule {
+public class MongoAsyncClientInstrumentationModule extends InstrumentationModule {
 
   public MongoAsyncClientInstrumentationModule() {
     super("mongo-async", "mongo-async-3.3", "mongo");

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/ChannelFutureListenerInstrumentation.java
@@ -28,7 +28,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFuture;
 
-final class ChannelFutureListenerInstrumentation implements TypeInstrumentation {
+public class ChannelFutureListenerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/NettyChannelInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/NettyChannelInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.jboss.netty.channel.Channel;
 
-final class NettyChannelInstrumentation implements TypeInstrumentation {
+public class NettyChannelInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/NettyChannelPipelineInstrumentation.java
@@ -38,7 +38,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseDecoder;
 import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
 import org.jboss.netty.handler.codec.http.HttpServerCodec;
 
-final class NettyChannelPipelineInstrumentation implements TypeInstrumentation {
+public class NettyChannelPipelineInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/ChannelFutureListenerInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ChannelFutureListenerInstrumentation implements TypeInstrumentation {
+public class ChannelFutureListenerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/NettyChannelPipelineInstrumentation.java
@@ -39,7 +39,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class NettyChannelPipelineInstrumentation implements TypeInstrumentation {
+public class NettyChannelPipelineInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/ChannelFutureListenerInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ChannelFutureListenerInstrumentation implements TypeInstrumentation {
+public class ChannelFutureListenerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
@@ -39,7 +39,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class NettyChannelPipelineInstrumentation implements TypeInstrumentation {
+public class NettyChannelPipelineInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/okhttp/okhttp-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2InstrumentationModule.java
+++ b/instrumentation/okhttp/okhttp-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2InstrumentationModule.java
@@ -33,7 +33,7 @@ public class OkHttp2InstrumentationModule extends InstrumentationModule {
     return singletonList(new OkHttpClientInstrumentation());
   }
 
-  private static final class OkHttpClientInstrumentation implements TypeInstrumentation {
+  public static class OkHttpClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<? super TypeDescription> typeMatcher() {
       return named("com.squareup.okhttp.OkHttpClient");

--- a/instrumentation/okhttp/okhttp-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttp3InstrumentationModule.java
+++ b/instrumentation/okhttp/okhttp-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttp3InstrumentationModule.java
@@ -35,7 +35,7 @@ public class OkHttp3InstrumentationModule extends InstrumentationModule {
     return singletonList(new OkHttpClientInstrumentation());
   }
 
-  private static final class OkHttpClientInstrumentation implements TypeInstrumentation {
+  public static class OkHttpClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("okhttp3.OkHttpClient");

--- a/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/BaggageUtilsInstrumentation.java
+++ b/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/BaggageUtilsInstrumentation.java
@@ -24,7 +24,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 // TODO: Actually bridge correlation context. We currently just stub out withBaggage
 // to have minimum functionality with SDK shim implementations.
 // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/973
-final class BaggageUtilsInstrumentation implements TypeInstrumentation {
+public class BaggageUtilsInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
     return named("application.io.opentelemetry.api.baggage.BaggageUtils");

--- a/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/ContextInstrumentation.java
+++ b/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/ContextInstrumentation.java
@@ -26,7 +26,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * sure there is no dependency on a system property or possibility of a user overriding this since
  * it's required for instrumentation in the agent to work properly.
  */
-final class ContextInstrumentation implements TypeInstrumentation {
+public class ContextInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/ContextStorageInstrumentation.java
+++ b/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/ContextStorageInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * sure there is no dependency on a system property or possibility of a user overriding this since
  * it's required for instrumentation in the agent to work properly.
  */
-final class ContextStorageInstrumentation implements TypeInstrumentation {
+public class ContextStorageInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/OpenTelemetryInstrumentation.java
+++ b/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/OpenTelemetryInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class OpenTelemetryInstrumentation implements TypeInstrumentation {
+public class OpenTelemetryInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/SpanInstrumentation.java
+++ b/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/SpanInstrumentation.java
@@ -20,7 +20,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class SpanInstrumentation implements TypeInstrumentation {
+public class SpanInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
     return named("application.io.opentelemetry.api.trace.PropagatedSpan");

--- a/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/anotations/WithSpanAnnotationInstrumentationModule.java
+++ b/instrumentation/opentelemetry-api-1.0/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/anotations/WithSpanAnnotationInstrumentationModule.java
@@ -32,7 +32,7 @@ import net.bytebuddy.matcher.ElementMatchers;
 
 /** Instrumentation for methods annotated with {@link WithSpan} annotation. */
 @AutoService(InstrumentationModule.class)
-public final class WithSpanAnnotationInstrumentationModule extends InstrumentationModule {
+public class WithSpanAnnotationInstrumentationModule extends InstrumentationModule {
 
   private static final String TRACE_ANNOTATED_METHODS_EXCLUDE_CONFIG =
       "otel.trace.annotated.methods.exclude";
@@ -46,7 +46,7 @@ public final class WithSpanAnnotationInstrumentationModule extends Instrumentati
     return singletonList(new AnnotatedMethodInstrumentation());
   }
 
-  private static final class AnnotatedMethodInstrumentation implements TypeInstrumentation {
+  public static class AnnotatedMethodInstrumentation implements TypeInstrumentation {
     private final ElementMatcher.Junction<AnnotationSource> annotatedMethodMatcher;
     // this matcher matches all methods that should be excluded from transformation
     private final ElementMatcher.Junction<MethodDescription> excludedMethodsMatcher;

--- a/instrumentation/oshi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/OshiInstrumentationModule.java
+++ b/instrumentation/oshi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/OshiInstrumentationModule.java
@@ -36,7 +36,7 @@ public class OshiInstrumentationModule extends InstrumentationModule {
     return singletonList(new SystemInfoInstrumentation());
   }
 
-  private static final class SystemInfoInstrumentation implements TypeInstrumentation {
+  public static class SystemInfoInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("oshi.SystemInfo");

--- a/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_3/PlayInstrumentationModule.java
+++ b/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_3/PlayInstrumentationModule.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class PlayInstrumentationModule extends InstrumentationModule {
+public class PlayInstrumentationModule extends InstrumentationModule {
 
   public PlayInstrumentationModule() {
     super("play", "play-2.3");
@@ -34,7 +34,7 @@ public final class PlayInstrumentationModule extends InstrumentationModule {
     return singletonList(new ActionInstrumentation());
   }
 
-  private static final class ActionInstrumentation implements TypeInstrumentation {
+  public static class ActionInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("play.api.mvc.Action");

--- a/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/PlayInstrumentationModule.java
+++ b/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/PlayInstrumentationModule.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class PlayInstrumentationModule extends InstrumentationModule {
+public class PlayInstrumentationModule extends InstrumentationModule {
 
   public PlayInstrumentationModule() {
     super("play", "play-2.4");
@@ -34,7 +34,7 @@ public final class PlayInstrumentationModule extends InstrumentationModule {
     return singletonList(new ActionInstrumentation());
   }
 
-  private static final class ActionInstrumentation implements TypeInstrumentation {
+  public static class ActionInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("play.api.mvc.Action");

--- a/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/PlayInstrumentationModule.java
+++ b/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/PlayInstrumentationModule.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class PlayInstrumentationModule extends InstrumentationModule {
+public class PlayInstrumentationModule extends InstrumentationModule {
 
   public PlayInstrumentationModule() {
     super("play", "play-2.6");
@@ -34,7 +34,7 @@ public final class PlayInstrumentationModule extends InstrumentationModule {
     return singletonList(new ActionInstrumentation());
   }
 
-  private static final class ActionInstrumentation implements TypeInstrumentation {
+  public static class ActionInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("play.api.mvc.Action");

--- a/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelInstrumentation.java
+++ b/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelInstrumentation.java
@@ -42,7 +42,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class RabbitChannelInstrumentation implements TypeInstrumentation {
+public class RabbitChannelInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitCommandInstrumentation.java
+++ b/instrumentation/rabbitmq-2.7/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitCommandInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class RabbitCommandInstrumentation implements TypeInstrumentation {
+public class RabbitCommandInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/ContinuationInstrumentation.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/ContinuationInstrumentation.java
@@ -20,7 +20,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import ratpack.func.Block;
 
-final class ContinuationInstrumentation implements TypeInstrumentation {
+public class ContinuationInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/DefaultExecutionInstrumentation.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/DefaultExecutionInstrumentation.java
@@ -19,7 +19,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import ratpack.exec.internal.Continuation;
 import ratpack.func.Action;
 
-final class DefaultExecutionInstrumentation implements TypeInstrumentation {
+public class DefaultExecutionInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/ServerErrorHandlerInstrumentation.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/ServerErrorHandlerInstrumentation.java
@@ -19,7 +19,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ServerErrorHandlerInstrumentation implements TypeInstrumentation {
+public class ServerErrorHandlerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/ServerRegistryInstrumentation.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/ServerRegistryInstrumentation.java
@@ -16,7 +16,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ServerRegistryInstrumentation implements TypeInstrumentation {
+public class ServerRegistryInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/reactor-3.1/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/ReactorInstrumentationModule.java
+++ b/instrumentation/reactor-3.1/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/ReactorInstrumentationModule.java
@@ -20,7 +20,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class ReactorInstrumentationModule extends InstrumentationModule {
+public class ReactorInstrumentationModule extends InstrumentationModule {
 
   public ReactorInstrumentationModule() {
     super("reactor", "reactor-3.1");
@@ -31,7 +31,7 @@ public final class ReactorInstrumentationModule extends InstrumentationModule {
     return singletonList(new HooksInstrumentation());
   }
 
-  private static final class HooksInstrumentation implements TypeInstrumentation {
+  public static class HooksInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("reactor.core.publisher.Hooks");

--- a/instrumentation/reactor-netty-0.9/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/ReactorNettyInstrumentationModule.java
+++ b/instrumentation/reactor-netty-0.9/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/ReactorNettyInstrumentationModule.java
@@ -38,7 +38,7 @@ import reactor.netty.http.client.HttpClientRequest;
  * to Netty.
  */
 @AutoService(InstrumentationModule.class)
-public final class ReactorNettyInstrumentationModule extends InstrumentationModule {
+public class ReactorNettyInstrumentationModule extends InstrumentationModule {
 
   public ReactorNettyInstrumentationModule() {
     super("reactor-netty", "reactor-netty-0.9");
@@ -49,7 +49,7 @@ public final class ReactorNettyInstrumentationModule extends InstrumentationModu
     return singletonList(new HttpClientInstrumentation());
   }
 
-  private static final class HttpClientInstrumentation implements TypeInstrumentation {
+  public static class HttpClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("reactor.netty.http.client.HttpClient");

--- a/instrumentation/rediscala-1.8/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaInstrumentationModule.java
+++ b/instrumentation/rediscala-1.8/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaInstrumentationModule.java
@@ -35,7 +35,7 @@ import scala.runtime.AbstractFunction1;
 import scala.util.Try;
 
 @AutoService(InstrumentationModule.class)
-public final class RediscalaInstrumentationModule extends InstrumentationModule {
+public class RediscalaInstrumentationModule extends InstrumentationModule {
 
   public RediscalaInstrumentationModule() {
     super("rediscala", "rediscala-1.8");
@@ -46,7 +46,7 @@ public final class RediscalaInstrumentationModule extends InstrumentationModule 
     return singletonList(new RequestInstrumentation());
   }
 
-  private static final class RequestInstrumentation implements TypeInstrumentation {
+  public static class RequestInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("redis.Request");

--- a/instrumentation/redisson-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonInstrumentation.java
+++ b/instrumentation/redisson-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonInstrumentation.java
@@ -25,7 +25,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.redisson.client.RedisConnection;
 
 @AutoService(InstrumentationModule.class)
-public final class RedissonInstrumentation extends InstrumentationModule {
+public class RedissonInstrumentation extends InstrumentationModule {
 
   public RedissonInstrumentation() {
     super("redisson", "redisson-3.0");
@@ -36,7 +36,7 @@ public final class RedissonInstrumentation extends InstrumentationModule {
     return singletonList(new RedisConnectionInstrumentation());
   }
 
-  private static final class RedisConnectionInstrumentation implements TypeInstrumentation {
+  public static class RedisConnectionInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("org.redisson.client.RedisConnection");

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientInstrumentationModule.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientInstrumentationModule.java
@@ -28,7 +28,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class RmiClientInstrumentationModule extends InstrumentationModule {
+public class RmiClientInstrumentationModule extends InstrumentationModule {
 
   public RmiClientInstrumentationModule() {
     super("rmi", "rmi-client");
@@ -39,7 +39,7 @@ public final class RmiClientInstrumentationModule extends InstrumentationModule 
     return singletonList(new ClientInstrumentation());
   }
 
-  private static final class ClientInstrumentation implements TypeInstrumentation {
+  public static class ClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return extendsClass(named("sun.rmi.server.UnicastRef"));

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
@@ -46,7 +46,7 @@ import sun.rmi.transport.Connection;
  * that instruction will essentially be garbage data and will cause the parsing loop to throw
  * exception and shutdown the connection which we do not want
  */
-public final class RmiClientContextInstrumentation implements TypeInstrumentation {
+public class RmiClientContextInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/server/RmiServerContextInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/server/RmiServerContextInstrumentation.java
@@ -21,7 +21,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import sun.rmi.transport.Target;
 
-public final class RmiServerContextInstrumentation implements TypeInstrumentation {
+public class RmiServerContextInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerInstrumentation.java
@@ -33,7 +33,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class RmiServerInstrumentation extends InstrumentationModule {
+public class RmiServerInstrumentation extends InstrumentationModule {
 
   public RmiServerInstrumentation() {
     super("rmi", "rmi-server");
@@ -44,7 +44,7 @@ public final class RmiServerInstrumentation extends InstrumentationModule {
     return singletonList(new ServerInstrumentation());
   }
 
-  private static final class ServerInstrumentation implements TypeInstrumentation {
+  public static class ServerInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return extendsClass(named("java.rmi.server.RemoteServer"));

--- a/instrumentation/scala-executors/src/main/java/io/opentelemetry/javaagent/instrumentation/scalaexecutors/ScalaForkJoinPoolInstrumentation.java
+++ b/instrumentation/scala-executors/src/main/java/io/opentelemetry/javaagent/instrumentation/scalaexecutors/ScalaForkJoinPoolInstrumentation.java
@@ -23,7 +23,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import scala.concurrent.forkjoin.ForkJoinTask;
 
-final class ScalaForkJoinPoolInstrumentation implements TypeInstrumentation {
+public class ScalaForkJoinPoolInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/scala-executors/src/main/java/io/opentelemetry/javaagent/instrumentation/scalaexecutors/ScalaForkJoinTaskInstrumentation.java
+++ b/instrumentation/scala-executors/src/main/java/io/opentelemetry/javaagent/instrumentation/scalaexecutors/ScalaForkJoinTaskInstrumentation.java
@@ -34,7 +34,7 @@ import scala.concurrent.forkjoin.ForkJoinTask;
  * <p>Note: There are quite a few separate implementations of {@code ForkJoinTask}/{@code
  * ForkJoinPool}: JVM, Akka, Scala, Netty to name a few. This class handles Scala version.
  */
-final class ScalaForkJoinTaskInstrumentation implements TypeInstrumentation {
+public class ScalaForkJoinTaskInstrumentation implements TypeInstrumentation {
 
   static final String TASK_CLASS_NAME = "scala.concurrent.forkjoin.ForkJoinTask";
 

--- a/instrumentation/servlet/servlet-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/HttpServletResponseInstrumentation.java
+++ b/instrumentation/servlet/servlet-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/HttpServletResponseInstrumentation.java
@@ -35,7 +35,7 @@ import net.bytebuddy.matcher.ElementMatcher;
  * ServletResponse, Throwable, Span, Scope)} can get it from context and set required span
  * attribute.
  */
-final class HttpServletResponseInstrumentation implements TypeInstrumentation {
+public class HttpServletResponseInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {
     return hasClassesNamed("javax.servlet.http.HttpServletResponse");

--- a/instrumentation/servlet/servlet-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/ServletAndFilterInstrumentation.java
+++ b/instrumentation/servlet/servlet-2.2/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/ServletAndFilterInstrumentation.java
@@ -19,7 +19,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ServletAndFilterInstrumentation implements TypeInstrumentation {
+public class ServletAndFilterInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/AsyncContextInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/AsyncContextInstrumentation.java
@@ -26,7 +26,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class AsyncContextInstrumentation implements TypeInstrumentation {
+public class AsyncContextInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/ServletAndFilterInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/ServletAndFilterInstrumentation.java
@@ -19,7 +19,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class ServletAndFilterInstrumentation implements TypeInstrumentation {
+public class ServletAndFilterInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {
     return hasClassesNamed("javax.servlet.Filter");

--- a/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentationModule.java
@@ -36,7 +36,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class RequestDispatcherInstrumentationModule extends InstrumentationModule {
+public class RequestDispatcherInstrumentationModule extends InstrumentationModule {
   public RequestDispatcherInstrumentationModule() {
     super("servlet", "servlet-dispatcher");
   }
@@ -51,7 +51,7 @@ public final class RequestDispatcherInstrumentationModule extends Instrumentatio
     return singletonMap("javax.servlet.RequestDispatcher", String.class.getName());
   }
 
-  private static final class RequestDispatcherInstrumentation implements TypeInstrumentation {
+  public static class RequestDispatcherInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("javax.servlet.RequestDispatcher");

--- a/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/http/HttpServletResponseInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/http/HttpServletResponseInstrumentationModule.java
@@ -31,7 +31,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class HttpServletResponseInstrumentationModule extends InstrumentationModule {
+public class HttpServletResponseInstrumentationModule extends InstrumentationModule {
   public HttpServletResponseInstrumentationModule() {
     super("servlet", "servlet-response");
   }
@@ -41,7 +41,7 @@ public final class HttpServletResponseInstrumentationModule extends Instrumentat
     return singletonList(new HttpServletResponseInstrumentation());
   }
 
-  private static final class HttpServletResponseInstrumentation implements TypeInstrumentation {
+  public static class HttpServletResponseInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("javax.servlet.http.HttpServletResponse");

--- a/instrumentation/spark-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/sparkjava/SparkInstrumentationModule.java
+++ b/instrumentation/spark-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/sparkjava/SparkInstrumentationModule.java
@@ -37,7 +37,7 @@ public class SparkInstrumentationModule extends InstrumentationModule {
     return singletonList(new RoutesInstrumentation());
   }
 
-  private static final class RoutesInstrumentation implements TypeInstrumentation {
+  public static class RoutesInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("spark.route.Routes");

--- a/instrumentation/spring/spring-data-1.8/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataInstrumentationModule.java
+++ b/instrumentation/spring/spring-data-1.8/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataInstrumentationModule.java
@@ -32,7 +32,7 @@ import org.springframework.data.repository.core.support.RepositoryFactorySupport
 import org.springframework.data.repository.core.support.RepositoryProxyPostProcessor;
 
 @AutoService(InstrumentationModule.class)
-public final class SpringDataInstrumentationModule extends InstrumentationModule {
+public class SpringDataInstrumentationModule extends InstrumentationModule {
 
   public SpringDataInstrumentationModule() {
     super("spring-data", "spring-data-1.8");

--- a/instrumentation/spring/spring-scheduling-3.1/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingInstrumentationModule.java
+++ b/instrumentation/spring/spring-scheduling-3.1/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingInstrumentationModule.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class SpringSchedulingInstrumentationModule extends InstrumentationModule {
+public class SpringSchedulingInstrumentationModule extends InstrumentationModule {
 
   public SpringSchedulingInstrumentationModule() {
     super("spring-scheduling", "spring-scheduling-3.1");
@@ -33,7 +33,7 @@ public final class SpringSchedulingInstrumentationModule extends Instrumentation
     return singletonList(new TaskInstrumentation());
   }
 
-  private static final class TaskInstrumentation implements TypeInstrumentation {
+  public static class TaskInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("org.springframework.scheduling.config.Task");

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/client/WebfluxClientInstrumentationModule.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/client/WebfluxClientInstrumentationModule.java
@@ -34,7 +34,7 @@ public class WebfluxClientInstrumentationModule extends InstrumentationModule {
     return singletonList(new WebClientBuilderInstrumentation());
   }
 
-  private static final class WebClientBuilderInstrumentation implements TypeInstrumentation {
+  public static class WebClientBuilderInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("org.springframework.web.reactive.function.client.WebClient");

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/DispatcherHandlerInstrumentation.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/DispatcherHandlerInstrumentation.java
@@ -18,7 +18,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class DispatcherHandlerInstrumentation implements TypeInstrumentation {
+public class DispatcherHandlerInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/HandlerAdapterInstrumentation.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/HandlerAdapterInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class HandlerAdapterInstrumentation implements TypeInstrumentation {
+public class HandlerAdapterInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/RouterFunctionInstrumentation.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/RouterFunctionInstrumentation.java
@@ -22,7 +22,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class RouterFunctionInstrumentation implements TypeInstrumentation {
+public class RouterFunctionInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
@@ -28,7 +28,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.ModelAndView;
 
-final class DispatcherServletInstrumentation implements TypeInstrumentation {
+public class DispatcherServletInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
@@ -29,7 +29,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class HandlerAdapterInstrumentation implements TypeInstrumentation {
+public class HandlerAdapterInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcInstrumentationModule.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcInstrumentationModule.java
@@ -13,7 +13,7 @@ import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public final class SpringWebMvcInstrumentationModule extends InstrumentationModule {
+public class SpringWebMvcInstrumentationModule extends InstrumentationModule {
   public SpringWebMvcInstrumentationModule() {
     super("spring-webmvc", "spring-webmvc-3.1");
   }

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/WebApplicationContextInstrumentation.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/WebApplicationContextInstrumentation.java
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
  * This instrumentation adds the HandlerMappingResourceNameFilter definition to the spring context
  * When the context is created, the filter will be added to the beginning of the filter chain.
  */
-final class WebApplicationContextInstrumentation implements TypeInstrumentation {
+public class WebApplicationContextInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SpymemcachedInstrumentationModule.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SpymemcachedInstrumentationModule.java
@@ -30,7 +30,7 @@ import net.spy.memcached.internal.GetFuture;
 import net.spy.memcached.internal.OperationFuture;
 
 @AutoService(InstrumentationModule.class)
-public final class SpymemcachedInstrumentationModule extends InstrumentationModule {
+public class SpymemcachedInstrumentationModule extends InstrumentationModule {
 
   public SpymemcachedInstrumentationModule() {
     super("spymemcached", "spymemcached-2.12");
@@ -41,7 +41,7 @@ public final class SpymemcachedInstrumentationModule extends InstrumentationModu
     return singletonList(new MemcachedClientInstrumentation());
   }
 
-  private static final class MemcachedClientInstrumentation implements TypeInstrumentation {
+  public static class MemcachedClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("net.spy.memcached.MemcachedClient");

--- a/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -33,7 +33,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 /** Instrument the Twilio SDK to identify calls as a separate service. */
-final class TwilioAsyncInstrumentation implements TypeInstrumentation {
+public class TwilioAsyncInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioSyncInstrumentation.java
+++ b/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioSyncInstrumentation.java
@@ -28,7 +28,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 /** Instrument the Twilio SDK to identify calls as a separate service. */
-final class TwilioSyncInstrumentation implements TypeInstrumentation {
+public class TwilioSyncInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {

--- a/instrumentation/vertx-reactive-3.5/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/VertxRxInstrumentationModule.java
+++ b/instrumentation/vertx-reactive-3.5/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/VertxRxInstrumentationModule.java
@@ -39,7 +39,7 @@ public class VertxRxInstrumentationModule extends InstrumentationModule {
     return singletonList(new AsyncResultSingleInstrumentation());
   }
 
-  private static final class AsyncResultSingleInstrumentation implements TypeInstrumentation {
+  public static class AsyncResultSingleInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       // Different versions of Vert.x has this class in different packages

--- a/instrumentation/vertx-web-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/VertxWebInstrumentationModule.java
+++ b/instrumentation/vertx-web-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/VertxWebInstrumentationModule.java
@@ -28,7 +28,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
-public final class VertxWebInstrumentationModule extends InstrumentationModule {
+public class VertxWebInstrumentationModule extends InstrumentationModule {
 
   public VertxWebInstrumentationModule() {
     super("vertx-web", "vertx-web-3.0", "vertx");
@@ -39,7 +39,7 @@ public final class VertxWebInstrumentationModule extends InstrumentationModule {
     return singletonList(new RouteInstrumentation());
   }
 
-  private static final class RouteInstrumentation implements TypeInstrumentation {
+  public static class RouteInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<ClassLoader> classLoaderOptimization() {
       return hasClassesNamed("io.vertx.ext.web.Route");

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InstrumentationModule.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InstrumentationModule.java
@@ -42,6 +42,9 @@ import org.slf4j.LoggerFactory;
  * Instrumentation module groups several connected {@link TypeInstrumentation}s together, sharing
  * classloader matcher, helper classes, muzzle safety checks, etc. Ideally all types in a single
  * instrumented library should live in a single module.
+ *
+ * <p>Classes extending {@link InstrumentationModule} should be public and non-final so that it's
+ * possible to extend and reuse them in vendor distributions.
  */
 public abstract class InstrumentationModule {
   private static final Logger log = LoggerFactory.getLogger(InstrumentationModule.class);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TypeInstrumentation.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TypeInstrumentation.java
@@ -16,6 +16,9 @@ import net.bytebuddy.matcher.ElementMatchers;
 
 /**
  * Interface representing a single type instrumentation. Part of an {@link InstrumentationModule}.
+ *
+ * <p>Classes implementing {@link TypeInstrumentation} should be public and non-final so that it's
+ * possible to extend and reuse them in vendor distributions.
  */
 public interface TypeInstrumentation {
   /**

--- a/testing-common/src/test/java/IbmResourceLevelInstrumentation.java
+++ b/testing-common/src/test/java/IbmResourceLevelInstrumentation.java
@@ -28,7 +28,7 @@ public class IbmResourceLevelInstrumentation extends InstrumentationModule {
     return singletonList(new ResourceLevelInstrumentation());
   }
 
-  private static final class ResourceLevelInstrumentation implements TypeInstrumentation {
+  public static class ResourceLevelInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
       return named("com.ibm.as400.resource.ResourceLevel");

--- a/testing-common/src/test/java/context/ContextTestInstrumentationModule.java
+++ b/testing-common/src/test/java/context/ContextTestInstrumentationModule.java
@@ -50,7 +50,7 @@ public class ContextTestInstrumentationModule extends InstrumentationModule {
     return store;
   }
 
-  private static final class ContextTestInstrumentation implements TypeInstrumentation {
+  public static class ContextTestInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<? super TypeDescription> typeMatcher() {
       return nameStartsWith(ContextTestInstrumentationModule.class.getName() + "$");


### PR DESCRIPTION
Fixes #1582

Adding a checkstyle rule to enforce this (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1582#issuecomment-724430470) seems to be non-trivial: checkstyle does not have a "public non-final" check by default, and I'm not sure that it's possible to check "A extends B, B implements TypeInstr" situation reliably. I'll create a separate issue for that.