### PR TITLE
Make factory method for netty 4.0 attribute keys public

### DIFF
--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AttributeKeys.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AttributeKeys.java
@@ -42,6 +42,8 @@ public class AttributeKeys {
    * prevents an issue with Apache Atlas project were this class loaded by multiple class loaders,
    * while the Attribute class is loaded by a third class loader and used internally for the
    * cassandra driver.
+   *
+   * <p>Keep this API public for vendor instrumentations
    */
   public static <T> AttributeKey<T> attributeKey(String key) {
     ConcurrentMap<String, AttributeKey<?>> classLoaderMap =

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AttributeKeys.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AttributeKeys.java
@@ -43,7 +43,7 @@ public class AttributeKeys {
    * while the Attribute class is loaded by a third class loader and used internally for the
    * cassandra driver.
    */
-  private static <T> AttributeKey<T> attributeKey(String key) {
+  public static <T> AttributeKey<T> attributeKey(String key) {
     ConcurrentMap<String, AttributeKey<?>> classLoaderMap =
         map.computeIfAbsent(AttributeKey.class.getClassLoader(), mapSupplier);
     if (classLoaderMap.containsKey(key)) {


### PR DESCRIPTION
Our custom instrumentation needs to create additional netty AttributeKey's. It would be useful to expose this.

Signed-off-by: Pavol Loffay <p.loffay@gmail.com>