### PR TITLE
Inject context for aws sdk 1.11 requests too.

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkClientTracer.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkClientTracer.java
@@ -10,8 +10,6 @@ import com.amazonaws.AmazonWebServiceResponse;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator.Setter;
 import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer;
 import java.net.URI;
@@ -63,15 +61,6 @@ public class AwsSdkClientTracer extends HttpClientTracer<Request<?>, Request<?>,
     return span;
   }
 
-  /**
-   * Override startScope not to inject context into the request since no need to propagate context
-   * to AWS backend services.
-   */
-  @Override
-  public Scope startScope(Span span, Request<?> request) {
-    return Context.current().with(span).with(CONTEXT_CLIENT_SPAN_KEY, span).makeCurrent();
-  }
-
   @Override
   public Span onResponse(Span span, Response<?> response) {
     if (response != null && response.getAwsResponse() instanceof AmazonWebServiceResponse) {
@@ -121,7 +110,7 @@ public class AwsSdkClientTracer extends HttpClientTracer<Request<?>, Request<?>,
 
   @Override
   protected Setter<Request<?>> getSetter() {
-    return null;
+    return AwsSdkInjectAdapter.INSTANCE;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkInjectAdapter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkInjectAdapter.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.awssdk.v1_11;
+
+import com.amazonaws.Request;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+
+final class AwsSdkInjectAdapter implements TextMapPropagator.Setter<Request<?>> {
+
+  static final AwsSdkInjectAdapter INSTANCE = new AwsSdkInjectAdapter();
+
+  @Override
+  public void set(Request<?> request, String name, String value) {
+    request.addHeader(name, value);
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/TracingRequestHandler.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/TracingRequestHandler.java
@@ -27,11 +27,6 @@ public class TracingRequestHandler extends RequestHandler2 {
   }
 
   @Override
-  public AmazonWebServiceRequest beforeMarshalling(AmazonWebServiceRequest request) {
-    return request;
-  }
-
-  @Override
   public void beforeRequest(Request<?> request) {
     AmazonWebServiceRequest originalRequest = request.getOriginalRequest();
     RequestMeta requestMeta = contextStore.get(originalRequest);

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/Aws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/Aws1ClientTest.groovy
@@ -160,7 +160,7 @@ class Aws1ClientTest extends AgentTestRunner {
         }
       }
     }
-    server.lastRequest.headers.get("traceparent") == null
+    server.lastRequest.headers.get("traceparent") != null
 
     where:
     service      | operation           | method | path                  | handlerCount | client                                                                                                                                             | call                                                                            | additionalAttributes              | body

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -123,7 +123,7 @@ class Aws0ClientTest extends AgentTestRunner {
         }
       }
     }
-    server.lastRequest.headers.get("traceparent") == null
+    server.lastRequest.headers.get("traceparent") != null
 
     where:
     service | operation           | method | path                  | handlerCount | client                                                                      | additionalAttributes              | call                                                                                                                                   | body


### PR DESCRIPTION
Comment is wrong - backend benefits greatly from a trace header :)