### PR TITLE
Add an AWS SDK type instrumentation on an 'entry point' type of class…

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInitializationInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInitializationInstrumentation.java
@@ -14,7 +14,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-final class AwsSdkInitializationInstrumentation implements TypeInstrumentation {
+public class AwsSdkInitializationInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<? super TypeDescription> typeMatcher() {
     // This is essentially the entry point of the AWS SDK, all clients implement it. We can ensure

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInitializationInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInitializationInstrumentation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
+import java.util.Collections;
+import java.util.Map;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+final class AwsSdkInitializationInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<? super TypeDescription> typeMatcher() {
+    // This is essentially the entry point of the AWS SDK, all clients implement it. We can ensure
+    // our interceptor service definition is injected as early as possible if we typematch against
+    // it.
+    return named("software.amazon.awssdk.core.SdkClient");
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    // Don't need to transform, just want to make sure helpers are injected as early as possible.
+    return Collections.emptyMap();
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInstrumentationModule.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
 
 import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
-import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
+import java.util.Arrays;
 import java.util.List;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -40,6 +40,7 @@ public class AwsSdkInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new AwsHttpClientInstrumentation());
+    return Arrays.asList(
+        new AwsHttpClientInstrumentation(), new AwsSdkInitializationInstrumentation());
   }
 }


### PR DESCRIPTION
… to ensure helper resources are injected before clients are made.

Working on #1643 brought to light that currently the AWS SDK type instrumentation runs too late since it only matches against `MakeHttpRequestStage` currently, something that happens during an SDK request. So the resource helper which registers our tracer only gets added after the first request is made, missing the first SDK client that is constructed. This currently isn't triggered by unit tests since the resource ends up on the classpath anyways without any injection.