### PR TITLE
Make twilio instrumentation consistent with others

### DIFF
--- a/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioSyncInstrumentation.java
+++ b/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioSyncInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.twilio;
 
+import static io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.twilio.TwilioTracer.tracer;
 import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.extendsClass;
@@ -15,10 +16,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
-import com.twilio.Twilio;
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.javaagent.instrumentation.api.CallDepthThreadLocalMap;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -74,19 +73,15 @@ public class TwilioSyncInstrumentation implements TypeInstrumentation {
     public static void methodEnter(
         @Advice.This Object that,
         @Advice.Origin("#m") String methodName,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-
-      // Ensure that we only create a span for the top-level Twilio client method; except in the
-      // case of async operations where we want visibility into how long the task was delayed from
-      // starting. Our call depth checker does not span threads, so the async case is handled
-      // automatically for us.
-      if (CallDepthThreadLocalMap.incrementCallDepth(Twilio.class) > 0) {
+      Context parentContext = currentContext();
+      if (!tracer().shouldStartSpan(parentContext)) {
         return;
       }
 
-      span = tracer().startSpan(that, methodName);
-      scope = tracer().startScope(span);
+      context = tracer().startSpan(parentContext, that, methodName);
+      scope = context.makeCurrent();
     }
 
     /** Method exit instrumentation. */
@@ -94,18 +89,17 @@ public class TwilioSyncInstrumentation implements TypeInstrumentation {
     public static void methodExit(
         @Advice.Thrown Throwable throwable,
         @Advice.Return Object response,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
       if (scope == null) {
         return;
       }
-      CallDepthThreadLocalMap.reset(Twilio.class);
 
       scope.close();
       if (throwable != null) {
-        tracer().endExceptionally(span, throwable);
+        tracer().endExceptionally(context, throwable);
       } else {
-        tracer().end(span, response);
+        tracer().end(context, response);
       }
     }
   }

--- a/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
@@ -5,7 +5,7 @@
 
 package test
 
-import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
+import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -142,7 +142,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(1) {
           name "MessageCreator.create"
-          kind INTERNAL
+          kind CLIENT
           errored false
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -186,7 +186,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(1) {
           name "CallCreator.create"
-          kind INTERNAL
+          kind CLIENT
           errored false
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Call"
@@ -252,7 +252,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(1) {
           name "MessageCreator.create"
-          kind INTERNAL
+          kind CLIENT
           childOf(span(0))
           errored false
           attributes {
@@ -334,7 +334,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(1) {
           name "MessageCreator.create"
-          kind INTERNAL
+          kind CLIENT
           childOf(span(0))
           errored false
           attributes {
@@ -413,7 +413,7 @@ class TwilioClientTest extends AgentTestRunner {
     message.body == "Hello, World!"
 
     assertTraces(1) {
-      trace(0, 3) {
+      trace(0, 2) {
         span(0) {
           name "test"
           errored false
@@ -423,20 +423,8 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(1) {
           name "MessageCreator.createAsync"
-          kind INTERNAL
+          kind CLIENT
           childOf(span(0))
-          errored false
-          attributes {
-            "twilio.type" "com.twilio.rest.api.v2010.account.Message"
-            "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
-            "twilio.sid" "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-            "twilio.status" "sent"
-          }
-        }
-        span(2) {
-          name "MessageCreator.create"
-          kind INTERNAL
-          childOf(span(1))
           errored false
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -484,7 +472,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(1) {
           name "MessageCreator.create"
-          kind INTERNAL
+          kind CLIENT
           errored true
           errorEvent(ApiException, "Testing Failure")
         }
@@ -512,7 +500,7 @@ class TwilioClientTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           name "MessageCreator.create"
-          kind INTERNAL
+          kind CLIENT
           hasNoParent()
           errored false
           attributes {
@@ -556,7 +544,7 @@ class TwilioClientTest extends AgentTestRunner {
     message.body == "Hello, World!"
 
     assertTraces(1) {
-      trace(0, 3) {
+      trace(0, 2) {
         span(0) {
           name "test"
           errored false
@@ -566,18 +554,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(1) {
           name "MessageCreator.createAsync"
-          kind INTERNAL
-          errored false
-          attributes {
-            "twilio.type" "com.twilio.rest.api.v2010.account.Message"
-            "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
-            "twilio.sid" "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-            "twilio.status" "sent"
-          }
-        }
-        span(2) {
-          name "MessageCreator.create"
-          kind INTERNAL
+          kind CLIENT
           errored false
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -627,7 +604,7 @@ class TwilioClientTest extends AgentTestRunner {
     expect:
 
     assertTraces(1) {
-      trace(0, 3) {
+      trace(0, 2) {
         span(0) {
           name "test"
           errored true
@@ -636,13 +613,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(1) {
           name "MessageCreator.createAsync"
-          kind INTERNAL
-          errored true
-          errorEvent(ApiException, "Testing Failure")
-        }
-        span(2) {
-          name "MessageCreator.create"
-          kind INTERNAL
+          kind CLIENT
           errored true
           errorEvent(ApiException, "Testing Failure")
         }


### PR DESCRIPTION
* Use `CONTEXT_CLIENT_SPAN_KEY` to prevent nested spans instead of `CallDepth`
* Convert span kind from `INTERNAL` to `CLIENT`
* Don't capture both async span and nested underlying sync span