### PR TITLE
Add jsp to test matrix application

### DIFF
--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/javaagent/jaxrs-client-2.0-jersey-2.0-javaagent.gradle
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/javaagent/jaxrs-client-2.0-jersey-2.0-javaagent.gradle
@@ -4,7 +4,7 @@ muzzle {
   pass {
     group = "org.glassfish.jersey.core"
     module = "jersey-client"
-    versions = "[2.0,)"
+    versions = "[2.0,3.0.0)"
   }
 }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/jaxrs-2.0-jersey-2.0-javaagent.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/jaxrs-2.0-jersey-2.0-javaagent.gradle
@@ -6,7 +6,7 @@ muzzle {
   pass {
     group = "org.glassfish.jersey.core"
     module = "jersey-server"
-    versions = "[2.0,]"
+    versions = "[2.0,3.0.0)"
   }
 }
 

--- a/smoke-tests/matrix/src/main/java/com/splunk/opentelemetry/appservers/javaee/JspServlet.java
+++ b/smoke-tests/matrix/src/main/java/com/splunk/opentelemetry/appservers/javaee/JspServlet.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.splunk.opentelemetry.appservers.javaee;
+
+import java.io.IOException;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class JspServlet extends HttpServlet {
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException, ServletException {
+    RequestDispatcher resultView = req.getRequestDispatcher("test.jsp");
+    resultView.forward(req, resp);
+  }
+
+}

--- a/smoke-tests/matrix/src/main/webapp/WEB-INF/web.xml
+++ b/smoke-tests/matrix/src/main/webapp/WEB-INF/web.xml
@@ -11,6 +11,10 @@
         <servlet-name>Greeting</servlet-name>
         <servlet-class>com.splunk.opentelemetry.appservers.javaee.GreetingServlet</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>Jsp</servlet-name>
+        <servlet-class>com.splunk.opentelemetry.appservers.javaee.JspServlet</servlet-class>
+    </servlet>
     <servlet-mapping>
         <servlet-name>Headers</servlet-name>
         <url-pattern>/headers</url-pattern>
@@ -18,5 +22,9 @@
     <servlet-mapping>
         <servlet-name>Greeting</servlet-name>
         <url-pattern>/greeting</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>Jsp</servlet-name>
+        <url-pattern>/jsp</url-pattern>
     </servlet-mapping>
 </web-app>

--- a/smoke-tests/matrix/src/main/webapp/test.jsp
+++ b/smoke-tests/matrix/src/main/webapp/test.jsp
@@ -1,0 +1,10 @@
+
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+  <head>
+    <title>Successful JSP test</title>
+  </head>
+  <body>
+    This JSP demonstrates that Otel instrumentation agent does not break JSP compilation and loading.
+  </body>
+</html>


### PR DESCRIPTION
JSP often use different classloaders and on-the-fly compilation. This demonstrates e.g. #1595 