### PR TITLE
Rename "normalize" to "sanitize"

### DIFF
--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -7,7 +7,7 @@
 
   <Match>
     <!-- ignore default encoding for auto-genned class -->
-    <Class name="io.opentelemetry.javaagent.instrumentation.api.db.normalizer.SimpleCharStream"/>
+    <Class name="io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.SimpleCharStream"/>
     <Bug pattern="DM_DEFAULT_ENCODING"/>
   </Match>
 

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraQueryNormalizer.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraQueryNormalizer.java
@@ -7,8 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.cassandra.v3_0;
 
 import static io.opentelemetry.javaagent.instrumentation.api.db.QueryNormalizationConfig.isQueryNormalizationEnabled;
 
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.ParseException;
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.SqlNormalizer;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.ParseException;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.SqlSanitizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +22,7 @@ public final class CassandraQueryNormalizer {
       return query;
     }
     try {
-      return SqlNormalizer.normalize(query);
+      return SqlSanitizer.sanitize(query);
     } catch (ParseException e) {
       log.debug("Could not normalize Cassandra query", e);
       return null;

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraQueryNormalizer.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraQueryNormalizer.java
@@ -7,8 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.cassandra.v4_0;
 
 import static io.opentelemetry.javaagent.instrumentation.api.db.QueryNormalizationConfig.isQueryNormalizationEnabled;
 
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.ParseException;
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.SqlNormalizer;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.ParseException;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.SqlSanitizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +22,7 @@ public final class CassandraQueryNormalizer {
       return query;
     }
     try {
-      return SqlNormalizer.normalize(query);
+      return SqlSanitizer.sanitize(query);
     } catch (ParseException e) {
       log.debug("Could not normalize Cassandra query", e);
       return null;

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseQueryNormalizer.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseQueryNormalizer.java
@@ -7,8 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.couchbase.v2_0;
 
 import static io.opentelemetry.javaagent.instrumentation.api.db.QueryNormalizationConfig.isQueryNormalizationEnabled;
 
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.ParseException;
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.SqlNormalizer;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.ParseException;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.SqlSanitizer;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -126,7 +126,7 @@ public final class CouchbaseQueryNormalizer {
       return query;
     }
     try {
-      return SqlNormalizer.normalize(query);
+      return SqlSanitizer.sanitize(query);
     } catch (ParseException e) {
       log.debug("Could not normalize Couchbase query", e);
       return null;

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeQueryNormalizer.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeQueryNormalizer.java
@@ -7,8 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.geode;
 
 import static io.opentelemetry.javaagent.instrumentation.api.db.QueryNormalizationConfig.isQueryNormalizationEnabled;
 
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.ParseException;
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.SqlNormalizer;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.ParseException;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.SqlSanitizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +22,7 @@ public final class GeodeQueryNormalizer {
       return query;
     }
     try {
-      return SqlNormalizer.normalize(query);
+      return SqlSanitizer.sanitize(query);
     } catch (ParseException e) {
       log.debug("Could not normalize Geode query", e);
       return null;

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -49,7 +49,7 @@ public class ConnectionInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void addDbInfo(
         @Advice.Argument(0) String sql, @Advice.Return PreparedStatement statement) {
-      SqlStatementInfo normalizedSql = JdbcUtils.normalizeAndExtractInfo(sql);
+      SqlStatementInfo normalizedSql = JdbcUtils.sanitizeAndExtractInfo(sql);
       if (normalizedSql != null) {
         JdbcMaps.preparedStatements.put(statement, normalizedSql);
       }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -49,9 +49,9 @@ public class ConnectionInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void addDbInfo(
         @Advice.Argument(0) String sql, @Advice.Return PreparedStatement statement) {
-      SqlStatementInfo normalizedSql = JdbcUtils.sanitizeAndExtractInfo(sql);
-      if (normalizedSql != null) {
-        JdbcMaps.preparedStatements.put(statement, normalizedSql);
+      SqlStatementInfo sanitizedSql = JdbcUtils.sanitizeAndExtractInfo(sql);
+      if (sanitizedSql != null) {
+        JdbcMaps.preparedStatements.put(statement, sanitizedSql);
       }
     }
   }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcTracer.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcTracer.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.jdbc;
 
 import static io.opentelemetry.javaagent.instrumentation.jdbc.JdbcUtils.connectionFromStatement;
-import static io.opentelemetry.javaagent.instrumentation.jdbc.JdbcUtils.normalizeAndExtractInfo;
+import static io.opentelemetry.javaagent.instrumentation.jdbc.JdbcUtils.sanitizeAndExtractInfo;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
@@ -71,7 +71,7 @@ public class JdbcTracer extends DatabaseClientTracer<DbInfo, SqlStatementInfo> {
   }
 
   public Context startSpan(Context parentContext, Statement statement, String query) {
-    return startSpan(parentContext, statement, normalizeAndExtractInfo(query));
+    return startSpan(parentContext, statement, sanitizeAndExtractInfo(query));
   }
 
   private Context startSpan(

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcUtils.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcUtils.java
@@ -8,9 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.jdbc;
 import static io.opentelemetry.javaagent.instrumentation.api.db.QueryNormalizationConfig.isQueryNormalizationEnabled;
 
 import io.opentelemetry.javaagent.instrumentation.api.db.SqlStatementInfo;
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.ParseException;
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.SqlNormalizer;
-import io.opentelemetry.javaagent.instrumentation.api.db.normalizer.SqlStatementInfoExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.ParseException;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.SqlSanitizer;
+import io.opentelemetry.javaagent.instrumentation.api.db.sanitizer.SqlStatementInfoExtractor;
 import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.Statement;
@@ -75,7 +75,7 @@ public abstract class JdbcUtils {
       return sql;
     }
     try {
-      return SqlNormalizer.normalize(sql);
+      return SqlSanitizer.sanitize(sql);
     } catch (Exception e) {
       log.debug("Could not normalize sql", e);
       return null;

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcUtils.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcUtils.java
@@ -69,7 +69,7 @@ public abstract class JdbcUtils {
     return connection;
   }
 
-  /** Returns null if the sql could not be normalized for any reason. */
+  /** Returns null if the sql could not be sanitized for any reason. */
   public static String sanitizeSql(String sql) {
     if (!NORMALIZATION_ENABLED) {
       return sql;
@@ -77,7 +77,7 @@ public abstract class JdbcUtils {
     try {
       return SqlSanitizer.sanitize(sql);
     } catch (Exception e) {
-      log.debug("Could not normalize sql", e);
+      log.debug("Could not sanitize sql", e);
       return null;
     }
   }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcUtils.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcUtils.java
@@ -70,7 +70,7 @@ public abstract class JdbcUtils {
   }
 
   /** Returns null if the sql could not be normalized for any reason. */
-  public static String normalizeSql(String sql) {
+  public static String sanitizeSql(String sql) {
     if (!NORMALIZATION_ENABLED) {
       return sql;
     }
@@ -82,9 +82,9 @@ public abstract class JdbcUtils {
     }
   }
 
-  public static SqlStatementInfo normalizeAndExtractInfo(String sql) {
+  public static SqlStatementInfo sanitizeAndExtractInfo(String sql) {
     try {
-      return SqlStatementInfoExtractor.extract(normalizeSql(sql));
+      return SqlStatementInfoExtractor.extract(sanitizeSql(sql));
     } catch (ParseException e) {
       log.debug("Could not extract sql info", e);
       return new SqlStatementInfo(null, null, null);

--- a/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
+++ b/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
@@ -185,7 +185,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$SemanticAttributes.DB_USER.key" username
             }
-            "$SemanticAttributes.DB_STATEMENT.key" normalizedQuery
+            "$SemanticAttributes.DB_STATEMENT.key" sanitizedQuery
             "$SemanticAttributes.DB_CONNECTION_STRING.key" url
           }
         }
@@ -197,7 +197,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
     connection.close()
 
     where:
-    system   | connection                                                           | username | query                                           | normalizedQuery                                 | spanName                                                | url
+    system   | connection                                                           | username | query                                           | sanitizedQuery                                 | spanName                                                | url
     "h2"     | new Driver().connect(jdbcUrls.get("h2"), null)                       | null     | "SELECT 3"                                      | "SELECT ?"                                      | "SELECT $dbNameLower"                                   | "h2:mem:"
     "derby"  | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null)            | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1"                | "SELECT ? FROM SYSIBM.SYSDUMMY1"                | "SELECT ${dbNameLower}.SYSIBM.SYSDUMMY1"                | "derby:memory:"
     "hsqldb" | new JDBCDriver().connect(jdbcUrls.get("hsqldb"), null)               | "SA"     | "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS" | "SELECT ? FROM INFORMATION_SCHEMA.SYSTEM_USERS" | "SELECT ${dbNameLower}.INFORMATION_SCHEMA.SYSTEM_USERS" | "hsqldb:mem:"
@@ -241,7 +241,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$SemanticAttributes.DB_USER.key" username
             }
-            "$SemanticAttributes.DB_STATEMENT.key" normalizedQuery
+            "$SemanticAttributes.DB_STATEMENT.key" sanitizedQuery
             "$SemanticAttributes.DB_CONNECTION_STRING.key" url
           }
         }
@@ -253,7 +253,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
     connection.close()
 
     where:
-    system  | connection                                                | username | query                            | normalizedQuery                  | spanName                                 | url
+    system  | connection                                                | username | query                            | sanitizedQuery                  | spanName                                 | url
     "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "SELECT 3"                       | "SELECT ?"                       | "SELECT $dbNameLower"                    | "h2:mem:"
     "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT ? FROM SYSIBM.SYSDUMMY1" | "SELECT ${dbNameLower}.SYSIBM.SYSDUMMY1" | "derby:memory:"
     "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "SELECT 3"                       | "SELECT ?"                       | "SELECT $dbNameLower"                    | "h2:mem:"
@@ -289,7 +289,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$SemanticAttributes.DB_USER.key" username
             }
-            "$SemanticAttributes.DB_STATEMENT.key" normalizedQuery
+            "$SemanticAttributes.DB_STATEMENT.key" sanitizedQuery
             "$SemanticAttributes.DB_CONNECTION_STRING.key" url
           }
         }
@@ -301,7 +301,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
     connection.close()
 
     where:
-    system  | connection                                                | username | query                            | normalizedQuery                  | spanName                                 | url
+    system  | connection                                                | username | query                            | sanitizedQuery                  | spanName                                 | url
     "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "SELECT 3"                       | "SELECT ?"                       | "SELECT $dbNameLower"                    | "h2:mem:"
     "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT ? FROM SYSIBM.SYSDUMMY1" | "SELECT ${dbNameLower}.SYSIBM.SYSDUMMY1" | "derby:memory:"
     "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "SELECT 3"                       | "SELECT ?"                       | "SELECT $dbNameLower"                    | "h2:mem:"
@@ -337,7 +337,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$SemanticAttributes.DB_USER.key" username
             }
-            "$SemanticAttributes.DB_STATEMENT.key" normalizedQuery
+            "$SemanticAttributes.DB_STATEMENT.key" sanitizedQuery
             "$SemanticAttributes.DB_CONNECTION_STRING.key" url
           }
         }
