### PR TITLE
Rename auto annotations to ext annotations

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -39,58 +39,58 @@ ext {
 
   deps = [
     // OpenTelemetry
-    opentelemetryApi            : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-api', version: versions.opentelemetry),
-    opentelemetryAutoAnnotations: dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-extension-annotations', version: versions.opentelemetryAnother),
-    opentelemetryContext        : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-context', version: versions.opentelemetryContext),
-    opentelemetryKotlin         : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-extension-kotlin', version: versions.opentelemetry),
-    opentelemetryTraceProps     : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-extension-trace-propagators', version: versions.opentelemetry),
-    opentelemetrySdk            : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-sdk', version: versions.opentelemetryAnother),
-    opentelemetryJaeger         : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-jaeger', version: versions.opentelemetryOther),
-    opentelemetryOtlp           : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: versions.opentelemetryOther),
-    opentelemetryZipkin         : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-zipkin', version: versions.opentelemetryOther),
-    opentelemetryPrometheus     : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-prometheus', version: versions.opentelemetryOther),
-    opentelemetryLogging        : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-logging', version: versions.opentelemetryOther),
-    opentelemetryProto          : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-proto', version: versions.opentelemetryAnother),
+    opentelemetryApi           : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-api', version: versions.opentelemetry),
+    opentelemetryExtAnnotations: dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-extension-annotations', version: versions.opentelemetryAnother),
+    opentelemetryContext       : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-context', version: versions.opentelemetryContext),
+    opentelemetryKotlin        : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-extension-kotlin', version: versions.opentelemetry),
+    opentelemetryTraceProps    : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-extension-trace-propagators', version: versions.opentelemetry),
+    opentelemetrySdk           : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-sdk', version: versions.opentelemetryAnother),
+    opentelemetryJaeger        : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-jaeger', version: versions.opentelemetryOther),
+    opentelemetryOtlp          : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: versions.opentelemetryOther),
+    opentelemetryZipkin        : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-zipkin', version: versions.opentelemetryOther),
+    opentelemetryPrometheus    : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-prometheus', version: versions.opentelemetryOther),
+    opentelemetryLogging       : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-logging', version: versions.opentelemetryOther),
+    opentelemetryProto         : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-proto', version: versions.opentelemetryAnother),
 
     // General
