### PR TITLE
Migrate test docker images to GHCR.

### DIFF
--- a/.github/workflows/build-grpc-smoke-dist.yaml
+++ b/.github/workflows/build-grpc-smoke-dist.yaml
@@ -24,7 +24,11 @@ jobs:
           job-id: grpc-smoke
 
       - name: Login to GitHub Package Registry
-        run: docker login -u ${{ secrets.BINTRAY_USER }} -p ${{ secrets.BINTRAY_API_KEY }} open-telemetry-docker-dev.bintray.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build Docker Image
         run: |

--- a/.github/workflows/build-play-smoke-dist.yaml
+++ b/.github/workflows/build-play-smoke-dist.yaml
@@ -24,7 +24,11 @@ jobs:
           job-id: play-smoke
 
       - name: Login to GitHub Package Registry
-        run: docker login -u ${{ secrets.BINTRAY_USER }} -p ${{ secrets.BINTRAY_API_KEY }} open-telemetry-docker-dev.bintray.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build Docker Image
         run: |

--- a/.github/workflows/build-smoke-dist-fakebackend.yaml
+++ b/.github/workflows/build-smoke-dist-fakebackend.yaml
@@ -24,7 +24,11 @@ jobs:
           job-id: fakebackend-smoke
 
       - name: Login to GitHub Package Registry
-        run: docker login -u ${{ secrets.BINTRAY_USER }} -p ${{ secrets.BINTRAY_API_KEY }} open-telemetry-docker-dev.bintray.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build Docker Image
         run: |

--- a/.github/workflows/build-springboot-smoke-dist.yaml
+++ b/.github/workflows/build-springboot-smoke-dist.yaml
@@ -24,7 +24,11 @@ jobs:
           job-id: springboot-smoke
 
       - name: Login to GitHub Package Registry
-        run: docker login -u ${{ secrets.BINTRAY_USER }} -p ${{ secrets.BINTRAY_API_KEY }} open-telemetry-docker-dev.bintray.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build Docker Image
         run: |

--- a/smoke-tests/fake-backend/build.gradle
+++ b/smoke-tests/fake-backend/build.gradle
@@ -31,6 +31,5 @@ dependencies {
 
 jib {
   from.image = "gcr.io/distroless/java-debian10:11"
-  to.image = "open-telemetry-docker-dev.bintray.io/java/smoke-fake-backend"
-  to.tags = [new Date().format("yyyyMMdd.HHmmSS")]
+  to.image = "ghcr.io/open-telemetry/java-test-containers:smoke-fake-backend-${new Date().format("yyyyMMdd.HHmmSS")}"
 }

--- a/smoke-tests/grpc/build.gradle
+++ b/smoke-tests/grpc/build.gradle
@@ -41,6 +41,5 @@ def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
   from.image = "bellsoft/liberica-openjdk-alpine:$targetJDK"
-  to.image = "open-telemetry-docker-dev.bintray.io/java/smoke-grpc-jdk$targetJDK"
-  to.tags = [tag]
+  to.image = "ghcr.io/open-telemetry/java-test-containers:smoke-grpc-jdk$targetJDK-$tag"
 }

--- a/smoke-tests/play/build.gradle
+++ b/smoke-tests/play/build.gradle
@@ -41,7 +41,6 @@ def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
   from.image = "bellsoft/liberica-openjdk-alpine:$targetJDK"
-  to.image = "open-telemetry-docker-dev.bintray.io/java/smoke-play-jdk$targetJDK"
-  to.tags = [tag]
+  to.image = "ghcr.io/open-telemetry/java-test-containers:smoke-play-jdk$targetJDK-$tag"
   container.mainClass = "play.core.server.ProdServerStart"
 }

--- a/smoke-tests/springboot/build.gradle
+++ b/smoke-tests/springboot/build.gradle
@@ -36,6 +36,5 @@ def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
   from.image = "bellsoft/liberica-openjdk-alpine:$targetJDK"
-  to.image = "open-telemetry-docker-dev.bintray.io/java/smoke-springboot-jdk$targetJDK"
-  to.tags = [tag]
+  to.image = "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk$targetJDK-$tag"
 }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GrpcSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GrpcSmokeTest.groovy
@@ -17,7 +17,7 @@ import spock.lang.Unroll
 class GrpcSmokeTest extends SmokeTest {
 
   protected String getTargetImage(int jdk) {
-    "open-telemetry-docker-dev.bintray.io/java/smoke-grpc-jdk$jdk:latest"
+    "ghcr.io/open-telemetry/java-test-containers:smoke-grpc-jdk$jdk-20201128.1734635"
   }
 
   @Unroll

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JaegerExporterSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JaegerExporterSmokeTest.groovy
@@ -15,7 +15,7 @@ import okhttp3.Request
 class JaegerExporterSmokeTest extends SmokeTest {
 
   protected String getTargetImage(int jdk) {
-    "open-telemetry-docker-dev.bintray.io/java/smoke-springboot-jdk$jdk:latest"
+    "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk$jdk-20201128.1734635"
   }
 
   @Override

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PlaySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PlaySmokeTest.groovy
@@ -11,7 +11,7 @@ import okhttp3.Request
 class PlaySmokeTest extends SmokeTest {
 
   protected String getTargetImage(int jdk) {
-    "open-telemetry-docker-dev.bintray.io/java/smoke-play-jdk$jdk:latest"
+    "ghcr.io/open-telemetry/java-test-containers:smoke-play-jdk$jdk-20201128.1734635"
   }
 
   def "play smoke test on JDK #jdk"(int jdk) {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
@@ -61,7 +61,7 @@ abstract class SmokeTest extends Specification {
   private GenericContainer collector
 
   def setupSpec() {
-    backend = new GenericContainer<>("open-telemetry-docker-dev.bintray.io/java/smoke-fake-backend:latest")
+    backend = new GenericContainer<>("ghcr.io/open-telemetry/java-test-containers:smoke-fake-backend-20201128.1734635")
       .withExposedPorts(8080)
       .waitingFor(Wait.forHttp("/health").forPort(8080))
       .withNetwork(network)

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -17,7 +17,7 @@ import spock.lang.Unroll
 class SpringBootSmokeTest extends SmokeTest {
 
   protected String getTargetImage(int jdk) {
-    "open-telemetry-docker-dev.bintray.io/java/smoke-springboot-jdk$jdk:20201120.373623860"
+    "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk$jdk-20201128.1734635"
   }
 
   @Unroll

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootWithSamplingSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootWithSamplingSmokeTest.groovy
@@ -15,7 +15,7 @@ class SpringBootWithSamplingSmokeTest extends SmokeTest {
   static final int ALLOWED_DEVIATION = 0.1 * NUM_TRIES
 
   protected String getTargetImage(int jdk) {
-    "open-telemetry-docker-dev.bintray.io/java/smoke-springboot-jdk$jdk:latest"
+    "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk$jdk-20201128.1734635"
   }
 
   @Override

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/ZipkinExporterSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/ZipkinExporterSmokeTest.groovy
@@ -11,7 +11,7 @@ import okhttp3.Request
 class ZipkinExporterSmokeTest extends SmokeTest{
 
   protected String getTargetImage(int jdk) {
-    "open-telemetry-docker-dev.bintray.io/java/smoke-springboot-jdk$jdk:latest"
+    "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk$jdk-20201128.1734635"
   }
 
   @Override


### PR DESCRIPTION
With the hopes that it is less flaky than bintray's docker repo. Pushed the images manually from my computer to bootstrap.

Also only references versioned images to allow updating smoke-tests without disrupting other PRs.