### PR TITLE
Support faas.id & cloud.account.id attributes in AWS Lambda

### DIFF
--- a/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
+++ b/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
@@ -31,6 +31,9 @@ dependencies {
     'commons-io:commons-io:2.2')
   implementation deps.slf4j
 
+  // 1.2.0 allows to get the function ARN
+  testLibrary group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.0'
+
   testImplementation deps.opentelemetryTraceProps
 
   testImplementation project(':instrumentation:aws-lambda-1.0:testing')

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0;
 
+import static io.opentelemetry.api.trace.attributes.SemanticAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.api.trace.attributes.SemanticAttributes.FAAS_EXECUTION;
+import static io.opentelemetry.api.trace.attributes.SemanticAttributes.FAAS_ID;
 import static io.opentelemetry.api.trace.attributes.SemanticAttributes.FAAS_TRIGGER;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -19,12 +21,30 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.attributes.SemanticAttributes.FaasTriggerValues;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.Collections;
 import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class AwsLambdaTracer extends BaseTracer {
 
   private static final String AWS_TRACE_HEADER_ENV_KEY = "_X_AMZN_TRACE_ID";
+  private static final MethodHandle GET_FUNCTION_ARN;
+
+  static {
+    MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+    MethodHandle getFunctionArn;
+    try {
+      getFunctionArn =
+          lookup.findVirtual(
+              Context.class, "getInvokedFunctionArn", MethodType.methodType(String.class));
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      getFunctionArn = null;
+    }
+    GET_FUNCTION_ARN = getFunctionArn;
+  }
 
   private final HttpSpanAttributes httpSpanAttributes = new HttpSpanAttributes();
 
@@ -69,10 +89,34 @@ public class AwsLambdaTracer extends BaseTracer {
   }
 
   private void setAttributes(SpanBuilder span, Context context, Object input) {
-    span.setAttribute(FAAS_EXECUTION, context.getAwsRequestId());
+    setCommonAttributes(span, context);
     if (input instanceof APIGatewayProxyRequestEvent) {
       span.setAttribute(FAAS_TRIGGER, FaasTriggerValues.HTTP.getValue());
       httpSpanAttributes.onRequest(span, (APIGatewayProxyRequestEvent) input);
+    }
+  }
+
+  private void setCommonAttributes(SpanBuilder span, Context context) {
+    span.setAttribute(FAAS_EXECUTION, context.getAwsRequestId());
+    String arn = getFunctionArn(context);
+    if (arn != null) {
+      span.setAttribute(FAAS_ID, arn);
+      String[] arnParts = arn.split(":");
+      if (arnParts.length >= 5) {
+        span.setAttribute(CLOUD_ACCOUNT_ID, arnParts[4]);
+      }
+    }
+  }
+
+  @Nullable
+  private String getFunctionArn(Context context) {
+    if (GET_FUNCTION_ARN == null) {
+      return null;
+    }
+    try {
+      return (String) GET_FUNCTION_ARN.invoke(context);
+    } catch (Throwable throwable) {
+      return null;
     }
   }
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
@@ -26,7 +26,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class AwsLambdaTracer extends BaseTracer {
@@ -49,7 +48,7 @@ public class AwsLambdaTracer extends BaseTracer {
 
   private final HttpSpanAttributes httpSpanAttributes = new HttpSpanAttributes();
   // cached accountId value
-  private volatile AtomicReference<String> accountId;
+  private volatile String accountId;
 
   public AwsLambdaTracer() {}
 
@@ -125,20 +124,20 @@ public class AwsLambdaTracer extends BaseTracer {
 
   @Nullable
   private String getAccountId(@Nullable String arn) {
+    if (arn == null) {
+      return null;
+    }
     if (accountId == null) {
       synchronized (this) {
         if (accountId == null) {
-          accountId = new AtomicReference<>();
-          if (arn != null) {
-            String[] arnParts = arn.split(":");
-            if (arnParts.length >= 5) {
-              accountId.set(arnParts[4]);
-            }
+          String[] arnParts = arn.split(":");
+          if (arnParts.length >= 5) {
+            accountId = arnParts[4];
           }
         }
       }
     }
-    return accountId.get();
+    return accountId;
   }
 
   private String spanName(Context context, Object input) {

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapperTest.groovy
@@ -75,6 +75,8 @@ class TracingRequestApiGatewayWrapperTest extends TracingRequestWrapperTestBase 
           name("/hello/{param}")
           kind SERVER
           attributes {
+            "$SemanticAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"
+            "$SemanticAttributes.CLOUD_ACCOUNT_ID.key" "123456789"
             "$SemanticAttributes.FAAS_EXECUTION.key" "1-22-333"
             "$SemanticAttributes.FAAS_TRIGGER.key" "http"
             "$SemanticAttributes.HTTP_METHOD.key" "GET"
@@ -105,6 +107,8 @@ class TracingRequestApiGatewayWrapperTest extends TracingRequestWrapperTestBase 
           name("my_function")
           kind SERVER
           attributes {
+            "$SemanticAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"
+            "$SemanticAttributes.CLOUD_ACCOUNT_ID.key" "123456789"
             "$SemanticAttributes.FAAS_EXECUTION.key" "1-22-333"
             "$SemanticAttributes.FAAS_TRIGGER.key" "http"
           }

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
@@ -62,6 +62,7 @@ class TracingRequestStreamWrapperTest extends InstrumentationSpecification imple
     def context = Mock(Context)
     context.getFunctionName() >> "my_function"
     context.getAwsRequestId() >> "1-22-333"
+    context.getInvokedFunctionArn() >> "arn:aws:lambda:us-east-1:123456789:function:test"
     def input = new ByteArrayInputStream("hello\n".getBytes(Charset.defaultCharset()))
     def output = new ByteArrayOutputStream()
 
@@ -74,6 +75,8 @@ class TracingRequestStreamWrapperTest extends InstrumentationSpecification imple
           name("my_function")
           kind SERVER
           attributes {
+            "$SemanticAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"
+            "$SemanticAttributes.CLOUD_ACCOUNT_ID.key" "123456789"
             "${SemanticAttributes.FAAS_EXECUTION.key}" "1-22-333"
           }
         }
@@ -86,6 +89,7 @@ class TracingRequestStreamWrapperTest extends InstrumentationSpecification imple
     def context = Mock(Context)
     context.getFunctionName() >> "my_function"
     context.getAwsRequestId() >> "1-22-333"
+    context.getInvokedFunctionArn() >> "arn:aws:lambda:us-east-1:123456789:function:test"
     def input = new ByteArrayInputStream("bye".getBytes(Charset.defaultCharset()))
     def output = new ByteArrayOutputStream()
 
@@ -106,6 +110,8 @@ class TracingRequestStreamWrapperTest extends InstrumentationSpecification imple
           errored true
           errorEvent(IllegalArgumentException, "bad argument")
           attributes {
+            "$SemanticAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"
+            "$SemanticAttributes.CLOUD_ACCOUNT_ID.key" "123456789"
             "${SemanticAttributes.FAAS_EXECUTION.key}" "1-22-333"
           }
         }

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
@@ -39,6 +39,8 @@ class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
           name("my_function")
           kind SERVER
           attributes {
+            "$SemanticAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"
+            "$SemanticAttributes.CLOUD_ACCOUNT_ID.key" "123456789"
             "${SemanticAttributes.FAAS_EXECUTION.key}" "1-22-333"
           }
         }
@@ -68,6 +70,8 @@ class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
           errored true
           errorEvent(IllegalArgumentException, "bad argument")
           attributes {
+            "$SemanticAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"
+            "$SemanticAttributes.CLOUD_ACCOUNT_ID.key" "123456789"
             "${SemanticAttributes.FAAS_EXECUTION.key}" "1-22-333"
           }
         }

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
@@ -30,6 +30,7 @@ class TracingRequestWrapperTestBase extends InstrumentationSpecification impleme
     context = Mock(Context)
     context.getFunctionName() >> "my_function"
     context.getAwsRequestId() >> "1-22-333"
+    context.getInvokedFunctionArn() >> "arn:aws:lambda:us-east-1:123456789:function:test"
 
     AgentTestRunner.setGlobalPropagators(DefaultContextPropagators.builder()
       .addTextMapPropagator(B3Propagator.getInstance()).build())


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1773 (this is the last thing that I wanted to support)

It probably needs to wait for the spec PR https://github.com/open-telemetry/opentelemetry-specification/pull/1265 to get merged. 