### PR TITLE
Configure maven-publish for uploading to bintray instead of bintray p…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ import nebula.plugin.release.git.opinion.Strategies
 plugins {
   id 'idea'
 
-  id "com.jfrog.artifactory" version "4.18.1" apply false
   id "nebula.release" version "15.3.0"
 
   id 'org.gradle.test-retry' version '1.2.0' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
   id 'idea'
 
   id "com.jfrog.artifactory" version "4.18.1" apply false
-  id 'com.jfrog.bintray' version '1.8.5' apply false
   id "nebula.release" version "15.3.0"
 
   id 'org.gradle.test-retry' version '1.2.0' apply false

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-apply plugin: 'com.jfrog.artifactory'
 
 publishing {
   repositories {
     maven {
-      url = "https://api.bintray.com/maven/open-telemetry/maven/opentelemetry-java-instrumentation/"
+      url = version.toString().contains('SNAPSHOT')
+        ? "https://oss.jfrog.org/artifactory/oss-snapshot-local/"
+        : "https://api.bintray.com/maven/open-telemetry/maven/opentelemetry-java-instrumentation/"
       credentials {
         username = System.getenv('BINTRAY_USER')
         password = System.getenv('BINTRAY_API_KEY')
@@ -88,25 +89,7 @@ private String artifactPrefix(Project p, String archivesBaseName) {
   return 'opentelemetry-'
 }
 
-// Snapshot publishing.
-artifactory {
-  contextUrl = 'https://oss.jfrog.org'
-  publish {
-    repository {
-      repoKey = 'oss-snapshot-local'
-      username = System.getenv("BINTRAY_USER")
-      password = System.getenv("BINTRAY_API_KEY")
-    }
-  }
-}
-
-tasks.publish.enabled = !version.toString().contains('SNAPSHOT')
 rootProject.tasks.release.finalizedBy tasks.publish
-
-artifactoryPublish {
-  enabled = version.toString().contains('SNAPSHOT')
-  publications('maven')
-}
 
 tasks.withType(Sign).configureEach {
   onlyIf { System.getenv("CI") != null }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,14 +1,18 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: 'com.jfrog.artifactory'
-apply plugin: 'com.jfrog.bintray'
 
 publishing {
   repositories {
     maven {
-      url = "$rootDir/build/repo"
+      url = "https://api.bintray.com/maven/open-telemetry/maven/opentelemetry-java-instrumentation/"
+      credentials {
+        username = System.getenv('BINTRAY_USER')
+        password = System.getenv('BINTRAY_API_KEY')
+      }
     }
   }
+
   publications {
     maven(MavenPublication) {
       if (project.tasks.findByName("shadowJar") != null && !findProperty('noShadowPublish')) {
@@ -84,36 +88,6 @@ private String artifactPrefix(Project p, String archivesBaseName) {
   return 'opentelemetry-'
 }
 
-bintray {
-  user = System.getenv('BINTRAY_USER')
-  key = System.getenv('BINTRAY_API_KEY')
-  publications = ['maven']
-  publish = false
-  pkg {
-    repo = 'maven'
-    name = 'opentelemetry-java-instrumentation'
-    licenses = ['Apache-2.0']
-    websiteUrl = 'https://github.com/open-telemetry/opentelemetry-java-instrumentation'
-    issueTrackerUrl = 'https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues'
-    vcsUrl = 'https://github.com/open-telemetry/opentelemetry-java-instrumentation.git'
-    userOrg = 'open-telemetry'
-
-    githubRepo = 'open-telemetry/opentelemetry-java-instrumentation'
-
-    version {
-      name = project.version
-      released = new Date()
-
-      mavenCentralSync {
-        user = System.getenv("SONATYPE_USER")
-        password = System.getenv("SONATYPE_KEY")
-      }
-    }
-  }
-}
-
-bintrayUpload.enabled = !version.toString().contains('SNAPSHOT')
-
 // Snapshot publishing.
 artifactory {
   contextUrl = 'https://oss.jfrog.org'
@@ -125,6 +99,9 @@ artifactory {
     }
   }
 }
+
+tasks.publish.enabled = !version.toString().contains('SNAPSHOT')
+rootProject.tasks.release.finalizedBy tasks.publish
 
 artifactoryPublish {
   enabled = version.toString().contains('SNAPSHOT')


### PR DESCRIPTION
…lugin, and oss artifactory instead of artifactory plugin.

Let's try out the option of maven-publish to bintray instead of gradle bintray plugin. Even if we decide not to use bintray, it's simply just reconfiguring this repositories block.

https://jfrog.com/blog/publishing-your-maven-project-to-bintray/

This doesn't attempt to fully automate things yet (i.e., we would probably want to extend the workflows to call the bintray API to publish after uploading everything) - first let's see if it works more reliably (confirmed the artifacts get published by running locally, then deleting the uploaded files)