### PR TITLE
Don't allow to run SDK initialisation multiple times

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
@@ -47,6 +47,11 @@ public class AgentInitializer {
   private static ClassLoader AGENT_CLASSLOADER = null;
 
   public static void initialize(Instrumentation inst, URL bootstrapUrl) {
+    if (AGENT_CLASSLOADER != null) {
+      // don't run initialization multiple times
+      return;
+    }
+
     startAgent(inst, bootstrapUrl);
 
     boolean appUsingCustomLogManager = isAppUsingCustomLogManager();

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
@@ -48,7 +48,7 @@ public class AgentInitializer {
 
   public static void initialize(Instrumentation inst, URL bootstrapUrl) {
     if (AGENT_CLASSLOADER != null) {
-      // don't run initialization multiple times
+      // don't run initialization multiple times, initialize can be called multiple times via dynamic attach
       return;
     }
 


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This PR adds check to `AgentInitializer` to skip initialization if the agent has been already loaded. This is useful in dynamic attach as protection to install the agent only once.  The `startAgent` has already this check, but the SDK does not so it can be installed multiple times.