### PR TITLE
Replace java test version rule with property.

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -76,7 +76,7 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          command: ./gradlew testJava${{ matrix.java }} --stacktrace -Dorg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }}
+          command: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -Dorg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }}
           timeout_minutes: 180
           max_attempts: 3
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Test
         uses: nick-invision/retry@v2.2.0
         with:
-          command: ./gradlew testJava${{ matrix.java }} --stacktrace -x :smoke-tests:test -Dorg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }}
+          command: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -x :smoke-tests:test -Dorg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }}
           timeout_minutes: 90
           max_attempts: 3
 

--- a/docs/contributing/running-tests.md
+++ b/docs/contributing/running-tests.md
@@ -22,8 +22,9 @@ instrumented library.
 
 #### Executing tests with specific java version
 
-We run all tests on Java 11 by default, along with Java 8 and 15. To run on the later, use
-`./gradlew testJava8` or `./gradlew testJava15`. If you don't have a JDK of these versions
+We run all tests on Java 11 by default, along with Java 8 and 15. To run on the later, set the
+`testJavaVersion` Gradle property to the desired major version, e.g., `./gradlew test -PtestJavaVersion=8`,
+`./gradlew test -PtestJavaVersion=15`. If you don't have a JDK of these versions
 installed, Gradle will automatically download it for you.
 
 #### Executing tests against the latest versions of libraries under instrumentation

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -194,43 +194,31 @@ def isJavaVersionAllowed(JavaVersion version) {
   return true
 }
 
-// We default to testing with Java 11 for most tests, but some tests don't support it, where we change
-// the default test task's version so commands like `./gradlew check` can test all projects regardless
-// of Java version.
-if (!isJavaVersionAllowed(JavaVersion.toVersion(DEFAULT_JAVA_VERSION))) {
-  tasks.withType(Test) {
-    javaLauncher = javaToolchains.launcherFor {
-      languageVersion = JavaLanguageVersion.of(project.getProperty('maxJavaVersionForTests').majorVersion)
+def testJavaVersion = rootProject.findProperty('testJavaVersion')
+if (testJavaVersion != null) {
+  def requestedJavaVersion = JavaVersion.toVersion(testJavaVersion)
+  def gradleJavaVersion = JavaVersion.current()
+
+  if (gradleJavaVersion != requestedJavaVersion) {
+    tasks.withType(Test).all {
+      javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(requestedJavaVersion.majorVersion)
+      }
+      enabled = isJavaVersionAllowed(requestedJavaVersion)
     }
   }
-}
-
-def addTestRule(String testTaskName) {
-  def prefix = testTaskName + "Java"
-  tasks.addRule("Pattern: $prefix<Version>: Runs tests using given java version") { String taskName ->
-    if (taskName.startsWith(prefix)) {
-      def requestedJavaVersion = JavaVersion.toVersion(taskName - prefix)
-      def gradleJavaVersion = JavaVersion.current()
-
-      if (gradleJavaVersion != requestedJavaVersion) {
-        tasks.withType(Test).all {
-          javaLauncher = javaToolchains.launcherFor {
-            languageVersion = JavaLanguageVersion.of(requestedJavaVersion.majorVersion)
-          }
-          enabled = isJavaVersionAllowed(requestedJavaVersion)
-        }
-      }
-
-      task(taskName) {
-        if (project.tasks.findByName(testTaskName) != null) {
-          dependsOn testTaskName
-        }
+} else {
+  // We default to testing with Java 11 for most tests, but some tests don't support it, where we change
+  // the default test task's version so commands like `./gradlew check` can test all projects regardless
+  // of Java version.
+  if (!isJavaVersionAllowed(JavaVersion.toVersion(DEFAULT_JAVA_VERSION))) {
+    tasks.withType(Test) {
+      javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(project.getProperty('maxJavaVersionForTests').majorVersion)
       }
     }
   }
 }
-
-addTestRule("test")
 
 tasks.withType(Test).configureEach {
   useJUnitPlatform()

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -228,7 +228,9 @@ tasks.withType(Test).configureEach {
   timeout = Duration.ofMinutes(15)
 
   // Disable all tests if skipTests property was specified
-  enabled = !project.rootProject.hasProperty("skipTests")
+  if (enabled) {
+    enabled = !project.rootProject.hasProperty("skipTests")
+  }
 
   retry {
     // You can see tests that were retried by this mechanism in the collected test reports and build scans.

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -227,11 +227,6 @@ tasks.withType(Test).configureEach {
   // This value is quite big because with lower values (3 mins) we were experiencing large number of false positives
   timeout = Duration.ofMinutes(15)
 
-  // Disable all tests if skipTests property was specified
-  if (enabled) {
-    enabled = !project.rootProject.hasProperty("skipTests")
-  }
-
   retry {
     // You can see tests that were retried by this mechanism in the collected test reports and build scans.
     maxRetries = System.getenv("CI") != null ? 5 : 0


### PR DESCRIPTION
The rule has always been a bit fishy, e.g., `./gradlew testJava8 testJava15` isn't well defined (I guess it runs the build with Java 15). While debugging, I found myself scratching my head on how to do something like `./gradlew clean -PtestJavaVersion=15`, which may not actually be any different with or without the property but would make sure the configuration is identical when cleaning vs building.