### PR TITLE
Add a simple description to POM.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,8 @@ nexusStaging {
   delayBetweenRetriesInMillis = 10000
 }
 
-tasks.release.finalizedBy tasks.closeAndReleaseRepository
+// Enable after verifying Maven Central publishing once through manual closing
+// tasks.release.finalizedBy tasks.closeAndReleaseRepository
 
 allprojects {
   apply from: "$rootDir/gradle/dependencies.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,14 @@ nexusStaging {
   packageGroup = "io.opentelemetry"
   username = System.getenv('SONATYPE_USER')
   password = System.getenv('SONATYPE_KEY')
+
+  // We have many artifacts so Maven Central takes a long time on its compliance checks. This sets
+  // the timeout for waiting for the repository to close to a comfortable 50 minutes.
+  numberOfRetries = 300
+  delayBetweenRetriesInMillis = 10000
 }
+
+tasks.release.finalizedBy tasks.closeAndReleaseRepository
 
 allprojects {
   apply from: "$rootDir/gradle/dependencies.gradle"

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -35,6 +35,7 @@ publishing {
 
       pom {
         name = 'OpenTelemetry Instrumentation for Java'
+        description = 'Instrumentation of Java libraries using OpenTelemetry.'
         packaging = 'jar'
         url = 'https://github.com/open-telemetry/opentelemetry-java-instrumentation'
 
@@ -86,6 +87,7 @@ private String artifactPrefix(Project p, String archivesBaseName) {
 }
 
 rootProject.tasks.release.finalizedBy tasks.publishToSonatype
+rootProject.tasks.closeAndReleaseRepository.dependsOn tasks.publishToSonatype
 
 tasks.withType(Sign).configureEach {
   onlyIf { System.getenv("CI") != null }


### PR DESCRIPTION
And increases timeout for closing the repo.

We'll want to push descriptions down to each artifact I think but for now this will let Maven Central checks pass.