### PR TITLE
Smoke tests declare shadowJar as an input to be rebuilt

### DIFF
--- a/instrumentation/apache-camel-2.20/javaagent/apache-camel-2.20-javaagent.gradle
+++ b/instrumentation/apache-camel-2.20/javaagent/apache-camel-2.20-javaagent.gradle
@@ -35,7 +35,7 @@ dependencies {
   testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
 
   testImplementation deps.testcontainers
-  testCompile "org.testcontainers:localstack:1.15.0-rc2"
+  testImplementation "org.testcontainers:localstack:1.15.0-rc2"
 
   latestDepTestLibrary group: 'org.apache.camel', name: 'camel-core', version: '2.+'
   latestDepTestLibrary group: 'org.apache.camel', name: 'camel-spring-boot-starter', version: '2.+'

--- a/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
+++ b/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
@@ -25,7 +25,7 @@ dependencies {
   // in public API.
   library group: 'com.amazonaws', name: 'aws-lambda-java-events', version: '2.2.1'
 
-  compile(
+  implementation(
     'com.fasterxml.jackson.core:jackson-databind:2.10.5.1',
     'com.fasterxml.jackson.module:jackson-module-afterburner:2.9.10',
     'commons-io:commons-io:2.2')

--- a/instrumentation/struts-2.3/javaagent/struts-2.3-javaagent.gradle
+++ b/instrumentation/struts-2.3/javaagent/struts-2.3-javaagent.gradle
@@ -20,8 +20,8 @@ dependencies {
   testImplementation(project(':testing-common'))
   testImplementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '8.0.0.v20110901'
   testImplementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '8.0.0.v20110901'
-  testRuntime group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
-  testRuntime group: 'javax.servlet', name: 'jsp-api', version: '2.0'
+  testRuntimeOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
+  testRuntimeOnly group: 'javax.servlet', name: 'jsp-api', version: '2.0'
 
   testInstrumentation project(":instrumentation:servlet:servlet-3.0:javaagent")
   testInstrumentation project(':instrumentation:jetty-8.0:javaagent')

--- a/javaagent-tooling/javaagent-tooling.gradle
+++ b/javaagent-tooling/javaagent-tooling.gradle
@@ -9,7 +9,9 @@ minimumInstructionCoverage = 0
 
 configurations {
   // classpath used by the instrumentation muzzle plugin
-  instrumentationMuzzle
+  instrumentationMuzzle {
+    extendsFrom implementation
+  }
 }
 
 dependencies {
@@ -52,7 +54,6 @@ dependencies {
   testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
 
   instrumentationMuzzle sourceSets.main.output
-  instrumentationMuzzle configurations.implementation
 }
 
 test {

--- a/smoke-tests/smoke-tests.gradle
+++ b/smoke-tests/smoke-tests.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 test {
-  inputs.files(tasks.findByPath(':javaagent:shadowJar').outputs.files.singleFile)
+  inputs.files(tasks.findByPath(':javaagent:shadowJar').outputs.files)
   maxParallelForks = 2
 
   doFirst {

--- a/smoke-tests/smoke-tests.gradle
+++ b/smoke-tests/smoke-tests.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 test {
-  dependsOn ':javaagent:shadowJar'
+  inputs.files(tasks.findByPath(':javaagent:shadowJar').outputs.files.singleFile)
   maxParallelForks = 2
 
   doFirst {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1079

Fix Gradle deprecation warnings.