### PR TITLE
Ignore Implementation-Version for runtime up-to-date checks like tests.

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -148,6 +148,14 @@ jar {
   }
 }
 
+normalization {
+  runtimeClasspath {
+    metaInf {
+      ignoreAttribute("Implementation-Version")
+    }
+  }
+}
+
 javadoc {
   options.addStringOption('Xdoclint:none', '-quiet')
 


### PR DESCRIPTION
It's hard for me to repro build cache failures in release builds on my computer, but in theory this seems like it would help.