### PR TITLE
Manually inject AWS SDK helpers since they are refrenced from resourc…

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInstrumentationModule.java
@@ -20,6 +20,20 @@ public class AwsSdkInstrumentationModule extends InstrumentationModule {
     super("aws-sdk", "aws-sdk-2.2");
   }
 
+  @Override
+  public String[] additionalHelperClassNames() {
+    return new String[] {
+      "io.opentelemetry.javaagent.instrumentation.awssdk.v2_2.TracingExecutionInterceptor",
+      "io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdk",
+      "io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkHttpClientTracer",
+      "io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkInjectAdapter",
+      "io.opentelemetry.instrumentation.awssdk.v2_2.RequestType",
+      "io.opentelemetry.instrumentation.awssdk.v2_2.SdkRequestDecorator",
+      "io.opentelemetry.instrumentation.awssdk.v2_2.DbRequestDecorator",
+      "io.opentelemetry.instrumentation.awssdk.v2_2.TracingExecutionInterceptor"
+    };
+  }
+
   /**
    * Injects resource file with reference to our {@link TracingExecutionInterceptor} to allow SDK's
    * service loading mechanism to pick it up.

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
@@ -45,10 +45,6 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
     delegate = AwsSdk.newInterceptor();
   }
 
-  public static void muzzleCheck() {
-    // Noop
-  }
-
   @Override
   public void beforeExecution(BeforeExecution context, ExecutionAttributes executionAttributes) {
     delegate.beforeExecution(context, executionAttributes);


### PR DESCRIPTION
…e file, not code.

I tried something like

```java
public static void muzzleCheck() {
  return new TracingExecutionInterceptor();
}
```

to get it to automatically detect helpers but didn't seem to work. For now restoring manual list so instrumentation loads again.