### PR TITLE
Hardcode expected values in tests

### DIFF
--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -11,7 +11,6 @@ import akka.http.javadsl.model.HttpMethods
 import akka.http.javadsl.model.HttpRequest
 import akka.http.javadsl.model.headers.RawHeader
 import akka.stream.ActorMaterializer
-import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import spock.lang.Shared
 import spock.lang.Timeout
@@ -64,7 +63,7 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest {
       trace(0, 1) {
         span(0) {
           hasNoParent()
-          name HttpClientTracer.DEFAULT_SPAN_NAME
+          name "HTTP request"
           kind CLIENT
           errored true
           errorEvent(NullPointerException)

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/Aws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/Aws1ClientTest.groovy
@@ -39,7 +39,6 @@ import com.amazonaws.services.sqs.model.CreateQueueRequest
 import com.amazonaws.services.sqs.model.SendMessageRequest
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import java.util.concurrent.atomic.AtomicReference
 import spock.lang.AutoCleanup
@@ -337,6 +336,6 @@ class Aws1ClientTest extends AgentTestRunner {
   }
 
   String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : HttpClientTracer.DEFAULT_SPAN_NAME
+    return method != null ? "HTTP $method" : "HTTP request"
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -26,7 +26,6 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.S3ClientOptions
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import java.util.concurrent.atomic.AtomicReference
 import spock.lang.AutoCleanup
@@ -279,6 +278,6 @@ class Aws0ClientTest extends AgentTestRunner {
   }
 
   String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : HttpClientTracer.DEFAULT_SPAN_NAME
+    return method != null ? "HTTP $method" : "HTTP request"
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -409,6 +409,6 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
   }
 
   String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : HttpClientTracer.DEFAULT_SPAN_NAME
+    return method != null ? "HTTP $method" : "HTTP request"
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -7,7 +7,6 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
 import groovy.json.JsonSlurper
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
@@ -112,6 +111,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
   }
 
   String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : HttpClientTracer.DEFAULT_SPAN_NAME
+    return method != null ? "HTTP $method" : "HTTP request"
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -8,7 +8,6 @@ import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 import groovy.json.JsonSlurper
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
@@ -116,6 +115,6 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
   }
 
   String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : HttpClientTracer.DEFAULT_SPAN_NAME
+    return method != null ? "HTTP $method" : "HTTP request"
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -7,7 +7,6 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
 import groovy.json.JsonSlurper
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
@@ -126,6 +125,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
   }
 
   String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : HttpClientTracer.DEFAULT_SPAN_NAME
+    return method != null ? "HTTP $method" : "HTTP request"
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -7,7 +7,6 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
 import groovy.json.JsonSlurper
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
@@ -112,6 +111,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
   }
 
   String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : HttpClientTracer.DEFAULT_SPAN_NAME
