### PR TITLE
Change link to snapshots to sonatype.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ See [Running the tests](./docs/contributing/running-tests.md) for more details.
 
 For developers testing code changes before a release is complete, there are
 snapshot builds of the `master` branch. They are available from
-[JFrog OSS repository](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/opentelemetry/instrumentation/)
+[Sonatype OSS snapshots repository](https://oss.sonatype.org/content/repositories/snapshots/)
 
 #### Building from source
 


### PR DESCRIPTION
When adding `nexus-publish` plugin I had ended up already switching accidentally. But as planned, updating the README.