### PR TITLE
Remove setGlobalPropagators calls from lambda tests.

### DIFF
--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapperTest.groovy
@@ -12,10 +12,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.google.common.collect.ImmutableMap
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.context.propagation.ContextPropagators
-import io.opentelemetry.extension.trace.propagation.B3Propagator
 
 class TracingRequestApiGatewayWrapperTest extends TracingRequestWrapperTestBase {
 
@@ -34,13 +31,8 @@ class TracingRequestApiGatewayWrapperTest extends TracingRequestWrapperTestBase 
     }
   }
 
-  def childSetupSpec() {
-    super.childSetupSpec()
-    OpenTelemetry.setGlobalPropagators(ContextPropagators.create(B3Propagator.getInstance()))
-  }
-
   def propagationHeaders() {
-    return ImmutableMap.of("X-B3-TraceId", "4fd0b6131f19f39af59518d127b0cafe", "X-B3-SpanId", "0000000000000456", "X-B3-Sampled", "true")
+    return Collections.singletonMap("traceparent", "00-4fd0b6131f19f39af59518d127b0cafe-0000000000000456-01")
   }
 
   def "handler traced with trace propagation"() {

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
@@ -11,10 +11,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.context.propagation.ContextPropagators
-import io.opentelemetry.extension.trace.propagation.B3Propagator
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
 import java.nio.charset.Charset
@@ -52,7 +49,6 @@ class TracingRequestStreamWrapperPropagationTest extends InstrumentationSpecific
   TracingRequestStreamWrapper wrapper
 
   def childSetup() {
-    OpenTelemetry.setGlobalPropagators(ContextPropagators.create(B3Propagator.getInstance()))
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, "io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestStreamWrapperPropagationTest\$TestRequestHandler::handleRequest")
     TracingRequestStreamWrapper.WRAPPED_LAMBDA = WrappedLambda.fromConfiguration()
     wrapper = new TracingRequestStreamWrapper()
@@ -67,7 +63,7 @@ class TracingRequestStreamWrapperPropagationTest extends InstrumentationSpecific
     String content =
       "{" +
         "\"headers\" : {" +
-        "\"X-B3-TraceId\": \"4fd0b6131f19f39af59518d127b0cafe\", \"X-B3-SpanId\": \"0000000000000456\", \"X-B3-Sampled\": \"true\"" +
+        "\"traceparent\": \"00-4fd0b6131f19f39af59518d127b0cafe-0000000000000456-01\"" +
         "}," +
         "\"body\" : \"hello\"" +
         "}"
@@ -100,7 +96,7 @@ class TracingRequestStreamWrapperPropagationTest extends InstrumentationSpecific
     String content =
       "{" +
         "\"headers\" : {" +
-        "\"X-B3-TraceId\": \"4fd0b6131f19f39af59518d127b0cafe\", \"X-B3-SpanId\": \"0000000000000456\", \"X-B3-Sampled\": \"true\"" +
+        "\"traceparent\": \"00-4fd0b6131f19f39af59518d127b0cafe-0000000000000456-01\"" +
         "}," +
         "\"body\" : \"bye\"" +
         "}"

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
@@ -9,9 +9,7 @@ import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
-import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
 import java.nio.charset.Charset
@@ -46,8 +44,6 @@ class TracingRequestStreamWrapperTest extends InstrumentationSpecification imple
   TracingRequestStreamWrapper wrapper
 
   def childSetup() {
-    // no propagators
-    OpenTelemetry.setGlobalPropagators(ContextPropagators.noop())
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, "io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestStreamWrapperTest\$TestRequestHandler::handleRequest")
     TracingRequestStreamWrapper.WRAPPED_LAMBDA = WrappedLambda.fromConfiguration()
     wrapper = new TracingRequestStreamWrapper()

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
@@ -6,9 +6,6 @@
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import com.amazonaws.services.lambda.runtime.Context
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.context.propagation.ContextPropagators
-import io.opentelemetry.extension.trace.propagation.B3Propagator
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
 import org.junit.Rule
@@ -31,8 +28,6 @@ class TracingRequestWrapperTestBase extends InstrumentationSpecification impleme
     context.getFunctionName() >> "my_function"
     context.getAwsRequestId() >> "1-22-333"
     context.getInvokedFunctionArn() >> "arn:aws:lambda:us-east-1:123456789:function:test"
-
-    OpenTelemetry.setGlobalPropagators(ContextPropagators.create(B3Propagator.getInstance()))
   }
 
   def setLambda(handler, wrapperClass) {

--- a/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/ApiGatewayProxyRequestTest.java
+++ b/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/ApiGatewayProxyRequestTest.java
@@ -13,22 +13,31 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
+import io.opentelemetry.api.DefaultOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.extension.trace.propagation.AwsXRayPropagator;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class ApiGatewayProxyRequestTest {
+
+  @AfterEach
+  void resetOpenTelemetry() {
+    OpenTelemetry.set(OpenTelemetrySdk.builder().build());
+  }
 
   @Test
   public void shouldCreateNoopRequestIfNoPropagatorsSet() throws IOException {
     // given
     InputStream mock = mock(InputStream.class);
-    OpenTelemetry.setGlobalPropagators(ContextPropagators.noop());
+    OpenTelemetry.set(
+        DefaultOpenTelemetry.builder().setPropagators(ContextPropagators.noop()).build());
     // when
     ApiGatewayProxyRequest created = ApiGatewayProxyRequest.forStream(mock);
     // then
@@ -40,7 +49,10 @@ class ApiGatewayProxyRequestTest {
   public void shouldCreateNoopRequestIfXRayPropagatorsSet() throws IOException {
     // given
     InputStream mock = mock(InputStream.class);
-    OpenTelemetry.setGlobalPropagators(ContextPropagators.create(AwsXRayPropagator.getInstance()));
+    OpenTelemetry.set(
+        DefaultOpenTelemetry.builder()
+            .setPropagators(ContextPropagators.create(AwsXRayPropagator.getInstance()))
+            .build());
     // when
     ApiGatewayProxyRequest created = ApiGatewayProxyRequest.forStream(mock);
     // then
@@ -53,7 +65,10 @@ class ApiGatewayProxyRequestTest {
     // given
     InputStream mock = mock(InputStream.class);
     given(mock.markSupported()).willReturn(true);
-    OpenTelemetry.setGlobalPropagators(ContextPropagators.create(B3Propagator.getInstance()));
+    OpenTelemetry.set(
+        DefaultOpenTelemetry.builder()
+            .setPropagators(ContextPropagators.create(B3Propagator.getInstance()))
+            .build());
     // when
     ApiGatewayProxyRequest created = ApiGatewayProxyRequest.forStream(mock);
     // then
@@ -68,8 +83,10 @@ class ApiGatewayProxyRequestTest {
     InputStream mock = mock(InputStream.class);
     given(mock.markSupported()).willReturn(false);
     given(mock.read(any(byte[].class))).willReturn(-1);
-
-    OpenTelemetry.setGlobalPropagators(ContextPropagators.create(B3Propagator.getInstance()));
+    OpenTelemetry.set(
+        DefaultOpenTelemetry.builder()
+            .setPropagators(ContextPropagators.create(B3Propagator.getInstance()))
+            .build());
     // when
     ApiGatewayProxyRequest created = ApiGatewayProxyRequest.forStream(mock);
     // then

--- a/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractorTest.java
+++ b/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractorTest.java
@@ -8,16 +8,24 @@ package io.opentelemetry.instrumentation.awslambda.v1_0;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.DefaultOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class ParentContextExtractorTest {
+
+  @AfterEach
+  void resetOpenTelemetry() {
+    OpenTelemetry.set(OpenTelemetrySdk.builder().build());
+  }
 
   @Test
   public void shouldExtractCaseInsensitiveHeaders() {
@@ -30,7 +38,10 @@ class ParentContextExtractorTest {
             "0000000000000456",
             "X-B3-Sampled",
             "true");
-    OpenTelemetry.setGlobalPropagators(ContextPropagators.create(B3Propagator.getInstance()));
+    OpenTelemetry.set(
+        DefaultOpenTelemetry.builder()
+            .setPropagators(ContextPropagators.create(B3Propagator.getInstance()))
+            .build());
 
     // when
     Context context = ParentContextExtractor.fromHttpHeaders(headers);


### PR DESCRIPTION
There will be some bigger work to

- Use `-autoconfigure` with the wrappers
- Probably allow programattically providing an SDK for non-wrappers

But this is a smaller change to help with upgrading to 0.14.0