### PR TITLE
Fix ByteBuddy tasks failing on daemon reuse.

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/collector/ReferenceCollector.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/collector/ReferenceCollector.java
@@ -16,6 +16,7 @@ import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.javaagent.tooling.muzzle.Reference;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLConnection;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -55,14 +56,7 @@ public class ReferenceCollector {
       String visitedClassName = instrumentationQueue.remove();
       visitedClasses.add(visitedClassName);
 
-      try (InputStream in =
-          checkNotNull(
-              ReferenceCollector.class
-                  .getClassLoader()
-                  .getResourceAsStream(Utils.getResourceName(visitedClassName)),
-              "Couldn't find class file %s",
-              visitedClassName)) {
-
+      try (InputStream in = getClassFileStream(visitedClassName)) {
         // only start from method bodies for the advice class (skips class/method references)
         ReferenceCollectingClassVisitor cv = new ReferenceCollectingClassVisitor(isAdviceClass);
         ClassReader reader = new ClassReader(in);
@@ -89,6 +83,24 @@ public class ReferenceCollector {
         isAdviceClass = false;
       }
     }
+  }
+
+  private static InputStream getClassFileStream(String className) throws IOException {
+    URLConnection connection =
+        checkNotNull(
+                ReferenceCollector.class
+                    .getClassLoader()
+                    .getResource(Utils.getResourceName(className)),
+                "Couldn't find class file %s",
+                className)
+            .openConnection();
+
+    // Since the JarFile cache is not per class loader, but global with path as key, using cache may
+    // cause the same instance of JarFile being used for consecutive builds, even if the file has
+    // been changed. There is still another cache in ZipFile.Source which checks last modified time
+    // as well, so the zip index is not scanned again on every class.
+    connection.setUseCaches(false);
+    return connection.getInputStream();
   }
 
   private void addReference(String refClassName, Reference reference) {


### PR DESCRIPTION
Fixes #1674. The issue was caused by a global `JarFile` cache in the JDK which caches `JarFile` instances with path as key globally with no regard to file modification times. This caused the same instance to be used across several builds in the daemon, which breaks when the file is rebuilt in between two invocations of the same task. The fix is to disable the use of cache when loading class file streams in `ReferenceCollector`.