@@ -349,7 +349,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
     connection.close()
 
     where:
-    system  | connection                                                | username | query                            | normalizedQuery                  | spanName                                 | url
+    system  | connection                                                | username | query                            | sanitizedQuery                  | spanName                                 | url
     "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "SELECT 3"                       | "SELECT ?"                       | "SELECT $dbNameLower"                    | "h2:mem:"
     "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT ? FROM SYSIBM.SYSDUMMY1" | "SELECT ${dbNameLower}.SYSIBM.SYSDUMMY1" | "derby:memory:"
     "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "SELECT 3"                       | "SELECT ?"                       | "SELECT $dbNameLower"                    | "h2:mem:"
@@ -498,7 +498,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
             if (username != null) {
               "$SemanticAttributes.DB_USER.key" username
             }
-            "$SemanticAttributes.DB_STATEMENT.key" normalizedQuery
+            "$SemanticAttributes.DB_STATEMENT.key" sanitizedQuery
             "$SemanticAttributes.DB_CONNECTION_STRING.key" url
           }
         }
@@ -510,7 +510,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
     connection?.close()
 
     where:
-    prepareStatement | system  | driver               | jdbcUrl                                        | username | query                            | normalizedQuery                  | spanName                                 | url
+    prepareStatement | system  | driver               | jdbcUrl                                        | username | query                            | sanitizedQuery                  | spanName                                 | url
     true             | "h2"    | new Driver()         | "jdbc:h2:mem:" + dbName                        | null     | "SELECT 3;"                      | "SELECT ?;"                      | "SELECT $dbNameLower"                    | "h2:mem:"
     true             | "derby" | new EmbeddedDriver() | "jdbc:derby:memory:" + dbName + ";create=true" | "APP"    | "SELECT 3 FROM SYSIBM.SYSDUMMY1" | "SELECT ? FROM SYSIBM.SYSDUMMY1" | "SELECT ${dbNameLower}.SYSIBM.SYSDUMMY1" | "derby:memory:"
     false            | "h2"    | new Driver()         | "jdbc:h2:mem:" + dbName                        | null     | "SELECT 3;"                      | "SELECT ?;"                      | "SELECT $dbNameLower"                    | "h2:mem:"
