### PR TITLE
Simplify netty-4.1 AttributeKeys

### DIFF
--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AttributeKeys.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AttributeKeys.java
@@ -24,17 +24,18 @@ public class AttributeKeys {
             }
           };
 
-  public static final AttributeKey<Context> CONNECT_CONTEXT_ATTRIBUTE_KEY =
-      attributeKey(AttributeKeys.class.getName() + ".connect.context");
+  public static final AttributeKey<Context> CONNECT_CONTEXT =
+      attributeKey(AttributeKeys.class.getName() + ".connect0context");
 
-  public static final AttributeKey<Context> SERVER_ATTRIBUTE_KEY =
-      attributeKey(AttributeKeys.class.getName() + ".context");
+  // this is the context that has the server span
+  public static final AttributeKey<Context> SERVER_SPAN =
+      attributeKey(AttributeKeys.class.getName() + ".server-span");
 
-  public static final AttributeKey<Span> CLIENT_ATTRIBUTE_KEY =
-      attributeKey(AttributeKeys.class.getName() + ".span");
+  public static final AttributeKey<Span> CLIENT_SPAN =
+      attributeKey(AttributeKeys.class.getName() + ".client-span");
 
-  public static final AttributeKey<Context> CLIENT_PARENT_ATTRIBUTE_KEY =
-      attributeKey(AttributeKeys.class.getName() + ".parent");
+  public static final AttributeKey<Context> CLIENT_PARENT_CONTEXT =
+      attributeKey(AttributeKeys.class.getName() + ".client-parent-context");
 
   /**
    * Generate an attribute key or reuse the one existing in the global app map. This implementation

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AttributeKeys.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AttributeKeys.java
@@ -25,7 +25,7 @@ public class AttributeKeys {
           };
 
   public static final AttributeKey<Context> CONNECT_CONTEXT =
-      attributeKey(AttributeKeys.class.getName() + ".connect0context");
+      attributeKey(AttributeKeys.class.getName() + ".connect-context");
 
   // this is the context that has the server span
   public static final AttributeKey<Context> SERVER_SPAN =

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/ChannelFutureListenerInstrumentation.java
@@ -58,8 +58,7 @@ final class ChannelFutureListenerInstrumentation implements TypeInstrumentation 
       if (cause == null) {
         return null;
       }
-      Context parentContext =
-          future.channel().attr(AttributeKeys.CONNECT_CONTEXT_ATTRIBUTE_KEY).getAndRemove();
+      Context parentContext = future.channel().attr(AttributeKeys.CONNECT_CONTEXT).getAndRemove();
       if (parentContext == null) {
         return null;
       }

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/NettyChannelPipelineInstrumentation.java
@@ -123,8 +123,7 @@ final class NettyChannelPipelineInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter
     public static void addParentSpan(@Advice.This ChannelPipeline pipeline) {
       Context context = Java8BytecodeBridge.currentContext();
-      Attribute<Context> attribute =
-          pipeline.channel().attr(AttributeKeys.CONNECT_CONTEXT_ATTRIBUTE_KEY);
+      Attribute<Context> attribute = pipeline.channel().attr(AttributeKeys.CONNECT_CONTEXT);
       attribute.compareAndSet(null, context);
     }
   }

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/HttpClientRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/HttpClientRequestTracingHandler.java
@@ -29,19 +29,18 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
     // TODO pass Context into Tracer.startSpan() and then don't need this scoping
     Scope parentScope = null;
-    Context parentContext =
-        ctx.channel().attr(AttributeKeys.CONNECT_CONTEXT_ATTRIBUTE_KEY).getAndRemove();
+    Context parentContext = ctx.channel().attr(AttributeKeys.CONNECT_CONTEXT).getAndRemove();
     if (parentContext != null) {
       parentScope = parentContext.makeCurrent();
     }
 
     HttpRequest request = (HttpRequest) msg;
 
-    ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).set(Context.current());
+    ctx.channel().attr(AttributeKeys.CLIENT_PARENT_CONTEXT).set(Context.current());
 
     Span span = tracer().startSpan(request);
     NetPeerUtils.setNetPeer(span, (InetSocketAddress) ctx.channel().remoteAddress());
-    ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).set(span);
+    ctx.channel().attr(AttributeKeys.CLIENT_SPAN).set(span);
 
     try (Scope scope = tracer().startScope(span, request.headers())) {
       ctx.write(msg, prm);

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/HttpClientResponseTracingHandler.java
@@ -20,9 +20,9 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
 
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) {
-    Attribute<Context> parentAttr = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY);
+    Attribute<Context> parentAttr = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_CONTEXT);
     Context parentContext = parentAttr.get();
-    Span span = ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).get();
+    Span span = ctx.channel().attr(AttributeKeys.CLIENT_SPAN).get();
 
     boolean finishSpan = msg instanceof HttpResponse;
 

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/NettyHttpServerTracer.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/NettyHttpServerTracer.java
@@ -42,12 +42,12 @@ public class NettyHttpServerTracer
 
   @Override
   protected void attachServerContext(Context context, Channel channel) {
-    channel.attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).set(context);
+    channel.attr(AttributeKeys.SERVER_SPAN).set(context);
   }
 
   @Override
   public Context getServerContext(Channel channel) {
-    return channel.attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).get();
+    return channel.attr(AttributeKeys.SERVER_SPAN).get();
   }
 
   @Override

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AttributeKeys.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AttributeKeys.java
@@ -8,51 +8,19 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 import io.netty.util.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.javaagent.instrumentation.api.WeakMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 public class AttributeKeys {
-  private static final WeakMap<ClassLoader, ConcurrentMap<String, AttributeKey<?>>> map =
-      WeakMap.Implementation.DEFAULT.get();
-  private static final WeakMap.ValueSupplier<ClassLoader, ConcurrentMap<String, AttributeKey<?>>>
-      mapSupplier =
-          new WeakMap.ValueSupplier<ClassLoader, ConcurrentMap<String, AttributeKey<?>>>() {
-            @Override
-            public ConcurrentMap<String, AttributeKey<?>> get(ClassLoader ignore) {
-              return new ConcurrentHashMap<>();
-            }
-          };
 
   public static final AttributeKey<Context> CONNECT_CONTEXT_ATTRIBUTE_KEY =
-      attributeKey(AttributeKeys.class.getName() + "connect.context");
+      AttributeKey.valueOf(AttributeKeys.class, "connect.context");
 
   // this attribute key is also used by ratpack instrumentation
   public static final AttributeKey<Context> SERVER_ATTRIBUTE_KEY =
-      attributeKey(AttributeKeys.class.getName() + ".context");
+      AttributeKey.valueOf(AttributeKeys.class.getName() + ".context");
 
   public static final AttributeKey<Span> CLIENT_ATTRIBUTE_KEY =
-      attributeKey(AttributeKeys.class.getName() + ".span");
+      AttributeKey.valueOf(AttributeKeys.class.getName() + ".span");
 
   public static final AttributeKey<Context> CLIENT_PARENT_ATTRIBUTE_KEY =
-      attributeKey(AttributeKeys.class.getName() + ".parent");
-
-  /**
-   * Generate an attribute key or reuse the one existing in the global app map. This implementation
-   * creates attributes only once even if the current class is loaded by several class loaders and
-   * prevents an issue with Apache Atlas project were this class loaded by multiple class loaders,
-   * while the Attribute class is loaded by a third class loader and used internally for the
-   * cassandra driver.
-   */
-  private static <T> AttributeKey<T> attributeKey(String key) {
-    ConcurrentMap<String, AttributeKey<?>> classLoaderMap =
-        map.computeIfAbsent(AttributeKey.class.getClassLoader(), mapSupplier);
-    if (classLoaderMap.containsKey(key)) {
-      return (AttributeKey<T>) classLoaderMap.get(key);
-    }
-
-    AttributeKey<T> value = AttributeKey.valueOf(key);
-    classLoaderMap.put(key, value);
-    return value;
-  }
+      AttributeKey.valueOf(AttributeKeys.class.getName() + ".parent");
 }

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AttributeKeys.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AttributeKeys.java
@@ -11,16 +11,18 @@ import io.opentelemetry.context.Context;
 
 public class AttributeKeys {
 
-  public static final AttributeKey<Context> CONNECT_CONTEXT_ATTRIBUTE_KEY =
+  public static final AttributeKey<Context> CONNECT_CONTEXT =
       AttributeKey.valueOf(AttributeKeys.class, "connect-context");
 
-  // this attribute key is also used by ratpack instrumentation
-  public static final AttributeKey<Context> SERVER_ATTRIBUTE_KEY =
+  // this is the context that has the server span
+  //
+  // note: this attribute key is also used by ratpack instrumentation
+  public static final AttributeKey<Context> SERVER_SPAN =
       AttributeKey.valueOf(AttributeKeys.class, "server-span");
 
-  public static final AttributeKey<Span> CLIENT_ATTRIBUTE_KEY =
+  public static final AttributeKey<Span> CLIENT_SPAN =
       AttributeKey.valueOf(AttributeKeys.class, "client-span");
 
-  public static final AttributeKey<Context> CLIENT_PARENT_ATTRIBUTE_KEY =
+  public static final AttributeKey<Context> CLIENT_PARENT_CONTEXT =
       AttributeKey.valueOf(AttributeKeys.class, "client-parent-context");
 }

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AttributeKeys.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AttributeKeys.java
@@ -12,15 +12,15 @@ import io.opentelemetry.context.Context;
 public class AttributeKeys {
 
   public static final AttributeKey<Context> CONNECT_CONTEXT_ATTRIBUTE_KEY =
-      AttributeKey.valueOf(AttributeKeys.class, "connect.context");
+      AttributeKey.valueOf(AttributeKeys.class, "connect-context");
 
   // this attribute key is also used by ratpack instrumentation
   public static final AttributeKey<Context> SERVER_ATTRIBUTE_KEY =
-      AttributeKey.valueOf(AttributeKeys.class.getName() + ".context");
+      AttributeKey.valueOf(AttributeKeys.class, "server-span");
 
   public static final AttributeKey<Span> CLIENT_ATTRIBUTE_KEY =
-      AttributeKey.valueOf(AttributeKeys.class.getName() + ".span");
+      AttributeKey.valueOf(AttributeKeys.class, "client-span");
 
   public static final AttributeKey<Context> CLIENT_PARENT_ATTRIBUTE_KEY =
-      AttributeKey.valueOf(AttributeKeys.class.getName() + ".parent");
+      AttributeKey.valueOf(AttributeKeys.class, "client-parent-context");
 }

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/ChannelFutureListenerInstrumentation.java
@@ -58,8 +58,7 @@ final class ChannelFutureListenerInstrumentation implements TypeInstrumentation 
       if (cause == null) {
         return null;
       }
