### PR TITLE
Revert "Release build can rely on master build checks instead of test…

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,10 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Wait for checks
-        uses: jitterbit/await-check-suites@v1
-        with:
-          timeoutSeconds: 3600
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -25,7 +21,7 @@ jobs:
         with:
           job-id: jdk11
           remote-build-cache-proxy-enabled: false
-          arguments: assemble final --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+          arguments: build final --stacktrace -Prelease.version=${{ github.event.inputs.version }}
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}


### PR DESCRIPTION
…ing again. (#1792)"

This reverts commit 6d046bf52a842e23a173d979a89898c3793ff000.

Just timed out waiting (perhaps it's waiting for new, not existing checks). Will play with it more later.