### PR TITLE
Updated jackson minor version to the latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
- 
+
 <p align="center">
   <strong>
     <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation#getting-started">Getting Started</a>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-
+ 
 <p align="center">
   <strong>
     <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation#getting-started">Getting Started</a>

--- a/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
+++ b/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
@@ -26,7 +26,7 @@ dependencies {
   library group: 'com.amazonaws', name: 'aws-lambda-java-events', version: '2.2.1'
 
   compile(
-    'com.fasterxml.jackson.core:jackson-databind:2.10.3',
+    'com.fasterxml.jackson.core:jackson-databind:2.10.5.1',
     'com.fasterxml.jackson.module:jackson-module-afterburner:2.9.10',
     'commons-io:commons-io:2.2')
   implementation deps.slf4j


### PR DESCRIPTION
The actual intent of this PR is to update the jackson-databind version that is used by aws-lambda instrumentation. The version that is currently being used contains several known security vulnerabilities.

See this for more details: [https://nvd.nist.gov/vuln/detail/CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649)