### PR TITLE
Propagate context even when no span

### DIFF
--- a/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/ExecutorInstrumentationUtils.java
+++ b/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/ExecutorInstrumentationUtils.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.api.concurrent;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.context.ContextPropagationDebug;
 import io.opentelemetry.javaagent.instrumentation.api.ContextStore;
@@ -26,14 +25,12 @@ public class ExecutorInstrumentationUtils {
       return false;
     }
 
-    Span span = Span.current();
     Class<?> taskClass = task.getClass();
     Class<?> enclosingClass = taskClass.getEnclosingClass();
 
-    return span.getSpanContext().isValid()
-        // TODO Workaround for
-        // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/787
-        && !taskClass.getName().equals("org.apache.tomcat.util.net.NioEndpoint$SocketProcessor")
+    // TODO NioEndpoint$SocketProcessor exclusion is a workaround for
+    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/787
+    return !taskClass.getName().equals("org.apache.tomcat.util.net.NioEndpoint$SocketProcessor")
         // Don't instrument the executor's own runnables.  These runnables may never return until
         // netty shuts down.
         && (enclosingClass == null

--- a/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/ExecutorInstrumentationUtils.java
+++ b/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/ExecutorInstrumentationUtils.java
@@ -28,9 +28,12 @@ public class ExecutorInstrumentationUtils {
     Class<?> taskClass = task.getClass();
     Class<?> enclosingClass = taskClass.getEnclosingClass();
 
-    // TODO NioEndpoint$SocketProcessor exclusion is a workaround for
-    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/787
-    return !taskClass.getName().equals("org.apache.tomcat.util.net.NioEndpoint$SocketProcessor")
+    // not much point in propagating root context
+    // plus it causes failures under otel.internal.failOnContextLeak=true
+    return Context.current() != Context.root()
+        // TODO Workaround for
+        // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/787
+        && !taskClass.getName().equals("org.apache.tomcat.util.net.NioEndpoint$SocketProcessor")
         // Don't instrument the executor's own runnables.  These runnables may never return until
         // netty shuts down.
         && (enclosingClass == null


### PR DESCRIPTION
This seems like the right thing to do, but also makes me a little nervous about clobbering an existing context with an empty context. May want to add a check for Context.root().