### PR TITLE
Replae grpc-netty-shaded with grpc-netty

### DIFF
--- a/javaagent-exporters/jaeger/jaeger.gradle
+++ b/javaagent-exporters/jaeger/jaeger.gradle
@@ -18,7 +18,7 @@ dependencies {
     exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
     exclude group: 'io.opentelemetry', module: 'opentelemetry-api'
   }
-  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.30.2'
+  implementation group: 'io.grpc', name: 'grpc-netty'
 }
 
 jar.enabled = false

--- a/javaagent-exporters/javaagent-exporters.gradle
+++ b/javaagent-exporters/javaagent-exporters.gradle
@@ -77,3 +77,16 @@ shadowJar {
   relocate "io.opentelemetry.extension.kotlin", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.kotlin"
   relocate "io.opentelemetry.extension.trace.propagation", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.trace.propagation"
 }
+
+// We can't apply boms globally to all projects because instrumentation needs fine-grained control
+// of versions. For now we just add to exporters which get the most benefit.
+subprojects {
+  dependencies {
+    configurations.all {
+      // Kotlin compiler classpaths don't support BOM nor need it.
+      if (it.name.endsWith('Classpath') && !it.name.startsWith('kotlin')) {
+        add(it.name, enforcedPlatform("io.grpc:grpc-bom:1.35.0"))
+      }
+    }
+  }
+}

--- a/javaagent-exporters/javaagent-exporters.gradle
+++ b/javaagent-exporters/javaagent-exporters.gradle
@@ -90,3 +90,13 @@ subprojects {
     }
   }
 }
+
+// Need to apply here too for tests.
+dependencies {
+  configurations.all {
+    // Kotlin compiler classpaths don't support BOM nor need it.
+    if (it.name.endsWith('Classpath') && !it.name.startsWith('kotlin')) {
+      add(it.name, enforcedPlatform("io.grpc:grpc-bom:1.35.0"))
+    }
+  }
+}

--- a/javaagent-exporters/otlp/otlp.gradle
+++ b/javaagent-exporters/otlp/otlp.gradle
@@ -22,7 +22,7 @@ dependencies {
     exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
     exclude group: 'io.opentelemetry', module: 'opentelemetry-api'
   }
-  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.33.1'
+  implementation group: 'io.grpc', name: 'grpc-netty'
 }
 
 jar.enabled = false


### PR DESCRIPTION
The main reason to use shaded is to prevent classpath conflicts, but we're in an isolated classloader and should be able to manage this ok. The other reason / downside is shaded includes 3 versions of boringssl for linux, mac, and windows. Now that latest versions of Java 8 include all the TLS features of Java 11, I think this is not as helpful as before (I've done some benchmarking and found very little difference with some advantages for JDK TLS) so we can save 3MB on our agent jar by using grpc-netty and not adding tcnative.