### PR TITLE
Start each server version once for smoke tests

### DIFF
--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -9,17 +9,33 @@ import io.opentelemetry.proto.trace.v1.Span
 import java.util.jar.Attributes
 import java.util.jar.JarFile
 import okhttp3.Request
+import org.junit.runner.RunWith
+import spock.lang.IgnoreIf
+import spock.lang.Shared
 import spock.lang.Unroll
 
+@RunWith(AppServerTestRunner)
 abstract class AppServerTest extends SmokeTest {
+  @Shared
+  String jdk
+  @Shared
+  String serverVersion
+
+  def setupSpec() {
+    AppServer a = AppServerTestRunner.currentAppServer(this.getClass())
+    serverVersion = a.version()
+    jdk = a.jdk()
+    startTarget(jdk, serverVersion)
+  }
+
+  def cleanupSpec() {
+    stopTarget()
+  }
 
   //TODO add assert that server spans were created by servers, not by servlets
   @Unroll
+  @IgnoreIf({ AppServerTestRunner.currentTestClass() == JettySmokeTest })
   def "#appServer smoke test on JDK #jdk"(String appServer, String jdk) {
-    setup:
-    if (!skipStartTarget()) {
-      startTarget(jdk, appServer)
-    }
     String url = "http://localhost:${target.getMappedPort(8080)}/app/greeting"
     def request = new Request.Builder().url(url).get().build()
     def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
@@ -40,8 +56,8 @@ abstract class AppServerTest extends SmokeTest {
     traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 2
 
     and: "Expected span names"
-    traces.countSpansByName('/app/greeting') == 1
-    traces.countSpansByName('/app/headers') == 1
+    traces.countSpansByName(getSpanName('/app/greeting')) == 1
+    traces.countSpansByName(getSpanName('/app/headers')) == 1
 
     and: "The span for the initial web request"
     traces.countFilteredAttributes("http.url", url) == 1
@@ -58,19 +74,261 @@ abstract class AppServerTest extends SmokeTest {
       .findAny()
       .isPresent()
 
-    cleanup:
-    if (!skipStartTarget()) {
-      stopTarget()
-    }
+    where:
+    [appServer, jdk] << getTestParams()
+  }
+
+  @Unroll
+  def "#appServer test static file found on JDK #jdk"(String appServer, String jdk) {
+    String url = "http://localhost:${target.getMappedPort(8080)}/app/hello.txt"
+    def request = new Request.Builder().url(url).get().build()
+    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
+
+    when:
+    def response = CLIENT.newCall(request).execute()
+    TraceInspector traces = new TraceInspector(waitForTraces())
+    Set<String> traceIds = traces.traceIds
+    String responseBody = response.body().string()
+
+    then: "There is one trace"
+    traceIds.size() == 1
+
+    and: "Response contains Hello"
+    responseBody.contains("Hello")
+
+    and: "There is one server span"
+    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
+
+    and: "Expected span names"
+    traces.countSpansByName(getSpanName('/app/hello.txt')) == 1
+
+    and: "The span for the initial web request"
+    traces.countFilteredAttributes("http.url", url) == 1
+
+    and: "Number of spans tagged with current otel library version"
+    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 1
+
+    and:
+    traces.findResourceAttribute("os.name")
+      .map { it.stringValue }
+      .findAny()
+      .isPresent()
 
     where:
     [appServer, jdk] << getTestParams()
   }
 
-  abstract List<List<Object>> getTestParams()
+  @Unroll
+  def "#appServer test static file not found on JDK #jdk"(String appServer, String jdk) {
+    String url = "http://localhost:${target.getMappedPort(8080)}/app/file-that-does-not-exist"
+    def request = new Request.Builder().url(url).get().build()
+    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
 
-  // override to start server only once for all tests
-  boolean skipStartTarget() {
-    false
+    when:
+    def response = CLIENT.newCall(request).execute()
+    TraceInspector traces = new TraceInspector(waitForTraces())
+    Set<String> traceIds = traces.traceIds
+
+    then: "There is one trace"
+    traceIds.size() == 1
+
+    and: "Response code is 404"
+    response.code() == 404
+
+    and: "There is one server span"
+    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
+
+    and: "Expected span names"
+    traces.countSpansByName(getSpanName('/app/file-that-does-not-exist')) == 1
+
+    and: "The span for the initial web request"
+    traces.countFilteredAttributes("http.url", url) == 1
+
+    and: "Number of spans tagged with current otel library version"
+    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == traces.countSpans()
+
+    and:
+    traces.findResourceAttribute("os.name")
+      .map { it.stringValue }
+      .findAny()
+      .isPresent()
+
+    where:
+    [appServer, jdk] << getTestParams()
+  }
+
+  @Unroll
+  @IgnoreIf({ AppServerTestRunner.currentTestClass() == GlassFishSmokeTest })
+  def "#appServer test request for WEB-INF/web.xml on JDK #jdk"(String appServer, String jdk) {
+    String url = "http://localhost:${target.getMappedPort(8080)}/app/WEB-INF/web.xml"
+    def request = new Request.Builder().url(url).get().build()
+    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
+
+    when:
+    def response = CLIENT.newCall(request).execute()
+    TraceInspector traces = new TraceInspector(waitForTraces())
+    Set<String> traceIds = traces.traceIds
+
+    then: "There is one trace"
+    traceIds.size() == 1
+
+    and: "Response code is 404"
+    response.code() == 404
+
+    and: "There is one server span"
+    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
+
+    and: "Expected span names"
+    traces.countSpansByName(getSpanName('/app/WEB-INF/web.xml')) == 1
+
+    and: "The span for the initial web request"
+    traces.countFilteredAttributes("http.url", url) == 1
+
+    and: "Number of spans tagged with current otel library version"
+    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == traces.countSpans()
+
+    and:
+    traces.findResourceAttribute("os.name")
+      .map { it.stringValue }
+      .findAny()
+      .isPresent()
+
+    where:
+    [appServer, jdk] << getTestParams()
+  }
+
+  @Unroll
+  @IgnoreIf({ AppServerTestRunner.currentTestClass() == JettySmokeTest })
+  def "#appServer test request with error JDK #jdk"(String appServer, String jdk) {
+    String url = "http://localhost:${target.getMappedPort(8080)}/app/exception"
+    def request = new Request.Builder().url(url).get().build()
+    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
+
+    when:
+    def response = CLIENT.newCall(request).execute()
+    TraceInspector traces = new TraceInspector(waitForTraces())
+    Set<String> traceIds = traces.traceIds
+
+    then: "There is one trace"
+    traceIds.size() == 1
+
+    and: "Response code is 500"
+    response.code() == 500
+
+    and: "There is one server span"
+    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
+
+    and: "Expected span names"
+    traces.countSpansByName(getSpanName('/app/exception')) == 1
+
+    and: "There is one exception"
+    traces.countFilteredEventAttributes('exception.message', 'This is expected') == 1
+
+    and: "The span for the initial web request"
+    traces.countFilteredAttributes("http.url", url) == 1
+
+    and: "Number of spans tagged with current otel library version"
+    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 1
+
+    and:
+    traces.findResourceAttribute("os.name")
+      .map { it.stringValue }
+      .findAny()
+      .isPresent()
+
+    where:
+    [appServer, jdk] << getTestParams()
+  }
+
+  @Unroll
+  def "#appServer test request outside deployed application JDK #jdk"(String appServer, String jdk) {
+    String url = "http://localhost:${target.getMappedPort(8080)}/this-is-definitely-not-there-but-there-should-be-a-trace-nevertheless"
+    def request = new Request.Builder().url(url).get().build()
+    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
+
+    when:
+    def response = CLIENT.newCall(request).execute()
+    TraceInspector traces = new TraceInspector(waitForTraces())
+    Set<String> traceIds = traces.traceIds
+
+    then: "There is one trace"
+    traceIds.size() == 1
+
+    and: "Response code is 404"
+    response.code() == 404
+
+    and: "There is one server span"
+    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
+
+    and: "Expected span names"
+    traces.countSpansByName(getSpanName('/this-is-definitely-not-there-but-there-should-be-a-trace-nevertheless')) == 1
+
+    and: "The span for the initial web request"
+    traces.countFilteredAttributes("http.url", url) == 1
+
+    and: "Number of spans tagged with current otel library version"
+    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == traces.countSpans()
+
+    and:
+    traces.findResourceAttribute("os.name")
+      .map { it.stringValue }
+      .findAny()
+      .isPresent()
+
+    where:
+    [appServer, jdk] << getTestParams()
+  }
+
+  @Unroll
+  @IgnoreIf({ AppServerTestRunner.currentTestClass() == JettySmokeTest })
+  def "#appServer async smoke test on JDK #jdk"(String appServer, String jdk) {
+    String url = "http://localhost:${target.getMappedPort(8080)}/app/asyncgreeting"
+    def request = new Request.Builder().url(url).get().build()
+    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
+
+    when:
+    def response = CLIENT.newCall(request).execute()
+    TraceInspector traces = new TraceInspector(waitForTraces())
+    Set<String> traceIds = traces.traceIds
+    String responseBody = response.body().string()
+
+    then: "There is one trace"
+    traceIds.size() == 1
+
+    and: "trace id is present in the HTTP headers as reported by the called endpoint"
+    responseBody.contains(traceIds.find())
+
+    and: "Server spans in the distributed trace"
+    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 2
+
+    and: "Expected span names"
+    traces.countSpansByName(getSpanName('/app/asyncgreeting')) == 1
+    traces.countSpansByName(getSpanName('/app/headers')) == 1
+
+    and: "The span for the initial web request"
+    traces.countFilteredAttributes("http.url", url) == 1
+
+    and: "Client and server spans for the remote call"
+    traces.countFilteredAttributes("http.url", "http://localhost:8080/app/headers") == 2
+
+    and: "Number of spans tagged with current otel library version"
+    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 3
+
+    and:
+    traces.findResourceAttribute("os.name")
+      .map { it.stringValue }
+      .findAny()
+      .isPresent()
+
+    where:
+    [appServer, jdk] << getTestParams()
+  }
+
+  protected abstract String getSpanName(String path);
+
+  protected List<List<Object>> getTestParams() {
+    return [
+      [serverVersion, jdk]
+    ]
   }
 }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -23,9 +23,9 @@ abstract class AppServerTest extends SmokeTest {
   String serverVersion
 
   def setupSpec() {
-    AppServer a = AppServerTestRunner.currentAppServer(this.getClass())
-    serverVersion = a.version()
-    jdk = a.jdk()
+    def appServer = AppServerTestRunner.currentAppServer(this.getClass())
+    serverVersion = appServer.version()
+    jdk = appServer.jdk()
     startTarget(jdk, serverVersion)
   }
 

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.smoketest
 
+import static org.junit.Assume.assumeTrue
+
 import io.opentelemetry.proto.trace.v1.Span
 import java.util.jar.Attributes
 import java.util.jar.JarFile
 import okhttp3.Request
 import org.junit.runner.RunWith
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -32,10 +33,27 @@ abstract class AppServerTest extends SmokeTest {
     stopTarget()
   }
 
+  boolean testSmoke() {
+    true
+  }
+
+  boolean testAsyncSmoke() {
+    true
+  }
+
+  boolean testException() {
+    true
+  }
+
+  boolean testRequestWebInfWebXml() {
+    true
+  }
+
   //TODO add assert that server spans were created by servers, not by servlets
   @Unroll
-  @IgnoreIf({ AppServerTestRunner.currentTestClass() == JettySmokeTest })
   def "#appServer smoke test on JDK #jdk"(String appServer, String jdk) {
+    assumeTrue(testSmoke())
+
     String url = "http://localhost:${target.getMappedPort(8080)}/app/greeting"
     def request = new Request.Builder().url(url).get().build()
     def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
@@ -158,8 +176,9 @@ abstract class AppServerTest extends SmokeTest {
   }
 
   @Unroll
-  @IgnoreIf({ AppServerTestRunner.currentTestClass() == GlassFishSmokeTest })
   def "#appServer test request for WEB-INF/web.xml on JDK #jdk"(String appServer, String jdk) {
+    assumeTrue(testRequestWebInfWebXml())
+
     String url = "http://localhost:${target.getMappedPort(8080)}/app/WEB-INF/web.xml"
     def request = new Request.Builder().url(url).get().build()
     def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
@@ -198,8 +217,9 @@ abstract class AppServerTest extends SmokeTest {
   }
 
   @Unroll
-  @IgnoreIf({ AppServerTestRunner.currentTestClass() == JettySmokeTest })
   def "#appServer test request with error JDK #jdk"(String appServer, String jdk) {
+    assumeTrue(testException())
+
     String url = "http://localhost:${target.getMappedPort(8080)}/app/exception"
     def request = new Request.Builder().url(url).get().build()
     def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
@@ -280,8 +300,9 @@ abstract class AppServerTest extends SmokeTest {
   }
 
   @Unroll
-  @IgnoreIf({ AppServerTestRunner.currentTestClass() == JettySmokeTest })
   def "#appServer async smoke test on JDK #jdk"(String appServer, String jdk) {
+    assumeTrue(testAsyncSmoke())
+
     String url = "http://localhost:${target.getMappedPort(8080)}/app/asyncgreeting"
     def request = new Request.Builder().url(url).get().build()
     def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GlassFishSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GlassFishSmokeTest.groovy
@@ -10,10 +10,12 @@ import java.time.Duration
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.containers.wait.strategy.WaitStrategy
 
+@AppServer(version = "5.2020.6", jdk = "8")
+@AppServer(version = "5.2020.6-jdk11", jdk = "11")
 class GlassFishSmokeTest extends AppServerTest {
 
   protected String getTargetImage(String jdk, String serverVersion) {
-    "ghcr.io/open-telemetry/java-test-containers:payara-${serverVersion}-jdk$jdk-20201207.405832649"
+    "ghcr.io/open-telemetry/java-test-containers:payara-${serverVersion}-jdk$jdk-20201215.422527843"
   }
 
   @Override
@@ -29,10 +31,7 @@ class GlassFishSmokeTest extends AppServerTest {
   }
 
   @Override
-  List<List<Object>> getTestParams() {
-    return [
-      ["5.2020.6", 8],
-      ["5.2020.6-jdk11", 11]
-    ]
+  protected String getSpanName(String path) {
+    return path
   }
 }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GlassFishSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GlassFishSmokeTest.groovy
@@ -34,4 +34,10 @@ class GlassFishSmokeTest extends AppServerTest {
   protected String getSpanName(String path) {
     return path
   }
+
+  @Override
+  boolean testRequestWebInfWebXml() {
+    false
+  }
+
 }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
@@ -30,6 +30,21 @@ class JettySmokeTest extends AppServerTest {
     return getJettySpanName()
   }
 
+  @Override
+  boolean testSmoke() {
+    false
+  }
+
+  @Override
+  boolean testAsyncSmoke() {
+    false
+  }
+
+  @Override
+  boolean testException() {
+    false
+  }
+
   @Unroll
   def "#appServer smoke test on JDK #jdk"(String appServer, String jdk) {
     String url = "http://localhost:${target.getMappedPort(8080)}/app/greeting"

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
@@ -1,0 +1,162 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.smoketest
+
+import io.opentelemetry.proto.trace.v1.Span
+import java.util.jar.Attributes
+import java.util.jar.JarFile
+import okhttp3.Request
+import spock.lang.Unroll
+
+@AppServer(version = "9.4.35", jdk = "8")
+@AppServer(version = "9.4.35", jdk = "11")
+@AppServer(version = "10.0.0", jdk = "11")
+@AppServer(version = "10.0.0", jdk = "15")
+class JettySmokeTest extends AppServerTest {
+
+  protected String getTargetImage(String jdk, String serverVersion) {
+    "ghcr.io/open-telemetry/java-test-containers:jetty-${serverVersion}-jdk$jdk-20201215.422527843"
+  }
+
+  def getJettySpanName() {
+    return serverVersion.startsWith("10.") ? "HandlerList.handle" : "HandlerCollection.handle"
+  }
+
+  @Override
+  protected String getSpanName(String path) {
+    return getJettySpanName()
+  }
+
+  @Unroll
+  def "#appServer smoke test on JDK #jdk"(String appServer, String jdk) {
+    String url = "http://localhost:${target.getMappedPort(8080)}/app/greeting"
+    def request = new Request.Builder().url(url).get().build()
+    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
+
+    when:
+    def response = CLIENT.newCall(request).execute()
+    TraceInspector traces = new TraceInspector(waitForTraces())
+    Set<String> traceIds = traces.traceIds
+    String responseBody = response.body().string()
+
+    then: "There is one trace"
+    traceIds.size() == 1
+
+    and: "trace id is present in the HTTP headers as reported by the called endpoint"
+    responseBody.contains(traceIds.find())
+
+    and: "Server spans in the distributed trace"
+    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 2
+
+    and: "Expected span names"
+    traces.countSpansByName(getJettySpanName()) == 2
+
+    and: "The span for the initial web request"
+    traces.countFilteredAttributes("http.url", url) == 1
+
+    and: "Client and server spans for the remote call"
+    traces.countFilteredAttributes("http.url", "http://localhost:8080/app/headers") == 2
+
+    and: "Number of spans tagged with current otel library version"
+    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 3
+
+    and:
+    traces.findResourceAttribute("os.name")
+      .map { it.stringValue }
+      .findAny()
+      .isPresent()
+
+    where:
+    [appServer, jdk] << getTestParams()
+  }
+
+  @Unroll
+  def "#appServer async smoke test on JDK #jdk"(String appServer, String jdk) {
+    String url = "http://localhost:${target.getMappedPort(8080)}/app/asyncgreeting"
+    def request = new Request.Builder().url(url).get().build()
+    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
+
+    when:
+    def response = CLIENT.newCall(request).execute()
+    TraceInspector traces = new TraceInspector(waitForTraces())
+    Set<String> traceIds = traces.traceIds
+    String responseBody = response.body().string()
+
+    then: "There is one trace"
+    traceIds.size() == 1
+
+    and: "trace id is present in the HTTP headers as reported by the called endpoint"
+    responseBody.contains(traceIds.find())
+
+    and: "Server spans in the distributed trace"
+    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 2
+
+    and: "Expected span names"
+    traces.countSpansByName(getJettySpanName()) == 2
+
+    and: "The span for the initial web request"
+    traces.countFilteredAttributes("http.url", url) == 1
+
+    and: "Client and server spans for the remote call"
+    traces.countFilteredAttributes("http.url", "http://localhost:8080/app/headers") == 2
+
+    and: "Number of spans tagged with current otel library version"
+    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 3
+
+    and:
+    traces.findResourceAttribute("os.name")
+      .map { it.stringValue }
+      .findAny()
+      .isPresent()
+
+    where:
+    [appServer, jdk] << getTestParams()
+  }
+
+  @Unroll
+  def "#appServer test request with error JDK #jdk"(String appServer, String jdk) {
+    String url = "http://localhost:${target.getMappedPort(8080)}/app/exception"
+    def request = new Request.Builder().url(url).get().build()
+    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
+
+    when:
+    def response = CLIENT.newCall(request).execute()
+    TraceInspector traces = new TraceInspector(waitForTraces())
+    Set<String> traceIds = traces.traceIds
+
+    then: "There is one trace"
+    traceIds.size() == 1
+
+    and: "Response code is 500"
+    response.code() == 500
+
+    and: "There is one server span"
+    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
+
+    and: "Expected span names"
+    traces.countSpansByName(getJettySpanName()) == 1
+
+    //FIXME: exception not reported on jetty
+//    and: "There is one exception"
+//    traces.countFilteredEventAttributes('exception.message', 'This is expected') == 1
+
+    and: "The span for the initial web request"
+    traces.countFilteredAttributes("http.url", url) == 1
+
+    and: "Number of spans tagged with current otel library version"
+    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 1
+
+    and:
+    traces.findResourceAttribute("os.name")
+      .map { it.stringValue }
+      .findAny()
+      .isPresent()
+
+    where:
+    [appServer, jdk] << getTestParams()
+  }
+
+}

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/LibertyServletOnlySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/LibertyServletOnlySmokeTest.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.smoketest
+
+import org.testcontainers.containers.BindMode
+import org.testcontainers.containers.GenericContainer
+
+@AppServer(version = "20.0.0.12", jdk = "8")
+class LibertyServletOnlySmokeTest extends LibertySmokeTest {
+
+  protected void customizeContainer(GenericContainer container) {
+    container.withClasspathResourceMapping("liberty-servlet.xml", "/config/server.xml", BindMode.READ_ONLY)
+  }
+
+}

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/LibertySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/LibertySmokeTest.groovy
@@ -5,284 +5,36 @@
 
 package io.opentelemetry.smoketest
 
-import io.opentelemetry.proto.trace.v1.Span
-import okhttp3.Request
-import spock.lang.Shared
-import spock.lang.Unroll
+import java.time.Duration
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.containers.wait.strategy.WaitStrategy
 
-import java.util.jar.Attributes
-import java.util.jar.JarFile
-
+@AppServer(version = "20.0.0.12", jdk = "8")
+@AppServer(version = "20.0.0.12", jdk = "11")
+@AppServer(version = "20.0.0.12", jdk = "8-jdk-openj9")
+@AppServer(version = "20.0.0.12", jdk = "11-jdk-openj9")
 class LibertySmokeTest extends AppServerTest {
-  //TODO run more configurations
-  @Shared
-  String jdk = 8
-  @Shared
-  String serverVersion = "20.0.0.12"
 
   protected String getTargetImage(String jdk, String serverVersion) {
     "ghcr.io/open-telemetry/java-test-containers:liberty-${serverVersion}-jdk$jdk-20201215.422527843"
   }
 
-  boolean skipStartTarget() {
-    true
-  }
-
-  def setupSpec() {
-    startTarget(jdk, serverVersion)
-  }
-
-  def cleanupSpec() {
-    stopTarget()
-  }
-
-  @Unroll
-  def "#appServer test static file found on JDK #jdk"(String appServer, String jdk) {
-    String url = "http://localhost:${target.getMappedPort(8080)}/app/hello.txt"
-    def request = new Request.Builder().url(url).get().build()
-    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
-
-    when:
-    def response = CLIENT.newCall(request).execute()
-    TraceInspector traces = new TraceInspector(waitForTraces())
-    Set<String> traceIds = traces.traceIds
-    String responseBody = response.body().string()
-
-    then: "There is one trace"
-    traceIds.size() == 1
-
-    and: "Response contains Hello"
-    responseBody.contains("Hello")
-
-    and: "There is one server span"
-    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
-
-    and: "Expected span names"
-    traces.countSpansByName('HTTP GET') == 1
-
-    and: "The span for the initial web request"
-    traces.countFilteredAttributes("http.url", url) == 1
-
-    and: "Number of spans tagged with current otel library version"
-    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 1
-
-    and:
-    traces.findResourceAttribute("os.name")
-      .map { it.stringValue }
-      .findAny()
-      .isPresent()
-
-    where:
-    [appServer, jdk] << getTestParams()
-  }
-
-  @Unroll
-  def "#appServer test static file not found on JDK #jdk"(String appServer, String jdk) {
-    String url = "http://localhost:${target.getMappedPort(8080)}/app/file-that-does-not-exist"
-    def request = new Request.Builder().url(url).get().build()
-    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
-
-    when:
-    def response = CLIENT.newCall(request).execute()
-    TraceInspector traces = new TraceInspector(waitForTraces())
-    Set<String> traceIds = traces.traceIds
-
-    then: "There is one trace"
-    traceIds.size() == 1
-
-    and: "Response code is 404"
-    response.code() == 404
-
-    and: "There is one server span"
-    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
-
-    and: "Expected span names"
-    traces.countSpansByName('HTTP GET') == 1
-
-    and: "The span for the initial web request"
-    traces.countFilteredAttributes("http.url", url) == 1
-
-    and: "Number of spans tagged with current otel library version"
-    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 1
-
-    and:
-    traces.findResourceAttribute("os.name")
-      .map { it.stringValue }
-      .findAny()
-      .isPresent()
-
-    where:
-    [appServer, jdk] << getTestParams()
-  }
-
-  @Unroll
-  def "#appServer test request for WEB-INF/web.xml on JDK #jdk"(String appServer, String jdk) {
-    String url = "http://localhost:${target.getMappedPort(8080)}/app/WEB-INF/web.xml"
-    def request = new Request.Builder().url(url).get().build()
-    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
-
-    when:
-    def response = CLIENT.newCall(request).execute()
-    TraceInspector traces = new TraceInspector(waitForTraces())
-    Set<String> traceIds = traces.traceIds
-
-    then: "There is one trace"
-    traceIds.size() == 1
-
-    and: "Response code is 404"
-    response.code() == 404
-
-    and: "There is one server span"
-    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
-
-    and: "Expected span names"
-    traces.countSpansByName('HTTP GET') == 1
-
-    and: "The span for the initial web request"
-    traces.countFilteredAttributes("http.url", url) == 1
-
-    and: "Number of spans tagged with current otel library version"
-    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 1
-
-    and:
-    traces.findResourceAttribute("os.name")
-      .map { it.stringValue }
-      .findAny()
-      .isPresent()
-
-    where:
-    [appServer, jdk] << getTestParams()
-  }
-
-  @Unroll
-  def "#appServer test request with error JDK #jdk"(String appServer, String jdk) {
-    String url = "http://localhost:${target.getMappedPort(8080)}/app/exception"
-    def request = new Request.Builder().url(url).get().build()
-    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
-
-    when:
-    def response = CLIENT.newCall(request).execute()
-    TraceInspector traces = new TraceInspector(waitForTraces())
-    Set<String> traceIds = traces.traceIds
-
-    then: "There is one trace"
-    traceIds.size() == 1
-
-    and: "Response code is 500"
-    response.code() == 500
-
-    and: "There is one server span"
-    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
-
-    and: "Expected span names"
-    traces.countSpansByName('/app/exception') == 1
-
-    and: "There is one exception"
-    traces.countFilteredEventAttributes('exception.message', 'This is expected') == 1
-
-    and: "The span for the initial web request"
-    traces.countFilteredAttributes("http.url", url) == 1
-
-    and: "Number of spans tagged with current otel library version"
-    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 1
-
-    and:
-    traces.findResourceAttribute("os.name")
-      .map { it.stringValue }
-      .findAny()
-      .isPresent()
-
-    where:
-    [appServer, jdk] << getTestParams()
-  }
-
-  @Unroll
-  def "#appServer test request outside deployed application JDK #jdk"(String appServer, String jdk) {
-    String url = "http://localhost:${target.getMappedPort(8080)}/this-is-definitely-not-there-but-there-should-be-a-trace-nevertheless"
-    def request = new Request.Builder().url(url).get().build()
-    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
-
-    when:
-    def response = CLIENT.newCall(request).execute()
-    TraceInspector traces = new TraceInspector(waitForTraces())
-    Set<String> traceIds = traces.traceIds
-
-    then: "There is one trace"
-    traceIds.size() == 1
-
-    and: "Response code is 404"
-    response.code() == 404
-
-    and: "There is one server span"
-    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
-
-    and: "Expected span names"
-    traces.countSpansByName('HTTP GET') == 1
-
-    and: "The span for the initial web request"
-    traces.countFilteredAttributes("http.url", url) == 1
-
-    and: "Number of spans tagged with current otel library version"
-    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 1
-
-    and:
-    traces.findResourceAttribute("os.name")
-      .map { it.stringValue }
-      .findAny()
-      .isPresent()
-
-    where:
-    [appServer, jdk] << getTestParams()
-  }
-
-  @Unroll
-  def "#appServer async smoke test on JDK #jdk"(String appServer, String jdk) {
-    String url = "http://localhost:${target.getMappedPort(8080)}/app/asyncgreeting"
-    def request = new Request.Builder().url(url).get().build()
-    def currentAgentVersion = new JarFile(agentPath).getManifest().getMainAttributes().get(Attributes.Name.IMPLEMENTATION_VERSION)
-
-    when:
-    def response = CLIENT.newCall(request).execute()
-    TraceInspector traces = new TraceInspector(waitForTraces())
-    Set<String> traceIds = traces.traceIds
-    String responseBody = response.body().string()
-
-    then: "There is one trace"
-    traceIds.size() == 1
-
-    and: "trace id is present in the HTTP headers as reported by the called endpoint"
-    responseBody.contains(traceIds.find())
-
-    and: "Server spans in the distributed trace"
-    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 2
-
-    and: "Expected span names"
-    traces.countSpansByName('/app/asyncgreeting') == 1
-    traces.countSpansByName('/app/headers') == 1
-
-    and: "The span for the initial web request"
-    traces.countFilteredAttributes("http.url", url) == 1
-
-    and: "Client and server spans for the remote call"
-    traces.countFilteredAttributes("http.url", "http://localhost:8080/app/headers") == 2
-
-    and: "Number of spans tagged with current otel library version"
-    traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 3
-
-    and:
-    traces.findResourceAttribute("os.name")
-      .map { it.stringValue }
-      .findAny()
-      .isPresent()
-
-    where:
-    [appServer, jdk] << getTestParams()
+  @Override
+  protected WaitStrategy getWaitStrategy() {
+    return Wait
+      .forLogMessage(".*server is ready to run a smarter planet.*", 1)
+      .withStartupTimeout(Duration.ofMinutes(3))
   }
 
   @Override
-  List<List<Object>> getTestParams() {
-    return [
-      [serverVersion, jdk]
-    ]
+  protected String getSpanName(String path) {
+    switch (path) {
+      case "/app/greeting":
+      case "/app/headers":
+      case "/app/exception":
+      case "/app/asyncgreeting":
+        return path
+    }
+    return 'HTTP GET'
   }
 }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
@@ -133,6 +133,7 @@ abstract class SmokeTest extends Specification {
   def cleanupSpec() {
     backend.stop()
     collector.stop()
+    network.close()
   }
 
   protected static Stream<AnyValue> findResourceAttribute(Collection<ExportTraceServiceRequest> traces,

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TomcatSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TomcatSmokeTest.groovy
@@ -5,42 +5,24 @@
 
 package io.opentelemetry.smoketest
 
-import io.opentelemetry.proto.trace.v1.Span
-import okhttp3.Request
-
+@AppServer(version = "7.0.107", jdk = "8")
+@AppServer(version = "8.5.60", jdk = "8")
+@AppServer(version = "8.5.60", jdk = "11")
+@AppServer(version = "9.0.40", jdk = "8")
+@AppServer(version = "9.0.40", jdk = "11")
 class TomcatSmokeTest extends AppServerTest {
 
   protected String getTargetImage(String jdk, String serverVersion) {
-    "ghcr.io/open-telemetry/java-test-containers:tomcat-${serverVersion}-jdk$jdk-20201207.405832649"
-  }
-
-  def "Server Handler test"() {
-    setup:
-    startTarget(8, "7.0.107")
-    String url = "http://localhost:${target.getMappedPort(8080)}/this_is_not_mapped_to_any_servlet"
-    def request = new Request.Builder().url(url).get().build()
-
-    when:
-    def response = CLIENT.newCall(request).execute()
-    TraceInspector traces = new TraceInspector(waitForTraces())
-
-    then:
-    !response.successful
-    response.code() == 404
-
-    traces.countSpansByKind(Span.SpanKind.SPAN_KIND_SERVER) == 1
-
-    traces.countSpansByName('CoyoteAdapter.service') == 1
+    "ghcr.io/open-telemetry/java-test-containers:tomcat-${serverVersion}-jdk$jdk-20201215.422527843"
   }
 
   @Override
-  List<List<Object>> getTestParams() {
-    return [
-      ["7.0.107", 8],
-      ["8.5.60", 8],
-      ["8.5.60", 11],
-      ["9.0.40", 8],
-      ["9.0.40", 11]
-    ]
+  protected String getSpanName(String path) {
+    switch (path) {
+      case "/app/WEB-INF/web.xml":
+      case "/this-is-definitely-not-there-but-there-should-be-a-trace-nevertheless":
+        return "CoyoteAdapter.service"
+    }
+    return path
   }
 }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TraceInspector.java
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TraceInspector.java
@@ -77,6 +77,10 @@ public class TraceInspector {
     return (int) getSpanStream().filter(it -> it.getKind().equals(spanKind)).count();
   }
 
+  protected int countSpans() {
+    return (int) getSpanStream().count();
+  }
+
   public int size() {
     return traces.size();
   }

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServer.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.smoketest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Repeatable(AppServers.class)
+@Inherited
+public @interface AppServer {
+  String version();
+
+  String jdk();
+}

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServerTestRunner.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServerTestRunner.java
@@ -74,7 +74,7 @@ public class AppServerTestRunner extends Sputnik {
   // used for ignoring tests defined in base class that are expected to fail
   // on currently running server
   public static Class<?> currentTestClass() {
-    Class<?> c = currentTestClass.get();
+    Class<?> testClass = currentTestClass.get();
     if (c == null) {
       throw new IllegalStateException("Current test class is not set");
     }

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServerTestRunner.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServerTestRunner.java
@@ -63,7 +63,7 @@ public class AppServerTestRunner extends Sputnik {
   // expose currently running app server
   // used to get current server and jvm version inside the test class
   public static AppServer currentAppServer(Class<?> testClass) {
-    AppServer a = runningAppServer.get(testClass);
+    AppServer appServer = runningAppServer.get(testClass);
     if (a == null) {
       throw new IllegalStateException("Test not running for " + testClass);
     }

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServerTestRunner.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServerTestRunner.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.smoketest;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+import org.spockframework.runtime.Sputnik;
+
+/**
+ * Customized spock test runner that runs tests on multiple app server versions based on {@link
+ * AppServer} annotations. This runner selects first server based on {@link AppServer} annotation
+ * calls setupSpec, all test method and cleanupSpec, selects next {@link AppServer} and calls the
+ * same methods. This process is repeated until tests have run for all {@link AppServer}
+ * annotations. Tests should start server in setupSpec and stop it in cleanupSpec.
+ */
+public class AppServerTestRunner extends Sputnik {
+  private static final Map<Class<?>, AppServer> runningAppServer =
+      Collections.synchronizedMap(new HashMap<>());
+  private static final ThreadLocal<Class<?>> currentTestClass = new ThreadLocal<>();
+  private final Class<?> testClass;
+  private final AppServer[] appServers;
+
+  public AppServerTestRunner(Class<?> clazz) throws InitializationError {
+    super(clazz);
+    testClass = clazz;
+    appServers = clazz.getAnnotationsByType(AppServer.class);
+    if (appServers.length == 0) {
+      throw new IllegalStateException("Add AppServer or AppServers annotation to test class");
+    }
+  }
+
+  @Override
+  public void run(RunNotifier notifier) {
+    // run tests for all app servers
+    try {
+      for (AppServer a : appServers) {
+        runningAppServer.put(testClass, a);
+        super.run(notifier);
+      }
+    } finally {
+      runningAppServer.remove(testClass);
+    }
+  }
+
+  @Override
+  public Description getDescription() {
+    //
+    currentTestClass.set(testClass);
+    try {
+      return super.getDescription();
+    } finally {
+      currentTestClass.remove();
+    }
+  }
+
+  // expose currently running app server
+  // used to get current server and jvm version inside the test class
+  public static AppServer currentAppServer(Class<?> testClass) {
+    AppServer a = runningAppServer.get(testClass);
+    if (a == null) {
+      throw new IllegalStateException("Test not running for " + testClass);
+    }
+    return a;
+  }
+
+  // expose current test class
+  // used for ignoring tests defined in base class that are expected to fail
+  // on currently running server
+  public static Class<?> currentTestClass() {
+    Class<?> c = currentTestClass.get();
+    if (c == null) {
+      throw new IllegalStateException("Current test class is not set");
+    }
+    return c;
+  }
+}

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServerTestRunner.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServerTestRunner.java
@@ -40,7 +40,7 @@ public class AppServerTestRunner extends Sputnik {
   public void run(RunNotifier notifier) {
     // run tests for all app servers
     try {
-      for (AppServer a : appServers) {
+      for (AppServer appServer : appServers) {
         runningAppServer.put(testClass, a);
         super.run(notifier);
       }

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServerTestRunner.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServerTestRunner.java
@@ -8,7 +8,6 @@ package io.opentelemetry.smoketest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
 import org.spockframework.runtime.Sputnik;
@@ -23,7 +22,6 @@ import org.spockframework.runtime.Sputnik;
 public class AppServerTestRunner extends Sputnik {
   private static final Map<Class<?>, AppServer> runningAppServer =
       Collections.synchronizedMap(new HashMap<>());
-  private static final ThreadLocal<Class<?>> currentTestClass = new ThreadLocal<>();
   private final Class<?> testClass;
   private final AppServer[] appServers;
 
@@ -41,7 +39,7 @@ public class AppServerTestRunner extends Sputnik {
     // run tests for all app servers
     try {
       for (AppServer appServer : appServers) {
-        runningAppServer.put(testClass, a);
+        runningAppServer.put(testClass, appServer);
         super.run(notifier);
       }
     } finally {
@@ -49,35 +47,13 @@ public class AppServerTestRunner extends Sputnik {
     }
   }
 
-  @Override
-  public Description getDescription() {
-    //
-    currentTestClass.set(testClass);
-    try {
-      return super.getDescription();
-    } finally {
-      currentTestClass.remove();
-    }
-  }
-
   // expose currently running app server
   // used to get current server and jvm version inside the test class
   public static AppServer currentAppServer(Class<?> testClass) {
     AppServer appServer = runningAppServer.get(testClass);
-    if (a == null) {
+    if (appServer == null) {
       throw new IllegalStateException("Test not running for " + testClass);
     }
-    return a;
-  }
-
-  // expose current test class
-  // used for ignoring tests defined in base class that are expected to fail
-  // on currently running server
-  public static Class<?> currentTestClass() {
-    Class<?> testClass = currentTestClass.get();
-    if (c == null) {
-      throw new IllegalStateException("Current test class is not set");
-    }
-    return c;
+    return appServer;
   }
 }

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServers.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AppServers.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.smoketest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface AppServers {
+  AppServer[] value();
+}

--- a/smoke-tests/src/test/resources/liberty-servlet.xml
+++ b/smoke-tests/src/test/resources/liberty-servlet.xml
@@ -1,0 +1,12 @@
+<server description="Sample Liberty server">
+  <variable name="default.http.port" defaultValue="8080"/>
+
+  <featureManager>
+    <feature>servlet-4.0</feature>
+  </featureManager>
+
+  <webApplication location="app.war" contextRoot="/app" />
+  <mpMetrics authentication="false"/>
+
+  <httpEndpoint host="*" httpPort="${default.http.port}" id="defaultHttpEndpoint"/>
+</server>


### PR DESCRIPTION
Introduce a custom test runner so we could start server once, run all tests on it, stop it and proceed with next server version. Run same smoke tests on tomcat, jetty, glassfish, wildfly and liberty.