-      Context parentContext =
-          future.channel().attr(AttributeKeys.CONNECT_CONTEXT_ATTRIBUTE_KEY).getAndRemove();
+      Context parentContext = future.channel().attr(AttributeKeys.CONNECT_CONTEXT).getAndRemove();
       if (parentContext == null) {
         return null;
       }

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
@@ -131,8 +131,7 @@ final class NettyChannelPipelineInstrumentation implements TypeInstrumentation {
   public static class ChannelPipelineConnectAdvice {
     @Advice.OnMethodEnter
     public static void addParentSpan(@Advice.This ChannelPipeline pipeline) {
-      Attribute<Context> attribute =
-          pipeline.channel().attr(AttributeKeys.CONNECT_CONTEXT_ATTRIBUTE_KEY);
+      Attribute<Context> attribute = pipeline.channel().attr(AttributeKeys.CONNECT_CONTEXT);
       attribute.compareAndSet(null, Java8BytecodeBridge.currentContext());
     }
   }

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/HttpClientRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/HttpClientRequestTracingHandler.java
@@ -29,19 +29,18 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
     // TODO pass Context into Tracer.startSpan() and then don't need this scoping
     Scope parentScope = null;
-    Context parentContext =
-        ctx.channel().attr(AttributeKeys.CONNECT_CONTEXT_ATTRIBUTE_KEY).getAndRemove();
+    Context parentContext = ctx.channel().attr(AttributeKeys.CONNECT_CONTEXT).getAndRemove();
     if (parentContext != null) {
       parentScope = parentContext.makeCurrent();
     }
 
     HttpRequest request = (HttpRequest) msg;
 
-    ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY).set(Context.current());
+    ctx.channel().attr(AttributeKeys.CLIENT_PARENT_CONTEXT).set(Context.current());
 
     Span span = tracer().startSpan(request);
     NetPeerUtils.setNetPeer(span, (InetSocketAddress) ctx.channel().remoteAddress());
