### PR TITLE
Hide spring non-spec'd attributes behind flag

### DIFF
--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/SpringWebfluxConfig.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/SpringWebfluxConfig.java
@@ -1,0 +1,12 @@
+package io.opentelemetry.javaagent.instrumentation.spring.webflux;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+
+public class SpringWebfluxConfig {
+
+  public static boolean captureExperimentalSpanAttributes() {
+    return Config.get()
+        .getBooleanProperty(
+            "otel.instrumentation.spring-webflux.experimental-span-attributes", false);
+  }
+}

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/SpringWebfluxConfig.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/SpringWebfluxConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.instrumentation.spring.webflux;
 
 import io.opentelemetry.instrumentation.api.config.Config;

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/HandlerAdapterAdvice.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/HandlerAdapterAdvice.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.servlet.ServletContextPath;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
+import io.opentelemetry.javaagent.instrumentation.spring.webflux.SpringWebfluxConfig;
 import net.bytebuddy.asm.Advice;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.reactive.HandlerMapping;
@@ -43,7 +44,9 @@ public class HandlerAdapterAdvice {
       }
 
       span.updateName(operationName);
-      span.setAttribute("spring-webflux.handler.type", handlerType);
+      if (SpringWebfluxConfig.captureExperimentalSpanAttributes()) {
+        span.setAttribute("spring-webflux.handler.type", handlerType);
+      }
 
       scope = context.makeCurrent();
     }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/RouteOnSuccessOrError.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/RouteOnSuccessOrError.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.servlet.ServletContextPath;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
+import io.opentelemetry.javaagent.instrumentation.spring.webflux.SpringWebfluxConfig;
 import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
 import org.springframework.web.reactive.function.server.HandlerFunction;
@@ -37,8 +38,10 @@ public class RouteOnSuccessOrError implements BiConsumer<HandlerFunction<?>, Thr
       if (predicateString != null) {
         Context context = (Context) serverRequest.attributes().get(AdviceUtils.CONTEXT_ATTRIBUTE);
         if (context != null) {
-          Span span = Span.fromContext(context);
-          span.setAttribute("spring-webflux.request.predicate", predicateString);
+          if (SpringWebfluxConfig.captureExperimentalSpanAttributes()) {
+            Span span = Span.fromContext(context);
+            span.setAttribute("spring-webflux.request.predicate", predicateString);
+          }
 
           Span serverSpan = context.get(BaseTracer.CONTEXT_SERVER_SPAN_KEY);
           if (serverSpan != null) {

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -8,6 +8,7 @@ import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.utils.ConfigUtils
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -25,6 +26,14 @@ import server.TestController
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [SpringWebFluxTestApplication, ForceNettyAutoConfiguration])
 class SpringWebfluxTest extends AgentTestRunner {
+  static final PREVIOUS_CONFIG = ConfigUtils.updateConfig {
+    // TODO run tests both with and without experimental span attributes
+    it.setProperty("otel.instrumentation.spring-webflux.experimental-span-attributes", "true")
+  }
+
+  def cleanupSpec() {
+    ConfigUtils.setConfig(PREVIOUS_CONFIG)
+  }
 
   @TestConfiguration
   static class ForceNettyAutoConfiguration {

--- a/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxHttpClientTracer.java
+++ b/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxHttpClientTracer.java
@@ -26,11 +26,6 @@ public class SpringWebfluxHttpClientTracer
 
   private static final SpringWebfluxHttpClientTracer TRACER = new SpringWebfluxHttpClientTracer();
 
-  private final boolean captureExperimentalSpanAttributes =
-      Config.get()
-          .getBooleanProperty(
-              "otel.instrumentation.spring-webflux.experimental-span-attributes", false);
-
   public static SpringWebfluxHttpClientTracer tracer() {
     return TRACER;
   }
@@ -38,7 +33,7 @@ public class SpringWebfluxHttpClientTracer
   private static final MethodHandle RAW_STATUS_CODE = findRawStatusCode();
 
   public void onCancel(Context context) {
-    if (captureExperimentalSpanAttributes) {
+    if (captureExperimentalSpanAttributes()) {
       Span span = Span.fromContext(context);
       span.setAttribute("spring-webflux.event", "cancelled");
       span.setAttribute("spring-webflux.message", "The subscription was cancelled");
@@ -104,5 +99,13 @@ public class SpringWebfluxHttpClientTracer
     } catch (IllegalAccessException | NoSuchMethodException e) {
       return null;
     }
+  }
+
+  // TODO cache this after
+  //  https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1643
+  private static boolean captureExperimentalSpanAttributes() {
+    return Config.get()
+        .getBooleanProperty(
+            "otel.instrumentation.spring-webflux.experimental-span-attributes", false);
   }
 }

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcTracer.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcTracer.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.springwebmvc;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.servlet.ServletContextPath;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import java.lang.reflect.Method;
@@ -22,6 +23,11 @@ import org.springframework.web.servlet.mvc.Controller;
 public class SpringWebMvcTracer extends BaseTracer {
 
   private static final SpringWebMvcTracer TRACER = new SpringWebMvcTracer();
+
+  private final boolean captureExperimentalSpanAttributes =
+      Config.get()
+          .getBooleanProperty(
+              "otel.instrumentation.spring-webmvc.experimental-span-attributes", false);
 
   public static SpringWebMvcTracer tracer() {
     return TRACER;
@@ -91,10 +97,12 @@ public class SpringWebMvcTracer extends BaseTracer {
   }
 
   private void onRender(Span span, ModelAndView mv) {
-    span.setAttribute("spring-webmvc.view.name", mv.getViewName());
-    View view = mv.getView();
-    if (view != null) {
-      span.setAttribute("spring-webmvc.view.type", spanNameForClass(view.getClass()));
+    if (captureExperimentalSpanAttributes) {
+      span.setAttribute("spring-webmvc.view.name", mv.getViewName());
+      View view = mv.getView();
+      if (view != null) {
+        span.setAttribute("spring-webmvc.view.type", spanNameForClass(view.getClass()));
+      }
     }
   }
 

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.instrumentation.test.utils.ConfigUtils
 import io.opentelemetry.sdk.trace.data.SpanData
 import okhttp3.FormBody
 import okhttp3.RequestBody
@@ -26,6 +27,14 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.web.servlet.view.RedirectView
 
 class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext> {
+  static final PREVIOUS_CONFIG = ConfigUtils.updateConfig {
+    // TODO run tests both with and without experimental span attributes
+    it.setProperty("otel.instrumentation.spring-webmvc.experimental-span-attributes", "true")
+  }
+
+  def cleanupSpec() {
+    ConfigUtils.setConfig(PREVIOUS_CONFIG)
+  }
 
   @Override
   ConfigurableApplicationContext startServer(int port) {


### PR DESCRIPTION
Introduces
* `otel.instrumentation.spring-webflux.experimental-span-attributes`
* `otel.instrumentation.spring-webmvc.experimental-span-attributes`
