### PR TITLE
Update exporter module names to match sdk repo

### DIFF
--- a/javaagent-exporters/jaeger/jaeger.gradle
+++ b/javaagent-exporters/jaeger/jaeger.gradle
@@ -5,7 +5,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 
-archivesBaseName = 'javaagent-exporters-jaeger'
+archivesBaseName = 'javaagent-exporter-jaeger'
 
 dependencies {
   compileOnly(project(":javaagent-spi"))

--- a/javaagent-exporters/logging/logging.gradle
+++ b/javaagent-exporters/logging/logging.gradle
@@ -5,7 +5,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 
-archivesBaseName = 'javaagent-exporters-logging'
+archivesBaseName = 'javaagent-exporter-logging'
 
 dependencies {
   compileOnly project(':javaagent-spi')

--- a/javaagent-exporters/otlp/otlp.gradle
+++ b/javaagent-exporters/otlp/otlp.gradle
@@ -5,7 +5,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 
-archivesBaseName = 'javaagent-exporters-otlp'
+archivesBaseName = 'javaagent-exporter-otlp'
 
 dependencies {
   compileOnly(project(':javaagent-spi'))

--- a/javaagent-exporters/prometheus/prometheus.gradle
+++ b/javaagent-exporters/prometheus/prometheus.gradle
@@ -5,7 +5,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 
-archivesBaseName = 'javaagent-exporters-prometheus'
+archivesBaseName = 'javaagent-exporter-prometheus'
 
 dependencies {
   compileOnly(project(':javaagent-spi'))

--- a/javaagent-exporters/zipkin/zipkin.gradle
+++ b/javaagent-exporters/zipkin/zipkin.gradle
@@ -5,7 +5,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 
-archivesBaseName = 'javaagent-exporters-zipkin'
+archivesBaseName = 'javaagent-exporter-zipkin'
 
 dependencies {
   compileOnly(project(':javaagent-spi'))


### PR DESCRIPTION
Changing `exporters` to `exporter` in the artifact names, similar to change that was made in SDK repo recently.