### PR TITLE
Create nexus staging repo in beginning of build instead of relying on…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ import nebula.plugin.release.git.opinion.Strategies
 plugins {
   id 'idea'
 
+  id "de.marcphilipp.nexus-publish" version "0.4.0" apply false
   id "io.codearte.nexus-staging" version "0.22.0"
   id "nebula.release" version "15.3.0"
 
@@ -30,10 +31,9 @@ nebulaRelease {
 }
 
 nexusStaging {
-  // We publish to two package groups so need to close each group individually until staging profile
-  // is set up. We'll run the command twice with the two groups.
-  // TODO(anuraaga): https://issues.sonatype.org/browse/OSSRH-62444
-  packageGroup = findProperty("mavenCentralGroup")
+  packageGroup = "io.opentelemetry"
+  username = System.getenv('SONATYPE_USER')
+  password = System.getenv('SONATYPE_KEY')
 }
 
 allprojects {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,25 +1,15 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-publishing {
-  repositories {
-    maven {
-      if (version.toString().contains('SNAPSHOT')) {
-        url = "https://oss.jfrog.org/artifactory/oss-snapshot-local/"
-        credentials {
-          username = System.getenv('BINTRAY_USER')
-          password = System.getenv('BINTRAY_API_KEY')
-        }
-      } else {
-        url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-        credentials {
-          username = System.getenv('SONATYPE_USER')
-          password = System.getenv('SONATYPE_KEY')
-        }
-      }
-    }
-  }
+apply plugin: 'de.marcphilipp.nexus-publish'
 
+nexusPublishing {
+  repositories {
+    sonatype()
+  }
+}
+
+publishing {
   publications {
     maven(MavenPublication) {
       if (project.tasks.findByName("shadowJar") != null && !findProperty('noShadowPublish')) {
@@ -95,7 +85,7 @@ private String artifactPrefix(Project p, String archivesBaseName) {
   return 'opentelemetry-'
 }
 
-rootProject.tasks.release.finalizedBy tasks.publish
+rootProject.tasks.release.finalizedBy tasks.publishToSonatype
 
 tasks.withType(Sign).configureEach {
   onlyIf { System.getenv("CI") != null }


### PR DESCRIPTION
… auto routing.

While testing, I found the similar behavior to what the plugin mentions in its README that CI uploads tend to create multiple staging repos unless creating it as a singleton initially. 