### PR TITLE
Bump gRPC version in smoke test

### DIFF
--- a/smoke-tests/grpc/build.gradle
+++ b/smoke-tests/grpc/build.gradle
@@ -19,11 +19,12 @@ repositories {
 }
 
 dependencies {
+  implementation platform("io.grpc:grpc-bom:1.33.1")
   implementation platform("org.apache.logging.log4j:log4j-bom:2.13.3")
 
-  implementation "io.grpc:grpc-netty-shaded:1.32.1"
-  implementation "io.grpc:grpc-protobuf:1.32.1"
-  implementation "io.grpc:grpc-stub:1.32.1"
+  implementation "io.grpc:grpc-netty-shaded"
+  implementation "io.grpc:grpc-protobuf"
+  implementation "io.grpc:grpc-stub"
   implementation "io.opentelemetry:opentelemetry-proto:0.12.0"
   implementation "io.opentelemetry:opentelemetry-extension-annotations:0.12.0"
   implementation "org.apache.logging.log4j:log4j-core"


### PR DESCRIPTION
And switches to bom for less chance of dependency hell.