@@ -632,7 +632,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "testdb"
             "$SemanticAttributes.DB_NAME.key" databaseName
-            "$SemanticAttributes.DB_STATEMENT.key" normalizedQuery
+            "$SemanticAttributes.DB_STATEMENT.key" sanitizedQuery
             "$SemanticAttributes.DB_CONNECTION_STRING.key" "testdb://localhost"
           }
         }
@@ -640,7 +640,7 @@ class JdbcInstrumentationTest extends AgentTestRunner {
     }
 
     where:
-    url                                         | query                 | normalizedQuery       | spanName            | databaseName
+    url                                         | query                 | sanitizedQuery       | spanName            | databaseName
     "jdbc:testdb://localhost?databaseName=test" | "SELECT * FROM table" | "SELECT * FROM table" | "SELECT test.table" | "test"
     "jdbc:testdb://localhost?databaseName=test" | "SELECT 42"           | "SELECT ?"            | "SELECT test"       | "test"
     "jdbc:testdb://localhost"                   | "SELECT * FROM table" | "SELECT * FROM table" | "SELECT table"      | null

--- a/javaagent-api/javaagent-api.gradle
+++ b/javaagent-api/javaagent-api.gradle
@@ -12,14 +12,14 @@ project.ext.minimumInstructionCoverage = 0.0
 
 javacc {
   configs {
-    normalizer {
-      inputFile = file('src/main/javacc/SqlNormalizer.jj')
-      packageName = 'io.opentelemetry.javaagent.instrumentation.api.db.normalizer'
+    sanitizer {
+      inputFile = file('src/main/javacc/SqlSanitizer.jj')
+      packageName = 'io.opentelemetry.javaagent.instrumentation.api.db.sanitizer'
       outputDir = file("${project.buildDir}/generated/javacc/sql")
     }
     statmentInfoExtractor {
       inputFile = file('src/main/javacc/SqlStatementInfoExtractor.jj')
-      packageName = 'io.opentelemetry.javaagent.instrumentation.api.db.normalizer'
+      packageName = 'io.opentelemetry.javaagent.instrumentation.api.db.sanitizer'
       outputDir = file("${project.buildDir}/generated/javacc/sql")
     }
   }

--- a/javaagent-api/src/main/javacc/SqlSanitizer.jj
+++ b/javaagent-api/src/main/javacc/SqlSanitizer.jj
@@ -9,16 +9,16 @@ options {
 	STATIC = false;
 }
 
-PARSER_BEGIN(SqlNormalizer)
+PARSER_BEGIN(SqlSanitizer)
 
-package io.opentelemetry.javaagent.instrumentation.api.db.normalizer;
+package io.opentelemetry.javaagent.instrumentation.api.db.sanitizer;
 
 import java.io.StringReader;
 
-public class SqlNormalizer {
+public class SqlSanitizer {
    public static final int LIMIT = 32 * 1024;
-   public static String normalize(String s) throws ParseException {
-     SqlNormalizer parser = new SqlNormalizer(new StringReader(s));
+   public static String sanitize(String s) throws ParseException {
+     SqlSanitizer parser = new SqlSanitizer(new StringReader(s));
      StringBuffer answer = parser.Input();
      if (answer.length() <= LIMIT) {
        return answer.toString();
@@ -28,7 +28,7 @@ public class SqlNormalizer {
      }
   }
 }
-PARSER_END(SqlNormalizer)
+PARSER_END(SqlSanitizer)
 
 StringBuffer Input() :
 {

--- a/javaagent-api/src/main/javacc/SqlStatementInfoExtractor.jj
+++ b/javaagent-api/src/main/javacc/SqlStatementInfoExtractor.jj
@@ -11,7 +11,7 @@ options {
 
 PARSER_BEGIN(SqlStatementInfoExtractor)
 
-package io.opentelemetry.javaagent.instrumentation.api.db.normalizer;
+package io.opentelemetry.javaagent.instrumentation.api.db.sanitizer;
 
 import io.opentelemetry.javaagent.instrumentation.api.db.SqlStatementInfo;
 import java.io.StringReader;

--- a/javaagent-api/src/test/groovy/io/opentelemetry/javaagent/instrumentation/api/db/sanitizer/SqlSanitizerTest.groovy
+++ b/javaagent-api/src/test/groovy/io/opentelemetry/javaagent/instrumentation/api/db/sanitizer/SqlSanitizerTest.groovy
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.api.db.normalizer
+package io.opentelemetry.javaagent.instrumentation.api.db.sanitizer
 
 import spock.lang.Specification
 import spock.lang.Timeout
 
 @Timeout(20)
-class SqlNormalizerTest extends Specification {
+class SqlSanitizerTest extends Specification {
 
   def "normalize #originalSql"() {
     setup:
-    def actualNormalized = SqlNormalizer.normalize(originalSql)
+    def actualNormalized = SqlSanitizer.sanitize(originalSql)
 
     expect:
     actualNormalized == normalizedSql
@@ -87,7 +87,7 @@ class SqlNormalizerTest extends Specification {
     setup:
     String s = "'"
     for (int i = 0; i < 10000; i++) {
-      assert SqlNormalizer.normalize(s) != null
+      assert SqlSanitizer.sanitize(s) != null
       s += "'"
     }
   }
@@ -98,7 +98,7 @@ class SqlNormalizerTest extends Specification {
     for (int i = 0; i < 10000; i++) {
       s += String.valueOf(i)
     }
-    assert "?" == SqlNormalizer.normalize(s)
+    assert "?" == SqlSanitizer.sanitize(s)
   }
 
   def "very long numbers at end of table name don't cause problem"() {
@@ -107,7 +107,7 @@ class SqlNormalizerTest extends Specification {
     for (int i = 0; i < 10000; i++) {
       s += String.valueOf(i)
     }
-    assert s.substring(0, SqlNormalizer.LIMIT) == SqlNormalizer.normalize(s)
+    assert s.substring(0, SqlSanitizer.LIMIT) == SqlSanitizer.sanitize(s)
   }
 
   def "test 32k truncation"() {
@@ -116,9 +116,9 @@ class SqlNormalizerTest extends Specification {
     for (int i = 0; i < 10000; i++) {
       s.append("SELECT * FROM TABLE WHERE FIELD = 1234 AND ")
     }
-    String normalized = SqlNormalizer.normalize(s.toString())
+    String normalized = SqlSanitizer.sanitize(s.toString())
     System.out.println(normalized.length())
-    assert normalized.length() <= SqlNormalizer.LIMIT
+    assert normalized.length() <= SqlSanitizer.LIMIT
     assert !normalized.contains("1234")
   }
 
@@ -130,7 +130,7 @@ class SqlNormalizerTest extends Specification {
       for (int c = 0; c < 1000; c++) {
         sb.append((char) r.nextInt((int) Character.MAX_VALUE))
       }
-      SqlNormalizer.normalize(sb.toString())
+      SqlSanitizer.sanitize(sb.toString())
     }
   }
 }

--- a/javaagent-api/src/test/groovy/io/opentelemetry/javaagent/instrumentation/api/db/sanitizer/SqlSanitizerTest.groovy
+++ b/javaagent-api/src/test/groovy/io/opentelemetry/javaagent/instrumentation/api/db/sanitizer/SqlSanitizerTest.groovy
@@ -116,10 +116,10 @@ class SqlSanitizerTest extends Specification {
     for (int i = 0; i < 10000; i++) {
       s.append("SELECT * FROM TABLE WHERE FIELD = 1234 AND ")
     }
-    String normalized = SqlSanitizer.sanitize(s.toString())
-    System.out.println(normalized.length())
-    assert normalized.length() <= SqlSanitizer.LIMIT
-    assert !normalized.contains("1234")
+    String sanitized = SqlSanitizer.sanitize(s.toString())
+    System.out.println(sanitized.length())
+    assert sanitized.length() <= SqlSanitizer.LIMIT
+    assert !sanitized.contains("1234")
   }
 
   def "random bytes don't cause exceptions or timeouts"() {

--- a/javaagent-api/src/test/groovy/io/opentelemetry/javaagent/instrumentation/api/db/sanitizer/SqlStatementInfoExtractorTest.groovy
+++ b/javaagent-api/src/test/groovy/io/opentelemetry/javaagent/instrumentation/api/db/sanitizer/SqlStatementInfoExtractorTest.groovy
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.api.db.normalizer
+package io.opentelemetry.javaagent.instrumentation.api.db.sanitizer
 
 import io.opentelemetry.javaagent.instrumentation.api.db.SqlStatementInfo
 import spock.lang.Specification


### PR DESCRIPTION
As suggested in #2065, it makes more sense to call this "sanitization" instead of "normalization", so this is just a rename for clarity.

It doesn't tackle the `normalizeQuery()` method on the DatabaseClientTracer, because that appears to be wholly separate concern (more like "extractQuery()" or something).