### PR TITLE
Update vendor distro example to 0.13

### DIFF
--- a/examples/distro/build.gradle
+++ b/examples/distro/build.gradle
@@ -8,8 +8,8 @@ subprojects {
 
     ext {
         versions = [
-                opentelemetry            : "0.12.0",
-                opentelemetryJavaagent   : "0.12.0",
+                opentelemetry            : "0.13.1",
+                opentelemetryJavaagent   : "0.13.0",
                 bytebuddy                : "1.10.10",
                 guava                    : "20.0"
 

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoIdGenerator.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoIdGenerator.java
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Custom {@link IdGenerator} which provides span and trace ids.
  *
- * @see io.opentelemetry.sdk.trace.TracerSdkProvider
+ * @see io.opentelemetry.sdk.trace.SdkTracerProvider
  * @see DemoTracerCustomizer
  */
 public class DemoIdGenerator implements IdGenerator {

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoTracerCustomizer.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoTracerCustomizer.java
@@ -1,39 +1,39 @@
 package com.example.javaagent;
 
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.javaagent.spi.TracerCustomizer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.trace.TracerSdkManagement;
+import io.opentelemetry.sdk.OpenTelemetrySdkBuilder;
+import io.opentelemetry.sdk.trace.SdkTracerManagement;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.config.TraceConfig;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 
 /**
  * This is the main entry point for the majority of Instrumentation Agent's customizations.
  * It allows for configuring various aspects of OpenTelemetrySdk.
- * See the {@link #configure(TracerSdkManagement)} method below.
- *
+ * See the {@link #configure(SdkTracerManagement)} method below.
+ * <p>
  * Also see https://github.com/open-telemetry/opentelemetry-java/issues/2022
  */
 public class DemoTracerCustomizer implements TracerCustomizer {
   @Override
-  public void configure(TracerSdkManagement ignore) {
-    OpenTelemetrySdk.Builder sdkBuilder = OpenTelemetrySdk.builder();
-
-    sdkBuilder.addSpanProcessor(new DemoSpanProcessor());
-    sdkBuilder.addSpanProcessor(SimpleSpanProcessor.builder(new DemoSpanExporter()).build());
-
-    TraceConfig currentConfig = TraceConfig.getDefault();
-    TraceConfig newConfig = currentConfig.toBuilder()
-        .setSampler(new DemoSampler())
-        .setMaxLengthOfAttributeValues(128)
+  public void configure(SdkTracerManagement tracerManagement) {
+    SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+        .setIdGenerator(new DemoIdGenerator())
+        .setTraceConfig(TraceConfig.getDefault().toBuilder()
+            .setSampler(new DemoSampler())
+            .setMaxLengthOfAttributeValues(128)
+            .build())
         .build();
-    sdkBuilder.setTraceConfig(newConfig);
 
-    sdkBuilder.setIdGenerator(new DemoIdGenerator());
-    sdkBuilder.setPropagators(ContextPropagators.create(new DemoPropagator()));
+    sdkTracerProvider.addSpanProcessor(new DemoSpanProcessor());
+    sdkTracerProvider.addSpanProcessor(SimpleSpanProcessor.builder(new DemoSpanExporter()).build());
 
-    OpenTelemetry.set(sdkBuilder.build());
+    OpenTelemetrySdkBuilder sdkBuilder = OpenTelemetrySdk.builder()
+        .setPropagators(ContextPropagators.create(new DemoPropagator()))
+        .setTracerProvider(sdkTracerProvider);
+    GlobalOpenTelemetry.set(sdkBuilder.build());
   }
-
 }


### PR DESCRIPTION
@anuraaga @jkwatson some feedback on the current released state of configuration:

- It is confusing that`addSpanProcessor` is on `SdkTracerProvider`, not on builder.
- There is `setTraceConfig` on `SdkTracerProviderBuilder` and `updateActiveTraceConfig` on `SdkTracerProvider`. It is unclear if different names mean different functionality.
- Still awkward to set Sampler
- `sdkTracerProvider.addSpanProcessor` returns `void`, breaking fluent interface
- Interplay between `OpenTelemetrySdkBuilder.build()` and `GlobalOpenTelemetry` is confusing