### PR TITLE
Just have accept-pr be a noop, which will naturally not succeed if de…

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -138,17 +138,11 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Run  muzzle
+      - name: Run muzzle
         run: ./gradlew ${{ matrix.module }}:muzzle --no-daemon
 
   accept-pr:
     needs: [ build, test, smoke-test, muzzle ]
     runs-on: ubuntu-latest
-    if: always()
     steps:
-      # run this action to get workflow conclusion
-      # You can get conclusion by env (env.WORKFLOW_CONCLUSION)
-      - uses: technote-space/workflow-conclusion-action@v1
-      - name: Fail build
-        if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure
-        run: exit 1
+      - run: echo "Build Succeeded"

--- a/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/ArmeriaServerTracer.java
+++ b/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/ArmeriaServerTracer.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.armeria.v1_0.server;
 
-import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria .common.HttpRequest;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.netty.util.AsciiString;


### PR DESCRIPTION
…pendencies fail.

Had `accept-pr` fail a perfectly good build on me. While I'm not sure, isn't it enough to have a no-op job instead of using the workflow-conclusion action?