### PR TITLE
Expose context in async apache HTTP client instrumentation

### DIFF
--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -150,6 +150,12 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
       delegate.close();
     }
 
+    /**
+     * Exposes context associated with the client invocation. Extending instrumentations can use
+     * this to access client span.
+     *
+     * @return context associated with the invocation.
+     */
     public Context getContext() {
       return context;
     }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -95,8 +95,8 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
   }
 
   public static class DelegatingRequestProducer implements HttpAsyncRequestProducer {
-    Context context;
-    HttpAsyncRequestProducer delegate;
+    private final Context context;
+    private final HttpAsyncRequestProducer delegate;
 
     public DelegatingRequestProducer(Context context, HttpAsyncRequestProducer delegate) {
       this.context = context;
@@ -148,6 +148,10 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
     @Override
     public void close() throws IOException {
       delegate.close();
+    }
+
+    public Context getContext() {
+      return context;
     }
   }
 


### PR DESCRIPTION
I need to access context in my instrumentation that builds on top of this one.