### PR TITLE
open AWS lambda wrapper for extensions

### DIFF
--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapper.java
@@ -12,5 +12,5 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
  * Wrapper for {@link TracingRequestHandler}. Allows for wrapping a lambda proxied through API
  * Gateway, enabling single span tracing and HTTP context propagation.
  */
-public final class TracingRequestApiGatewayWrapper
+public class TracingRequestApiGatewayWrapper
     extends TracingRequestWrapperBase<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {}

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapper.java
@@ -9,4 +9,4 @@ package io.opentelemetry.instrumentation.awslambda.v1_0;
  * Wrapper for {@link TracingRequestHandler}. Allows for wrapping a regular lambda, not proxied
  * through API Gateway. Therefore, HTTP headers propagation is not supported.
  */
-public final class TracingRequestWrapper extends TracingRequestWrapperBase<Object, Object> {}
+public class TracingRequestWrapper extends TracingRequestWrapperBase<Object, Object> {}


### PR DESCRIPTION
Cosmetic change - removing "final" modifier from wrappers. Makes extension (eg for configuration purposes) possible. We actually have such use case in Splunk currently.  