### PR TITLE
Fix spring webflux tests

### DIFF
--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.instrumentation.api.config.Config
+
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
@@ -26,13 +28,17 @@ import server.TestController
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [SpringWebFluxTestApplication, ForceNettyAutoConfiguration])
 class SpringWebfluxTest extends AgentTestRunner {
-  static final PREVIOUS_CONFIG = ConfigUtils.updateConfig {
-    // TODO run tests both with and without experimental span attributes
-    it.setProperty("otel.instrumentation.spring-webflux.experimental-span-attributes", "true")
+  static Config previousConfig
+
+  def setupSpec() {
+    previousConfig = ConfigUtils.updateConfig {
+      // TODO run tests both with and without experimental span attributes
+      it.setProperty("otel.instrumentation.spring-webflux.experimental-span-attributes", "true")
+    }
   }
 
   def cleanupSpec() {
-    ConfigUtils.setConfig(PREVIOUS_CONFIG)
+    ConfigUtils.setConfig(previousConfig)
   }
 
   @TestConfiguration


### PR DESCRIPTION
Move setup from static initializer to setupSpec to ensure that property is set for both SpringWebfluxTest and SingleThreadedSpringWebfluxTest not only the one that runs first. Currently the one that runs first clears property in cleanupSpec and the other test fails.
This is a regression from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1906