-    slf4j                       : "org.slf4j:slf4j-api:${versions.slf4j}",
-    guava                       : "com.google.guava:guava:$versions.guava",
-    bytebuddy                   : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: "${versions.bytebuddy}"),
-    bytebuddyagent              : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: "${versions.bytebuddy}"),
-    autoservice                 : [
+    slf4j                      : "org.slf4j:slf4j-api:${versions.slf4j}",
+    guava                      : "com.google.guava:guava:$versions.guava",
+    bytebuddy                  : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy', version: "${versions.bytebuddy}"),
+    bytebuddyagent             : dependencies.create(group: 'net.bytebuddy', name: 'byte-buddy-agent', version: "${versions.bytebuddy}"),
+    autoservice                : [
       dependencies.create(group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc3'),
       dependencies.create(group: 'com.google.auto', name: 'auto-common', version: '0.8'),
       // These are the last versions that support guava 20.0.  Upgrading has odd interactions with shadow.
       dependencies.create(group: 'com.google.guava', name: 'guava', version: "${versions.guava}"),
     ],
-    autoValueAnnotations        : "com.google.auto.value:auto-value-annotations:${versions.autoValue}",
+    autoValueAnnotations       : "com.google.auto.value:auto-value-annotations:${versions.autoValue}",
     // annotation processor
-    autoValue                   : "com.google.auto.value:auto-value:${versions.autoValue}",
-    prometheus                  : [
+    autoValue                  : "com.google.auto.value:auto-value:${versions.autoValue}",
+    prometheus                 : [
       dependencies.create(group: 'io.prometheus', name: 'simpleclient', version: "${versions.prometheus}"),
       dependencies.create(group: 'io.prometheus', name: 'simpleclient_httpserver', version: "${versions.prometheus}"),
     ],
 
     // Testing
 
-    spock                       : [
+    spock                      : [
       dependencies.create("org.spockframework:spock-core:${versions.spock}", {
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'
       }),
       // Used by Spock for mocking:
       dependencies.create(group: 'org.objenesis', name: 'objenesis', version: '3.1')
     ],
-    groovy                      : "org.codehaus.groovy:groovy-all:${versions.groovy}",
-    systemLambda                : "com.github.stefanbirkner:system-lambda:${versions.systemLambda}",
-    testcontainers              : "org.testcontainers:testcontainers:1.15.0-rc2",
-    testLogging                 : [
+    groovy                     : "org.codehaus.groovy:groovy-all:${versions.groovy}",
+    systemLambda               : "com.github.stefanbirkner:system-lambda:${versions.systemLambda}",
+    testcontainers             : "org.testcontainers:testcontainers:1.15.0-rc2",
+    testLogging                : [
       dependencies.create(group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback),
       dependencies.create(group: 'org.slf4j', name: 'log4j-over-slf4j', version: versions.slf4j),
       dependencies.create(group: 'org.slf4j', name: 'jcl-over-slf4j', version: versions.slf4j),
       dependencies.create(group: 'org.slf4j', name: 'jul-to-slf4j', version: versions.slf4j),
     ],
-    scala                       : dependencies.create(group: 'org.scala-lang', name: 'scala-library', version: "${versions.scala}"),
-    kotlin                      : dependencies.create(group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: "${versions.kotlin}"),
-    coroutines                  : dependencies.create(group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: "${versions.coroutines}"),
+    scala                      : dependencies.create(group: 'org.scala-lang', name: 'scala-library', version: "${versions.scala}"),
+    kotlin                     : dependencies.create(group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: "${versions.kotlin}"),
+    coroutines                 : dependencies.create(group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: "${versions.coroutines}"),
   ]
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
+++ b/instrumentation/spring/spring-boot-autoconfigure/spring-boot-autoconfigure.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation project(':instrumentation:spring:spring-webmvc-3.1:library')
   implementation project(':instrumentation:spring:spring-webflux-5.0:library')
 
-  compileOnly deps.opentelemetryAutoAnnotations
+  compileOnly deps.opentelemetryExtAnnotations
   compileOnly group: 'io.grpc', name: 'grpc-api', version: '1.30.2'
   compileOnly deps.opentelemetryLogging
   compileOnly deps.opentelemetryJaeger
@@ -32,7 +32,7 @@ dependencies {
   }
 
   testImplementation deps.opentelemetrySdk
-  testImplementation deps.opentelemetryAutoAnnotations
+  testImplementation deps.opentelemetryExtAnnotations
   testImplementation group: 'io.grpc', name: 'grpc-api', version: '1.30.2'
   testImplementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.30.2'
   testImplementation deps.opentelemetryLogging

--- a/instrumentation/spring/starters/spring-starter/spring-starter.gradle
+++ b/instrumentation/spring/starters/spring-starter/spring-starter.gradle
@@ -9,7 +9,7 @@ dependencies {
   api group: "org.springframework.boot", name: "spring-boot-starter", version: versions.springboot
   api group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springboot
   api project(':instrumentation:spring:spring-boot-autoconfigure')
-  api deps.opentelemetryAutoAnnotations
+  api deps.opentelemetryExtAnnotations
   api deps.opentelemetryApi
   api deps.opentelemetryLogging
   api deps.opentelemetrySdk

--- a/opentelemetry-ext-annotations-shaded-for-instrumenting/opentelemetry-ext-annotations-shaded-for-instrumenting.gradle
+++ b/opentelemetry-ext-annotations-shaded-for-instrumenting/opentelemetry-ext-annotations-shaded-for-instrumenting.gradle
@@ -5,7 +5,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  implementation deps.opentelemetryAutoAnnotations
+  implementation deps.opentelemetryExtAnnotations
   implementation deps.opentelemetryContext
 }
 

--- a/testing-common/testing-common.gradle
+++ b/testing-common/testing-common.gradle
@@ -47,7 +47,7 @@ dependencies {
 
   api deps.groovy
 
-  testImplementation deps.opentelemetryAutoAnnotations
+  testImplementation deps.opentelemetryExtAnnotations
   testImplementation project(':instrumentation:external-annotations:javaagent')
 
   testImplementation group: 'cglib', name: 'cglib', version: '3.2.5'


### PR DESCRIPTION
Cleanup from after `opentelemetry-auto-annotations` was renamed to `opentelemetry-extension-annotations`