+    return method != null ? "HTTP $method" : "HTTP request"
   }
 }

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/UrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/UrlConnectionTest.groovy
@@ -9,7 +9,6 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTra
 
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 
 class UrlConnectionTest extends AgentTestRunner {
@@ -61,6 +60,6 @@ class UrlConnectionTest extends AgentTestRunner {
   }
 
   String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : HttpClientTracer.DEFAULT_SPAN_NAME
+    return method != null ? "HTTP $method" : "HTTP request"
   }
 }

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
@@ -10,7 +10,6 @@ import com.google.common.io.Files
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import io.opentelemetry.javaagent.instrumentation.jms.JmsTracer
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
@@ -110,8 +109,8 @@ class Jms2Test extends AgentTestRunner {
     destination                      | destinationType | destinationName
     session.createQueue("someQueue") | "queue"         | "someQueue"
     session.createTopic("someTopic") | "topic"         | "someTopic"
-    session.createTemporaryQueue()   | "queue"         | JmsTracer.TEMP_DESTINATION_NAME
-    session.createTemporaryTopic()   | "topic"         | JmsTracer.TEMP_DESTINATION_NAME
+    session.createTemporaryQueue()   | "queue"         | "(temporary)"
+    session.createTemporaryTopic()   | "topic"         | "(temporary)"
   }
 
   def "sending to a MessageListener on #destinationName #destinationType generates a span"() {
@@ -149,8 +148,8 @@ class Jms2Test extends AgentTestRunner {
     destination                      | destinationType | destinationName
     session.createQueue("someQueue") | "queue"         | "someQueue"
     session.createTopic("someTopic") | "topic"         | "someTopic"
-    session.createTemporaryQueue()   | "queue"         | JmsTracer.TEMP_DESTINATION_NAME
-    session.createTemporaryTopic()   | "topic"         | JmsTracer.TEMP_DESTINATION_NAME
+    session.createTemporaryQueue()   | "queue"         | "(temporary)"
+    session.createTemporaryTopic()   | "topic"         | "(temporary)"
   }
 
   def "failing to receive message with receiveNoWait on #destinationName #destinationType works"() {
@@ -234,7 +233,7 @@ class Jms2Test extends AgentTestRunner {
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
         "${SemanticAttributes.MESSAGING_DESTINATION.key}" destinationName
         "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" destinationType
-        if (destinationName == JmsTracer.TEMP_DESTINATION_NAME) {
+        if (destinationName == "(temporary)") {
           "${SemanticAttributes.MESSAGING_TEMP_DESTINATION.key}" true
         }
       }
@@ -263,7 +262,7 @@ class Jms2Test extends AgentTestRunner {
           //In some tests we don't know exact messageId, so we pass "" and verify just the existence of the attribute
           "${SemanticAttributes.MESSAGING_MESSAGE_ID.key}" { it == messageId || messageId == "" }
         }
-        if (destinationName == JmsTracer.TEMP_DESTINATION_NAME) {
+        if (destinationName == "(temporary)") {
           "${SemanticAttributes.MESSAGING_TEMP_DESTINATION.key}" true
         }
       }

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
@@ -9,7 +9,6 @@ import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import io.opentelemetry.javaagent.instrumentation.jms.JmsTracer
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
@@ -83,8 +82,8 @@ class Jms1Test extends AgentTestRunner {
     destination                      | destinationType | destinationName
     session.createQueue("someQueue") | "queue"         | "someQueue"
     session.createTopic("someTopic") | "topic"         | "someTopic"
-    session.createTemporaryQueue()   | "queue"         | JmsTracer.TEMP_DESTINATION_NAME
-    session.createTemporaryTopic()   | "topic"         | JmsTracer.TEMP_DESTINATION_NAME
+    session.createTemporaryQueue()   | "queue"         | "(temporary)"
+    session.createTemporaryTopic()   | "topic"         | "(temporary)"
   }
 
   def "sending to a MessageListener on #destinationName #destinationType generates a span"() {
@@ -122,8 +121,8 @@ class Jms1Test extends AgentTestRunner {
     destination                      | destinationType | destinationName
     session.createQueue("someQueue") | "queue"         | "someQueue"
     session.createTopic("someTopic") | "topic"         | "someTopic"
-    session.createTemporaryQueue()   | "queue"         | JmsTracer.TEMP_DESTINATION_NAME
-    session.createTemporaryTopic()   | "topic"         | JmsTracer.TEMP_DESTINATION_NAME
+    session.createTemporaryQueue()   | "queue"         | "(temporary)"
+    session.createTemporaryTopic()   | "topic"         | "(temporary)"
   }
 
   def "failing to receive message with receiveNoWait on #destinationName #destinationType works"() {
@@ -233,7 +232,7 @@ class Jms1Test extends AgentTestRunner {
             "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" destinationType
             "${SemanticAttributes.MESSAGING_MESSAGE_ID.key}" receivedMessage.getJMSMessageID()
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "receive"
-            if (destinationName == JmsTracer.TEMP_DESTINATION_NAME) {
+            if (destinationName == "(temporary)") {
               "${SemanticAttributes.MESSAGING_TEMP_DESTINATION.key}" true
             }
           }
@@ -249,8 +248,8 @@ class Jms1Test extends AgentTestRunner {
     destination                      | destinationType | destinationName
     session.createQueue("someQueue") | "queue"         | "someQueue"
     session.createTopic("someTopic") | "topic"         | "someTopic"
-    session.createTemporaryQueue()   | "queue"         | JmsTracer.TEMP_DESTINATION_NAME
-    session.createTemporaryTopic()   | "topic"         | JmsTracer.TEMP_DESTINATION_NAME
+    session.createTemporaryQueue()   | "queue"         | "(temporary)"
+    session.createTemporaryTopic()   | "topic"         | "(temporary)"
   }
 
   static producerSpan(TraceAssert trace, int index, String destinationType, String destinationName) {
@@ -263,7 +262,7 @@ class Jms1Test extends AgentTestRunner {
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
         "${SemanticAttributes.MESSAGING_DESTINATION.key}" destinationName
         "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" destinationType
-        if (destinationName == JmsTracer.TEMP_DESTINATION_NAME) {
+        if (destinationName == "(temporary)") {
           "${SemanticAttributes.MESSAGING_TEMP_DESTINATION.key}" true
         }
       }
@@ -292,7 +291,7 @@ class Jms1Test extends AgentTestRunner {
           //In some tests we don't know exact messageId, so we pass "" and verify just the existence of the attribute
           "${SemanticAttributes.MESSAGING_MESSAGE_ID.key}" { it == messageId || messageId == "" }
         }
-        if (destinationName == JmsTracer.TEMP_DESTINATION_NAME) {
+        if (destinationName == "(temporary)") {
           "${SemanticAttributes.MESSAGING_TEMP_DESTINATION.key}" true
         }
       }

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringTemplateJms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringTemplateJms1Test.groovy
@@ -8,7 +8,6 @@ import static Jms1Test.producerSpan
 
 import com.google.common.base.Stopwatch
 import io.opentelemetry.instrumentation.test.AgentTestRunner
-import io.opentelemetry.javaagent.instrumentation.jms.JmsTracer
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import javax.jms.Connection
@@ -106,10 +105,10 @@ class SpringTemplateJms1Test extends AgentTestRunner {
       }
       trace(2, 1) {
         // receive doesn't propagate the trace, so this is a root
-        producerSpan(it, 0, "queue", JmsTracer.TEMP_DESTINATION_NAME)
+        producerSpan(it, 0, "queue", "(temporary)")
       }
       trace(3, 1) {
-        consumerSpan(it, 0, "queue", JmsTracer.TEMP_DESTINATION_NAME, receivedMessage.getJMSMessageID(), null, "receive")
+        consumerSpan(it, 0, "queue", "(temporary)", receivedMessage.getJMSMessageID(), null, "receive")
       }
     }
 

--- a/instrumentation/log4j/log4j-1.2/javaagent/src/test/groovy/Log4j1MdcTest.groovy
+++ b/instrumentation/log4j/log4j-1.2/javaagent/src/test/groovy/Log4j1MdcTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.api.log.LoggingContextConstants.SAMPLED
-import static io.opentelemetry.instrumentation.api.log.LoggingContextConstants.SPAN_ID
-import static io.opentelemetry.instrumentation.api.log.LoggingContextConstants.TRACE_ID
-
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import io.opentelemetry.instrumentation.test.utils.TraceUtils
@@ -30,14 +26,14 @@ class Log4j1MdcTest extends AgentTestRunner {
 
     events.size() == 2
     events[0].message == "log message 1"
-    events[0].getMDC(TRACE_ID) == null
-    events[0].getMDC(SPAN_ID) == null
-    events[0].getMDC(SAMPLED) == null
+    events[0].getMDC("traceId") == null
+    events[0].getMDC("spanId") == null
+    events[0].getMDC("sampled") == null
 
     events[1].message == "log message 2"
-    events[1].getMDC(TRACE_ID) == null
-    events[1].getMDC(SPAN_ID) == null
-    events[1].getMDC(SAMPLED) == null
+    events[1].getMDC("traceId") == null
+    events[1].getMDC("spanId") == null
+    events[1].getMDC("sampled") == null
   }
 
   def "ids when span"() {
@@ -62,20 +58,20 @@ class Log4j1MdcTest extends AgentTestRunner {
 
     events.size() == 3
     events[0].message == "log message 1"
-    events[0].getMDC(TRACE_ID) == span1.spanContext.traceIdAsHexString
-    events[0].getMDC(SPAN_ID) == span1.spanContext.spanIdAsHexString
-    events[0].getMDC(SAMPLED) == "true"
+    events[0].getMDC("traceId") == span1.spanContext.traceIdAsHexString
+    events[0].getMDC("spanId") == span1.spanContext.spanIdAsHexString
+    events[0].getMDC("sampled") == "true"
 
     events[1].message == "log message 2"
-    events[1].getMDC(TRACE_ID) == null
-    events[1].getMDC(SPAN_ID) == null
-    events[1].getMDC(SAMPLED) == null
+    events[1].getMDC("traceId") == null
+    events[1].getMDC("spanId") == null
+    events[1].getMDC("sampled") == null
 
     events[2].message == "log message 3"
     // this explicit getMDCCopy() call here is to make sure that whole instrumentation is tested
     events[2].getMDCCopy()
-    events[2].getMDC(TRACE_ID) == span2.spanContext.traceIdAsHexString
-    events[2].getMDC(SPAN_ID) == span2.spanContext.spanIdAsHexString
-    events[2].getMDC(SAMPLED) == "true"
+    events[2].getMDC("traceId") == span2.spanContext.traceIdAsHexString
+    events[2].getMDC("spanId") == span2.spanContext.spanIdAsHexString
+    events[2].getMDC("sampled") == "true"
   }
 }

--- a/instrumentation/log4j/log4j-2-testing/log4j-2-testing.gradle
+++ b/instrumentation/log4j/log4j-2-testing/log4j-2-testing.gradle
@@ -10,7 +10,6 @@ dependencies {
   implementation deps.groovy
   implementation deps.opentelemetryApi
   implementation deps.spock
-  implementation project(':instrumentation-api')
 
   annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.7'
 }

--- a/instrumentation/log4j/log4j-2-testing/src/main/groovy/Log4j2Test.groovy
+++ b/instrumentation/log4j/log4j-2-testing/src/main/groovy/Log4j2Test.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.api.log.LoggingContextConstants.SAMPLED
-import static io.opentelemetry.instrumentation.api.log.LoggingContextConstants.SPAN_ID
-import static io.opentelemetry.instrumentation.api.log.LoggingContextConstants.TRACE_ID
-
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.log4j.v2_13_2.ListAppender
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
@@ -31,14 +27,14 @@ abstract class Log4j2Test extends InstrumentationSpecification {
     then:
     events.size() == 2
     events[0].message.formattedMessage == "log message 1"
-    events[0].getContextData().getValue(TRACE_ID) == null
-    events[0].getContextData().getValue(SPAN_ID) == null
-    events[0].getContextData().getValue(SAMPLED) == null
+    events[0].getContextData().getValue("traceId") == null
+    events[0].getContextData().getValue("spanId") == null
+    events[0].getContextData().getValue("sampled") == null
 
     events[1].message.formattedMessage == "log message 2"
-    events[1].getContextData().getValue(TRACE_ID) == null
-    events[1].getContextData().getValue(SPAN_ID) == null
-    events[1].getContextData().getValue(SAMPLED) == null
+    events[1].getContextData().getValue("traceId") == null
+    events[1].getContextData().getValue("spanId") == null
+    events[1].getContextData().getValue("sampled") == null
   }
 
   def "ids when span"() {
@@ -63,18 +59,18 @@ abstract class Log4j2Test extends InstrumentationSpecification {
     then:
     events.size() == 3
     events[0].message.formattedMessage == "log message 1"
-    events[0].getContextData().getValue(TRACE_ID) == span1.spanContext.traceIdAsHexString
-    events[0].getContextData().getValue(SPAN_ID) == span1.spanContext.spanIdAsHexString
-    events[0].getContextData().getValue(SAMPLED) == "true"
+    events[0].getContextData().getValue("traceId") == span1.spanContext.traceIdAsHexString
+    events[0].getContextData().getValue("spanId") == span1.spanContext.spanIdAsHexString
+    events[0].getContextData().getValue("sampled") == "true"
 
     events[1].message.formattedMessage == "log message 2"
-    events[1].getContextData().getValue(TRACE_ID) == null
-    events[1].getContextData().getValue(SPAN_ID) == null
-    events[1].getContextData().getValue(SAMPLED) == null
+    events[1].getContextData().getValue("traceId") == null
+    events[1].getContextData().getValue("spanId") == null
+    events[1].getContextData().getValue("sampled") == null
 
     events[2].message.formattedMessage == "log message 3"
-    events[2].getContextData().getValue(TRACE_ID) == span2.spanContext.traceIdAsHexString
-    events[2].getContextData().getValue(SPAN_ID) == span2.spanContext.spanIdAsHexString
-    events[2].getContextData().getValue(SAMPLED) == "true"
+    events[2].getContextData().getValue("traceId") == span2.spanContext.traceIdAsHexString
+    events[2].getContextData().getValue("spanId") == span2.spanContext.spanIdAsHexString
+    events[2].getContextData().getValue("sampled") == "true"
   }
 }

--- a/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.AgentTestRunner
-import io.opentelemetry.javaagent.instrumentation.jdbc.JdbcUtils
 
 class SlickTest extends AgentTestRunner {
 
@@ -40,7 +40,7 @@ class SlickTest extends AgentTestRunner {
             "$SemanticAttributes.DB_SYSTEM.key" "h2"
             "$SemanticAttributes.DB_NAME.key" SlickUtils.Db()
             "$SemanticAttributes.DB_USER.key" SlickUtils.Username()
-            "$SemanticAttributes.DB_STATEMENT.key" JdbcUtils.normalizeSql(SlickUtils.TestQuery())
+            "$SemanticAttributes.DB_STATEMENT.key" "SELECT ?"
             "$SemanticAttributes.DB_CONNECTION_STRING.key" "h2:mem:"
           }
         }

--- a/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
 import io.opentelemetry.api.trace.attributes.SemanticAttributes

--- a/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
@@ -18,7 +18,6 @@ import com.twilio.http.TwilioRestClient
 import com.twilio.rest.api.v2010.account.Call
 import com.twilio.rest.api.v2010.account.Message
 import com.twilio.type.PhoneNumber
-import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
@@ -652,6 +651,6 @@ class TwilioClientTest extends AgentTestRunner {
   }
 
   String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : HttpClientTracer.DEFAULT_SPAN_NAME
+    return method != null ? "HTTP $method" : "HTTP request"
   }
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -14,7 +14,6 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTra
 import static org.junit.Assume.assumeTrue
 
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -445,7 +444,7 @@ abstract class HttpClientTest extends AgentTestRunner {
   }
 
   String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : HttpClientTracer.DEFAULT_SPAN_NAME
+    return method != null ? "HTTP $method" : "HTTP request"
   }
 
   int extraClientSpans() {


### PR DESCRIPTION
I think this makes sense even outside of #1643 (where the agent tests no longer have access to the classes that the expected values are derived from).

I think it's good anyways to have the expected values be hardcoded instead of derived, so that if you change the underlying constants (or normalization algorithm) you are forced to also update the tests, which makes it clear that the change has end user impact.