### PR TITLE
Close request to avoid warnings in stderr

### DIFF
--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootWithSamplingSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootWithSamplingSmokeTest.groovy
@@ -31,7 +31,7 @@ class SpringBootWithSamplingSmokeTest extends SmokeTest {
 
     when:
     for (int i = 1; i <= NUM_TRIES; i++) {
-      CLIENT.newCall(request).execute()
+      CLIENT.newCall(request).execute().close()
     }
     Collection<ExportTraceServiceRequest> traces = waitForTraces()
 


### PR DESCRIPTION
Running SpringBootWithSamplingSmokeTest produces lots of warnings like
```
Jan 12, 2021 7:14:48 PM okhttp3.internal.platform.Platform log
WARNING: A connection to http://localhost:55350/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```