### PR TITLE
Explicitly use AwsXRayPropagator in lambda sqs instrumentation.

### DIFF
--- a/instrumentation/aws-lambda-1.0/javaagent/aws-lambda-1.0-javaagent.gradle
+++ b/instrumentation/aws-lambda-1.0/javaagent/aws-lambda-1.0-javaagent.gradle
@@ -38,7 +38,3 @@ dependencies {
 
   testImplementation project(':instrumentation:aws-lambda-1.0:testing')
 }
-
-tasks.withType(Test) {
-  jvmArgs '-Dotel.propagators=tracecontext,xray'
-}

--- a/instrumentation/aws-lambda-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambda/v1_0/AwsLambdaInstrumentationModule.java
+++ b/instrumentation/aws-lambda-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambda/v1_0/AwsLambdaInstrumentationModule.java
@@ -19,6 +19,11 @@ public class AwsLambdaInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public String[] additionalHelperClassNames() {
+    return new String[] {"io.opentelemetry.extension.trace.propagation.AwsXRayPropagator"};
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new AwsLambdaRequestHandlerInstrumentation());
   }

--- a/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
+++ b/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
@@ -31,6 +31,8 @@ dependencies {
     'commons-io:commons-io:2.2')
   implementation deps.slf4j
 
+  implementation deps.opentelemetryTraceProps
+
   // 1.2.0 allows to get the function ARN
   testLibrary group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.0'
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractor.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractor.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.awslambda.v1_0.MapUtils.lowercase
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.extension.trace.propagation.AwsXRayPropagator;
 import java.util.Collections;
 import java.util.Map;
 
@@ -26,8 +27,7 @@ public class ParentContextExtractor {
   static final String AWS_TRACE_HEADER_PROPAGATOR_KEY = "x-amzn-trace-id";
 
   static Context fromXRayHeader(String parentHeader) {
-    return OpenTelemetry.getGlobalPropagators()
-        .getTextMapPropagator()
+    return AwsXRayPropagator.getInstance()
         .extract(
             Context.current(),
             Collections.singletonMap(AWS_TRACE_HEADER_PROPAGATOR_KEY, parentHeader),

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsHandlerTest.groovy
@@ -8,21 +8,9 @@ package io.opentelemetry.instrumentation.awslambda.v1_0
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
-import io.opentelemetry.context.propagation.ContextPropagators
-import io.opentelemetry.context.propagation.TextMapPropagator
-import io.opentelemetry.extension.trace.propagation.AwsXRayPropagator
 import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
 
 class AwsLambdaSqsHandlerTest extends AbstractAwsLambdaSqsHandlerTest implements InstrumentationTestTrait {
-
-  // Lambda instrumentation requires XRay propagator to be enabled.
-  static {
-    def propagators = ContextPropagators.create(
-      TextMapPropagator.composite(W3CTraceContextPropagator.instance, AwsXRayPropagator.instance))
-    OpenTelemetry.setGlobalPropagators(propagators)
-  }
 
   static class TestHandler extends TracingSqsEventHandler {
     @Override

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsMessageHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsMessageHandlerTest.groovy
@@ -10,25 +10,11 @@ import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
-import io.opentelemetry.context.propagation.ContextPropagators
-import io.opentelemetry.context.propagation.TextMapPropagator
-import io.opentelemetry.extension.trace.propagation.AwsXRayPropagator
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
 
 class AwsLambdaSqsMessageHandlerTest extends InstrumentationSpecification implements InstrumentationTestTrait {
-
-  // Lambda instrumentation requires XRay propagator to be enabled.
-  static {
-    def propagators = ContextPropagators.create(
-      TextMapPropagator.composite(
-        W3CTraceContextPropagator.instance,
-        AwsXRayPropagator.instance))
-    OpenTelemetry.setGlobalPropagators(propagators)
-  }
 
   private static final String AWS_TRACE_HEADER1 = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"
   private static final String AWS_TRACE_HEADER2 = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad9;Sampled=1"

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTest.groovy
@@ -7,21 +7,9 @@ package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
-import io.opentelemetry.context.propagation.ContextPropagators
-import io.opentelemetry.context.propagation.TextMapPropagator
-import io.opentelemetry.extension.trace.propagation.AwsXRayPropagator
 import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
 
 class AwsLambdaTest extends AbstractAwsLambdaRequestHandlerTest implements InstrumentationTestTrait {
-
-  // Lambda instrumentation requires XRay propagator to be enabled.
-  static {
-    def propagators = ContextPropagators.create(
-      TextMapPropagator.composite(W3CTraceContextPropagator.instance, AwsXRayPropagator.instance))
-    OpenTelemetry.setGlobalPropagators(propagators)
-  }
 
   def cleanup() {
     assert forceFlushCalled()


### PR DESCRIPTION
We initially decided to have xray be explicitly configured for use with aws sdk / lambda, but since changed so aws sdk always uses the xray propagator which is shaded / bundled into the agent. There's no reason not to do similar for lambda.