### PR TITLE
Fix port used for self-call

### DIFF
--- a/smoke-tests/springboot/build.gradle
+++ b/smoke-tests/springboot/build.gradle
@@ -37,4 +37,5 @@ def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 jib {
   from.image = "bellsoft/liberica-openjdk-alpine:$targetJDK"
   to.image = "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk$targetJDK-$tag"
+  container.ports = ["8080"]
 }

--- a/smoke-tests/springboot/src/main/java/io/opentelemetry/smoketest/springboot/controller/PropagatingController.java
+++ b/smoke-tests/springboot/src/main/java/io/opentelemetry/smoketest/springboot/controller/PropagatingController.java
@@ -18,9 +18,8 @@ package io.opentelemetry.smoketest.springboot.controller;
 
 import io.opentelemetry.api.trace.Span;
 import java.net.URI;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
@@ -35,18 +34,19 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
  */
 @RestController
 public class PropagatingController {
-  private static final Logger LOGGER = LoggerFactory.getLogger(PropagatingController.class);
-
   private final RestTemplate restTemplate;
+  private final Environment environment;
 
-  public PropagatingController(RestTemplateBuilder restTemplateBuilder) {
+  public PropagatingController(RestTemplateBuilder restTemplateBuilder, Environment environment) {
     this.restTemplate = restTemplateBuilder.build();
+    this.environment = environment;
   }
 
   @RequestMapping("/front")
   public String front() {
     URI backend = ServletUriComponentsBuilder
         .fromCurrentContextPath()
+        .port(environment.getProperty("local.server.port"))
         .path("/back")
         .build()
         .toUri();


### PR DESCRIPTION
Bugfix for #1781. When used in testcontainer, the port for the initial call differs from the port which should be used for the second call.