### PR TITLE
Switch gRPC instrumentation to instrument public ServerBuilder class.

### DIFF
--- a/instrumentation/grpc-1.5/javaagent/grpc-1.5-javaagent.gradle
+++ b/instrumentation/grpc-1.5/javaagent/grpc-1.5-javaagent.gradle
@@ -20,7 +20,7 @@ muzzle {
   pass {
     group = "io.grpc"
     module = "grpc-core"
-    versions = "[1.5.0, 1.33.0)" // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1453
+    versions = "[1.5.0,)"
   }
 }
 
@@ -34,12 +34,6 @@ dependencies {
   testLibrary group: 'io.grpc', name: 'grpc-netty', version: grpcVersion
   testLibrary group: 'io.grpc', name: 'grpc-protobuf', version: grpcVersion
   testLibrary group: 'io.grpc', name: 'grpc-stub', version: grpcVersion
-
-  // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1453
-  latestDepTestLibrary group: 'io.grpc', name: 'grpc-core', version: '1.32.+'
-  latestDepTestLibrary group: 'io.grpc', name: 'grpc-netty', version: '1.32.+'
-  latestDepTestLibrary group: 'io.grpc', name: 'grpc-protobuf', version: '1.32.+'
-  latestDepTestLibrary group: 'io.grpc', name: 'grpc-stub', version: '1.32.+'
 
   testImplementation project(':instrumentation:grpc-1.5:testing')
 }

--- a/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcInstrumentationModule.java
+++ b/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcInstrumentationModule.java
@@ -10,7 +10,9 @@ import static java.util.Arrays.asList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @AutoService(InstrumentationModule.class)
 public class GrpcInstrumentationModule extends InstrumentationModule {
@@ -22,5 +24,10 @@ public class GrpcInstrumentationModule extends InstrumentationModule {
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
         new GrpcClientBuilderBuildInstrumentation(), new GrpcServerBuilderInstrumentation());
+  }
+
+  @Override
+  protected Map<String, String> contextStore() {
+    return Collections.singletonMap("io.grpc.ServerBuilder", Boolean.class.getName());
   }
 }

--- a/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcInstrumentationModule.java
+++ b/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcInstrumentationModule.java
@@ -10,9 +10,7 @@ import static java.util.Arrays.asList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 @AutoService(InstrumentationModule.class)
 public class GrpcInstrumentationModule extends InstrumentationModule {
@@ -24,10 +22,5 @@ public class GrpcInstrumentationModule extends InstrumentationModule {
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
         new GrpcClientBuilderBuildInstrumentation(), new GrpcServerBuilderInstrumentation());
-  }
-
-  @Override
-  protected Map<String, String> contextStore() {
-    return Collections.singletonMap("io.grpc.ServerBuilder", Boolean.class.getName());
   }
 }

--- a/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcServerBuilderInstrumentation.java
+++ b/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcServerBuilderInstrumentation.java
@@ -5,14 +5,21 @@
 
 package io.opentelemetry.javaagent.instrumentation.grpc.v1_5;
 
-import static java.util.Collections.singletonMap;
+import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.safeHasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
+import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
 import io.opentelemetry.instrumentation.grpc.v1_5.server.TracingServerInterceptor;
+import io.opentelemetry.javaagent.instrumentation.api.ContextStore;
+import io.opentelemetry.javaagent.instrumentation.api.InstrumentationContext;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -22,32 +29,59 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class GrpcServerBuilderInstrumentation implements TypeInstrumentation {
 
   @Override
+  public ElementMatcher<ClassLoader> classLoaderOptimization() {
+    return hasClassesNamed("io.grpc.ServerBuilder");
+  }
+
+  @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return named("io.grpc.internal.AbstractServerImplBuilder");
+    return safeHasSuperType(named("io.grpc.ServerBuilder"));
   }
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    return singletonMap(
-        isMethod().and(named("build")),
-        GrpcServerBuilderInstrumentation.class.getName() + "$AddInterceptorAdvice");
+    Map<ElementMatcher<MethodDescription>, String> transformers = new HashMap<>();
+    transformers.put(
+        isMethod()
+            .and(isPublic())
+            .and(named("intercept"))
+            .and(takesArgument(0, named("io.grpc.ServerInterceptor"))),
+        GrpcServerBuilderInstrumentation.class.getName() + "$InterceptAdvice");
+    transformers.put(
+        isMethod().and(isPublic()).and(named("build")).and(takesArguments(0)),
+        GrpcServerBuilderInstrumentation.class.getName() + "$BuildAdvice");
+    return transformers;
   }
 
-  public static class AddInterceptorAdvice {
+  public static class InterceptAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void addInterceptor(
-        @Advice.FieldValue("interceptors") List<ServerInterceptor> interceptors) {
-      boolean shouldRegister = true;
-      for (ServerInterceptor interceptor : interceptors) {
-        if (interceptor instanceof TracingServerInterceptor) {
-          shouldRegister = false;
-          break;
-        }
+    public static void onEnter(
+        @Advice.This ServerBuilder<?> serverBuilder,
+        @Advice.Argument(0) ServerInterceptor interceptor) {
+      // Check against unshaded name.
+      if (interceptor
+          .getClass()
+          .getName()
+          .equals("io.opentelemetry.instrumentation.grpc.v1_5.server.TracingServerInterceptor")) {
+        @SuppressWarnings("rawtypes")
+        ContextStore<ServerBuilder, Boolean> instrumentationContext =
+            InstrumentationContext.get(ServerBuilder.class, Boolean.class);
+        instrumentationContext.put(serverBuilder, true);
       }
-      if (shouldRegister) {
-        interceptors.add(TracingServerInterceptor.newInterceptor());
+    }
+  }
+
+  public static class BuildAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.This ServerBuilder<?> serverBuilder) {
+      ContextStore<ServerBuilder, Boolean> instrumentationContext =
+          InstrumentationContext.get(ServerBuilder.class, Boolean.class);
+      if (Boolean.TRUE.equals(instrumentationContext.get(serverBuilder))) {
+        return;
       }
+      serverBuilder.intercept(TracingServerInterceptor.newInterceptor());
     }
   }
 }

--- a/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcServerBuilderInstrumentation.java
+++ b/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcServerBuilderInstrumentation.java
@@ -67,7 +67,7 @@ public class GrpcServerBuilderInstrumentation implements TypeInstrumentation {
         @SuppressWarnings("rawtypes")
         ContextStore<ServerBuilder, Boolean> instrumentationContext =
             InstrumentationContext.get(ServerBuilder.class, Boolean.class);
-        instrumentationContext.put(serverBuilder, true);
+        instrumentationContext.put(serverBuilder, /* alreadyRegistered= */ true);
       }
     }
   }
@@ -78,7 +78,8 @@ public class GrpcServerBuilderInstrumentation implements TypeInstrumentation {
     public static void onEnter(@Advice.This ServerBuilder<?> serverBuilder) {
       ContextStore<ServerBuilder, Boolean> instrumentationContext =
           InstrumentationContext.get(ServerBuilder.class, Boolean.class);
-      if (Boolean.TRUE.equals(instrumentationContext.get(serverBuilder))) {
+      boolean alreadyRegistered = instrumentationContext.get(serverBuilder);
+      if (Boolean.TRUE.equals(alreadyRegistered)) {
         return;
       }
       serverBuilder.intercept(TracingServerInterceptor.newInterceptor());


### PR DESCRIPTION
This would have been harder if tracing server interceptor had to be at the beginning of the list, but since it doesn't, we can just instrument the public type without problem.

Fixes #1453