### PR TITLE
Have bytebuddy task depend on resources.

### DIFF
--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ByteBuddyPluginConfigurator.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/bytebuddy/ByteBuddyPluginConfigurator.java
@@ -68,6 +68,8 @@ public class ByteBuddyPluginConfigurator {
 
       if (compile != null) {
         Task languageTask = createLanguageTask(compile, taskName + language);
+        // We also process resources for SPI classes.
+        languageTask.dependsOn(sourceSet.getProcessResourcesTaskName());
         byteBuddyTask.dependsOn(languageTask);
       }
     }


### PR DESCRIPTION
Not sure why this doesn't happen consistently on CI. After a clean it happened for me no problem.

Fixes #1937
Fixes #1938
Fixes #1939