### PR TITLE
Add exporter factory for JaegerThriftSpanExporter

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -46,6 +46,7 @@ ext {
     opentelemetryTraceProps    : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-extension-trace-propagators', version: versions.opentelemetry),
     opentelemetrySdk           : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-sdk', version: versions.opentelemetryAnother),
     opentelemetryJaeger        : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-jaeger', version: versions.opentelemetryOther),
+    opentelemetryJaegerThrift  : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-jaeger-thrift', version: versions.opentelemetryOther),
     opentelemetryOtlp          : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: versions.opentelemetryOther),
     opentelemetryZipkin        : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-zipkin', version: versions.opentelemetryOther),
     opentelemetryPrometheus    : dependencies.create(group: 'io.opentelemetry', name: 'opentelemetry-exporter-prometheus', version: versions.opentelemetryOther),

--- a/javaagent-exporters/jaeger-thrift/jaeger-thrift.gradle
+++ b/javaagent-exporters/jaeger-thrift/jaeger-thrift.gradle
@@ -1,0 +1,26 @@
+plugins {
+  id "com.github.johnrengelman.shadow"
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/publish.gradle"
+
+archivesBaseName = 'javaagent-exporter-jaeger-thrift'
+
+dependencies {
+  compileOnly(project(":javaagent-spi"))
+  compileOnly deps.opentelemetrySdk
+
+  annotationProcessor deps.autoservice
+  compileOnly deps.autoservice
+
+  implementation(deps.opentelemetryJaegerThrift) {
+    exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
+    exclude group: 'io.opentelemetry', module: 'opentelemetry-api'
+  }
+}
+
+jar.enabled = false
+shadowJar {
+  archiveClassifier = ''
+}

--- a/javaagent-exporters/jaeger-thrift/jaeger-thrift.gradle
+++ b/javaagent-exporters/jaeger-thrift/jaeger-thrift.gradle
@@ -18,7 +18,6 @@ dependencies {
     exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
     exclude group: 'io.opentelemetry', module: 'opentelemetry-api'
   }
-  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.30.2'
 }
 
 jar.enabled = false

--- a/javaagent-exporters/jaeger-thrift/jaeger-thrift.gradle
+++ b/javaagent-exporters/jaeger-thrift/jaeger-thrift.gradle
@@ -18,6 +18,7 @@ dependencies {
     exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
     exclude group: 'io.opentelemetry', module: 'opentelemetry-api'
   }
+  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.30.2'
 }
 
 jar.enabled = false

--- a/javaagent-exporters/jaeger-thrift/src/main/java/io/opentelemetry/javaagent/exporters/jaeger/JaegerThriftExporterFactory.java
+++ b/javaagent-exporters/jaeger-thrift/src/main/java/io/opentelemetry/javaagent/exporters/jaeger/JaegerThriftExporterFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.exporters.jaeger;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.exporter.jaeger.thrift.JaegerThriftSpanExporter;
+import io.opentelemetry.javaagent.spi.exporter.SpanExporterFactory;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.Set;
+
+@AutoService(SpanExporterFactory.class)
+public class JaegerThriftExporterFactory implements SpanExporterFactory {
+
+  @Override
+  public SpanExporter fromConfig(Properties config) {
+    return JaegerThriftSpanExporter.builder().readProperties(config).build();
+  }
+
+  @Override
+  public Set<String> getNames() {
+    return Collections.singleton("jaeger-thrift");
+  }
+}

