### PR TITLE
Inject context into AWS SDK 2.2 HTTP request from interceptor.

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkInjectAdapter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkInjectAdapter.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v2_2;
+
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+final class AwsSdkInjectAdapter implements TextMapPropagator.Setter<SdkHttpRequest.Builder> {
+
+  static final AwsSdkInjectAdapter INSTANCE = new AwsSdkInjectAdapter();
+
+  @Override
+  public void set(SdkHttpRequest.Builder builder, String name, String value) {
+    builder.appendHeader(name, value);
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -148,7 +148,7 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         }
       }
     }
-    server.lastRequest.headers.get("traceparent") == null
+    server.lastRequest.headers.get("traceparent") != null
   }
 
   static dynamoDbRequestDataTable(client) {
@@ -226,7 +226,7 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         }
       }
     }
-    server.lastRequest.headers.get("traceparent") == null
+    server.lastRequest.headers.get("traceparent") != null
 
     where:
     service   | operation           | method | path                  | requestId                              | builder                 | call                                                                                             | body
@@ -314,7 +314,7 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         }
       }
     }
-    server.lastRequest.headers.get("traceparent") == null
+    server.lastRequest.headers.get("traceparent") != null
 
     where:
     service | operation           | method | path                  | requestId                              | builder                  | call                                                                                                                             | body


### PR DESCRIPTION
Back in the day, we added logic to make sure downstream HTTP instrumentation like Apache, Netty don't create client spans and therefore don't inject context. But we never updated the SDK to inject - it's safe to inject in the SDK because the injected headers will get signed. This is also required for full functionality with X-Ray.

Fixes #1728
/cc @jamal