### PR TITLE
fixing Apache Camel instrumentation propagation order

### DIFF
--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelEventNotifier.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelEventNotifier.java
@@ -61,8 +61,8 @@ final class CamelEventNotifier extends EventNotifierSupport {
         sd.getOperationName(ese.getExchange(), ese.getEndpoint(), CamelDirection.OUTBOUND);
     Span span = CamelTracer.TRACER.startSpan(name, sd.getInitiatorSpanKind());
     sd.pre(span, ese.getExchange(), ese.getEndpoint(), CamelDirection.OUTBOUND);
-    CamelPropagationUtil.injectParent(Context.current(), ese.getExchange().getIn().getHeaders());
     ActiveSpanManager.activate(ese.getExchange(), span, CamelDirection.OUTBOUND);
+    CamelPropagationUtil.injectParent(Context.current(), ese.getExchange().getIn().getHeaders());
 
     LOG.debug("[Exchange sending] Initiator span started: {}", span);
   }

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/RestCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/RestCamelTest.groovy
@@ -75,6 +75,7 @@ class RestCamelTest extends AgentTestRunner {
         it.span(1) {
           name "GET"
           kind CLIENT
+          parentSpanId(span(0).spanId)
           attributes {
             "$SemanticAttributes.HTTP_METHOD.key" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE.key" 200
@@ -84,6 +85,7 @@ class RestCamelTest extends AgentTestRunner {
         it.span(2) {
           name "/api/{module}/unit/{unitId}"
           kind SERVER
+          parentSpanId(span(1).spanId)
           attributes {
             "$SemanticAttributes.HTTP_URL.key" "http://localhost:$port/api/firstModule/unit/unitOne"
             "$SemanticAttributes.HTTP_STATUS_CODE.key" 200
@@ -98,6 +100,7 @@ class RestCamelTest extends AgentTestRunner {
         it.span(3) {
           name "/api/{module}/unit/{unitId}"
           kind INTERNAL
+          parentSpanId(span(2).spanId)
           attributes {
             "$SemanticAttributes.HTTP_METHOD.key" "GET"
             "$SemanticAttributes.HTTP_URL.key" "http://localhost:$port/api/firstModule/unit/unitOne"
@@ -107,6 +110,7 @@ class RestCamelTest extends AgentTestRunner {
         it.span(4) {
           name "moduleUnit"
           kind INTERNAL
+          parentSpanId(span(3).spanId)
           attributes {
             "apache-camel.uri" "direct://moduleUnit"
           }

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/TwoServicesWithDirectClientCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/TwoServicesWithDirectClientCamelTest.groovy
@@ -87,6 +87,7 @@ class TwoServicesWithDirectClientCamelTest extends AgentTestRunner {
                 it.span(1) {
                     name "POST"
                     kind CLIENT
+                    parentSpanId(span(0).spanId)
                     attributes {
                         "$SemanticAttributes.HTTP_METHOD.key" "POST"
                         "$SemanticAttributes.HTTP_URL.key" "http://localhost:$portOne/serviceOne"
@@ -97,6 +98,7 @@ class TwoServicesWithDirectClientCamelTest extends AgentTestRunner {
                 it.span(2) {
                     name "/serviceOne"
                     kind SERVER
+                    parentSpanId(span(1).spanId)
                     attributes {
                         "$SemanticAttributes.HTTP_METHOD.key" "POST"
                         "$SemanticAttributes.HTTP_URL.key" "http://localhost:$portOne/serviceOne"
@@ -107,6 +109,7 @@ class TwoServicesWithDirectClientCamelTest extends AgentTestRunner {
                 it.span(3) {
                     name "POST"
                     kind CLIENT
+                  parentSpanId(span(2).spanId)
                     attributes {
                         "$SemanticAttributes.HTTP_METHOD.key" "POST"
                         "$SemanticAttributes.HTTP_URL.key" "http://0.0.0.0:$portTwo/serviceTwo"
@@ -117,6 +120,7 @@ class TwoServicesWithDirectClientCamelTest extends AgentTestRunner {
                 it.span(4) {
                     name "/serviceTwo"
                     kind SERVER
+                    parentSpanId(span(3).spanId)
                     attributes {
                         "$SemanticAttributes.HTTP_METHOD.key" "POST"
                         "$SemanticAttributes.HTTP_STATUS_CODE.key" 200
@@ -132,6 +136,7 @@ class TwoServicesWithDirectClientCamelTest extends AgentTestRunner {
                 it.span(5) {
                     name "/serviceTwo"
                     kind INTERNAL
+                    parentSpanId(span(4).spanId)
                     attributes {
                         "$SemanticAttributes.HTTP_METHOD.key" "POST"
                         "$SemanticAttributes.HTTP_URL.key" "http://0.0.0.0:$portTwo/serviceTwo"


### PR DESCRIPTION
Fixes #2051

- current context is injected as parent for propagation AFTER the "current" span has been activated
- test cases now check parent/child relationship! :)  