### PR TITLE
Add package prefix to classloader ignore matcher

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ClassLoaderMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ClassLoaderMatcher.java
@@ -59,6 +59,9 @@ public final class ClassLoaderMatcher {
       if (canSkipClassLoaderByName(cl)) {
         return true;
       }
+      if (canSkipClassLoaderByPackagePrefix(cl)) {
+        return true;
+      }
       Boolean v = skipCache.getIfPresent(cl);
       if (v != null) {
         return v;
@@ -90,6 +93,18 @@ public final class ClassLoaderMatcher {
         default:
           return false;
       }
+    }
+
+    private static boolean canSkipClassLoaderByPackagePrefix(ClassLoader loader) {
+      String name = loader.getClass().getName();
+      if (name.startsWith("datadog.")
+          || name.startsWith("com.dynatrace.")
+          || name.startsWith("com.appdynamics.")
+          || name.startsWith("com.newrelic.")
+          || name.startsWith("com.nr.agent.")) {
+        return true;
+      }
+      return false;
     }
 
     /**

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ClassLoaderMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ClassLoaderMatcher.java
@@ -59,9 +59,6 @@ public final class ClassLoaderMatcher {
       if (canSkipClassLoaderByName(cl)) {
         return true;
       }
-      if (canSkipClassLoaderByPackagePrefix(cl)) {
-        return true;
-      }
       Boolean v = skipCache.getIfPresent(cl);
       if (v != null) {
         return v;
@@ -80,7 +77,9 @@ public final class ClassLoaderMatcher {
     }
 
     private static boolean canSkipClassLoaderByName(ClassLoader loader) {
-      switch (loader.getClass().getName()) {
+      String name = loader.getClass().getName();
+      // check by FQCN
+      switch (name) {
         case "org.codehaus.groovy.runtime.callsite.CallSiteClassLoader":
         case "sun.reflect.DelegatingClassLoader":
         case "jdk.internal.reflect.DelegatingClassLoader":
@@ -90,17 +89,13 @@ public final class ClassLoaderMatcher {
         case AGENT_CLASSLOADER_NAME:
         case EXPORTER_CLASSLOADER_NAME:
           return true;
-        default:
-          return false;
       }
-    }
-
-    private static boolean canSkipClassLoaderByPackagePrefix(ClassLoader loader) {
-      String name = loader.getClass().getName();
+      // check by package prefix
       if (name.startsWith("datadog.")
           || name.startsWith("com.dynatrace.")
           || name.startsWith("com.appdynamics.")
-          || name.startsWith("com.newrelic.")
+          || name.startsWith("com.newrelic.agent.")
+          || name.startsWith("com.newrelic.api.agent.")
           || name.startsWith("com.nr.agent.")) {
         return true;
       }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ClassLoaderMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ClassLoaderMatcher.java
@@ -89,6 +89,8 @@ public final class ClassLoaderMatcher {
         case AGENT_CLASSLOADER_NAME:
         case EXPORTER_CLASSLOADER_NAME:
           return true;
+        default:
+          // noop
       }
       // check by package prefix
       if (name.startsWith("datadog.")


### PR DESCRIPTION
Related to #1534 

OTEL agent already ignores other agent's classes by package prefix.
However agets also use non-shaded classes (usually present in agent classloader),
these classes are not excluded by package prefix and have to be excluded
by classloader. One example is Okhttp client used by DataDog agent.

Signed-off-by: Pavol Loffay <p.loffay@gmail.com>