### PR TITLE
Shade trace propagators so they can be injected in instrumentation th…

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInstrumentationModule.java
@@ -30,7 +30,8 @@ public class AwsSdkInstrumentationModule extends InstrumentationModule {
       "io.opentelemetry.instrumentation.awssdk.v2_2.RequestType",
       "io.opentelemetry.instrumentation.awssdk.v2_2.SdkRequestDecorator",
       "io.opentelemetry.instrumentation.awssdk.v2_2.DbRequestDecorator",
-      "io.opentelemetry.instrumentation.awssdk.v2_2.TracingExecutionInterceptor"
+      "io.opentelemetry.instrumentation.awssdk.v2_2.TracingExecutionInterceptor",
+      "io.opentelemetry.extension.trace.propagation.AwsXRayPropagator"
     };
   }
 

--- a/instrumentation/instrumentation.gradle
+++ b/instrumentation/instrumentation.gradle
@@ -73,6 +73,7 @@ shadowJar {
   relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"
   relocate "io.opentelemetry.spi", "io.opentelemetry.javaagent.shaded.io.opentelemetry.spi"
   relocate "io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context"
+  relocate "io.opentelemetry.extension.trace.propagation", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.trace.propagation"
 
   // this is for instrumentation on opentelemetry-api itself
   relocate "application.io.opentelemetry", "io.opentelemetry"

--- a/javaagent-exporters/javaagent-exporters.gradle
+++ b/javaagent-exporters/javaagent-exporters.gradle
@@ -67,4 +67,5 @@ shadowJar {
   relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"
   relocate "io.opentelemetry.spi", "io.opentelemetry.javaagent.shaded.io.opentelemetry.spi"
   relocate "io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context"
+  relocate "io.opentelemetry.extension.trace.propagation", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.trace.propagation"
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExporterClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExporterClassLoader.java
@@ -33,6 +33,9 @@ public class ExporterClassLoader extends URLClassLoader {
           rule(
               "#io.opentelemetry.context",
               "#io.opentelemetry.javaagent.shaded.io.opentelemetry.context"),
+          rule(
+              "#io.opentelemetry.extension.trace.propagation",
+              "#io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.trace.propagation"),
           rule("#java.util.logging.Logger", "#io.opentelemetry.javaagent.bootstrap.PatchLogger"),
           rule("#org.slf4j", "#io.opentelemetry.javaagent.slf4j"));
 

--- a/javaagent/javaagent.gradle
+++ b/javaagent/javaagent.gradle
@@ -92,6 +92,7 @@ tasks.withType(ShadowJar).configureEach {
   relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"
   relocate "io.opentelemetry.spi", "io.opentelemetry.javaagent.shaded.io.opentelemetry.spi"
   relocate "io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context"
+  relocate "io.opentelemetry.extension.trace.propagation", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.trace.propagation"
 }
 
 dependencies {


### PR DESCRIPTION
…at benefits from a hard-coded propagation format. And inject XRay propagator as helper in AWS SDK instrumentation.

Assuming my manual commands to do so worked OK, confirmed with my AWS SDK integration that the instrumentation works.