### PR TITLE
Enable caching of bytebuddy cache.

### DIFF
--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ByteBuddyPluginConfigurator.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ByteBuddyPluginConfigurator.java
@@ -68,6 +68,7 @@ public class ByteBuddyPluginConfigurator {
   private Task createLanguageTask(AbstractCompile compileTask, String name) {
     ByteBuddySimpleTask task = project.getTasks().create(name, ByteBuddySimpleTask.class);
     task.setGroup("Byte Buddy");
+    task.getOutputs().cacheIf(unused -> true);
 
     File classesDirectory = compileTask.getDestinationDir();
     File rawClassesDirectory =


### PR DESCRIPTION
I noticed bytebuddyjava task is never cached, and it seems like rerunning it causes downstream tasks like tests to always run. Allowing it to be cached fixes this - I could confirm that now `./gradlew test` `./gradlew clean` `./gradlew test` is fast, before it reran tests every single time.

That being said, I'm a bit nervous of this change since I would expect bytebuddyjava to be deterministic and not affect downstream tasks - @agoallikmaa can you doublecheck there isn't anything else wrong with the task to make sure us caching it won't cause any pollution?