-    ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).set(span);
+    ctx.channel().attr(AttributeKeys.CLIENT_SPAN).set(span);
 
     try (Scope ignored = tracer().startScope(span, request.headers())) {
       ctx.write(msg, prm);

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/HttpClientResponseTracingHandler.java
@@ -20,9 +20,9 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
 
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) {
-    Attribute<Context> parentAttr = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_ATTRIBUTE_KEY);
+    Attribute<Context> parentAttr = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_CONTEXT);
     Context parentContext = parentAttr.get();
-    Span span = ctx.channel().attr(AttributeKeys.CLIENT_ATTRIBUTE_KEY).get();
+    Span span = ctx.channel().attr(AttributeKeys.CLIENT_SPAN).get();
 
     boolean finishSpan = msg instanceof HttpResponse;
 

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/NettyHttpServerTracer.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/NettyHttpServerTracer.java
@@ -42,12 +42,12 @@ public class NettyHttpServerTracer
 
   @Override
   protected void attachServerContext(Context context, Channel channel) {
-    channel.attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).set(context);
+    channel.attr(AttributeKeys.SERVER_SPAN).set(context);
   }
 
   @Override
   public Context getServerContext(Channel channel) {
-    return channel.attr(AttributeKeys.SERVER_ATTRIBUTE_KEY).get();
+    return channel.attr(AttributeKeys.SERVER_SPAN).get();
   }
 
   @Override

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/TracingHandler.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/TracingHandler.java
@@ -21,7 +21,7 @@ public final class TracingHandler implements Handler {
   @Override
   public void handle(Context ctx) {
     Attribute<io.opentelemetry.context.Context> spanAttribute =
-        ctx.getDirectChannelAccess().getChannel().attr(AttributeKeys.SERVER_ATTRIBUTE_KEY);
+        ctx.getDirectChannelAccess().getChannel().attr(AttributeKeys.SERVER_SPAN);
     io.opentelemetry.context.Context serverSpanContext = spanAttribute.get();
 
     // Relying on executor instrumentation to assume the netty span is in context as the parent.

--- a/instrumentation/reactor-netty-0.9/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/ReactorNettyInstrumentationModule.java
+++ b/instrumentation/reactor-netty-0.9/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/ReactorNettyInstrumentationModule.java
@@ -116,7 +116,7 @@ public final class ReactorNettyInstrumentationModule extends InstrumentationModu
     @Override
     public void accept(HttpClientRequest r, Connection c) {
       Context context = r.currentContext().get(MapConnect.CONTEXT_ATTRIBUTE);
-      c.channel().attr(AttributeKeys.CONNECT_CONTEXT_ATTRIBUTE_KEY).set(context);
+      c.channel().attr(AttributeKeys.CONNECT_CONTEXT).set(context);
     }
   }
 }


### PR DESCRIPTION
This logic appears to have been copied over unnecessarily from `netty-4.0` instrumentation.

`netty-4.1` has `AttributeKey.valueOf(..)` which serves the same purpose of ensuring AttributeKey uniqueness at the netty layer.