### PR TITLE
Pass around context more instead of span (HttpServerTracer)

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
@@ -12,7 +12,6 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.attributes.SemanticAttributes;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
@@ -70,60 +69,44 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
   }
 
   /**
-   * Creates new scoped context, based on the current context, with the given span.
-   *
-   * <p>Attaches new context to the request to avoid creating duplicate server spans.
-   */
-  public Scope startScope(Span span, STORAGE storage) {
-    return startScope(span, storage, Context.current());
-  }
-
-  /**
-   * Creates new scoped context, based on the given context, with the given span.
-   *
-   * <p>Attaches new context to the request to avoid creating duplicate server spans.
-   */
-  public Scope startScope(Span span, STORAGE storage, Context context) {
-    return context.makeCurrent();
-  }
-
-  /**
-   * Convenience method. Delegates to {@link #end(Span, Object, long)}, passing {@code timestamp}
+   * Convenience method. Delegates to {@link #end(Context, Object, long)}, passing {@code timestamp}
    * value of {@code -1}.
    */
   // TODO should end methods remove SPAN attribute from request as well?
-  public void end(Span span, RESPONSE response) {
-    end(span, response, -1);
+  public void end(Context context, RESPONSE response) {
+    end(context, response, -1);
   }
 
   // TODO should end methods remove SPAN attribute from request as well?
-  public void end(Span span, RESPONSE response, long timestamp) {
+  public void end(Context context, RESPONSE response, long timestamp) {
+    Span span = Span.fromContext(context);
     setStatus(span, responseStatus(response));
     endSpan(span, timestamp);
   }
 
   /**
-   * Convenience method. Delegates to {@link #endExceptionally(Span, Throwable, Object)}, passing
+   * Convenience method. Delegates to {@link #endExceptionally(Context, Throwable, Object)}, passing
    * {@code response} value of {@code null}.
    */
-  @Override
-  public void endExceptionally(Span span, Throwable throwable) {
-    endExceptionally(span, throwable, null);
+  public void endExceptionally(Context context, Throwable throwable) {
+    endExceptionally(context, throwable, null);
   }
 
   /**
-   * Convenience method. Delegates to {@link #endExceptionally(Span, Throwable, Object, long)},
+   * Convenience method. Delegates to {@link #endExceptionally(Context, Throwable, Object, long)},
    * passing {@code timestamp} value of {@code -1}.
    */
-  public void endExceptionally(Span span, Throwable throwable, RESPONSE response) {
-    endExceptionally(span, throwable, response, -1);
+  public void endExceptionally(Context context, Throwable throwable, RESPONSE response) {
+    endExceptionally(context, throwable, response, -1);
   }
 
   /**
    * If {@code response} is {@code null}, the {@code http.status_code} will be set to {@code 500}
    * and the {@link Span} status will be set to {@link io.opentelemetry.api.trace.StatusCode#ERROR}.
    */
-  public void endExceptionally(Span span, Throwable throwable, RESPONSE response, long timestamp) {
+  public void endExceptionally(
+      Context context, Throwable throwable, RESPONSE response, long timestamp) {
+    Span span = Span.fromContext(context);
     onError(span, unwrapThrowable(throwable));
     if (response == null) {
       setStatus(span, 500);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
@@ -47,9 +47,16 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
   public Context startSpan(
       REQUEST request,
       CONNECTION connection,
-      STORAGE storage,
+      @Nullable STORAGE storage,
       String spanName,
       long startTimestamp) {
+
+    // not checking if inside of nested SERVER span because of concerns about context leaking
+    // and so always starting with a clean context here
+
+    // also we can't conditionally start a span in this method, because the caller won't know
+    // whether to call end() or not on the Span in the Context
+
     Context parentContext = extract(request, getGetter());
     SpanBuilder builder = tracer.spanBuilder(spanName).setSpanKind(SERVER).setParent(parentContext);
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
@@ -55,7 +55,7 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
     // and so always starting with a clean context here
 
     // also we can't conditionally start a span in this method, because the caller won't know
-    // whether to call end() or not on the Span in the Context
+    // whether to call end() or not on the Span in the returned Context
 
     Context parentContext = extract(request, getGetter());
     SpanBuilder builder = tracer.spanBuilder(spanName).setSpanKind(SERVER).setParent(parentContext);

--- a/instrumentation-core/servlet-2.2/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
+++ b/instrumentation-core/servlet-2.2/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.servlet;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.attributes.SemanticAttributes;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator.Getter;
 import io.opentelemetry.instrumentation.api.servlet.ServletContextPath;
 import io.opentelemetry.instrumentation.api.tracer.HttpServerTracer;
@@ -26,19 +25,12 @@ public abstract class ServletHttpServerTracer<RESPONSE>
   private static final Logger log = LoggerFactory.getLogger(ServletHttpServerTracer.class);
 
   public Context startSpan(HttpServletRequest request) {
-    return startSpan(request, request, getSpanName(request));
-  }
-
-  @Override
-  public Scope startScope(Span span, HttpServletRequest request) {
-    Context context = Context.current();
-    // if we start returning Context from startSpan() then we can add ServletContextPath there
-    // (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1481)
+    Context context = startSpan(request, request, request, getSpanName(request));
     String contextPath = request.getContextPath();
     if (contextPath != null && !contextPath.isEmpty() && !contextPath.equals("/")) {
       context = context.with(ServletContextPath.CONTEXT_KEY, contextPath);
     }
-    return super.startScope(span, request, context);
+    return context;
   }
 
   @Override

--- a/instrumentation-core/servlet-2.2/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
+++ b/instrumentation-core/servlet-2.2/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
@@ -101,10 +101,10 @@ public abstract class ServletHttpServerTracer<RESPONSE>
     return super.unwrapThrowable(result);
   }
 
-  public void setPrincipal(Span span, HttpServletRequest request) {
+  public void setPrincipal(Context context, HttpServletRequest request) {
     Principal principal = request.getUserPrincipal();
     if (principal != null) {
-      span.setAttribute(SemanticAttributes.ENDUSER_ID, principal.getName());
+      Span.fromContext(context).setAttribute(SemanticAttributes.ENDUSER_ID, principal.getName());
     }
   }
 

--- a/instrumentation/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpServerInstrumentationModule.java
+++ b/instrumentation/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpServerInstrumentationModule.java
@@ -96,7 +96,7 @@ public class AkkaHttpServerInstrumentationModule extends InstrumentationModule {
 
     @Override
     public HttpResponse apply(HttpRequest request) {
-      Context ctx = tracer().startSpan(request, request, "akka.request");
+      Context ctx = tracer().startSpan(request, request, null, "akka.request");
       Span span = Java8BytecodeBridge.spanFromContext(ctx);
       try (Scope ignored = tracer().startScope(span, null)) {
         HttpResponse response = userHandler.apply(request);
@@ -122,7 +122,7 @@ public class AkkaHttpServerInstrumentationModule extends InstrumentationModule {
 
     @Override
     public Future<HttpResponse> apply(HttpRequest request) {
-      Context ctx = tracer().startSpan(request, request, "akka.request");
+      Context ctx = tracer().startSpan(request, request, null, "akka.request");
       Span span = Java8BytecodeBridge.spanFromContext(ctx);
       try (Scope ignored = tracer().startScope(span, null)) {
         return userHandler

--- a/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/ArmeriaServerTracer.java
+++ b/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/ArmeriaServerTracer.java
@@ -19,7 +19,8 @@ import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ArmeriaServerTracer
-    extends HttpServerTracer<HttpRequest, RequestLog, ServiceRequestContext, Void> {
+    extends HttpServerTracer<
+        HttpRequest, RequestLog, ServiceRequestContext, ServiceRequestContext> {
 
   ArmeriaServerTracer() {}
 
@@ -29,7 +30,7 @@ public class ArmeriaServerTracer
 
   @Override
   @Nullable
-  public Context getServerContext(Void ctx) {
+  public Context getServerContext(ServiceRequestContext ctx) {
     return null;
   }
 
@@ -92,7 +93,7 @@ public class ArmeriaServerTracer
   }
 
   @Override
-  protected void attachServerContext(Context context, Void ctx) {}
+  protected void attachServerContext(Context context, ServiceRequestContext ctx) {}
 
   private static class ArmeriaGetter implements Getter<HttpRequest> {
 

--- a/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/ArmeriaServerTracer.java
+++ b/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/ArmeriaServerTracer.java
@@ -19,8 +19,7 @@ import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ArmeriaServerTracer
-    extends HttpServerTracer<
-        HttpRequest, RequestLog, ServiceRequestContext, ServiceRequestContext> {
+    extends HttpServerTracer<HttpRequest, RequestLog, ServiceRequestContext, Void> {
 
   ArmeriaServerTracer() {}
 
@@ -30,7 +29,7 @@ public class ArmeriaServerTracer
 
   @Override
   @Nullable
-  public Context getServerContext(ServiceRequestContext ctx) {
+  public Context getServerContext(Void ctx) {
     return null;
   }
 
@@ -93,7 +92,7 @@ public class ArmeriaServerTracer
   }
 
   @Override
-  protected void attachServerContext(Context context, ServiceRequestContext ctx) {}
+  protected void attachServerContext(Context context, Void ctx) {}
 
   private static class ArmeriaGetter implements Getter<HttpRequest> {
 

--- a/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/OpenTelemetryService.java
+++ b/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/OpenTelemetryService.java
@@ -59,10 +59,9 @@ public class OpenTelemetryService extends SimpleDecoratingHttpService {
     long requestStartTimeMicros =
         ctx.log().ensureAvailable(RequestLogProperty.REQUEST_START_TIME).requestStartTimeMicros();
     long requestStartTimeNanos = TimeUnit.MICROSECONDS.toNanos(requestStartTimeMicros);
-    Context context = serverTracer.startSpan(req, ctx, null, spanName, requestStartTimeNanos);
-    Span span = Span.fromContext(context);
+    Context context = serverTracer.startSpan(req, ctx, ctx, spanName, requestStartTimeNanos);
 
-    if (span.isRecording()) {
+    if (Span.fromContext(context).isRecording()) {
       ctx.log()
           .whenComplete()
           .thenAccept(
@@ -70,14 +69,14 @@ public class OpenTelemetryService extends SimpleDecoratingHttpService {
                 long requestEndTimeNanos = requestStartTimeNanos + log.responseDurationNanos();
                 if (log.responseCause() != null) {
                   serverTracer.endExceptionally(
-                      span, log.responseCause(), log, requestEndTimeNanos);
+                      context, log.responseCause(), log, requestEndTimeNanos);
                 } else {
-                  serverTracer.end(span, log, requestEndTimeNanos);
+                  serverTracer.end(context, log, requestEndTimeNanos);
                 }
               });
     }
 
-    try (Scope ignored = span.makeCurrent()) {
+    try (Scope ignored = context.makeCurrent()) {
       return unwrap().serve(ctx, req);
     }
   }

--- a/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/OpenTelemetryService.java
+++ b/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/OpenTelemetryService.java
@@ -59,7 +59,7 @@ public class OpenTelemetryService extends SimpleDecoratingHttpService {
     long requestStartTimeMicros =
         ctx.log().ensureAvailable(RequestLogProperty.REQUEST_START_TIME).requestStartTimeMicros();
     long requestStartTimeNanos = TimeUnit.MICROSECONDS.toNanos(requestStartTimeMicros);
-    Context context = serverTracer.startSpan(req, ctx, spanName, requestStartTimeNanos);
+    Context context = serverTracer.startSpan(req, ctx, null, spanName, requestStartTimeNanos);
     Span span = Span.fromContext(context);
 
     if (span.isRecording()) {

--- a/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/OpenTelemetryService.java
+++ b/instrumentation/armeria-1.0/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_0/server/OpenTelemetryService.java
@@ -59,7 +59,7 @@ public class OpenTelemetryService extends SimpleDecoratingHttpService {
     long requestStartTimeMicros =
         ctx.log().ensureAvailable(RequestLogProperty.REQUEST_START_TIME).requestStartTimeMicros();
     long requestStartTimeNanos = TimeUnit.MICROSECONDS.toNanos(requestStartTimeMicros);
-    Context context = serverTracer.startSpan(req, ctx, ctx, spanName, requestStartTimeNanos);
+    Context context = serverTracer.startSpan(req, ctx, null, spanName, requestStartTimeNanos);
 
     if (Span.fromContext(context).isRecording()) {
       ctx.log()

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpCodecFilterAdvice.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpCodecFilterAdvice.java
@@ -7,9 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.grizzly;
 
 import static io.opentelemetry.javaagent.instrumentation.grizzly.GrizzlyHttpServerTracer.tracer;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
 import java.lang.reflect.Method;
 import net.bytebuddy.asm.Advice;
 import org.glassfish.grizzly.filterchain.FilterChainContext;
@@ -31,11 +29,9 @@ public class HttpCodecFilterAdvice {
       return;
     }
     HttpRequestPacket httpRequest = (HttpRequestPacket) httpHeader;
-    Context extractedContext = tracer().startSpan(httpRequest, httpRequest, ctx, method);
-    Span span = Java8BytecodeBridge.spanFromContext(extractedContext);
 
-    // We don't actually want to attach new context to this thread, as actual request will continue
-    // on some other thread. But we do want to attach that new context to FilterChainContext
-    tracer().startScope(span, ctx).close();
+    // We don't want to attach the new context to this thread, as actual request will continue on
+    // some other thread where we will read and attach it via tracer().getServerContext(ctx).
+    tracer().startSpan(httpRequest, httpRequest, ctx, method);
   }
 }

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpCodecFilterAdvice.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpCodecFilterAdvice.java
@@ -31,7 +31,7 @@ public class HttpCodecFilterAdvice {
       return;
     }
     HttpRequestPacket httpRequest = (HttpRequestPacket) httpHeader;
-    Context extractedContext = tracer().startSpan(httpRequest, httpRequest, method);
+    Context extractedContext = tracer().startSpan(httpRequest, httpRequest, ctx, method);
     Span span = Java8BytecodeBridge.spanFromContext(extractedContext);
 
     // We don't actually want to attach new context to this thread, as actual request will continue

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpCodecFilterOldAdvice.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpCodecFilterOldAdvice.java
@@ -31,7 +31,7 @@ public class HttpCodecFilterOldAdvice {
       return;
     }
     HttpRequestPacket httpRequest = (HttpRequestPacket) httpHeader;
-    Context extractedContext = tracer().startSpan(httpRequest, httpRequest, method);
+    Context extractedContext = tracer().startSpan(httpRequest, httpRequest, ctx, method);
     Span span = Java8BytecodeBridge.spanFromContext(extractedContext);
 
     // We don't actually want to attach new context to this thread, as actual request will continue

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpCodecFilterOldAdvice.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpCodecFilterOldAdvice.java
@@ -7,9 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.grizzly;
 
 import static io.opentelemetry.javaagent.instrumentation.grizzly.GrizzlyHttpServerTracer.tracer;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
 import java.lang.reflect.Method;
 import net.bytebuddy.asm.Advice;
 import org.glassfish.grizzly.filterchain.FilterChainContext;
@@ -31,11 +29,9 @@ public class HttpCodecFilterOldAdvice {
       return;
     }
     HttpRequestPacket httpRequest = (HttpRequestPacket) httpHeader;
-    Context extractedContext = tracer().startSpan(httpRequest, httpRequest, ctx, method);
-    Span span = Java8BytecodeBridge.spanFromContext(extractedContext);
 
-    // We don't actually want to attach new context to this thread, as actual request will continue
-    // on some other thread. But we do want to attach that new context to FilterChainContext
-    tracer().startScope(span, ctx).close();
+    // We don't want to attach the new context to this thread, as actual request will continue on
+    // some other thread where we will read and attach it via tracer().getServerContext(ctx).
+    tracer().startSpan(httpRequest, httpRequest, ctx, method);
   }
 }

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpServerFilterAdvice.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/HttpServerFilterAdvice.java
@@ -7,7 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.grizzly;
 
 import static io.opentelemetry.javaagent.instrumentation.grizzly.GrizzlyHttpServerTracer.tracer;
 
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import net.bytebuddy.asm.Advice;
 import org.glassfish.grizzly.filterchain.FilterChainContext;
 import org.glassfish.grizzly.http.HttpResponsePacket;
@@ -16,9 +16,9 @@ public class HttpServerFilterAdvice {
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void onExit(
       @Advice.Argument(0) FilterChainContext ctx, @Advice.Argument(2) HttpResponsePacket response) {
-    Span span = tracer().getServerSpan(ctx);
-    if (span != null) {
-      tracer().end(span, response);
+    Context context = tracer().getServerContext(ctx);
+    if (context != null) {
+      tracer().end(context, response);
     }
   }
 }

--- a/instrumentation/jetty-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/JettyHandlerAdvice.java
+++ b/instrumentation/jetty-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/JettyHandlerAdvice.java
@@ -34,7 +34,7 @@ public class JettyHandlerAdvice {
       return;
     }
 
-    Context ctx = tracer().startSpan(request, request, method);
+    Context ctx = tracer().startSpan(request, request, request, method);
     span = Java8BytecodeBridge.spanFromContext(ctx);
     scope = tracer().startScope(span, request);
   }

--- a/instrumentation/jetty-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/JettyHandlerAdvice.java
+++ b/instrumentation/jetty-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/JettyHandlerAdvice.java
@@ -7,10 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.jetty;
 
 import static io.opentelemetry.javaagent.instrumentation.jetty.JettyHttpServerTracer.tracer;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
 import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TagSettingAsyncListener;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -25,7 +23,7 @@ public class JettyHandlerAdvice {
       @Advice.Origin Method method,
       @Advice.This Object source,
       @Advice.Argument(value = 2, readOnly = false) HttpServletRequest request,
-      @Advice.Local("otelSpan") Span span,
+      @Advice.Local("otelContext") Context context,
       @Advice.Local("otelScope") Scope scope) {
 
     Context attachedContext = tracer().getServerContext(request);
@@ -34,9 +32,8 @@ public class JettyHandlerAdvice {
       return;
     }
 
-    Context ctx = tracer().startSpan(request, request, request, method);
-    span = Java8BytecodeBridge.spanFromContext(ctx);
-    scope = tracer().startScope(span, request);
+    context = tracer().startSpan(request, request, request, method);
+    scope = context.makeCurrent();
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -44,22 +41,22 @@ public class JettyHandlerAdvice {
       @Advice.Argument(2) HttpServletRequest request,
       @Advice.Argument(3) HttpServletResponse response,
       @Advice.Thrown Throwable throwable,
-      @Advice.Local("otelSpan") Span span,
+      @Advice.Local("otelContext") Context context,
       @Advice.Local("otelScope") Scope scope) {
     if (scope == null) {
       return;
     }
     scope.close();
 
-    if (span == null) {
+    if (context == null) {
       // an existing span was found
       return;
     }
 
-    tracer().setPrincipal(span, request);
+    tracer().setPrincipal(context, request);
 
     if (throwable != null) {
-      tracer().endExceptionally(span, throwable, response);
+      tracer().endExceptionally(context, throwable, response);
       return;
     }
 
@@ -68,7 +65,9 @@ public class JettyHandlerAdvice {
     // In case of async servlets wait for the actual response to be ready
     if (request.isAsyncStarted()) {
       try {
-        request.getAsyncContext().addListener(new TagSettingAsyncListener(responseHandled, span));
+        request
+            .getAsyncContext()
+            .addListener(new TagSettingAsyncListener(responseHandled, context));
       } catch (IllegalStateException e) {
         // org.eclipse.jetty.server.Request may throw an exception here if request became
         // finished after check above. We just ignore that exception and move on.
@@ -77,7 +76,7 @@ public class JettyHandlerAdvice {
 
     // Check again in case the request finished before adding the listener.
     if (!request.isAsyncStarted() && responseHandled.compareAndSet(false, true)) {
-      tracer().end(span, response);
+      tracer().end(context, response);
     }
   }
 }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
@@ -46,7 +46,8 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
 
     HttpRequest request = (HttpRequest) msg.getMessage();
 
-    Context context = tracer().startSpan(request, ctx.getChannel(), "netty.request");
+    Context context =
+        tracer().startSpan(request, ctx.getChannel(), channelTraceContext, "netty.request");
     Span span = Java8BytecodeBridge.spanFromContext(context);
     try (Scope ignored = tracer().startScope(span, channelTraceContext)) {
       ctx.sendUpstream(msg);

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
@@ -7,11 +7,9 @@ package io.opentelemetry.javaagent.instrumentation.netty.v3_8.server;
 
 import static io.opentelemetry.javaagent.instrumentation.netty.v3_8.server.NettyHttpServerTracer.tracer;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.instrumentation.api.ContextStore;
-import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
 import io.opentelemetry.javaagent.instrumentation.netty.v3_8.ChannelTraceContext;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
@@ -48,11 +46,11 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
 
     Context context =
         tracer().startSpan(request, ctx.getChannel(), channelTraceContext, "netty.request");
-    Span span = Java8BytecodeBridge.spanFromContext(context);
-    try (Scope ignored = tracer().startScope(span, channelTraceContext)) {
+    try (Scope ignored = context.makeCurrent()) {
       ctx.sendUpstream(msg);
+      // the span is ended normally in HttpServerResponseTracingHandler
     } catch (Throwable throwable) {
-      tracer().endExceptionally(span, throwable);
+      tracer().endExceptionally(context, throwable);
       throw throwable;
     }
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerResponseTracingHandler.java
@@ -7,7 +7,6 @@ package io.opentelemetry.javaagent.instrumentation.netty.v3_8.server;
 
 import static io.opentelemetry.javaagent.instrumentation.netty.v3_8.server.NettyHttpServerTracer.tracer;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.instrumentation.api.ContextStore;
@@ -37,13 +36,12 @@ public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHan
       return;
     }
 
-    Span span = Span.fromContext(context);
     try (Scope ignored = context.makeCurrent()) {
       ctx.sendDownstream(msg);
     } catch (Throwable throwable) {
-      tracer().endExceptionally(span, throwable);
+      tracer().endExceptionally(context, throwable);
       throw throwable;
     }
-    tracer().end(span, (HttpResponse) msg.getMessage());
+    tracer().end(context, (HttpResponse) msg.getMessage());
   }
 }

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
@@ -11,10 +11,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpRequest;
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
 
 public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapter {
 
@@ -35,11 +33,11 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     }
 
     Context context = tracer().startSpan((HttpRequest) msg, channel, channel, "netty.request");
-    Span span = Java8BytecodeBridge.spanFromContext(context);
-    try (Scope ignored = tracer().startScope(span, channel)) {
+    try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
+      // the span is ended normally in HttpServerResponseTracingHandler
     } catch (Throwable throwable) {
-      tracer().endExceptionally(span, throwable);
+      tracer().endExceptionally(context, throwable);
       throw throwable;
     }
   }

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
@@ -34,7 +34,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       return;
     }
 
-    Context context = tracer().startSpan((HttpRequest) msg, channel, "netty.request");
+    Context context = tracer().startSpan((HttpRequest) msg, channel, channel, "netty.request");
     Span span = Java8BytecodeBridge.spanFromContext(context);
     try (Scope ignored = tracer().startScope(span, channel)) {
       ctx.fireChannelRead(msg);

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerResponseTracingHandler.java
@@ -11,7 +11,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponse;
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
@@ -25,13 +24,12 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       return;
     }
 
-    Span span = Span.fromContext(context);
     try (Scope ignored = context.makeCurrent()) {
       ctx.write(msg, prm);
     } catch (Throwable throwable) {
-      tracer().endExceptionally(span, throwable);
+      tracer().endExceptionally(context, throwable);
       throw throwable;
     }
-    tracer().end(span, (HttpResponse) msg);
+    tracer().end(context, (HttpResponse) msg);
   }
 }

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
@@ -11,10 +11,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpRequest;
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
 
 public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapter {
 
@@ -35,11 +33,11 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     }
 
     Context context = tracer().startSpan((HttpRequest) msg, channel, channel, "netty.request");
-    Span span = Java8BytecodeBridge.spanFromContext(context);
-    try (Scope ignored = tracer().startScope(span, channel)) {
+    try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
+      // the span is ended normally in HttpServerResponseTracingHandler
     } catch (Throwable throwable) {
-      tracer().endExceptionally(span, throwable);
+      tracer().endExceptionally(context, throwable);
       throw throwable;
     }
   }

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
@@ -34,7 +34,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       return;
     }
 
-    Context context = tracer().startSpan((HttpRequest) msg, channel, "netty.request");
+    Context context = tracer().startSpan((HttpRequest) msg, channel, channel, "netty.request");
     Span span = Java8BytecodeBridge.spanFromContext(context);
     try (Scope ignored = tracer().startScope(span, channel)) {
       ctx.fireChannelRead(msg);

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerResponseTracingHandler.java
@@ -11,7 +11,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponse;
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
@@ -25,13 +24,12 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       return;
     }
 
-    Span span = Span.fromContext(context);
     try (Scope ignored = context.makeCurrent()) {
       ctx.write(msg, prm);
     } catch (Throwable throwable) {
-      tracer().endExceptionally(span, throwable);
+      tracer().endExceptionally(context, throwable);
       throw throwable;
     }
-    tracer().end(span, (HttpResponse) msg);
+    tracer().end(context, (HttpResponse) msg);
   }
 }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3HttpServerTracer.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3HttpServerTracer.java
@@ -37,24 +37,25 @@ public class Servlet3HttpServerTracer extends ServletHttpServerTracer<HttpServle
 
   @Override
   public void endExceptionally(
-      Span span, Throwable throwable, HttpServletResponse response, long timestamp) {
+      Context context, Throwable throwable, HttpServletResponse response, long timestamp) {
     if (response.isCommitted()) {
-      super.endExceptionally(span, throwable, response, timestamp);
+      super.endExceptionally(context, throwable, response, timestamp);
     } else {
       // passing null response to super, in order to capture as 500 / INTERNAL, due to servlet spec
       // https://javaee.github.io/servlet-spec/downloads/servlet-4.0/servlet-4_0_FINAL.pdf:
       // "If a servlet generates an error that is not handled by the error page mechanism as
       // described above, the container must ensure to send a response with status 500."
-      super.endExceptionally(span, throwable, null, timestamp);
+      super.endExceptionally(context, throwable, null, timestamp);
     }
   }
 
   @Override
-  public void end(Span span, HttpServletResponse response, long timestamp) {
-    super.end(span, response, timestamp);
+  public void end(Context context, HttpServletResponse response, long timestamp) {
+    super.end(context, response, timestamp);
   }
 
-  public void onTimeout(Span span, long timeout) {
+  public void onTimeout(Context context, long timeout) {
+    Span span = Span.fromContext(context);
     span.setStatus(StatusCode.ERROR);
     span.setAttribute("timeout", timeout);
     span.end();

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/TagSettingAsyncListener.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/TagSettingAsyncListener.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v3_0;
 
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
@@ -16,24 +16,24 @@ public class TagSettingAsyncListener implements AsyncListener {
       new Servlet3HttpServerTracer();
 
   private final AtomicBoolean responseHandled;
-  private final Span span;
+  private final Context context;
 
-  public TagSettingAsyncListener(AtomicBoolean responseHandled, Span span) {
+  public TagSettingAsyncListener(AtomicBoolean responseHandled, Context context) {
     this.responseHandled = responseHandled;
-    this.span = span;
+    this.context = context;
   }
 
   @Override
   public void onComplete(AsyncEvent event) {
     if (responseHandled.compareAndSet(false, true)) {
-      servletHttpServerTracer.end(span, (HttpServletResponse) event.getSuppliedResponse());
+      servletHttpServerTracer.end(context, (HttpServletResponse) event.getSuppliedResponse());
     }
   }
 
   @Override
   public void onTimeout(AsyncEvent event) {
     if (responseHandled.compareAndSet(false, true)) {
-      servletHttpServerTracer.onTimeout(span, event.getAsyncContext().getTimeout());
+      servletHttpServerTracer.onTimeout(context, event.getAsyncContext().getTimeout());
     }
   }
 
@@ -41,7 +41,7 @@ public class TagSettingAsyncListener implements AsyncListener {
   public void onError(AsyncEvent event) {
     if (responseHandled.compareAndSet(false, true)) {
       servletHttpServerTracer.endExceptionally(
-          span, event.getThrowable(), (HttpServletResponse) event.getSuppliedResponse());
+          context, event.getThrowable(), (HttpServletResponse) event.getSuppliedResponse());
     }
   }
 

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/WebMvcTracingFilter.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/WebMvcTracingFilter.java
@@ -31,7 +31,7 @@ public class WebMvcTracingFilter extends OncePerRequestFilter implements Ordered
   public void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
-    Context ctx = tracer.startSpan(request, request, FILTER_CLASS + "." + FILTER_METHOD);
+    Context ctx = tracer.startSpan(request, request, request, FILTER_CLASS + "." + FILTER_METHOD);
     Span serverSpan = Span.fromContext(ctx);
     try (Scope ignored = tracer.startScope(serverSpan, request)) {
       filterChain.doFilter(request, response);

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/WebMvcTracingFilter.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/WebMvcTracingFilter.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.spring.webmvc;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -32,12 +31,11 @@ public class WebMvcTracingFilter extends OncePerRequestFilter implements Ordered
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     Context ctx = tracer.startSpan(request, request, request, FILTER_CLASS + "." + FILTER_METHOD);
-    Span serverSpan = Span.fromContext(ctx);
-    try (Scope ignored = tracer.startScope(serverSpan, request)) {
+    try (Scope ignored = ctx.makeCurrent()) {
       filterChain.doFilter(request, response);
-      tracer.end(serverSpan, response);
+      tracer.end(ctx, response);
     } catch (Throwable t) {
-      tracer.endExceptionally(serverSpan, t, response);
+      tracer.endExceptionally(ctx, t, response);
       throw t;
     }
   }


### PR DESCRIPTION
Follow-on to #1525

* now adds `CONTEXT_SERVER_SPAN_KEY` in `startSpan()` instead of `startScope()`
* `HttpServerTracer.startScope()` doesn't do anything after above change, so removed
* pass `Context` to `end()` and `endExceptionally()`, since now don't typically have Span reference handy to pass in