### PR TITLE
Update snapshot url in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ See [Running the tests](./docs/contributing/running-tests.md) for more details.
 
 For developers testing code changes before a release is complete, there are
 snapshot builds of the `master` branch. They are available from
-[Sonatype OSS snapshots repository](https://oss.sonatype.org/content/repositories/snapshots/)
+[Sonatype OSS snapshots repository](https://oss.sonatype.org/content/repositories/snapshots/io/opentelemetry/)
 
 #### Building from source
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ See [Running the tests](./docs/contributing/running-tests.md) for more details.
 
 For developers testing code changes before a release is complete, there are
 snapshot builds of the `master` branch. They are available from
-[Sonatype OSS snapshots repository](https://oss.sonatype.org/content/repositories/snapshots/io/opentelemetry/)
+the Sonatype OSS snapshots repository at https://oss.sonatype.org/content/repositories/snapshots/ ([browse](https://oss.sonatype.org/content/repositories/snapshots/io/opentelemetry/))
 
 #### Building from source
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,8 +10,8 @@ to calculate the current version based on git tags. This plugin looks for the la
 ## Snapshot builds
 Every successful CI build of the master branch automatically executes `./gradlew snapshot` as the last task.
 This signals Nebula plugin to build and publish to
-[JFrog OSS repository](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/opentelemetry/instrumentation/) next _minor_ release version.
-This means version `vX.(Y+1).0-SNAPSHOT`.
+[Sonatype OSS snapshots repository](https://oss.sonatype.org/content/repositories/snapshots/io/opentelemetry/)
+next _minor_ release version. This means version `vX.(Y+1).0-SNAPSHOT`.
 
 ## Starting the Release
 


### PR DESCRIPTION
The old jfrog url was still in `RELEASING.md` and I changed the links to go to the org (so that when users click it it's meaningful).