### PR TITLE
Fix jetty muzzle task

### DIFF
--- a/instrumentation/jetty-8.0/javaagent/jetty-8.0-javaagent.gradle
+++ b/instrumentation/jetty-8.0/javaagent/jetty-8.0-javaagent.gradle
@@ -4,7 +4,8 @@ muzzle {
   pass {
     group = "org.eclipse.jetty"
     module = 'jetty-server'
-    versions = "[8.0.0.v20110901,)"
+    // jetty 11 uses servlet 5.0
+    versions = "[8.0.0.v20110901,11)"
     assertInverse = true
   }
 }


### PR DESCRIPTION
Jetty 11 uses servlet 5.0 API which has completely different package names:

```
FAILED MUZZLE VALIDATION: io.opentelemetry.javaagent.instrumentation.servlet.v3_0.Servlet3InstrumentationModule mismatches:
-- io.opentelemetry.instrumentation.servlet.ServletHttpServerTracer:98 Missing class javax.servlet.ServletException
-- io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TagSettingAsyncListener:29 Missing class javax.servlet.AsyncEvent
-- io.opentelemetry.javaagent.instrumentation.servlet.v3_0.AsyncContextInstrumentation$DispatchAdvice:57 Missing class javax.servlet.AsyncContext
-- io.opentelemetry.javaagent.instrumentation.servlet.v3_0.Servlet3Advice:27 Missing class javax.servlet.http.HttpServletRequest
-- io.opentelemetry.javaagent.instrumentation.servlet.v3_0.Servlet3Advice:77 Missing class javax.servlet.AsyncListener
-- io.opentelemetry.javaagent.instrumentation.servlet.v3_0.AsyncContextInstrumentation$DispatchAdvice:62 Missing class javax.servlet.ServletRequest
-- io.opentelemetry.javaagent.instrumentation.servlet.v3_0.Servlet3Advice:27 Missing class javax.servlet.http.HttpServletResponse
-- io.opentelemetry.javaagent.instrumentation.servlet.v3_0.TagSettingAsyncListener:29 Missing class javax.servlet.ServletResponse
```