--- a/javaagent-exporters/javaagent-exporters.gradle
+++ b/javaagent-exporters/javaagent-exporters.gradle
@@ -14,6 +14,7 @@ dependencies {
 
   testImplementation project(':javaagent-exporters:otlp')
   testImplementation project(':javaagent-exporters:jaeger')
+  testImplementation project(':javaagent-exporters:jaeger-thrift')
   testImplementation project(':javaagent-exporters:logging')
   testImplementation project(':javaagent-exporters:zipkin')
   testImplementation project(':javaagent-exporters:prometheus')
@@ -22,6 +23,7 @@ dependencies {
 tasks.withType(Test).configureEach() {
   dependsOn ':javaagent-exporters:otlp:shadowJar'
   dependsOn ':javaagent-exporters:jaeger:shadowJar'
+  dependsOn ':javaagent-exporters:jaeger-thrift:shadowJar'
   dependsOn ':javaagent-exporters:logging:shadowJar'
   dependsOn ':javaagent-exporters:zipkin:shadowJar'
   dependsOn ':javaagent-exporters:prometheus:shadowJar'
@@ -30,6 +32,7 @@ tasks.withType(Test).configureEach() {
     systemProperty 'adapterRoot', "$rootDir/javaagent-exporters"
     systemProperty 'otlpExporterJar', project(':javaagent-exporters:otlp').tasks.shadowJar.archivePath
     systemProperty 'jaegerExporterJar', project(':javaagent-exporters:jaeger').tasks.shadowJar.archivePath
+    systemProperty 'jaegerThriftExporterJar', project(':javaagent-exporters:jaeger-thrift').tasks.shadowJar.archivePath
     systemProperty 'loggingExporterJar', project(':javaagent-exporters:logging').tasks.shadowJar.archivePath
     systemProperty 'zipkinExporterJar', project(':javaagent-exporters:zipkin').tasks.shadowJar.archivePath
     systemProperty 'prometheusExporterJar', project(':javaagent-exporters:prometheus').tasks.shadowJar.archivePath
@@ -44,6 +47,7 @@ dependencies {
   shadowInclude project(path: ':javaagent-exporters:logging', configuration: 'shadow')
   shadowInclude project(path: ':javaagent-exporters:otlp', configuration: 'shadow')
   shadowInclude project(path: ':javaagent-exporters:jaeger', configuration: 'shadow')
+  shadowInclude project(path: ':javaagent-exporters:jaeger-thrift', configuration: 'shadow')
   shadowInclude project(path: ':javaagent-exporters:zipkin', configuration: 'shadow')
   shadowInclude project(path: ':javaagent-exporters:prometheus', configuration: 'shadow')
 }

--- a/javaagent-exporters/src/test/groovy/io/opentelemetry/javaagent/exporteradapters/ExporterAdaptersTest.groovy
+++ b/javaagent-exporters/src/test/groovy/io/opentelemetry/javaagent/exporteradapters/ExporterAdaptersTest.groovy
@@ -17,6 +17,9 @@ class ExporterAdaptersTest extends Specification {
   def jaegerExporterJar = System.getProperty("jaegerExporterJar")
 
   @Shared
+  def jaegerThriftExporterJar = System.getProperty("jaegerThriftExporterJar")
+
+  @Shared
   def loggingExporterJar = System.getProperty("loggingExporterJar")
 
   @Shared
@@ -30,7 +33,7 @@ class ExporterAdaptersTest extends Specification {
     file != null
 
     where:
-    exporter << [otlpExporterJar, jaegerExporterJar, loggingExporterJar, zipkinExporterJar]
+    exporter << [otlpExporterJar, jaegerExporterJar, jaegerThriftExporterJar, loggingExporterJar, zipkinExporterJar]
   }
 
   def "test exporter load"() {
@@ -51,10 +54,11 @@ class ExporterAdaptersTest extends Specification {
     f.getClass().getName() == classname
 
     where:
-    exporter           | classname
-    otlpExporterJar    | 'io.opentelemetry.javaagent.exporters.otlp.OtlpSpanExporterFactory'
-    jaegerExporterJar  | 'io.opentelemetry.javaagent.exporters.jaeger.JaegerExporterFactory'
-    loggingExporterJar | 'io.opentelemetry.javaagent.exporters.logging.LoggingExporterFactory'
-    zipkinExporterJar  | 'io.opentelemetry.javaagent.exporters.zipkin.ZipkinExporterFactory'
+    exporter                | classname
+    otlpExporterJar         | 'io.opentelemetry.javaagent.exporters.otlp.OtlpSpanExporterFactory'
+    jaegerExporterJar       | 'io.opentelemetry.javaagent.exporters.jaeger.JaegerExporterFactory'
+    jaegerThriftExporterJar | 'io.opentelemetry.javaagent.exporters.jaeger.JaegerThriftExporterFactory'
+    loggingExporterJar      | 'io.opentelemetry.javaagent.exporters.logging.LoggingExporterFactory'
+    zipkinExporterJar       | 'io.opentelemetry.javaagent.exporters.zipkin.ZipkinExporterFactory'
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -202,6 +202,7 @@ include ':instrumentation-core:servlet-2.2'
 // exporter adapters
 include ":javaagent-exporters"
 include ":javaagent-exporters:jaeger"
+include ":javaagent-exporters:jaeger-thrift"
 include ":javaagent-exporters:logging"
 include ":javaagent-exporters:otlp"
 include ":javaagent-exporters:zipkin"

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JaegerThriftExporterSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JaegerThriftExporterSmokeTest.groovy
@@ -5,14 +5,15 @@
 
 package io.opentelemetry.smoketest
 
-import static java.util.stream.Collectors.toSet
-
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
-import java.util.jar.Attributes
-import java.util.jar.JarFile
 import okhttp3.Request
 
-class JaegerExporterSmokeTest extends SmokeTest {
+import java.util.jar.Attributes
+import java.util.jar.JarFile
+
+import static java.util.stream.Collectors.toSet
+
+class JaegerThriftExporterSmokeTest extends SmokeTest {
 
   protected String getTargetImage(int jdk, String serverVersion) {
     "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk$jdk-20201204.400701583"
@@ -21,12 +22,12 @@ class JaegerExporterSmokeTest extends SmokeTest {
   @Override
   protected Map<String, String> getExtraEnv() {
     return [
-      "OTEL_EXPORTER"                : "jaeger",
-      "OTEL_EXPORTER_JAEGER_ENDPOINT": "collector:14250"
+      "OTEL_EXPORTER"                : "jaeger-thrift",
+      "OTEL_EXPORTER_JAEGER_ENDPOINT": "http://collector:14268/api/traces"
     ]
   }
 
-  def "spring boot smoke test with jaeger grpc"() {
+  def "spring boot smoke test with jaeger thrift"() {
     setup:
     startTarget(11)
 

--- a/smoke-tests/src/test/resources/otel.yaml
+++ b/smoke-tests/src/test/resources/otel.yaml
@@ -12,6 +12,8 @@ receivers:
   zipkin:
   jaeger:
     protocols:
+      thrift_http:
+        endpoint: 0.0.0.0:14268
       grpc:
 
 processors:


### PR DESCRIPTION
This resolves #1609

I just followed the existing patterns/conventions.

I wasn't entirely sure why the jaeger grpc exporter needed the shaded netty, so I didn't bring it over.  Does this exporter need something similarly shaded?