### PR TITLE
Don't override preconfigured propagators.

### DIFF
--- a/javaagent-tooling/javaagent-tooling.gradle
+++ b/javaagent-tooling/javaagent-tooling.gradle
@@ -36,6 +36,8 @@ dependencies {
   implementation deps.slf4j
 
   testImplementation project(':testing-common')
+  testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.18.1'
+  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
 
   instrumentationMuzzle sourceSets.main.output
   instrumentationMuzzle configurations.implementation

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializer.java
@@ -88,23 +88,17 @@ public class PropagatorsInitializer {
               W3CBaggagePropagator.getInstance()));
     }
 
-    List<Propagator> propagators = new ArrayList<>(propagatorIds.size());
     List<TextMapPropagator> textMapPropagators = new ArrayList<>();
     textMapPropagators.add(preconfiguredPropagator);
 
     for (String propagatorId : propagatorIds) {
       Propagator propagator = TEXTMAP_PROPAGATORS.get(propagatorId);
       if (propagator != null) {
-        propagators.add(propagator);
+        textMapPropagators.add(propagator);
         log.info("Added " + propagatorId + " propagator");
       } else {
         log.warn("No matching propagator for " + propagatorId);
       }
-    }
-    if (propagators.size() > 1) {
-      textMapPropagators.addAll(propagators);
-    } else if (propagators.size() == 1) {
-      textMapPropagators.add(propagators.get(0));
     }
     return createPropagatorsRemovingNoops(textMapPropagators);
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializer.java
@@ -58,25 +58,34 @@ public class PropagatorsInitializer {
    * </ul>
    */
   public static void initializePropagators(List<String> propagatorIds) {
-    initializePropagators(propagatorIds, () -> GlobalOpenTelemetry.get().getPropagators().getTextMapPropagator(),
+    initializePropagators(
+        propagatorIds,
+        () -> GlobalOpenTelemetry.get().getPropagators().getTextMapPropagator(),
         p -> GlobalOpenTelemetry.get().setPropagators(p));
   }
 
-  //exists for testing
-  static void initializePropagators(List<String> propagatorIds, Supplier<TextMapPropagator> preconfiguredPropagator,
+  // exists for testing
+  static void initializePropagators(
+      List<String> propagatorIds,
+      Supplier<TextMapPropagator> preconfiguredPropagator,
       Consumer<ContextPropagators> globalSetter) {
-    ContextPropagators propagators = createPropagators(propagatorIds, preconfiguredPropagator.get());
+    ContextPropagators propagators =
+        createPropagators(propagatorIds, preconfiguredPropagator.get());
     // Register it in the global propagators:
     globalSetter.accept(propagators);
   }
 
-  private static ContextPropagators createPropagators(List<String> propagatorIds, TextMapPropagator preconfiguredPropagator) {
+  private static ContextPropagators createPropagators(
+      List<String> propagatorIds, TextMapPropagator preconfiguredPropagator) {
     /* Only override the default propagators *if* the caller specified any. */
     if (propagatorIds.size() == 0) {
       // TODO this is probably temporary until default propagators are supplied by SDK
       //  https://github.com/open-telemetry/opentelemetry-java/issues/1742
-      return createPropagatorsRemovingNoops(Arrays.asList(preconfiguredPropagator,
-          W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance()));
+      return createPropagatorsRemovingNoops(
+          Arrays.asList(
+              preconfiguredPropagator,
+              W3CTraceContextPropagator.getInstance(),
+              W3CBaggagePropagator.getInstance()));
     }
 
     List<Propagator> propagators = new ArrayList<>(propagatorIds.size());
@@ -100,12 +109,13 @@ public class PropagatorsInitializer {
     return createPropagatorsRemovingNoops(textMapPropagators);
   }
 
-  private static ContextPropagators createPropagatorsRemovingNoops(List<TextMapPropagator> textMapPropagators) {
-    return ContextPropagators.create(TextMapPropagator.composite(
+  private static ContextPropagators createPropagatorsRemovingNoops(
+      List<TextMapPropagator> textMapPropagators) {
+    return ContextPropagators.create(
+        TextMapPropagator.composite(
             textMapPropagators.stream()
                 .filter(propagator -> propagator != TextMapPropagator.noop())
-                .collect(toSet())
-        ));
+                .collect(toSet())));
   }
 
   enum Propagator implements TextMapPropagator {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializer.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.tooling;
 
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -104,7 +104,7 @@ public class PropagatorsInitializer {
     return ContextPropagators.create(TextMapPropagator.composite(
             textMapPropagators.stream()
                 .filter(propagator -> propagator != TextMapPropagator.noop())
-                .collect(toList())
+                .collect(toSet())
         ));
   }
 

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializerTest.java
@@ -20,14 +20,23 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class PropagatorsInitializerTest {
 
+  AtomicReference<ContextPropagators> seen;
+  TextMapPropagator mockPreconfigured;
+
+  @BeforeEach
+  void setup(){
+    seen = new AtomicReference<>();
+    mockPreconfigured = mock(TextMapPropagator.class);
+  }
+
   @Test
   void initialize_noIdsPassedNotPreconfigured() {
     List<String> ids = emptyList();
-    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
     Consumer<ContextPropagators> setter = seen::set;
 
     PropagatorsInitializer.initializePropagators(ids, TextMapPropagator::noop, setter);
@@ -46,7 +55,6 @@ class PropagatorsInitializerTest {
   @Test
   void initialize_noIdsPassedWithPreconfigured() {
     List<String> ids = emptyList();
-    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
     Consumer<ContextPropagators> setter = seen::set;
     TextMapPropagator mockPropagator = mock(TextMapPropagator.class);
     Supplier<TextMapPropagator> preconfigured = () -> mockPropagator;
@@ -68,7 +76,6 @@ class PropagatorsInitializerTest {
   @Test
   void initialize_preconfiguredSameAsId() {
     List<String> ids = singletonList("jaeger");
-    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
     Consumer<ContextPropagators> setter = seen::set;
     Supplier<TextMapPropagator> preconfigured = () -> PropagatorsInitializer.Propagator.JAEGER;
 
@@ -81,7 +88,6 @@ class PropagatorsInitializerTest {
   @Test
   void initialize_preconfiguredDuplicatedInIds() {
     List<String> ids = Arrays.asList("b3", "jaeger", "b3");
-    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
     Consumer<ContextPropagators> setter = seen::set;
     Supplier<TextMapPropagator> preconfigured = () -> PropagatorsInitializer.Propagator.JAEGER;
 
@@ -101,7 +107,6 @@ class PropagatorsInitializerTest {
   @Test
   void initialize_justOneId() {
     List<String> ids = singletonList("jaeger");
-    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
     Consumer<ContextPropagators> setter = seen::set;
     Supplier<TextMapPropagator> preconfigured = TextMapPropagator::noop;
 
@@ -114,7 +119,6 @@ class PropagatorsInitializerTest {
   @Test
   void initialize_idsWithNoPreconfigured() {
     List<String> ids = Arrays.asList("b3", "unknown-but-no-harm-done", "jaeger");
-    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
     Consumer<ContextPropagators> setter = seen::set;
     Supplier<TextMapPropagator> preconfigured = TextMapPropagator::noop;
 
@@ -134,9 +138,7 @@ class PropagatorsInitializerTest {
   @Test
   void initialize_idsAndPreconfigured() {
     List<String> ids = Arrays.asList("jaeger", "xray");
-    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
     Consumer<ContextPropagators> setter = seen::set;
-    TextMapPropagator mockPreconfigured = mock(TextMapPropagator.class);
     when(mockPreconfigured.fields()).thenReturn(singletonList("mocked"));
     Supplier<TextMapPropagator> preconfigured = () -> mockPreconfigured;
 

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializerTest.java
@@ -1,0 +1,102 @@
+package io.opentelemetry.javaagent.tooling;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class PropagatorsInitializerTest {
+
+  @Test
+  void initialize_noIdsPassedNotPreconfigured() {
+    List<String> ids = emptyList();
+    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
+    Consumer<ContextPropagators> setter = seen::set;
+
+    PropagatorsInitializer.initializePropagators(ids, TextMapPropagator::noop, setter);
+
+    assertThat(seen.get().getTextMapPropagator())
+        .extracting("textPropagators")
+        .isInstanceOfSatisfying(TextMapPropagator[].class, p -> assertThat(p).containsExactlyInAnyOrder(
+            W3CTraceContextPropagator.getInstance(),
+            W3CBaggagePropagator.getInstance()
+        ));
+  }
+
+  @Test
+  void initialize_noIdsPassedWithPreconfigured() {
+    List<String> ids = emptyList();
+    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
+    Consumer<ContextPropagators> setter = seen::set;
+    TextMapPropagator mockPropagator = mock(TextMapPropagator.class);
+    Supplier<TextMapPropagator> preconfigured = () -> mockPropagator;
+
+    PropagatorsInitializer.initializePropagators(ids, preconfigured, setter);
+
+    assertThat(seen.get().getTextMapPropagator())
+        .extracting("textPropagators")
+        .isInstanceOfSatisfying(TextMapPropagator[].class, p -> assertThat(p).containsExactlyInAnyOrder(
+            W3CTraceContextPropagator.getInstance(),
+            W3CBaggagePropagator.getInstance(),
+            mockPropagator
+        ));
+  }
+
+  @Test
+  void initialize_justOneId() {
+    List<String> ids = singletonList("jaeger");
+    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
+    Consumer<ContextPropagators> setter = seen::set;
+    Supplier<TextMapPropagator> preconfigured = TextMapPropagator::noop;
+
+    PropagatorsInitializer.initializePropagators(ids, preconfigured, setter);
+
+    assertThat(seen.get().getTextMapPropagator()).isSameAs(PropagatorsInitializer.Propagator.JAEGER);
+  }
+
+  @Test
+  void initialize_idsWithNoPreconfigured() {
+    List<String> ids = Arrays.asList("b3", "unknown-but-no-harm-done", "jaeger");
+    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
+    Consumer<ContextPropagators> setter = seen::set;
+    Supplier<TextMapPropagator> preconfigured = TextMapPropagator::noop;
+
+    PropagatorsInitializer.initializePropagators(ids, preconfigured, setter);
+
+    assertThat(seen.get().getTextMapPropagator())
+        .extracting("textPropagators")
+        .isInstanceOfSatisfying(TextMapPropagator[].class, p -> assertThat(p).containsExactlyInAnyOrder(PropagatorsInitializer.Propagator.B3, PropagatorsInitializer.Propagator.JAEGER));
+  }
+
+  @Test
+  void initialize_idsAndPreconfigured() {
+    List<String> ids = Arrays.asList("jaeger", "xray");
+    AtomicReference<ContextPropagators> seen = new AtomicReference<>();
+    Consumer<ContextPropagators> setter = seen::set;
+    TextMapPropagator mockPreconfigured = mock(TextMapPropagator.class);
+    when(mockPreconfigured.fields()).thenReturn(singletonList("mocked"));
+    Supplier<TextMapPropagator> preconfigured = () -> mockPreconfigured;
+
+    PropagatorsInitializer.initializePropagators(ids, preconfigured, setter);
+
+    assertThat(seen.get().getTextMapPropagator())
+        .extracting("textPropagators")
+        .isInstanceOfSatisfying(TextMapPropagator[].class, p -> assertThat(p).containsExactlyInAnyOrder(
+            mockPreconfigured,
+            PropagatorsInitializer.Propagator.JAEGER,
+            PropagatorsInitializer.Propagator.XRAY
+        ));
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializerTest.java
@@ -29,7 +29,7 @@ class PropagatorsInitializerTest {
   TextMapPropagator mockPreconfigured;
 
   @BeforeEach
-  void setup(){
+  void setup() {
     seen = new AtomicReference<>();
     mockPreconfigured = mock(TextMapPropagator.class);
   }

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/PropagatorsInitializerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.tooling;
 
 import static java.util.Collections.emptyList;
@@ -29,10 +34,13 @@ class PropagatorsInitializerTest {
 
     assertThat(seen.get().getTextMapPropagator())
         .extracting("textPropagators")
-        .isInstanceOfSatisfying(TextMapPropagator[].class, p -> assertThat(p).containsExactlyInAnyOrder(
-            W3CTraceContextPropagator.getInstance(),
-            W3CBaggagePropagator.getInstance()
-        ));
+        .isInstanceOfSatisfying(
+            TextMapPropagator[].class,
+            p ->
+                assertThat(p)
+                    .containsExactlyInAnyOrder(
+                        W3CTraceContextPropagator.getInstance(),
+                        W3CBaggagePropagator.getInstance()));
   }
 
   @Test
@@ -47,11 +55,14 @@ class PropagatorsInitializerTest {
 
     assertThat(seen.get().getTextMapPropagator())
         .extracting("textPropagators")
-        .isInstanceOfSatisfying(TextMapPropagator[].class, p -> assertThat(p).containsExactlyInAnyOrder(
-            W3CTraceContextPropagator.getInstance(),
-            W3CBaggagePropagator.getInstance(),
-            mockPropagator
-        ));
+        .isInstanceOfSatisfying(
+            TextMapPropagator[].class,
+            p ->
+                assertThat(p)
+                    .containsExactlyInAnyOrder(
+                        W3CTraceContextPropagator.getInstance(),
+                        W3CBaggagePropagator.getInstance(),
+                        mockPropagator));
   }
 
   @Test
@@ -63,7 +74,8 @@ class PropagatorsInitializerTest {
 
     PropagatorsInitializer.initializePropagators(ids, preconfigured, setter);
 
-    assertThat(seen.get().getTextMapPropagator()).isSameAs(PropagatorsInitializer.Propagator.JAEGER);
+    assertThat(seen.get().getTextMapPropagator())
+        .isSameAs(PropagatorsInitializer.Propagator.JAEGER);
   }
 
   @Test
@@ -77,10 +89,13 @@ class PropagatorsInitializerTest {
 
     assertThat(seen.get().getTextMapPropagator())
         .extracting("textPropagators")
-        .isInstanceOfSatisfying(TextMapPropagator[].class, p -> assertThat(p).containsExactlyInAnyOrder(
-            PropagatorsInitializer.Propagator.B3,
-            PropagatorsInitializer.Propagator.JAEGER
-        ));
+        .isInstanceOfSatisfying(
+            TextMapPropagator[].class,
+            p ->
+                assertThat(p)
+                    .containsExactlyInAnyOrder(
+                        PropagatorsInitializer.Propagator.B3,
+                        PropagatorsInitializer.Propagator.JAEGER));
   }
 
   @Test
@@ -92,7 +107,8 @@ class PropagatorsInitializerTest {
 
     PropagatorsInitializer.initializePropagators(ids, preconfigured, setter);
 
-    assertThat(seen.get().getTextMapPropagator()).isSameAs(PropagatorsInitializer.Propagator.JAEGER);
+    assertThat(seen.get().getTextMapPropagator())
+        .isSameAs(PropagatorsInitializer.Propagator.JAEGER);
   }
 
   @Test
@@ -106,7 +122,13 @@ class PropagatorsInitializerTest {
 
     assertThat(seen.get().getTextMapPropagator())
         .extracting("textPropagators")
-        .isInstanceOfSatisfying(TextMapPropagator[].class, p -> assertThat(p).containsExactlyInAnyOrder(PropagatorsInitializer.Propagator.B3, PropagatorsInitializer.Propagator.JAEGER));
+        .isInstanceOfSatisfying(
+            TextMapPropagator[].class,
+            p ->
+                assertThat(p)
+                    .containsExactlyInAnyOrder(
+                        PropagatorsInitializer.Propagator.B3,
+                        PropagatorsInitializer.Propagator.JAEGER));
   }
 
   @Test
@@ -122,10 +144,13 @@ class PropagatorsInitializerTest {
 
     assertThat(seen.get().getTextMapPropagator())
         .extracting("textPropagators")
-        .isInstanceOfSatisfying(TextMapPropagator[].class, p -> assertThat(p).containsExactlyInAnyOrder(
-            mockPreconfigured,
-            PropagatorsInitializer.Propagator.JAEGER,
-            PropagatorsInitializer.Propagator.XRAY
-        ));
+        .isInstanceOfSatisfying(
+            TextMapPropagator[].class,
+            p ->
+                assertThat(p)
+                    .containsExactlyInAnyOrder(
+                        mockPreconfigured,
+                        PropagatorsInitializer.Propagator.JAEGER,
+                        PropagatorsInitializer.Propagator.XRAY));
   }
 }


### PR DESCRIPTION
This resolves #1681.

In that bug, it's described how the `PropagatorsInitializer` will overwrite any customized propagators configured earlier in the `GlobalOpenTelemetry.set(sdkWithCustomPropagators)`.

Now, in `initializePropagators()`, we pull the preconfigured propgatation from the global via `GlobalOpenTelemetry.get().getPropagators().getTextMapPropagator()` and pass this down.  If propagators were preconfigured (not noops), they will be composited along with the other kinds.

There weren't any tests around the existing behavior, so this backfills tests.  The bug was then fixed and the code cleaned up a little (but not too much, because sdk changes will likely result in additional changes in the near future).