### PR TITLE
Fix liberty docker images

### DIFF
--- a/smoke-tests/matrix/src/liberty.dockerfile
+++ b/smoke-tests/matrix/src/liberty.dockerfile
@@ -10,8 +10,8 @@ ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
     WLP_SKIP_MAXPERMSIZE=true
 
-COPY --from=liberty $CONFIG $CONFIG
 COPY --from=liberty $LIBERTY $LIBERTY
+RUN ln -s /opt/ol/wlp/usr/servers/defaultServer /config
 
 COPY --chown=1001:0 liberty.xml /config/server.xml
 COPY --chown=1001:0 app.war /config/apps/

--- a/smoke-tests/matrix/src/liberty.xml
+++ b/smoke-tests/matrix/src/liberty.xml
@@ -1,6 +1,10 @@
 <server description="Sample Liberty server">
   <variable name="default.http.port" defaultValue="8080"/>
 
+  <featureManager>
+    <feature>javaee-8.0</feature>
+  </featureManager>
+
   <webApplication location="app.war" contextRoot="/app" />
   <mpMetrics authentication="false"/>
 


### PR DESCRIPTION
- enable javaee-8.0 feature, without any features enabled nothing works as servlet support is also a feature
- liberty base image symlinks config directory, can't copy it because it copies the target directory instead of symlink 