### PR TITLE
Fix integration with jersey-client 2.30

### DIFF
--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/jaxrs-client-2.0-common-javaagent.gradle
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/jaxrs-client-2.0-common-javaagent.gradle
@@ -44,8 +44,8 @@ dependencies {
 
   testInstrumentation project(':instrumentation:apache-httpclient:apache-httpclient-4.0:javaagent')
 
-  latestDepTestLibrary group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '[2+, 3)'
-  latestDepTestLibrary group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '[2+, 3)'
+  latestDepTestLibrary group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.+'
+  latestDepTestLibrary group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.+'
   latestDepTestLibrary group: 'org.apache.cxf', name: 'cxf-rt-rs-client', version: '3.2.6'
   latestDepTestLibrary group: 'org.jboss.resteasy', name: 'resteasy-client', version: '3.0.26.Final'
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/jaxrs-client-2.0-common-javaagent.gradle
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/jaxrs-client-2.0-common-javaagent.gradle
@@ -44,8 +44,8 @@ dependencies {
 
   testInstrumentation project(':instrumentation:apache-httpclient:apache-httpclient-4.0:javaagent')
 
-  latestDepTestLibrary group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.27'
-  latestDepTestLibrary group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.27'
+  latestDepTestLibrary group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '[2+, 3)'
+  latestDepTestLibrary group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '[2+, 3)'
   latestDepTestLibrary group: 'org.apache.cxf', name: 'cxf-rt-rs-client', version: '3.2.6'
   latestDepTestLibrary group: 'org.jboss.resteasy', name: 'resteasy-client', version: '3.0.26.Final'
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JerseyClientUtil.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JerseyClientUtil.java
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import org.glassfish.jersey.client.ClientRequest;
 
-public class JerseyClientUtil {
+public final class JerseyClientUtil {
 
   public static Future<?> addErrorReporting(ClientRequest context, Future<?> future) {
     // since jersey 2.30 jersey internally uses CompletableFuture
@@ -42,4 +42,6 @@ public class JerseyClientUtil {
       tracer().endExceptionally((Context) prop, exception);
     }
   }
+
+  private JerseyClientUtil() {}
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JerseyClientUtil.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JerseyClientUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.jaxrsclient.v2_0;
+
+import static io.opentelemetry.javaagent.instrumentation.jaxrsclient.v2_0.JaxRsClientTracer.tracer;
+
+import io.opentelemetry.context.Context;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import org.glassfish.jersey.client.ClientRequest;
+
+public class JerseyClientUtil {
+
+  public static Future<?> addErrorReporting(ClientRequest context, Future<?> future) {
+    // since jersey 2.30 jersey internally uses CompletableFuture
+    // we can't wrap it with WrappedFuture as it causes ClassCastException when casting
+    // to CompletableFuture
+    if (future instanceof CompletableFuture) {
+      future =
+          ((CompletableFuture<?>) future)
+              .whenComplete(
+                  (result, exception) -> {
+                    if (exception != null) {
+                      handleException(context, exception);
+                    }
+                  });
+    } else {
+      if (!(future instanceof WrappedFuture)) {
+        future = new WrappedFuture<>(future, context);
+      }
+    }
+
+    return future;
+  }
+
+  public static void handleException(ClientRequest context, Throwable exception) {
+    Object prop = context.getProperty(ClientTracingFilter.CONTEXT_PROPERTY_NAME);
+    if (prop instanceof Context) {
+      tracer().endExceptionally((Context) prop, exception);
+    }
+  }
+}

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/WrappedFuture.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/WrappedFuture.java
@@ -5,9 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrsclient.v2_0;
 
-import static io.opentelemetry.javaagent.instrumentation.jaxrsclient.v2_0.JaxRsClientTracer.tracer;
+import static io.opentelemetry.javaagent.instrumentation.jaxrsclient.v2_0.JerseyClientUtil.handleException;
 
-import io.opentelemetry.context.Context;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -44,10 +43,7 @@ public class WrappedFuture<T> implements Future<T> {
     try {
       return wrapped.get();
     } catch (ExecutionException e) {
-      Object prop = context.getProperty(ClientTracingFilter.CONTEXT_PROPERTY_NAME);
-      if (prop instanceof Context) {
-        tracer().endExceptionally((Context) prop, e.getCause());
-      }
+      handleException(context, e.getCause());
       throw e;
     }
   }
@@ -58,10 +54,7 @@ public class WrappedFuture<T> implements Future<T> {
     try {
       return wrapped.get(timeout, unit);
     } catch (ExecutionException e) {
-      Object prop = context.getProperty(ClientTracingFilter.CONTEXT_PROPERTY_NAME);
-      if (prop instanceof Context) {
-        tracer().endExceptionally((Context) prop, e.getCause());
-      }
+      handleException(context, e.getCause());
       throw e;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2031
We can't use WrappedFuture on jersey-client 2.30 as  jersey-client attempts to cast it to CompletableFuture.