### PR TITLE
Use -P correctly instead of -D for specifying toolchain paths

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,8 +6,8 @@ on:
     - cron: "24 3 * * *"
   workflow_dispatch:
   push:
-    #branches:
-    #  - master
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,8 +6,8 @@ on:
     - cron: "24 3 * * *"
   workflow_dispatch:
   push:
-    branches:
-      - master
+    #branches:
+    #  - master
 
 jobs:
   build:
@@ -76,7 +76,7 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          command: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -Dorg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }}
+          command: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -Dorg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-detect=false
           timeout_minutes: 180
           max_attempts: 3
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -76,7 +76,7 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         with:
-          command: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -Dorg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-detect=false
+          command: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
           timeout_minutes: 180
           max_attempts: 3
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Test
         uses: nick-invision/retry@v2.2.0
         with:
-          command: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -x :smoke-tests:test -Dorg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }}
+          command: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -x :smoke-tests:test -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
           timeout_minutes: 90
           max_attempts: 3
 


### PR DESCRIPTION
And add flag to disable autodownload to better catch this.

No clue why this seems to make our build go from turtle to rabbit (or was it the turtle that's actually faster, forget...)