### PR TITLE
adding AWS SQS tests to Apache Camel instrumentation

### DIFF
--- a/instrumentation/apache-camel-2.20/javaagent/apache-camel-2.20-javaagent.gradle
+++ b/instrumentation/apache-camel-2.20/javaagent/apache-camel-2.20-javaagent.gradle
@@ -22,7 +22,6 @@ dependencies {
   testLibrary group: 'org.apache.camel', name: 'camel-undertow', version: '2.20.1'
 
   testLibrary group: 'org.apache.camel', name: 'camel-aws', version: '2.20.1'
-  testLibrary group: 'org.elasticmq', name: 'elasticmq-rest-sqs_2.12', version: '1.0.0'
 
   testInstrumentation project(':instrumentation:apache-httpclient:apache-httpclient-2.0:javaagent')
   testInstrumentation project(':instrumentation:servlet:servlet-3.0:javaagent')
@@ -34,6 +33,9 @@ dependencies {
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter', version: '1.5.17.RELEASE'
 
   testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
+
+  testImplementation deps.testcontainers
+  testCompile "org.testcontainers:localstack:1.15.0-rc2"
 
   latestDepTestLibrary group: 'org.apache.camel', name: 'camel-core', version: '2.+'
   latestDepTestLibrary group: 'org.apache.camel', name: 'camel-spring-boot-starter', version: '2.+'

--- a/instrumentation/apache-camel-2.20/javaagent/apache-camel-2.20-javaagent.gradle
+++ b/instrumentation/apache-camel-2.20/javaagent/apache-camel-2.20-javaagent.gradle
@@ -21,8 +21,12 @@ dependencies {
   testLibrary group: 'org.apache.camel', name: 'camel-jaxb-starter', version: '2.20.1'
   testLibrary group: 'org.apache.camel', name: 'camel-undertow', version: '2.20.1'
 
+  testLibrary group: 'org.apache.camel', name: 'camel-aws', version: '2.20.1'
+  testLibrary group: 'org.elasticmq', name: 'elasticmq-rest-sqs_2.12', version: '1.0.0'
+
   testInstrumentation project(':instrumentation:apache-httpclient:apache-httpclient-2.0:javaagent')
   testInstrumentation project(':instrumentation:servlet:servlet-3.0:javaagent')
+  testInstrumentation project(':instrumentation:aws-sdk:aws-sdk-1.11:javaagent')
 
   testImplementation group: 'org.spockframework', name: 'spock-spring', version: "$versions.spock"
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsCamelTest.groovy
@@ -37,7 +37,7 @@ class SqsCamelTest extends AgentTestRunner {
     println getClass().name + " SQS server started at: localhost:$sqsPort/"
 
     def app = new SpringApplication(SqsConfig)
-    app.setDefaultProperties(ImmutableMap.of("sqs.port", sqsPort))
+    app.setDefaultProperties(["sqs.port": sqsPort]))
     server = app.run()
   }
 
@@ -178,4 +178,3 @@ class SqsCamelTest extends AgentTestRunner {
     }
   }
 }
