### PR TITLE
Use Context more in DatabaseClientTracer

### DIFF
--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraDatabaseClientTracer.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraDatabaseClientTracer.java
@@ -10,6 +10,7 @@ import com.datastax.driver.core.Host;
 import com.datastax.driver.core.Session;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.attributes.SemanticAttributes;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import io.opentelemetry.javaagent.instrumentation.api.db.DbSystem;
@@ -53,9 +54,10 @@ public class CassandraDatabaseClientTracer extends DatabaseClientTracer<Session,
     return null;
   }
 
-  public void end(Span span, ExecutionInfo executionInfo) {
+  public void end(Context context, ExecutionInfo executionInfo) {
+    Span span = Span.fromContext(context);
     Host host = executionInfo.getQueriedHost();
     NetPeerUtils.INSTANCE.setNetPeer(span, host.getSocketAddress());
-    end(span);
+    end(context);
   }
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraDatabaseClientTracer.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraDatabaseClientTracer.java
@@ -10,6 +10,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import io.opentelemetry.javaagent.instrumentation.api.db.DbSystem;
@@ -48,11 +49,12 @@ public class CassandraDatabaseClientTracer extends DatabaseClientTracer<CqlSessi
     return null;
   }
 
-  public void onResponse(Span span, ExecutionInfo executionInfo) {
+  public void onResponse(Context context, ExecutionInfo executionInfo) {
     Node coordinator = executionInfo.getCoordinator();
     if (coordinator != null) {
       SocketAddress socketAddress = coordinator.getEndPoint().resolve();
       if (socketAddress instanceof InetSocketAddress) {
+        Span span = Span.fromContext(context);
         NetPeerUtils.INSTANCE.setNetPeer(span, ((InetSocketAddress) socketAddress));
       }
     }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/RestResponseListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/RestResponseListener.java
@@ -7,33 +7,33 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v5_0;
 
 import static io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestClientTracer.tracer;
 
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 
 public class RestResponseListener implements ResponseListener {
 
   private final ResponseListener listener;
-  private final Span span;
+  private final Context context;
 
-  public RestResponseListener(ResponseListener listener, Span span) {
+  public RestResponseListener(ResponseListener listener, Context context) {
     this.listener = listener;
-    this.span = span;
+    this.context = context;
   }
 
   @Override
   public void onSuccess(Response response) {
     if (response.getHost() != null) {
-      tracer().onResponse(span, response);
+      tracer().onResponse(context, response);
     }
-    tracer().end(span);
+    tracer().end(context);
 
     listener.onSuccess(response);
   }
 
   @Override
   public void onFailure(Exception e) {
-    tracer().endExceptionally(span, e);
+    tracer().endExceptionally(context, e);
     listener.onFailure(e);
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/Elasticsearch6RestClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/Elasticsearch6RestClientInstrumentationModule.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v6_4;
 
+import static io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestClientTracer.tracer;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -14,7 +15,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
@@ -63,23 +64,25 @@ public class Elasticsearch6RestClientInstrumentationModule extends Instrumentati
     public static void onEnter(
         @Advice.Argument(0) Request request,
         @Advice.Argument(value = 1, readOnly = false) ResponseListener responseListener,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
 
-      span = tracer().startSpan(null, request.getMethod() + " " + request.getEndpoint());
-      scope = tracer().startScope(span);
+      context =
+          tracer()
+              .startSpan(currentContext(), null, request.getMethod() + " " + request.getEndpoint());
+      scope = context.makeCurrent();
 
-      responseListener = new RestResponseListener(responseListener, span);
+      responseListener = new RestResponseListener(responseListener, context);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
       scope.close();
       if (throwable != null) {
-        tracer().endExceptionally(span, throwable);
+        tracer().endExceptionally(context, throwable);
       }
     }
   }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/RestResponseListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/RestResponseListener.java
@@ -7,33 +7,33 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v6_4;
 
 import static io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestClientTracer.tracer;
 
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 
 public class RestResponseListener implements ResponseListener {
 
   private final ResponseListener listener;
-  private final Span span;
+  private final Context context;
 
-  public RestResponseListener(ResponseListener listener, Span span) {
+  public RestResponseListener(ResponseListener listener, Context context) {
     this.listener = listener;
-    this.span = span;
+    this.context = context;
   }
 
   @Override
   public void onSuccess(Response response) {
     if (response.getHost() != null) {
-      tracer().onResponse(span, response);
+      tracer().onResponse(context, response);
     }
-    tracer().end(span);
+    tracer().end(context);
 
     listener.onSuccess(response);
   }
 
   @Override
   public void onFailure(Exception e) {
-    tracer().endExceptionally(span, e);
+    tracer().endExceptionally(context, e);
     listener.onFailure(e);
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestClientTracer.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestClientTracer.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.attributes.SemanticAttributes;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import java.net.InetSocketAddress;
@@ -19,12 +20,12 @@ public class ElasticsearchRestClientTracer extends DatabaseClientTracer<Void, St
     return TRACER;
   }
 
-  public Span onResponse(Span span, Response response) {
+  public void onResponse(Context context, Response response) {
     if (response != null && response.getHost() != null) {
+      Span span = Span.fromContext(context);
       NetPeerUtils.INSTANCE.setNetPeer(span, response.getHost().getHostName(), null);
       span.setAttribute(SemanticAttributes.NET_PEER_PORT, (long) response.getHost().getPort());
     }
-    return span;
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientInstrumentationModule.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_0;
 
+import static io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticsearchTransportClientTracer.tracer;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -13,7 +14,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
@@ -66,27 +67,27 @@ public class Elasticsearch5TransportClientInstrumentationModule extends Instrume
     public static void onEnter(
         @Advice.Argument(0) Action action,
         @Advice.Argument(1) ActionRequest actionRequest,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope,
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      span = tracer().startSpan(null, action);
-      scope = tracer().startScope(span);
+      context = tracer().startSpan(currentContext(), null, action);
+      scope = context.makeCurrent();
 
-      tracer().onRequest(span, action.getClass(), actionRequest.getClass());
-      actionListener = new TransportActionListener<>(actionRequest, actionListener, span);
+      tracer().onRequest(context, action.getClass(), actionRequest.getClass());
+      actionListener = new TransportActionListener<>(actionRequest, actionListener, context);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
       scope.close();
 
       if (throwable != null) {
-        tracer().endExceptionally(span, throwable);
+        tracer().endExceptionally(context, throwable);
       }
     }
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientInstrumentationModule.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_3;
 
+import static io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticsearchTransportClientTracer.tracer;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -13,7 +14,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
@@ -67,27 +68,27 @@ public class Elasticsearch53TransportClientInstrumentationModule extends Instrum
     public static void onEnter(
         @Advice.Argument(0) Action action,
         @Advice.Argument(1) ActionRequest actionRequest,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope,
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      span = tracer().startSpan(null, action);
-      scope = tracer().startScope(span);
+      context = tracer().startSpan(currentContext(), null, action);
+      scope = context.makeCurrent();
 
-      tracer().onRequest(span, action.getClass(), actionRequest.getClass());
-      actionListener = new TransportActionListener<>(actionRequest, actionListener, span);
+      tracer().onRequest(context, action.getClass(), actionRequest.getClass());
+      actionListener = new TransportActionListener<>(actionRequest, actionListener, context);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
       scope.close();
 
       if (throwable != null) {
-        tracer().endExceptionally(span, throwable);
+        tracer().endExceptionally(context, throwable);
       }
     }
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/TransportActionListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/TransportActionListener.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.javaagent.instrumentation.elasticsearch.transport
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.attributes.SemanticAttributes;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -26,16 +27,18 @@ import org.elasticsearch.action.support.replication.ReplicationResponse;
 public class TransportActionListener<T extends ActionResponse> implements ActionListener<T> {
 
   private final ActionListener<T> listener;
-  private final Span span;
+  private final Context context;
 
   public TransportActionListener(
-      ActionRequest actionRequest, ActionListener<T> listener, Span span) {
+      ActionRequest actionRequest, ActionListener<T> listener, Context context) {
     this.listener = listener;
-    this.span = span;
+    this.context = context;
     onRequest(actionRequest);
   }
 
   private void onRequest(ActionRequest request) {
+    Span span = Span.fromContext(context);
+
     if (request instanceof IndicesRequest) {
       IndicesRequest req = (IndicesRequest) request;
       String[] indices = req.indices();
@@ -60,6 +63,8 @@ public class TransportActionListener<T extends ActionResponse> implements Action
 
   @Override
   public void onResponse(T response) {
+    Span span = Span.fromContext(context);
+
     if (response.remoteAddress() != null) {
       NetPeerUtils.INSTANCE.setNetPeer(
           span, response.remoteAddress().getHost(), response.remoteAddress().getAddress());
@@ -114,7 +119,7 @@ public class TransportActionListener<T extends ActionResponse> implements Action
 
   @Override
   public void onFailure(Exception e) {
-    tracer().endExceptionally(span, e);
+    tracer().endExceptionally(context, e);
     listener.onFailure(e);
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/TransportActionListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/TransportActionListener.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.javaagent.instrumentation.elasticsearch.transport
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.attributes.SemanticAttributes;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -30,16 +31,17 @@ import org.elasticsearch.action.support.replication.ReplicationResponse;
 public class TransportActionListener<T extends ActionResponse> implements ActionListener<T> {
 
   private final ActionListener<T> listener;
-  private final Span span;
+  private final Context context;
 
   public TransportActionListener(
-      ActionRequest actionRequest, ActionListener<T> listener, Span span) {
+      ActionRequest actionRequest, ActionListener<T> listener, Context context) {
     this.listener = listener;
-    this.span = span;
+    this.context = context;
     onRequest(actionRequest);
   }
 
   private void onRequest(ActionRequest request) {
+    Span span = Span.fromContext(context);
     if (request instanceof IndicesRequest) {
       IndicesRequest req = (IndicesRequest) request;
       String[] indices = req.indices();
@@ -64,6 +66,8 @@ public class TransportActionListener<T extends ActionResponse> implements Action
 
   @Override
   public void onResponse(T response) {
+    Span span = Span.fromContext(context);
+
     if (response.remoteAddress() != null) {
       NetPeerUtils.INSTANCE.setNetPeer(
           span,
@@ -114,13 +118,13 @@ public class TransportActionListener<T extends ActionResponse> implements Action
       span.setAttribute("elasticsearch.node.cluster.name", resp.getClusterName().value());
     }
 
-    tracer().end(span);
+    tracer().end(context);
     listener.onResponse(response);
   }
 
   @Override
   public void onFailure(Exception e) {
-    tracer().endExceptionally(span, e);
+    tracer().endExceptionally(context, e);
     listener.onFailure(e);
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportClientTracer.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportClientTracer.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.attributes.SemanticAttributes;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import java.net.InetSocketAddress;
 import org.elasticsearch.action.Action;
@@ -20,10 +21,10 @@ public class ElasticsearchTransportClientTracer
     return TRACER;
   }
 
-  public Span onRequest(Span span, Class action, Class request) {
+  public void onRequest(Context context, Class action, Class request) {
+    Span span = Span.fromContext(context);
     span.setAttribute("elasticsearch.action", action.getSimpleName());
     span.setAttribute("elasticsearch.request", request.getSimpleName());
-    return span;
   }
 
   @Override

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jdbc;
 
+import static io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.jdbc.JdbcTracer.tracer;
 import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
@@ -14,9 +15,8 @@ import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.javaagent.instrumentation.api.CallDepth;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.sql.Statement;
 import java.util.Map;
@@ -50,32 +50,31 @@ public class StatementInstrumentation implements TypeInstrumentation {
     public static void onEnter(
         @Advice.Argument(0) String sql,
         @Advice.This Statement statement,
-        @Advice.Local("otelSpan") Span span,
-        @Advice.Local("otelScope") Scope scope,
-        @Advice.Local("otelCallDepth") CallDepth callDepth) {
-
-      callDepth = tracer().getCallDepth();
-      if (callDepth.getAndIncrement() == 0) {
-        span = tracer().startSpan(statement, sql);
-        if (span != null) {
-          scope = tracer().startScope(span);
-        }
+        @Advice.Local("otelContext") Context context,
+        @Advice.Local("otelScope") Scope scope) {
+      Context parentContext = currentContext();
+      if (!tracer().shouldStartSpan(parentContext)) {
+        return;
       }
+
+      context = tracer().startSpan(parentContext, statement, sql);
+      scope = context.makeCurrent();
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelSpan") Span span,
-        @Advice.Local("otelScope") Scope scope,
-        @Advice.Local("otelCallDepth") CallDepth callDepth) {
-      if (callDepth.decrementAndGet() == 0 && scope != null) {
-        scope.close();
-        if (throwable == null) {
-          tracer().end(span);
-        } else {
-          tracer().endExceptionally(span, throwable);
-        }
+        @Advice.Local("otelContext") Context context,
+        @Advice.Local("otelScope") Scope scope) {
+      if (scope == null) {
+        return;
+      }
+
+      scope.close();
+      if (throwable == null) {
+        tracer().end(context);
+      } else {
+        tracer().endExceptionally(context, throwable);
       }
     }
   }

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisInstrumentationModule.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v1_4;
 
+import static io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.jedis.v1_4.JedisClientTracer.tracer;
 import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static java.util.Collections.singletonList;
@@ -16,9 +17,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.javaagent.instrumentation.api.CallDepthThreadLocalMap;
 import io.opentelemetry.javaagent.instrumentation.jedis.v1_4.JedisClientTracer.CommandWithArgs;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
@@ -84,32 +84,31 @@ public class JedisInstrumentationModule extends InstrumentationModule {
     public static void onEnter(
         @Advice.This Connection connection,
         @Advice.Argument(0) Command command,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      int callDepth = CallDepthThreadLocalMap.incrementCallDepth(Connection.class);
-      if (callDepth > 0) {
+      Context parentContext = currentContext();
+      if (!tracer().shouldStartSpan(parentContext)) {
         return;
       }
 
-      span = tracer().startSpan(connection, new CommandWithArgs(command));
-      scope = tracer().startScope(span);
+      context = tracer().startSpan(parentContext, connection, new CommandWithArgs(command));
+      scope = context.makeCurrent();
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
       if (scope == null) {
         return;
       }
       scope.close();
-      CallDepthThreadLocalMap.reset(Connection.class);
 
       if (throwable != null) {
-        tracer().endExceptionally(span, throwable);
+        tracer().endExceptionally(context, throwable);
       } else {
-        tracer().end(span);
+        tracer().end(context);
       }
     }
   }
@@ -121,32 +120,31 @@ public class JedisInstrumentationModule extends InstrumentationModule {
         @Advice.This Connection connection,
         @Advice.Argument(0) Command command,
         @Advice.Argument(1) byte[][] args,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      int callDepth = CallDepthThreadLocalMap.incrementCallDepth(Connection.class);
-      if (callDepth > 0) {
+      Context parentContext = currentContext();
+      if (!tracer().shouldStartSpan(parentContext)) {
         return;
       }
 
-      span = tracer().startSpan(connection, new CommandWithArgs(command, args));
-      scope = tracer().startScope(span);
+      context = tracer().startSpan(parentContext, connection, new CommandWithArgs(command, args));
+      scope = context.makeCurrent();
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelSpan") Span span,
+        @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
       if (scope == null) {
         return;
       }
-      scope.close();
-      CallDepthThreadLocalMap.reset(Connection.class);
 
+      scope.close();
       if (throwable != null) {
-        tracer().endExceptionally(span, throwable);
+        tracer().endExceptionally(context, throwable);
       } else {
-        tracer().end(span);
+        tracer().end(context);
       }
     }
   }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/ConnectionFutureAdvice.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/ConnectionFutureAdvice.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
+import static io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceConnectionDatabaseClientTracer.tracer;
 
 import io.lettuce.core.ConnectionFuture;
 import io.lettuce.core.RedisURI;
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import net.bytebuddy.asm.Advice;
 
@@ -18,24 +19,24 @@ public class ConnectionFutureAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static void onEnter(
       @Advice.Argument(1) RedisURI redisUri,
-      @Advice.Local("otelSpan") Span span,
+      @Advice.Local("otelContext") Context context,
       @Advice.Local("otelScope") Scope scope) {
-    span = tracer().startSpan(redisUri, "CONNECT");
-    scope = tracer().startScope(span);
+    context = tracer().startSpan(currentContext(), redisUri, "CONNECT");
+    scope = context.makeCurrent();
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void stopSpan(
       @Advice.Thrown Throwable throwable,
       @Advice.Return ConnectionFuture<?> connectionFuture,
-      @Advice.Local("otelSpan") Span span,
+      @Advice.Local("otelContext") Context context,
       @Advice.Local("otelScope") Scope scope) {
     scope.close();
 
     if (throwable != null) {
-      tracer().endExceptionally(span, throwable);
+      tracer().endExceptionally(context, throwable);
       return;
     }
-    connectionFuture.handleAsync(new LettuceAsyncBiFunction<>(span));
+    connectionFuture.handleAsync(new LettuceAsyncBiFunction<>(context));
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncBiFunction.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncBiFunction.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceDatabaseClientTracer.tracer;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import java.util.concurrent.CancellationException;
 import java.util.function.BiFunction;
 
@@ -23,19 +24,20 @@ import java.util.function.BiFunction;
 public class LettuceAsyncBiFunction<T, U extends Throwable, R>
     implements BiFunction<T, Throwable, R> {
 
-  private final Span span;
+  private final Context context;
 
-  public LettuceAsyncBiFunction(Span span) {
-    this.span = span;
+  public LettuceAsyncBiFunction(Context context) {
+    this.context = context;
   }
 
   @Override
   public R apply(T t, Throwable throwable) {
     if (throwable instanceof CancellationException) {
+      Span span = Span.fromContext(context);
       span.setAttribute("lettuce.command.cancelled", true);
-      tracer().end(span);
+      tracer().end(context);
     } else {
-      tracer().endExceptionally(span, throwable);
+      tracer().endExceptionally(context, throwable);
     }
     return null;
   }

--- a/instrumentation/mongo/mongo-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/TracingCommandListener.java
+++ b/instrumentation/mongo/mongo-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/TracingCommandListener.java
@@ -11,33 +11,33 @@ import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.event.CommandSucceededEvent;
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class TracingCommandListener implements CommandListener {
 
-  private final Map<Integer, Span> spanMap = new ConcurrentHashMap<>();
+  private final Map<Integer, Context> contextMap = new ConcurrentHashMap<>();
 
   @Override
   public void commandStarted(CommandStartedEvent event) {
-    Span span = tracer().startSpan(event, event.getCommand());
-    spanMap.put(event.getRequestId(), span);
+    Context context = tracer().startSpan(Context.current(), event, event.getCommand());
+    contextMap.put(event.getRequestId(), context);
   }
 
   @Override
   public void commandSucceeded(CommandSucceededEvent event) {
-    Span span = spanMap.remove(event.getRequestId());
-    if (span != null) {
-      tracer().end(span);
+    Context context = contextMap.remove(event.getRequestId());
+    if (context != null) {
+      tracer().end(context);
     }
   }
 
   @Override
   public void commandFailed(CommandFailedEvent event) {
-    Span span = spanMap.remove(event.getRequestId());
-    if (span != null) {
-      tracer().endExceptionally(span, event.getThrowable());
+    Context context = contextMap.remove(event.getRequestId());
+    if (context != null) {
+      tracer().endExceptionally(context, event.getThrowable());
     }
   }
 }

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/BulkGetCompletionListener.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/BulkGetCompletionListener.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.spymemcached;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import java.util.concurrent.ExecutionException;
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.internal.BulkGetFuture;
@@ -13,8 +14,9 @@ import net.spy.memcached.internal.BulkGetFuture;
 public class BulkGetCompletionListener extends CompletionListener<BulkGetFuture<?>>
     implements net.spy.memcached.internal.BulkGetCompletionListener {
 
-  public BulkGetCompletionListener(MemcachedConnection connection, String methodName) {
-    super(connection, methodName);
+  public BulkGetCompletionListener(
+      Context parentContext, MemcachedConnection connection, String methodName) {
+    super(parentContext, connection, methodName);
   }
 
   @Override

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/CompletionListener.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/CompletionListener.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.spymemcached;
 import static io.opentelemetry.javaagent.instrumentation.spymemcached.MemcacheClientTracer.tracer;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import net.spy.memcached.MemcachedConnection;
@@ -19,13 +20,15 @@ public abstract class CompletionListener<T> {
   static final String HIT = "hit";
   static final String MISS = "miss";
 
-  private final Span span;
+  private final Context context;
 
-  public CompletionListener(MemcachedConnection connection, String methodName) {
-    span = tracer().startSpan(connection, methodName);
+  public CompletionListener(
+      Context parentContext, MemcachedConnection connection, String methodName) {
+    context = tracer().startSpan(parentContext, connection, methodName);
   }
 
   protected void closeAsyncSpan(T future) {
+    Span span = Span.fromContext(context);
     try {
       processResult(span, future);
     } catch (CancellationException e) {
@@ -51,7 +54,7 @@ public abstract class CompletionListener<T> {
   }
 
   protected void closeSyncSpan(Throwable thrown) {
-    tracer().endExceptionally(span, thrown);
+    tracer().endExceptionally(context, thrown);
   }
 
   protected abstract void processResult(Span span, T future)

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/GetCompletionListener.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/GetCompletionListener.java
@@ -6,14 +6,16 @@
 package io.opentelemetry.javaagent.instrumentation.spymemcached;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import java.util.concurrent.ExecutionException;
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.internal.GetFuture;
 
 public class GetCompletionListener extends CompletionListener<GetFuture<?>>
     implements net.spy.memcached.internal.GetCompletionListener {
-  public GetCompletionListener(MemcachedConnection connection, String methodName) {
-    super(connection, methodName);
+  public GetCompletionListener(
+      Context parentContext, MemcachedConnection connection, String methodName) {
+    super(parentContext, connection, methodName);
   }
 
   @Override

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/OperationCompletionListener.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/OperationCompletionListener.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.spymemcached;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import java.util.concurrent.ExecutionException;
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.internal.OperationFuture;
@@ -13,8 +14,9 @@ import net.spy.memcached.internal.OperationFuture;
 public class OperationCompletionListener
     extends CompletionListener<OperationFuture<? extends Object>>
     implements net.spy.memcached.internal.OperationCompletionListener {
-  public OperationCompletionListener(MemcachedConnection connection, String methodName) {
-    super(connection, methodName);
+  public OperationCompletionListener(
+      Context parentContext, MemcachedConnection connection, String methodName) {
+    super(parentContext, connection, methodName);
   }
 
   @Override

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SyncCompletionListener.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SyncCompletionListener.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.spymemcached;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
 import net.spy.memcached.MemcachedConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,8 +15,9 @@ public class SyncCompletionListener extends CompletionListener<Void> {
 
   private static final Logger log = LoggerFactory.getLogger(SyncCompletionListener.class);
 
-  public SyncCompletionListener(MemcachedConnection connection, String methodName) {
-    super(connection, methodName);
+  public SyncCompletionListener(
+      Context parentContext, MemcachedConnection connection, String methodName) {
+    super(parentContext, connection, methodName);
   }
 
   @Override


### PR DESCRIPTION
* Pass `Context` in to `DatabaseClientTracer.startSpan()` and return new `Context`
* Add `CONTEXT_CLIENT_SPAN_KEY` in `startSpan()`
* Remove `DatabaseClientTracer.startScope()` and use `Context.makeCurrent()` directly instead
* Added `DatabaseClientTracer.shouldStartSpan()` but only used it to replace existing call depth tracking for now