### PR TITLE
Fix mongo-common testLatestDeps

### DIFF
--- a/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
+++ b/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
@@ -18,19 +18,19 @@ class MongoClientTracerTest extends Specification {
     def tracer = new MongoClientTracer()
 
     expect:
-    tracer.normalizeQuery(
+    normalizeQueryAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonInt32(1))) ==
-      '{ "cmd" : "?" }'
+      '{"cmd": "?"}'
 
-    tracer.normalizeQuery(
+    normalizeQueryAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonInt32(1))
         .append("sub", new BsonDocument("a", new BsonInt32(1)))) ==
-      '{ "cmd" : "?", "sub" : { "a" : "?" } }'
+      '{"cmd": "?", "sub": {"a": "?"}}'
 
-    tracer.normalizeQuery(
+    normalizeQueryAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonInt32(1))
         .append("sub", new BsonArray(asList(new BsonInt32(1))))) ==
-      '{ "cmd" : "?", "sub" : ["?"] }'
+      '{"cmd": "?", "sub": ["?"]}'
   }
 
   def 'should only preserve string value if it is the value of the first top-level key'() {
@@ -38,34 +38,47 @@ class MongoClientTracerTest extends Specification {
     def tracer = new MongoClientTracer()
 
     expect:
-    tracer.normalizeQuery(
+    normalizeQueryAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonString("c"))
         .append("f", new BsonString("c"))
         .append("sub", new BsonString("c"))) ==
-      '{ "cmd" : "c", "f" : "?", "sub" : "?" }'
+      '{"cmd": "c", "f": "?", "sub": "?"}'
   }
 
   def 'should truncate simple command'() {
     setup:
     def tracer = new MongoClientTracer(20)
 
-    expect:
-    tracer.normalizeQuery(
+    def normalized = normalizeQueryAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonString("c"))
         .append("f1", new BsonString("c1"))
-        .append("f2", new BsonString("c2"))) ==
-      '{ "cmd" : "c", "f1" '
+        .append("f2", new BsonString("c2")))
+    expect:
+    // this can vary because of different whitespace for different mongo versions
+    normalized == '{"cmd": "c", "f1": "' || normalized == '{"cmd": "c", "f1" '
   }
 
   def 'should truncate array'() {
     setup:
     def tracer = new MongoClientTracer(27)
 
-    expect:
-    tracer.normalizeQuery(
+    def normalized = normalizeQueryAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonString("c"))
-        .append("f1", new BsonArray(asList(new BsonString("c1"), new BsonString("c2"))))
-        .append("f2", new BsonString("c3"))) ==
-      '{ "cmd" : "c", "f1" : ["?",'
+        .append("f1", new BsonArray(Arrays.asList(new BsonString("c1"), new BsonString("c2"))))
+        .append("f2", new BsonString("c3")))
+    expect:
+    // this can vary because of different whitespace for different mongo versions
+    normalized == '{"cmd": "c", "f1": ["?", "?' || normalized == '{"cmd": "c", "f1": ["?",'
+  }
+
+  def normalizeQueryAcrossVersions(MongoClientTracer tracer, BsonDocument query) {
+    return normalizeAcrossVersions(tracer.normalizeQuery(query))
+  }
+
+  def normalizeAcrossVersions(String json) {
+    json = json.replaceAll('\\{ ', '{')
+    json = json.replaceAll(' }', '}')
+    json = json.replaceAll(' :', ':')
+    return json
   }
 }


### PR DESCRIPTION
Reverts part of #1804.

Probably will re-revert it in #1643, where we aren't (currently) able to mix unit tests and "full agent" tests in a single module, so probably `mongo-common` will only be unit tests, which don't have "library" dependencies, but we can worry about that over there.

Closes #1815, #1816, #1817, #1819