### PR TITLE
Change kafka non-spec'd attributes

### DIFF
--- a/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaClientsConfig.java
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaClientsConfig.java
@@ -7,7 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.kafkaclients;
 
 import io.opentelemetry.instrumentation.api.config.Config;
 
-public final class KafkaClientsConfiguration {
+public final class KafkaClientsConfig {
 
   public static boolean isPropagationEnabled() {
     return Config.get().getBooleanProperty("otel.instrumentation.kafka.client-propagation", true);
@@ -18,5 +18,5 @@ public final class KafkaClientsConfiguration {
         .getBooleanProperty("otel.instrumentation.kafka.experimental-span-attributes", false);
   }
 
-  private KafkaClientsConfiguration() {}
+  private KafkaClientsConfig() {}
 }

--- a/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaClientsConfiguration.java
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaClientsConfiguration.java
@@ -7,11 +7,16 @@ package io.opentelemetry.javaagent.instrumentation.kafkaclients;
 
 import io.opentelemetry.instrumentation.api.config.Config;
 
-public final class KafkaClientConfiguration {
+public final class KafkaClientsConfiguration {
 
   public static boolean isPropagationEnabled() {
     return Config.get().getBooleanProperty("otel.instrumentation.kafka.client-propagation", true);
   }
 
-  private KafkaClientConfiguration() {}
+  public static boolean captureExperimentalSpanAttributes() {
+    return Config.get()
+        .getBooleanProperty("otel.instrumentation.kafka.experimental-span-attributes", false);
+  }
+
+  private KafkaClientsConfiguration() {}
 }

--- a/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaConsumerTracer.java
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaConsumerTracer.java
@@ -46,7 +46,7 @@ public class KafkaConsumerTracer extends BaseTracer {
   }
 
   private Context extractParent(ConsumerRecord<?, ?> record) {
-    if (KafkaClientsConfiguration.isPropagationEnabled()) {
+    if (KafkaClientsConfig.isPropagationEnabled()) {
       return extract(record.headers(), GETTER);
     } else {
       return Context.current();
@@ -64,7 +64,7 @@ public class KafkaConsumerTracer extends BaseTracer {
       span.setAttribute(SemanticAttributes.MESSAGING_KAFKA_TOMBSTONE, true);
     }
 
-    if (KafkaClientsConfiguration.captureExperimentalSpanAttributes()) {
+    if (KafkaClientsConfig.captureExperimentalSpanAttributes()) {
       span.setAttribute("kafka.offset", record.offset());
 
       // don't record a duration if the message was sent from an old Kafka client

--- a/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerTracer.java
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerTracer.java
@@ -36,7 +36,7 @@ public class KafkaProducerTracer extends BaseTracer {
   // value of the broker(s) is >= 2
   public boolean shouldPropagate(ApiVersions apiVersions) {
     return apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2
-        && KafkaClientsConfiguration.isPropagationEnabled();
+        && KafkaClientsConfig.isPropagationEnabled();
   }
 
   public String spanNameOnProduce(ProducerRecord<?, ?> record) {

--- a/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerTracer.java
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerTracer.java
@@ -36,7 +36,7 @@ public class KafkaProducerTracer extends BaseTracer {
   // value of the broker(s) is >= 2
   public boolean shouldPropagate(ApiVersions apiVersions) {
     return apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2
-        && KafkaClientConfiguration.isPropagationEnabled();
+        && KafkaClientsConfiguration.isPropagationEnabled();
   }
 
   public String spanNameOnProduce(ProducerRecord<?, ?> record) {

--- a/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/TracingIterator.java
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/TracingIterator.java
@@ -32,7 +32,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
       Iterator<ConsumerRecord<?, ?>> delegateIterator, KafkaConsumerTracer tracer) {
     this.delegateIterator = delegateIterator;
     this.tracer = tracer;
-    this.propagationEnabled = KafkaClientConfiguration.isPropagationEnabled();
+    this.propagationEnabled = KafkaClientsConfiguration.isPropagationEnabled();
   }
 
   @Override

--- a/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/TracingIterator.java
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/TracingIterator.java
@@ -32,7 +32,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
       Iterator<ConsumerRecord<?, ?>> delegateIterator, KafkaConsumerTracer tracer) {
     this.delegateIterator = delegateIterator;
     this.tracer = tracer;
-    this.propagationEnabled = KafkaClientsConfiguration.isPropagationEnabled();
+    this.propagationEnabled = KafkaClientsConfig.isPropagationEnabled();
   }
 
   @Override

--- a/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
@@ -23,6 +23,8 @@ import org.springframework.kafka.test.utils.KafkaTestUtils
 class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
   static final PREVIOUS_CONFIG = ConfigUtils.updateConfigAndResetInstrumentation {
     it.setProperty("otel.instrumentation.kafka.client-propagation", "false")
+    // TODO run tests both with and without experimental span attributes
+    it.setProperty("otel.instrumentation.kafka.experimental-span-attributes", "true")
   }
 
   def cleanupSpec() {
@@ -97,8 +99,8 @@ class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
             "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
-            "kafka-clients.offset" 0
-            "kafka-clients.record.queue_time_ms" { it >= 0 }
+            "kafka.offset" 0
+            "kafka.record.queue_time_ms" { it >= 0 }
           }
         }
       }

--- a/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
+import io.opentelemetry.instrumentation.test.utils.ConfigUtils
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -28,6 +29,14 @@ import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 
 class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
+  static final PREVIOUS_CONFIG = ConfigUtils.updateConfigAndResetInstrumentation {
+    // TODO run tests both with and without experimental span attributes
+    it.setProperty("otel.instrumentation.kafka.experimental-span-attributes", "true")
+  }
+
+  def cleanupSpec() {
+    ConfigUtils.setConfig(PREVIOUS_CONFIG)
+  }
 
   def "test kafka produce and consume"() {
     setup:
@@ -108,8 +117,8 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
             "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
-            "kafka-clients.offset" 0
-            "kafka-clients.record.queue_time_ms" { it >= 0 }
+            "kafka.offset" 0
+            "kafka.record.queue_time_ms" { it >= 0 }
           }
         }
         basicSpan(it, 3, "producer callback", span(0))
@@ -198,8 +207,8 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
             "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
-            "kafka-clients.offset" 0
-            "kafka-clients.record.queue_time_ms" { it >= 0 }
+            "kafka.offset" 0
+            "kafka.record.queue_time_ms" { it >= 0 }
           }
         }
         basicSpan(it, 3, "producer callback", span(0))
@@ -284,8 +293,8 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
             "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
             "${SemanticAttributes.MESSAGING_KAFKA_TOMBSTONE.key}" true
-            "kafka-clients.offset" 0
-            "kafka-clients.record.queue_time_ms" { it >= 0 }
+            "kafka.offset" 0
+            "kafka.record.queue_time_ms" { it >= 0 }
           }
         }
       }
@@ -357,8 +366,8 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
             "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
-            "kafka-clients.offset" 0
-            "kafka-clients.record.queue_time_ms" { it >= 0 }
+            "kafka.offset" 0
+            "kafka.record.queue_time_ms" { it >= 0 }
           }
         }
       }

