### PR TITLE
Sign artifacts in build instead of in bintray.

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -151,6 +151,8 @@ jobs:
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
         run: ./gradlew snapshot --stacktrace
 
   issue:

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -74,3 +74,5 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRGIT_USER: ${{ github.actor }}
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,3 +27,5 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRGIT_USER: ${{ github.actor }}
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'com.jfrog.bintray'
 
@@ -103,10 +104,6 @@ bintray {
       name = project.version
       released = new Date()
 
-      gpg {
-        sign = true
-      }
-
       mavenCentralSync {
         user = System.getenv("SONATYPE_USER")
         password = System.getenv("SONATYPE_KEY")
@@ -132,4 +129,13 @@ artifactory {
 artifactoryPublish {
   enabled = version.toString().contains('SNAPSHOT')
   publications('maven')
+}
+
+tasks.withType(Sign).configureEach {
+  onlyIf { System.getenv("CI") != null }
+}
+
+signing {
+  useInMemoryPgpKeys(System.getenv("GPG_PRIVATE_KEY"), System.getenv("GPG_PASSWORD"))
+  sign publishing.publications.maven
 }


### PR DESCRIPTION
We don't have to do this, but figured I'd whip it up as an idea.

This configures the build to sign artifacts instead of using Bintray's global key. This allows users to verify that the signing key is indeed owned by OTel (perhaps using Nexus Pro and a strict verification policy), possibly reduces some load on Bintray during publishing, and gives some flexibility if we want to try other publishing options.

For now, I just made a key for OpenTelemetry Java

```
pub   rsa2048 2020-11-27 [SC]
      3F05DDA9F317301E927136D417A27CE7A60FF5F0
uid           [ultimate] OpenTelemetry Java
sub   rsa2048 2020-11-27 [E]
```
`gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys  3F05DDA9F317301E927136D417A27CE7A60FF5F0`

We can change the key as we want to - not sure if it makes sense to have a global GPG key for OTel or stick with one for OTel Java. Otherwise, I'd need a way to share this key with other maintainers, especially the revocation key.