### PR TITLE
Update more config property names

### DIFF
--- a/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
+++ b/instrumentation/executors/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
@@ -29,7 +29,7 @@ public abstract class AbstractExecutorInstrumentation implements TypeInstrumenta
       "otel.instrumentation.executors.include";
 
   private static final String EXECUTORS_INCLUDE_ALL_PROPERTY_NAME =
-      "otel.instrumentation.executors.includeAll";
+      "otel.instrumentation.executors.include-all";
 
   // hopefully these configuration properties can be static after
   // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1345

--- a/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixTracer.java
+++ b/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixTracer.java
@@ -20,7 +20,7 @@ public class HystrixTracer extends BaseTracer {
   private final boolean extraTags;
 
   private HystrixTracer() {
-    extraTags = Config.get().getBooleanProperty("otel.hystrix.tags.enabled", false);
+    extraTags = Config.get().getBooleanProperty("otel.instrumentation.hystrix.tags", false);
   }
 
   @Override

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -14,15 +14,12 @@ import rx.schedulers.Schedulers
 
 class HystrixObservableChainTest extends AgentTestRunner {
   static {
-    // Disable so failure testing below doesn't inadvertently change the behavior.
-    System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
-
     // Uncomment for debugging:
     // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")
   }
 
   static final PREVIOUS_CONFIG = ConfigUtils.updateConfig {
-    it.setProperty("otel.hystrix.tags.enabled", "true")
+    it.setProperty("otel.instrumentation.hystrix.tags", "true")
   }
 
   def cleanupSpec() {

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -14,6 +14,9 @@ import rx.schedulers.Schedulers
 
 class HystrixObservableChainTest extends AgentTestRunner {
   static {
+    // Disable so failure testing below doesn't inadvertently change the behavior.
+    System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
+
     // Uncomment for debugging:
     // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")
   }

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -18,15 +18,12 @@ import rx.schedulers.Schedulers
 
 class HystrixObservableTest extends AgentTestRunner {
   static {
-    // Disable so failure testing below doesn't inadvertently change the behavior.
-    System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
-
     // Uncomment for debugging:
     // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")
   }
 
   static final PREVIOUS_CONFIG = ConfigUtils.updateConfig {
-    it.setProperty("otel.hystrix.tags.enabled", "true")
+    it.setProperty("otel.instrumentation.hystrix.tags", "true")
   }
 
   def cleanupSpec() {

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -18,6 +18,9 @@ import rx.schedulers.Schedulers
 
 class HystrixObservableTest extends AgentTestRunner {
   static {
+    // Disable so failure testing below doesn't inadvertently change the behavior.
+    System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
+
     // Uncomment for debugging:
     // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")
   }

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -16,6 +16,9 @@ import spock.lang.Timeout
 @Timeout(10)
 class HystrixTest extends AgentTestRunner {
   static {
+    // Disable so failure testing below doesn't inadvertently change the behavior.
+    System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
+
     // Uncomment for debugging:
     // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")
   }

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -16,15 +16,12 @@ import spock.lang.Timeout
 @Timeout(10)
 class HystrixTest extends AgentTestRunner {
   static {
-    // Disable so failure testing below doesn't inadvertently change the behavior.
-    System.setProperty("hystrix.command.default.circuitBreaker.enabled", "false")
-
     // Uncomment for debugging:
     // System.setProperty("hystrix.command.default.execution.timeout.enabled", "false")
   }
 
   static final PREVIOUS_CONFIG = ConfigUtils.updateConfig {
-    it.setProperty("otel.hystrix.tags.enabled", "true")
+    it.setProperty("otel.instrumentation.hystrix.tags", "true")
   }
 
   def cleanupSpec() {

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaClientConfiguration.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaClientConfiguration.java
@@ -10,7 +10,7 @@ import io.opentelemetry.instrumentation.api.config.Config;
 public final class KafkaClientConfiguration {
 
   public static boolean isPropagationEnabled() {
-    return Config.get().getBooleanProperty("otel.kafka.client.propagation.enabled", true);
+    return Config.get().getBooleanProperty("otel.instrumentation.kafka.client-propagation", true);
   }
 
   private KafkaClientConfiguration() {}

--- a/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -3,16 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import static io.opentelemetry.api.trace.Span.Kind.CONSUMER
+import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 import static io.opentelemetry.instrumentation.test.utils.ConfigUtils.setConfig
 import static io.opentelemetry.instrumentation.test.utils.ConfigUtils.updateConfig
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
-import static io.opentelemetry.api.trace.Span.Kind.CONSUMER
-import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 
+import io.opentelemetry.api.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.api.config.Config
 import io.opentelemetry.instrumentation.test.AgentTestRunner
-import io.opentelemetry.api.trace.attributes.SemanticAttributes
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -613,7 +614,7 @@ class KafkaClientTest extends AgentTestRunner {
 
   private static Config setPropagation(boolean propagationEnabled) {
     return updateConfig {
-      it.setProperty("otel.kafka.client.propagation.enabled", Boolean.toString(propagationEnabled))
+      it.setProperty("otel.instrumentation.kafka.client-propagation", Boolean.toString(propagationEnabled))
     }
   }
 }

--- a/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.Span.Kind.CONSUMER
 import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 import static io.opentelemetry.instrumentation.test.utils.ConfigUtils.setConfig

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TracerInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TracerInstaller.java
@@ -33,8 +33,8 @@ public class TracerInstaller {
   private static final Logger log = LoggerFactory.getLogger(TracerInstaller.class);
 
   private static final String EXPORTER_JAR_CONFIG = "otel.exporter.jar";
-  private static final String EXPORTERS_CONFIG = "otel.exporter";
-  private static final String PROPAGATORS_CONFIG = "otel.propagators";
+  private static final String EXPORTERS_CONFIG = "otel.exporter"; // this name is from spec
+  private static final String PROPAGATORS_CONFIG = "otel.propagators"; // this name is from spec
   private static final String JAVAAGENT_ENABLED_CONFIG = "otel.javaagent.enabled";
   private static final List<String> DEFAULT_EXPORTERS = Collections.singletonList("otlp");
 


### PR DESCRIPTION
Following convention discussed in #1414:

* `otel.instrumentation.executors.includeAll` --> `otel.instrumentation.executors.include-all`
* `otel.hystrix.tags.enabled` --> `otel.instrumentation.hystrix.tags`
* `otel.kafka.client.propagation.enabled` --> `otel.instrumentation.kafka.client-propagation`