### PR TITLE
Remove servlet.context span attribute from JSP instrumentation

### DIFF
--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/HttpJspPageInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/HttpJspPageInstrumentation.java
@@ -54,7 +54,6 @@ public class HttpJspPageInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelSpan") Span span,
         @Advice.Local("otelScope") Scope scope) {
       span = tracer().startSpan(tracer().spanNameOnRender(req), Kind.INTERNAL);
-      span.setAttribute("servlet.context", req.getContextPath());
       tracer().onRender(span, req);
       scope = span.makeCurrent();
     }

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/JspTracer.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/JspTracer.java
@@ -10,7 +10,6 @@ import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.HttpJspPage;
 import org.apache.jasper.JspCompilationContext;
@@ -32,11 +31,6 @@ public class JspTracer extends BaseTracer {
 
   public void onCompile(Span span, JspCompilationContext jspCompilationContext) {
     if (jspCompilationContext != null) {
-      ServletContext servletContext = jspCompilationContext.getServletContext();
-      if (servletContext != null) {
-        span.setAttribute("servlet.context", servletContext.getContextPath());
-      }
-
       Compiler compiler = jspCompilationContext.getCompiler();
       if (compiler != null) {
         span.setAttribute("jsp.compiler", compiler.getClass().getName());

--- a/instrumentation/jsp-2.3/src/test/groovy/JspInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/src/test/groovy/JspInstrumentationBasicTests.groovy
@@ -113,7 +113,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Compile /$jspFileName"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -123,7 +122,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Render /$jspFileName"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -174,7 +172,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Compile /getQuery.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.getQuery_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -184,7 +181,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Render /getQuery.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -232,7 +228,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Compile /post.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.post_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -242,7 +237,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Render /post.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -299,7 +293,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Compile /$jspFileName"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -321,7 +314,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
             }
           }
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -371,7 +363,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Compile /includes/includeHtml.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -381,7 +372,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Render /includes/includeHtml.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -425,7 +415,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Compile /includes/includeMulti.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -435,7 +424,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Render /includes/includeMulti.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -444,7 +432,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Compile /common/javaLoopH2.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -454,7 +441,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Render /common/javaLoopH2.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -463,7 +449,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Compile /common/javaLoopH2.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -473,7 +458,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           name "Render /common/javaLoopH2.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -519,7 +503,6 @@ class JspInstrumentationBasicTests extends AgentTestRunner {
           errored true
           errorEvent(JasperException, String)
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }

--- a/instrumentation/jsp-2.3/src/test/groovy/JspInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/src/test/groovy/JspInstrumentationForwardTests.groovy
@@ -111,7 +111,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /$forwardFromFileName"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -121,7 +120,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /$forwardFromFileName"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -130,7 +128,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /$forwardDestFileName"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardDestClassPrefix$jspForwardDestClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -140,7 +137,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /$forwardDestFileName"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/$forwardFromFileName"
             "jsp.requestURL" baseUrl + "/$forwardDestFileName"
           }
@@ -190,7 +186,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /forwards/forwardToHtml.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -200,7 +195,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /forwards/forwardToHtml.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -244,7 +238,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /forwards/forwardToIncludeMulti.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -254,7 +247,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /forwards/forwardToIncludeMulti.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -263,7 +255,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /includes/includeMulti.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -273,7 +264,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /includes/includeMulti.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
           }
@@ -283,7 +273,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /common/javaLoopH2.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -293,7 +282,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /common/javaLoopH2.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
           }
@@ -303,7 +291,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /common/javaLoopH2.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -313,7 +300,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /common/javaLoopH2.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
           }
@@ -358,7 +344,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /forwards/forwardToJspForward.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -368,7 +353,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /forwards/forwardToJspForward.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -377,7 +361,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /forwards/forwardToSimpleJava.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -387,7 +370,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /forwards/forwardToSimpleJava.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
             "jsp.requestURL" baseUrl + "/forwards/forwardToSimpleJava.jsp"
           }
@@ -397,7 +379,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /common/loop.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.loop_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -407,7 +388,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /common/loop.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
             "jsp.requestURL" baseUrl + "/common/loop.jsp"
           }
@@ -453,7 +433,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /forwards/forwardToCompileError.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -464,7 +443,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           errored true
           errorEvent(JasperException, String)
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }
@@ -474,7 +452,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           errored true
           errorEvent(JasperException, String)
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.compileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -519,7 +496,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Compile /forwards/forwardToNonExistent.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToNonExistent_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
@@ -529,7 +505,6 @@ class JspInstrumentationForwardTests extends AgentTestRunner {
           name "Render /forwards/forwardToNonExistent.jsp"
           errored false
           attributes {
-            "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
           }
         }


### PR DESCRIPTION
We aren't capturing this attribute anywhere else anymore, I think it was just oversight that it didn't get removed from JSP isntrumentation.