### PR TITLE
Fix muzzle log level in tests

### DIFF
--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestRunner.java
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestRunner.java
@@ -71,7 +71,7 @@ public abstract class AgentTestRunner extends Specification {
     System.setProperty("otel.threadPropagationDebugger", "true");
     System.setProperty("otel.internal.failOnContextLeak", "true");
     // always print muzzle warnings
-    System.setProperty("io.opentelemetry.javaagent.slf4j.simpleLogger.log.muzzleMatcher", "true");
+    System.setProperty("io.opentelemetry.javaagent.slf4j.simpleLogger.log.muzzleMatcher", "warn");
   }
 
   /**


### PR DESCRIPTION
It was supposed to be `warn` from the start - it's a log level, not a boolean;  it was probably a copy-paste issue.