### PR TITLE
AWS lambda - configurable flush timeout

### DIFF
--- a/instrumentation/aws-lambda-1.0/library/README.md
+++ b/instrumentation/aws-lambda-1.0/library/README.md
@@ -3,10 +3,10 @@
 This package contains libraries to help instrument AWS lambda functions in your code.
 
 ## Using wrappers
-To use the instrumentation, configure `OTEL_LAMBDA_HANDLER` env property to your lambda handler method in following format `package.ClassName::methodName`
+To use the instrumentation, configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER` env property to your lambda handler method in following format `package.ClassName::methodName`
 and use one of wrappers as your lambda `Handler`.
 
-In order to configure a span flush timeout (default is set to 1 second), please configure `OTEL_LAMBDA_FLUSH_TIMEOUT` env property. The value is in seconds.
+In order to configure a span flush timeout (default is set to 1 second), please configure `OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT` env property. The value is in seconds.
 
 Available wrappers:
 - `io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestWrapper` - for wrapping regular handlers (implementing `RequestHandler`)

--- a/instrumentation/aws-lambda-1.0/library/README.md
+++ b/instrumentation/aws-lambda-1.0/library/README.md
@@ -6,6 +6,8 @@ This package contains libraries to help instrument AWS lambda functions in your 
 To use the instrumentation, configure `OTEL_LAMBDA_HANDLER` env property to your lambda handler method in following format `package.ClassName::methodName`
 and use one of wrappers as your lambda `Handler`.
 
+In order to configure a span flush timeout (default is set to 1 second), please configure `OTEL_LAMBDA_FLUSH_TIMEOUT` env property. The value is in seconds.
+
 Available wrappers:
 - `io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestWrapper` - for wrapping regular handlers (implementing `RequestHandler`)
 - `io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestApiGatewayWrapper` - for wrapping regular handlers (implementing `RequestHandler`) proxied through API Gateway, enabling HTTP context propagation

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapper.java
@@ -22,6 +22,10 @@ public class TracingRequestStreamWrapper extends TracingRequestStreamHandler {
   // visible for testing
   static WrappedLambda WRAPPED_LAMBDA = WrappedLambda.fromConfiguration();
 
+  public TracingRequestStreamWrapper() {
+    super(WrapperConfiguration.flushTimeout());
+  }
+
   @Override
   protected void doHandleRequest(InputStream inputStream, OutputStream output, Context context)
       throws IOException {

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapper.java
@@ -13,9 +13,9 @@ import java.io.OutputStream;
 
 /**
  * Wrapper for {@link TracingRequestStreamHandler}. Allows for wrapping a regular lambda, enabling
- * single span tracing. Main lambda class should be configured as env property OTEL_LAMBDA_HANDLER
- * in package.ClassName::methodName format. Lambda class must implement {@link
- * RequestStreamHandler}.
+ * single span tracing. Main lambda class should be configured as env property
+ * OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER in package.ClassName::methodName format. Lambda class
+ * must implement {@link RequestStreamHandler}.
  */
 public class TracingRequestStreamWrapper extends TracingRequestStreamHandler {
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperBase.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperBase.java
@@ -15,6 +15,10 @@ import java.lang.reflect.Method;
  */
 abstract class TracingRequestWrapperBase<I, O> extends TracingRequestHandler<I, O> {
 
+  protected TracingRequestWrapperBase() {
+    super(WrapperConfiguration.flushTimeout());
+  }
+
   // visible for testing
   static WrappedLambda WRAPPED_LAMBDA = WrappedLambda.fromConfiguration();
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperBase.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperBase.java
@@ -11,7 +11,7 @@ import java.lang.reflect.Method;
 
 /**
  * Base abstract wrapper for {@link TracingRequestHandler}. Provides: - delegation to a lambda via
- * env property OTEL_LAMBDA_HANDLER in package.ClassName::methodName format
+ * env property OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER in package.ClassName::methodName format
  */
 abstract class TracingRequestWrapperBase<I, O> extends TracingRequestHandler<I, O> {
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/WrappedLambda.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/WrappedLambda.java
@@ -17,7 +17,8 @@ import java.util.Optional;
 /** Model for wrapped lambda function (object, class, method). */
 class WrappedLambda {
 
-  public static final String OTEL_LAMBDA_HANDLER_ENV_KEY = "OTEL_LAMBDA_HANDLER";
+  public static final String OTEL_LAMBDA_HANDLER_ENV_KEY =
+      "OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER";
 
   private final Object targetObject;
   private final Class<?> targetClass;

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/WrapperConfiguration.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/WrapperConfiguration.java
@@ -9,7 +9,8 @@ public final class WrapperConfiguration {
 
   private WrapperConfiguration() {}
 
-  public static final String OTEL_LAMBDA_FLUSH_TIMEOUT_ENV_KEY = "OTEL_LAMBDA_FLUSH_TIMEOUT";
+  public static final String OTEL_LAMBDA_FLUSH_TIMEOUT_ENV_KEY =
+      "OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT";
   public static final long OTEL_LAMBDA_FLUSH_TIMEOUT_DEFAULT = 1;
 
   public static final long flushTimeout() {

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/WrapperConfiguration.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/WrapperConfiguration.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awslambda.v1_0;
+
+public final class WrapperConfiguration {
+
+  private WrapperConfiguration() {}
+
+  public static final String OTEL_LAMBDA_FLUSH_TIMEOUT_ENV_KEY = "OTEL_LAMBDA_FLUSH_TIMEOUT";
+  public static final long OTEL_LAMBDA_FLUSH_TIMEOUT_DEFAULT = 1;
+
+  public static final long flushTimeout() {
+    String lambdaFlushTimeout = System.getenv(OTEL_LAMBDA_FLUSH_TIMEOUT_ENV_KEY);
+    if (lambdaFlushTimeout != null && !lambdaFlushTimeout.isEmpty()) {
+      try {
+        return Long.parseLong(lambdaFlushTimeout);
+      } catch (NumberFormatException nfe) {
+        // ignored - default used
+      }
+    }
+    return OTEL_LAMBDA_FLUSH_TIMEOUT_DEFAULT;
+  }
+}


### PR DESCRIPTION
Closes #1959 

- handler's flush timeout is configurable now
- wrapper uses env prop to set the timeout (= 1 sec default)