--- a/instrumentation/kafka-streams-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsTracer.java
+++ b/instrumentation/kafka-streams-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsTracer.java
@@ -10,11 +10,16 @@ import static io.opentelemetry.javaagent.instrumentation.kafkastreams.TextMapExt
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.api.trace.attributes.SemanticAttributes;
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import org.apache.kafka.streams.processor.internals.StampedRecord;
 
 public class KafkaStreamsTracer extends BaseTracer {
   private static final KafkaStreamsTracer TRACER = new KafkaStreamsTracer();
+
+  private final boolean captureExperimentalSpanAttributes =
+      Config.get()
+          .getBooleanProperty("otel.instrumentation.kafka.experimental-span-attributes", false);
 
   public static KafkaStreamsTracer tracer() {
     return TRACER;
@@ -45,7 +50,9 @@ public class KafkaStreamsTracer extends BaseTracer {
   public void onConsume(Span span, StampedRecord record) {
     if (record != null) {
       span.setAttribute(SemanticAttributes.MESSAGING_KAFKA_PARTITION, record.partition());
-      span.setAttribute("kafka-streams.offset", record.offset());
+      if (captureExperimentalSpanAttributes) {
+        span.setAttribute("kafka.offset", record.offset());
+      }
     }
   }
 

--- a/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
@@ -12,6 +12,7 @@ import io.opentelemetry.api.trace.propagation.HttpTraceContext
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.TextMapPropagator
 import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.utils.ConfigUtils
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -32,6 +33,15 @@ import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Shared
 
 class KafkaStreamsTest extends AgentTestRunner {
+  static final PREVIOUS_CONFIG = ConfigUtils.updateConfigAndResetInstrumentation {
+    // TODO run tests both with and without experimental span attributes
+    it.setProperty("otel.instrumentation.kafka.experimental-span-attributes", "true")
+  }
+
+  def cleanupSpec() {
+    ConfigUtils.setConfig(PREVIOUS_CONFIG)
+  }
+
   static final STREAM_PENDING = "test.pending"
   static final STREAM_PROCESSED = "test.processed"
 
@@ -150,8 +160,8 @@ class KafkaStreamsTest extends AgentTestRunner {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
             "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
-            "kafka-clients.offset" 0
-            "kafka-clients.record.queue_time_ms" { it >= 0 }
+            "kafka.offset" 0
+            "kafka.record.queue_time_ms" { it >= 0 }
           }
         }
         // STREAMING span 1
@@ -166,7 +176,7 @@ class KafkaStreamsTest extends AgentTestRunner {
             "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
             "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
-            "kafka-streams.offset" 0
+            "kafka.offset" 0
             "asdf" "testing"
           }
         }
@@ -195,8 +205,8 @@ class KafkaStreamsTest extends AgentTestRunner {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
             "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
-            "kafka-clients.offset" 0
-            "kafka-clients.record.queue_time_ms" { it >= 0 }
+            "kafka.offset" 0
+            "kafka.record.queue_time_ms" { it >= 0 }
             "testing" 123
           }
         }


### PR DESCRIPTION
I think in the `kafka-clients` and `kafka-stream` case, it's nicer to consolidate their properties under `kafka` for purposes of configuration.

We have one other configuration property already uses just `kafka` (`otel.instrumentation.kafka.client-propagation`).

These are the span attribute name changes in this PR:

* `kafka-clients.offset` -> `kafka.offset`
* `kafka-streams.offset` -> `kafka.offset`
* `kafka-clients.record.queue_time_ms` -> `kafka.record.queue_time_ms`

The PR also hides them behind an `otel.instrumentation.kafka.experimental-span-attributes` flag.