### PR TITLE
Improve servlet22 response status handling

### DIFF
--- a/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Advice.java
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Advice.java
@@ -43,6 +43,8 @@ public class Servlet2Advice {
 
     context = tracer().startSpan(httpServletRequest);
     scope = context.makeCurrent();
+    // reset response status from previous request
+    InstrumentationContext.get(ServletResponse.class, Integer.class).put(response, null);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -73,11 +75,15 @@ public class Servlet2Advice {
 
     tracer().setPrincipal(context, (HttpServletRequest) request);
 
+    int responseStatusCode = HttpServletResponse.SC_OK;
     Integer responseStatus =
         InstrumentationContext.get(ServletResponse.class, Integer.class).get(response);
+    if (responseStatus != null) {
+      responseStatusCode = responseStatus;
+    }
 
     ResponseWithStatus responseWithStatus =
-        new ResponseWithStatus((HttpServletResponse) response, responseStatus);
+        new ResponseWithStatus((HttpServletResponse) response, responseStatusCode);
     if (throwable == null) {
       tracer().end(context, responseWithStatus);
     } else {

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Advice.java
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Advice.java
@@ -44,6 +44,7 @@ public class Servlet2Advice {
     context = tracer().startSpan(httpServletRequest);
     scope = context.makeCurrent();
     // reset response status from previous request
+    // (some servlet containers reuse response objects to reduce memory allocations)
     InstrumentationContext.get(ServletResponse.class, Integer.class).put(response, null);
   }
 

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2HttpServerTracer.java
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2HttpServerTracer.java
@@ -23,4 +23,9 @@ public class Servlet2HttpServerTracer extends ServletHttpServerTracer<ResponseWi
   protected int responseStatus(ResponseWithStatus responseWithStatus) {
     return responseWithStatus.getStatus();
   }
+
+  @Override
+  protected boolean isResponseCommitted(ResponseWithStatus responseWithStatus) {
+    return responseWithStatus.getResponse().isCommitted();
+  }
 }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3HttpServerTracer.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3HttpServerTracer.java
@@ -36,22 +36,8 @@ public class Servlet3HttpServerTracer extends ServletHttpServerTracer<HttpServle
   }
 
   @Override
-  public void endExceptionally(
-      Context context, Throwable throwable, HttpServletResponse response, long timestamp) {
-    if (response.isCommitted()) {
-      super.endExceptionally(context, throwable, response, timestamp);
-    } else {
-      // passing null response to super, in order to capture as 500 / INTERNAL, due to servlet spec
-      // https://javaee.github.io/servlet-spec/downloads/servlet-4.0/servlet-4_0_FINAL.pdf:
-      // "If a servlet generates an error that is not handled by the error page mechanism as
-      // described above, the container must ensure to send a response with status 500."
-      super.endExceptionally(context, throwable, null, timestamp);
-    }
-  }
-
-  @Override
-  public void end(Context context, HttpServletResponse response, long timestamp) {
-    super.end(context, response, timestamp);
+  protected boolean isResponseCommitted(HttpServletResponse response) {
+    return response.isCommitted();
   }
 
   public void onTimeout(Context context, long timeout) {


### PR DESCRIPTION
If servlet doesn't set response status then currently there is a NPE when casting Integer -> int in Servlet2Advice#stopSpan. This happens when running "test exception" in JettyServlet2Test with other tests commented out. In JettyServlet2Test "test exception" currently passes only when it is run after "test error" as our integration ends up using response status set from previous request, reset response status when creating span to avoid this.