-

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsCamelTest.groovy
@@ -1,0 +1,183 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test
+
+import static io.opentelemetry.api.trace.Span.Kind.CLIENT
+import static io.opentelemetry.api.trace.Span.Kind.CONSUMER
+import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
+import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
+
+import com.google.common.collect.ImmutableMap
+import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.utils.PortUtils
+import org.apache.camel.CamelContext
+import org.apache.camel.ProducerTemplate
+import org.elasticmq.rest.sqs.SQSRestServer
+import org.elasticmq.rest.sqs.SQSRestServerBuilder
+import org.springframework.boot.SpringApplication
+import org.springframework.context.ConfigurableApplicationContext
+import spock.lang.Shared
+
+class SqsCamelTest extends AgentTestRunner {
+
+  @Shared
+  ConfigurableApplicationContext server
+
+  @Shared
+  SQSRestServer sqs
+  @Shared
+  int sqsPort
+
+  def setupSpec() {
+    sqsPort = PortUtils.randomOpenPort()
+    sqs = SQSRestServerBuilder.withPort(sqsPort).withInterface("localhost").start()
+    println getClass().name + " SQS server started at: localhost:$sqsPort/"
+
+    def app = new SpringApplication(SqsConfig)
+    app.setDefaultProperties(ImmutableMap.of("sqs.port", sqsPort))
+    server = app.run()
+  }
+
+  def cleanupSpec() {
+    if (server != null) {
+      server.close()
+      server = null
+    }
+    if (sqs != null) {
+      sqs.stopAndWait()
+    }
+  }
+
+  def "simple sqs producer-consumer services"() {
+    setup:
+    def camelContext = server.getBean(CamelContext)
+    ProducerTemplate template = camelContext.createProducerTemplate()
+
+    when:
+    template.sendBody("direct:input", "{\"type\": \"hello\"}")
+    // wait for SQS to send back
+    Thread.sleep(2000)
+
+    then:
+    assertTraces(5) {
+      trace(0, 3) {
+        def parent = it
+        it.span(0) {
+          name "input"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "apache-camel.uri" "direct://input"
+          }
+        }
+        it.span(1) {
+          name "sqsCamelTest"
+          kind PRODUCER
+          parentSpanId parent.span(0).spanId
+          attributes {
+            "apache-camel.uri" "aws-sqs://sqsCamelTest?amazonSQSClient=%23sqsClient"
+            "messaging.destination" "sqsCamelTest"
+          }
+        }
+        it.span(2) {
+          name "sqsCamelTest"
+          kind CONSUMER
+          parentSpanId parent.span(1).spanId
+          attributes {
+            "apache-camel.uri" "aws-sqs://sqsCamelTest?amazonSQSClient=%23sqsClient&messageAttributeNames=traceparent"
+            "messaging.destination" "sqsCamelTest"
+            "messaging.message_id" String
+          }
+        }
+      }
+      trace(1, 1) {
+        it.span(0) {
+          name "SQS.ReceiveMessage"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" "http://localhost:$sqsPort"
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
+            "aws.service" "AmazonSQS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" "http://localhost:$sqsPort"
+            "net.peer.name" "localhost"
+            "net.peer.port" sqsPort
+            "net.transport" "IP.TCP"
+          }
+        }
+      }
+      trace(2, 1) {
+        it.span(0) {
+          name "SQS.DeleteMessage"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" "http://localhost:$sqsPort"
+            "aws.operation" "DeleteMessageRequest"
+            "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
+            "aws.service" "AmazonSQS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" "http://localhost:$sqsPort"
+            "net.peer.name" "localhost"
+            "net.peer.port" sqsPort
+            "net.transport" "IP.TCP"
+          }
+        }
+      }
+      trace(3, 1) {
+        it.span(0) {
+          name "SQS.ReceiveMessage"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" "http://localhost:$sqsPort"
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
+            "aws.service" "AmazonSQS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" "http://localhost:$sqsPort"
+            "net.peer.name" "localhost"
+            "net.peer.port" sqsPort
+            "net.transport" "IP.TCP"
+          }
+        }
+      }
+      trace(4, 1) {
+        it.span(0) {
+          name "SQS.ReceiveMessage"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" "http://localhost:$sqsPort"
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
+            "aws.service" "AmazonSQS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" "http://localhost:$sqsPort"
+            "net.peer.name" "localhost"
+            "net.peer.port" sqsPort
+            "net.transport" "IP.TCP"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsCamelTest.groovy
@@ -58,14 +58,12 @@ class SqsCamelTest extends AgentTestRunner {
 
     when:
     template.sendBody("direct:input", "{\"type\": \"hello\"}")
-    // wait for SQS to send back
-    Thread.sleep(2000)
 
     then:
     assertTraces(5) {
       trace(0, 3) {
-        def parent = it
-        it.span(0) {
+
+        span(0) {
           name "input"
           kind INTERNAL
           hasNoParent()
@@ -73,19 +71,19 @@ class SqsCamelTest extends AgentTestRunner {
             "apache-camel.uri" "direct://input"
           }
         }
-        it.span(1) {
+        span(1) {
           name "sqsCamelTest"
           kind PRODUCER
-          parentSpanId parent.span(0).spanId
+          childOf span(0)
           attributes {
             "apache-camel.uri" "aws-sqs://sqsCamelTest?amazonSQSClient=%23sqsClient"
             "messaging.destination" "sqsCamelTest"
           }
         }
-        it.span(2) {
+        span(2) {
           name "sqsCamelTest"
           kind CONSUMER
-          parentSpanId parent.span(1).spanId
+          childOf span(1)
           attributes {
             "apache-camel.uri" "aws-sqs://sqsCamelTest?amazonSQSClient=%23sqsClient&messageAttributeNames=traceparent"
             "messaging.destination" "sqsCamelTest"
@@ -94,7 +92,7 @@ class SqsCamelTest extends AgentTestRunner {
         }
       }
       trace(1, 1) {
-        it.span(0) {
+        span(0) {
           name "SQS.ReceiveMessage"
           kind CLIENT
           hasNoParent()
@@ -115,7 +113,7 @@ class SqsCamelTest extends AgentTestRunner {
         }
       }
       trace(2, 1) {
-        it.span(0) {
+        span(0) {
           name "SQS.DeleteMessage"
           kind CLIENT
           hasNoParent()
@@ -136,7 +134,7 @@ class SqsCamelTest extends AgentTestRunner {
         }
       }
       trace(3, 1) {
-        it.span(0) {
+        span(0) {
           name "SQS.ReceiveMessage"
           kind CLIENT
           hasNoParent()

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsConfig.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsConfig.groovy
@@ -5,17 +5,15 @@
 
 package test
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.client.builder.AwsClientBuilder
+
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import org.apache.camel.LoggingLevel
 import org.apache.camel.builder.RouteBuilder
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.annotation.Bean
+import org.testcontainers.containers.localstack.LocalStackContainer
 
 @SpringBootConfiguration
 @EnableAutoConfiguration
@@ -49,9 +47,10 @@ class SqsConfig {
   }
 
   @Bean
-  AmazonSQSAsync sqsClient(@Value("\${sqs.port}") int port) {
-    def credentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials("x", "x"))
-    def endpointConfiguration = new AwsClientBuilder.EndpointConfiguration("http://localhost:"+port, "elasticmq")
-    return AmazonSQSAsyncClient.asyncBuilder().withCredentials(credentials).withEndpointConfiguration(endpointConfiguration).build()
+  AmazonSQSAsync sqsClient(LocalStackContainer localstack) {
+
+    return AmazonSQSAsyncClient.asyncBuilder().withEndpointConfiguration(localstack.getEndpointConfiguration(LocalStackContainer.Service.SQS))
+      .withCredentials(localstack.getDefaultCredentialsProvider())
+      .build()
   }
 }

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsConfig.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsConfig.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test
+
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import org.apache.camel.LoggingLevel
+import org.apache.camel.builder.RouteBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.context.annotation.Bean
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+class SqsConfig {
+
+  @Bean
+  RouteBuilder consumerRoute() {
+    return new RouteBuilder() {
+
+      @Override
+      void configure() throws Exception {
+        from("aws-sqs://sqsCamelTest?amazonSQSClient=#sqsClient&messageAttributeNames=traceparent")
+          .log(LoggingLevel.INFO, "test", "RECEIVER got body : \${body}")
+          .log(LoggingLevel.INFO, "test", "RECEIVER got headers : \${headers}")
+      }
+    }
+  }
+
+  @Bean
+  RouteBuilder producerRoute() {
+    return new RouteBuilder() {
+
+      @Override
+      void configure() throws Exception {
+        from("direct:input")
+          .log(LoggingLevel.INFO, "test", "SENDING body: \${body}")
+          .log(LoggingLevel.INFO, "test", "SENDING headers: \${headers}")
+          .to("aws-sqs://sqsCamelTest?amazonSQSClient=#sqsClient")
+      }
+    }
+  }
+
+  @Bean
+  AmazonSQSAsync sqsClient(@Value("\${sqs.port}") int port) {
+    def credentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials("x", "x"))
+    def endpointConfiguration = new AwsClientBuilder.EndpointConfiguration("http://localhost:"+port, "elasticmq")
+    return AmazonSQSAsyncClient.asyncBuilder().withCredentials(credentials).withEndpointConfiguration(endpointConfiguration).build()
+  }
+}

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsConfig.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsConfig.groovy
@@ -5,7 +5,6 @@
 
 package test
 
-
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/resources/logback-test.xml
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/resources/logback-test.xml
@@ -16,5 +16,6 @@
   <logger name="io.opentelemetry.javaagent.instrumentation.apachecamel" level="trace"/>
   <logger name="org.apache.camel" level="debug" />
   <logger name="test" level="trace"/>
+  <logger name="org.testcontainers" level="debug" />
 
 </configuration>


### PR DESCRIPTION
Closes #2060 

Adding SQS tests for Apache Camel. 
For this purpose, additional library (SQS local mock in fact) is added - https://github.com/softwaremill/elasticmq, licensed under Apache 2.0 (https://github.com/softwaremill/elasticmq/blob/master/LICENSE.txt).