### PR TITLE
Hide non-spec span attributes behind flag for Hystrix instrumentation

### DIFF
--- a/instrumentation/hystrix-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixTracer.java
+++ b/instrumentation/hystrix-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixTracer.java
@@ -17,11 +17,9 @@ public class HystrixTracer extends BaseTracer {
     return TRACER;
   }
 
-  private final boolean extraTags;
-
-  private HystrixTracer() {
-    extraTags = Config.get().getBooleanProperty("otel.instrumentation.hystrix.tags", false);
-  }
+  private final boolean captureExperimentalSpanAttributes =
+      Config.get()
+          .getBooleanProperty("otel.instrumentation.hystrix.experimental-span-attributes", false);
 
   @Override
   protected String getInstrumentationName() {
@@ -37,7 +35,7 @@ public class HystrixTracer extends BaseTracer {
       String spanName = groupName + "." + commandName + "." + methodName;
 
       span.updateName(spanName);
-      if (extraTags) {
+      if (captureExperimentalSpanAttributes) {
         span.setAttribute("hystrix.command", commandName);
         span.setAttribute("hystrix.group", groupName);
         span.setAttribute("hystrix.circuit-open", circuitOpen);

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
@@ -22,7 +22,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
   }
 
   static final PREVIOUS_CONFIG = ConfigUtils.updateConfig {
-    it.setProperty("otel.instrumentation.hystrix.tags", "true")
+    it.setProperty("otel.instrumentation.hystrix.experimental-span-attributes", "true")
   }
 
   def cleanupSpec() {

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
@@ -26,7 +26,7 @@ class HystrixObservableTest extends AgentTestRunner {
   }
 
   static final PREVIOUS_CONFIG = ConfigUtils.updateConfig {
-    it.setProperty("otel.instrumentation.hystrix.tags", "true")
+    it.setProperty("otel.instrumentation.hystrix.experimental-span-attributes", "true")
   }
 
   def cleanupSpec() {

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
@@ -24,7 +24,7 @@ class HystrixTest extends AgentTestRunner {
   }
 
   static final PREVIOUS_CONFIG = ConfigUtils.updateConfig {
-    it.setProperty("otel.instrumentation.hystrix.tags", "true")
+    it.setProperty("otel.instrumentation.hystrix.experimental-span-attributes", "true")
   }
 
   def cleanupSpec() {


### PR DESCRIPTION
Staying with convention of `otel.instrumentation.<instrumentation-id>.<property-name>`, in this case proposing `otel.instrumentation.<instrumentation-id>.experimental-span-attributes` for each instrumentation that has experimental span attributes.

Part of #1874