### PR TITLE
Let smoke test use non-default servlet context

### DIFF
--- a/.github/workflows/build-test-matrix.yaml
+++ b/.github/workflows/build-test-matrix.yaml
@@ -31,5 +31,8 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build Docker Image
-        run: ./gradlew buildMatrix pushMatrix
+        run: |
+          TAG="$(date '+%Y%m%d').$GITHUB_RUN_ID"
+          echo "Using extra tag $TAG"
+          ./gradlew buildMatrix pushMatrix -PextraTag=$TAG
         working-directory: smoke-tests/matrix

--- a/smoke-tests/matrix/build.gradle
+++ b/smoke-tests/matrix/build.gradle
@@ -72,7 +72,8 @@ targets.each { server, data ->
         }
       }
 
-      def image = "ghcr.io/open-telemetry/java-test-containers:$server-$version-jdk$jdk"
+      def extraTag = findProperty("extraTag") ?: new Date().format("yyyyMMdd.HHmmSS")
+      def image = "ghcr.io/open-telemetry/java-test-containers:$server-$version-jdk$jdk-$extraTag"
       matrix.add(image)
       def buildTask = tasks.register("${server}Image-$version-jdk$jdk", DockerBuildImage) {
         it.dependsOn(prepareTask)

--- a/smoke-tests/matrix/src/jetty.dockerfile
+++ b/smoke-tests/matrix/src/jetty.dockerfile
@@ -15,7 +15,7 @@ COPY --from=jetty $TMPDIR $TMPDIR
 WORKDIR $JETTY_BASE
 COPY --from=jetty docker-entrypoint.sh generate-jetty-start.sh /
 
-COPY app.war $JETTY_BASE/webapps/ROOT.war
+COPY app.war $JETTY_BASE/webapps/
 
 EXPOSE 8080
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/smoke-tests/matrix/src/liberty.xml
+++ b/smoke-tests/matrix/src/liberty.xml
@@ -1,7 +1,7 @@
 <server description="Sample Liberty server">
   <variable name="default.http.port" defaultValue="8080"/>
 
-  <webApplication location="app.war" contextRoot="/" />
+  <webApplication location="app.war" contextRoot="/app" />
   <mpMetrics authentication="false"/>
 
   <httpEndpoint host="*" httpPort="${default.http.port}" id="defaultHttpEndpoint"/>

--- a/smoke-tests/matrix/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/smoke-tests/matrix/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,3 +1,0 @@
-<glassfish-web-app>
-  <context-root>/</context-root>
-</glassfish-web-app>

--- a/smoke-tests/matrix/src/tomcat.dockerfile
+++ b/smoke-tests/matrix/src/tomcat.dockerfile
@@ -3,4 +3,4 @@ ARG jdk
 
 FROM tomcat:${version}-jdk${jdk}-adoptopenjdk-hotspot
 
-COPY app.war /usr/local/tomcat/webapps/ROOT.war
+COPY app.war /usr/local/tomcat/webapps/

--- a/smoke-tests/matrix/src/wildfly.dockerfile
+++ b/smoke-tests/matrix/src/wildfly.dockerfile
@@ -43,4 +43,4 @@ EXPOSE 8080
 # This will boot WildFly in the standalone mode and bind to all interface
 CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0"]
 
-COPY app.war /opt/jboss/wildfly/standalone/deployments/ROOT.war
+COPY app.war /opt/jboss/wildfly/standalone/deployments/


### PR DESCRIPTION
Also start building test matrix images with timestamp-based tag as well.