### PR TITLE
Enable Java 15 for akka http instrumentation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: setup-test-java
         name: Set up JDK ${{ matrix.java }} for running tests
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.3
         with:
           java-version: ${{ matrix.java }}
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: setup-test-java
         name: Set up JDK ${{ matrix.java }} for running tests
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
 

--- a/instrumentation/akka-http-10.0/javaagent/akka-http-10.0-javaagent.gradle
+++ b/instrumentation/akka-http-10.0/javaagent/akka-http-10.0-javaagent.gradle
@@ -1,9 +1,3 @@
-ext {
-  // TODO remove once Scala/akka supports Java 15
-  // https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
-  maxJavaVersionForTests = JavaVersion.VERSION_14
-}
-
 apply from: "$rootDir/gradle/instrumentation.gradle"
 apply from: "$rootDir/gradle/test-with-scala.gradle"
 apply plugin: 'org.unbroken-dome.test-sets'

--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -58,7 +58,7 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest {
     Http.get(system).singleRequest(null, materializer)
 
     then:
-    thrown NullPointerException
+    def e = thrown NullPointerException
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -66,7 +66,7 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest {
           name "HTTP request"
           kind CLIENT
           errored true
-          errorEvent(NullPointerException)
+          errorEvent(NullPointerException, e.getMessage())
         }
       }
     }


### PR DESCRIPTION
This enables java 15 for akka http and resolves #1255.

![image](https://user-images.githubusercontent.com/75337021/101693261-365a7c00-3a26-11eb-85bc-ab006518b77a.png)
