### PR TITLE
Tests for ServletHttpServerTracer.getSpanName()

### DIFF
--- a/instrumentation-core/servlet-2.2/servlet-2.2.gradle
+++ b/instrumentation-core/servlet-2.2/servlet-2.2.gradle
@@ -7,4 +7,8 @@ dependencies {
   implementation deps.slf4j
 
   compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.2'
+
+  testImplementation group: 'javax.servlet', name: 'servlet-api', version: '2.2'
+  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.18.1'
 }

--- a/instrumentation-core/servlet-2.2/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
+++ b/instrumentation-core/servlet-2.2/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
@@ -124,15 +124,15 @@ public abstract class ServletHttpServerTracer<RESPONSE>
   }
 
   public static String getSpanName(HttpServletRequest request) {
-    String spanName = request.getServletPath();
-    if (spanName.isEmpty()) {
+    String servletPath = request.getServletPath();
+    if (servletPath.isEmpty()) {
       return "HTTP " + request.getMethod();
     }
     String contextPath = request.getContextPath();
-    if (contextPath != null && !contextPath.isEmpty() && !contextPath.equals("/")) {
-      spanName = contextPath + spanName;
+    if (contextPath == null || contextPath.isEmpty() || contextPath.equals("/")) {
+      return servletPath;
     }
-    return spanName;
+    return contextPath + servletPath;
   }
 
   /**

--- a/instrumentation-core/servlet-2.2/src/test/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracerTest.java
+++ b/instrumentation-core/servlet-2.2/src/test/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.servlet;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -23,7 +28,8 @@ public class ServletHttpServerTracerTest {
   void testGetSpanName_nullSpanName() {
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getServletPath()).thenReturn(null);
-    assertThatThrownBy(() -> ServletHttpServerTracer.getSpanName(request)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> ServletHttpServerTracer.getSpanName(request))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/instrumentation-core/servlet-2.2/src/test/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracerTest.java
+++ b/instrumentation-core/servlet-2.2/src/test/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracerTest.java
@@ -1,0 +1,64 @@
+package io.opentelemetry.instrumentation.servlet;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+
+public class ServletHttpServerTracerTest {
+
+  @Test
+  void testGetSpanName_emptySpanName() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getServletPath()).thenReturn("");
+    when(request.getMethod()).thenReturn("PUT");
+    String spanName = ServletHttpServerTracer.getSpanName(request);
+    assertThat(spanName).isEqualTo("HTTP PUT");
+  }
+
+  @Test
+  void testGetSpanName_nullSpanName() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getServletPath()).thenReturn(null);
+    assertThatThrownBy(() -> ServletHttpServerTracer.getSpanName(request)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void testGetSpanName_nullContextPath() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getServletPath()).thenReturn("/swizzler");
+    when(request.getContextPath()).thenReturn(null);
+    String spanName = ServletHttpServerTracer.getSpanName(request);
+    assertThat(spanName).isEqualTo("/swizzler");
+  }
+
+  @Test
+  void testGetSpanName_emptyContextPath() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getServletPath()).thenReturn("/swizzler");
+    when(request.getContextPath()).thenReturn("");
+    String spanName = ServletHttpServerTracer.getSpanName(request);
+    assertThat(spanName).isEqualTo("/swizzler");
+  }
+
+  @Test
+  void testGetSpanName_slashContextPath() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getServletPath()).thenReturn("/swizzler");
+    when(request.getContextPath()).thenReturn("/");
+    String spanName = ServletHttpServerTracer.getSpanName(request);
+    assertThat(spanName).isEqualTo("/swizzler");
+  }
+
+  @Test
+  void testGetSpanName_appendsSpanNameToContext() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getServletPath()).thenReturn("/swizzler");
+    when(request.getContextPath()).thenReturn("/path/to");
+    String spanName = ServletHttpServerTracer.getSpanName(request);
+    assertThat(spanName).isEqualTo("/path/to/swizzler");
+  }
+}

--- a/instrumentation-core/servlet-2.2/src/test/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracerTest.java
+++ b/instrumentation-core/servlet-2.2/src/test/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracerTest.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.instrumentation.servlet;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
While investigating span naming around http servlets, I discovered that there was a gap in coverage for the static `getSpanName()` method, so I built some.  I also made a couple small readability cleanups in that method while in there.