### PR TITLE
end to end latency benchmark

### DIFF
--- a/benchmark-e2e/benchmark-e2e.gradle
+++ b/benchmark-e2e/benchmark-e2e.gradle
@@ -1,0 +1,18 @@
+apply from: "$rootDir/gradle/java.gradle"
+
+description = 'e2e benchmark'
+
+dependencies {
+  implementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
+  implementation 'org.slf4j:slf4j-simple:1.6.1'
+  implementation 'org.testcontainers:testcontainers:1.15.0'
+}
+
+test {
+  dependsOn ':javaagent:shadowJar'
+  maxParallelForks = 2
+
+  doFirst {
+    jvmArgs "-Dio.opentelemetry.smoketest.agent.shadowJar.path=${project(':javaagent').tasks.shadowJar.archivePath}"
+  }
+}

--- a/benchmark-e2e/src/main/java/io/opentelemetry/e2ebenchmark/E2EAgentBenchmark.java
+++ b/benchmark-e2e/src/main/java/io/opentelemetry/e2ebenchmark/E2EAgentBenchmark.java
@@ -25,7 +25,7 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 public class E2EAgentBenchmark {
-  private static String APP_NAME = System.getenv().getOrDefault("APP_IMAGE", "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk8-20201204.400701583");
+  private static final String APP_NAME = System.getenv().getOrDefault("APP_IMAGE", "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk8-20201204.400701583");
 
   private List<GenericContainer<?>> containers;
   private static final Logger LOG = LoggerFactory.getLogger(E2EAgentBenchmark.class);

--- a/benchmark-e2e/src/main/java/io/opentelemetry/e2ebenchmark/E2EAgentBenchmark.java
+++ b/benchmark-e2e/src/main/java/io/opentelemetry/e2ebenchmark/E2EAgentBenchmark.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.e2ebenchmark;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+public class E2EAgentBenchmark {
+  private static String app = System.getenv("APP_IMAGE");
+
+  private List<GenericContainer<?>> containers;
+  private static final Logger LOG = LoggerFactory.getLogger(E2EAgentBenchmark.class);
+
+  // docker images
+  private static final DockerImageName APP_IMAGE = DockerImageName.parse(app);
+  private static final DockerImageName OTLP_COLLECTOR_IMAGE =
+      DockerImageName.parse("otel/opentelemetry-collector-dev:latest");
+  private static final DockerImageName WRK_IMAGE = DockerImageName.parse("quay.io/dim/wrk:stable");
+
+  @BeforeEach
+  void setUp() {
+    containers = new ArrayList<>();
+  }
+
+  @AfterEach
+  void tearDown() {
+    containers.forEach(GenericContainer::stop);
+  }
+
+  @Test
+  void run() throws Exception {
+    runBenchmark();
+  }
+
+  private void runBenchmark() throws Exception {
+    if (app == null || app.equals("")) {
+      // setting default image to benchmark
+      app = "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk8-20201204.400701583";
+    }
+
+    String agentPath = System.getProperty("io.opentelemetry.smoketest.agent.shadowJar.path");
+
+    // otlp collector container
+    GenericContainer<?> collector =
+        new GenericContainer<>(OTLP_COLLECTOR_IMAGE)
+            .withNetwork(Network.SHARED)
+            .withNetworkAliases("collector")
+            .withLogConsumer(new Slf4jLogConsumer(LOG))
+            .withExposedPorts(55680, 13133)
+            .waitingFor(Wait.forHttp("/").forPort(13133))
+            .withCopyFileToContainer(
+                MountableFile.forClasspathResource("collector-config.yml"),
+                "/etc/collector/collector-config.yml")
+            .withCommand("--config /etc/collector/collector-config.yml --log-level=DEBUG");
+    containers.add(collector);
+
+    // sample app container
+    GenericContainer<?> app =
+        new GenericContainer<>(APP_IMAGE)
+            .withNetwork(Network.SHARED)
+            .withLogConsumer(new Slf4jLogConsumer(LOG))
+            .withNetworkAliases("app")
+            .withCopyFileToContainer(
+                MountableFile.forHostPath(agentPath), "/opentelemetry-javaagent-all.jar")
+            .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "collector:55680")
+            .withEnv("JAVA_TOOL_OPTIONS", "-javaagent:/opentelemetry-javaagent-all.jar")
+            .withExposedPorts(8080);
+    containers.add(app);
+
+    // wrk benchmark container
+    GenericContainer<?> wrk =
+        new GenericContainer<>(WRK_IMAGE)
+            .withNetwork(Network.SHARED)
+            .withLogConsumer(new Slf4jLogConsumer(LOG))
+            .withCreateContainerCmdModifier(it -> it.withEntrypoint("wrk"))
+            .withCommand("-t4 -c128 -d300s http://app:8080/ --latency");
+    containers.add(wrk);
+
+    wrk.dependsOn(app, collector);
+    Startables.deepStart(Stream.of(wrk)).join();
+
+    LOG.info("Benchmark started");
+    printContainerMapping(collector);
+    printContainerMapping(app);
+
+    while (wrk.isRunning()) {
+      Thread.sleep(1000);
+    }
+
+    Thread.sleep(5000);
+    LOG.info("Benchmark complete, wrk output:");
+    LOG.info(wrk.getLogs().replace("\n\n", "\n"));
+  }
+
+  static void printContainerMapping(GenericContainer<?> container) {
+    System.out.println(
+        String.format(
+            "Container %s ports exposed at %s",
+            container.getDockerImageName(),
+            container.getExposedPorts().stream()
+                .map(
+                    port ->
+                        new AbstractMap.SimpleImmutableEntry<>(
+                            port,
+                            "http://"
+                                + container.getContainerIpAddress()
+                                + ":"
+                                + container.getMappedPort(port)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
+  }
+}

--- a/benchmark-e2e/src/main/java/io/opentelemetry/e2ebenchmark/E2EAgentBenchmark.java
+++ b/benchmark-e2e/src/main/java/io/opentelemetry/e2ebenchmark/E2EAgentBenchmark.java
@@ -25,13 +25,13 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 public class E2EAgentBenchmark {
-  private static String app = System.getenv("APP_IMAGE");
+  private static String APP_NAME = System.getenv().getOrDefault("APP_IMAGE", "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk8-20201204.400701583");
 
   private List<GenericContainer<?>> containers;
   private static final Logger LOG = LoggerFactory.getLogger(E2EAgentBenchmark.class);
 
   // docker images
-  private static final DockerImageName APP_IMAGE = DockerImageName.parse(app);
+  private static final DockerImageName APP_IMAGE = DockerImageName.parse(APP_NAME);
   private static final DockerImageName OTLP_COLLECTOR_IMAGE =
       DockerImageName.parse("otel/opentelemetry-collector-dev:latest");
   private static final DockerImageName WRK_IMAGE = DockerImageName.parse("quay.io/dim/wrk:stable");
@@ -52,11 +52,6 @@ public class E2EAgentBenchmark {
   }
 
   private void runBenchmark() throws Exception {
-    if (app == null || app.equals("")) {
-      // setting default image to benchmark
-      app = "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk8-20201204.400701583";
-    }
-
     String agentPath = System.getProperty("io.opentelemetry.smoketest.agent.shadowJar.path");
 
     // otlp collector container

--- a/benchmark-e2e/src/main/java/io/opentelemetry/e2ebenchmark/E2EAgentBenchmark.java
+++ b/benchmark-e2e/src/main/java/io/opentelemetry/e2ebenchmark/E2EAgentBenchmark.java
@@ -25,7 +25,11 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 public class E2EAgentBenchmark {
-  private static final String APP_NAME = System.getenv().getOrDefault("APP_IMAGE", "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk8-20201204.400701583");
+  private static final String APP_NAME =
+      System.getenv()
+          .getOrDefault(
+              "APP_IMAGE",
+              "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk8-20201204.400701583");
 
   private List<GenericContainer<?>> containers;
   private static final Logger LOG = LoggerFactory.getLogger(E2EAgentBenchmark.class);

--- a/benchmark-e2e/src/main/resources/collector-config.yml
+++ b/benchmark-e2e/src/main/resources/collector-config.yml
@@ -1,0 +1,34 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:55680
+
+exporters:
+  logging:
+    loglevel: info
+
+processors:
+  batch:
+  queued_retry:
+
+extensions:
+  health_check:
+
+service:
+  extensions: health_check
+  pipelines:
+    traces:
+      processors:
+        - batch
+      receivers:
+        - otlp
+      exporters:
+        - logging
+    metrics:
+      processors:
+        - batch
+      receivers:
+        - otlp
+      exporters:
+        - logging

--- a/settings.gradle
+++ b/settings.gradle
@@ -215,6 +215,7 @@ include ":javaagent-exporters:prometheus"
 include ':benchmark'
 include ':benchmark-integration'
 include ':benchmark-integration:jetty-perftest'
+include ':benchmark-e2e'
 
 def setBuildFile(project) {
   if (['javaagent', 'library', 'testing'].contains(project.projectDir.name) && project.path != ':javaagent') {


### PR DESCRIPTION
Using wrk (HTTP benchmarking) end to end latency benchmark for any sample app configured with agent and collector setup with receiver. I am also planning to add support for collecting cpu and memory data using oshi instrumentation probably in next PR.

Inspired from this server integrated benchmark: https://github.com/openzipkin/zipkin/blob/master/benchmarks/src/test/java/zipkin2/server/ServerIntegratedBenchmark.java