### PR TITLE
WIP: First draft of proposed async/binding aspect APIs

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/AttributeBinder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/AttributeBinder.java
@@ -1,0 +1,302 @@
+package io.opentelemetry.instrumentation.api.tracer.binding;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+public class AttributeBinder {
+
+    public static AttributeBinding bind(String name, Type type) {
+
+        if (type == String.class) {
+            return (builder, arg) -> builder.setAttribute(name, (String) arg);
+        }
+        if (type == int.class || type == Integer.class) {
+            return (builder, arg) -> builder.setAttribute(name, (Integer) arg);
+        }
+        if (type == long.class || type == Long.class) {
+            return (builder, arg) -> builder.setAttribute(name, (Long) arg);
+        }
+        if (type == boolean.class || type == Boolean.class) {
+            return (builder, arg) -> builder.setAttribute(name, (Boolean) arg);
+        }
+        if (type == double.class || type == Double.class) {
+            return (builder, arg) -> builder.setAttribute(name, (Double) arg);
+        }
+        if (type == float.class || type == Float.class) {
+            return (builder, arg) -> builder.setAttribute(name, (Float) arg);
+        }
+        if (type == String[].class) {
+            AttributeKey<List<String>> key = AttributeKey.stringArrayKey(name);
+            return (builder, arg) -> builder.setAttribute(key, Arrays.asList((String[]) arg));
+        }
+        if (type == Long[].class) {
+            AttributeKey<List<Long>> key = AttributeKey.longArrayKey(name);
+            return (builder, arg) -> builder.setAttribute(key, Arrays.asList((Long[]) arg));
+        }
+        if (type == Boolean[].class) {
+            AttributeKey<List<Boolean>> key = AttributeKey.booleanArrayKey(name);
+            return (builder, arg) -> builder.setAttribute(key, Arrays.asList((Boolean[]) arg));
+        }
+        if (type == Double[].class) {
+            AttributeKey<List<Double>> key = AttributeKey.doubleArrayKey(name);
+            return (builder, arg) -> builder.setAttribute(key, Arrays.asList((Double[]) arg));
+        }
+        if (type == Integer[].class) {
+            return boxedIntegerArrayConverter(name);
+        }
+        if (type == Float[].class) {
+            return boxedFloatArrayConverter(name);
+        }
+        if (type == int[].class) {
+            return intArrayConverter(name);
+        }
+        if (type == float[].class) {
+            return floatArrayConverter(name);
+        }
+        if (type == double[].class) {
+            return doubleArrayConverter(name);
+        }
+        if (type == long[].class) {
+            return longArrayConverter(name);
+        }
+        if (type == boolean[].class) {
+            return booleanArrayConverter(name);
+        }
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            Type rawClass = parameterizedType.getRawType();
+
+            if (rawClass == List.class || rawClass == Set.class || rawClass == Collection.class || rawClass == EnumSet.class) {
+                Type componentType = parameterizedType.getActualTypeArguments()[0];
+                return collectionConverter(name, componentType);
+            }
+        }
+        if (type == Object.class) {
+            return objectConverter(name);
+        }
+
+        return defaultConverter(name);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static AttributeBinding collectionConverter(String name, Type componentType) {
+        if (componentType == String.class) {
+            return collectionConverter(AttributeKey.stringArrayKey(name), String.class);
+        }
+        if (componentType == Long.class) {
+            return collectionConverter(AttributeKey.longArrayKey(name), Long.class);
+        }
+        if (componentType == Integer.class) {
+            return collectionConverter(AttributeKey.longArrayKey(name), Integer.class, Integer::longValue);
+        }
+        if (componentType == Double.class) {
+            return collectionConverter(AttributeKey.doubleArrayKey(name), Double.class);
+        }
+        if (componentType == Float.class) {
+            return collectionConverter(AttributeKey.doubleArrayKey(name), Float.class, Float::doubleValue);
+        }
+        if (componentType instanceof Class) {
+            Class<?> componentClass = (Class<?>) componentType;
+            if (componentClass.isEnum()) {
+                return collectionConverter(AttributeKey.stringArrayKey(name), Enum.class, Enum::toString);
+            }
+        }
+        return AttributeBinder.objectCollectionConverter(name);
+    }
+
+    private static <T> AttributeBinding collectionConverter(AttributeKey<List<T>> attributeKey, Class<T> componentType) {
+
+        return collectionConverter(attributeKey, componentType, Function.identity());
+    }
+
+    private static <T, A> AttributeBinding collectionConverter(
+            AttributeKey<List<A>> attributeKey,
+            Class<T> componentType,
+            Function<T, A> mapping) {
+
+        return (builder, arg) -> {
+            if (arg == null) {
+                return builder;
+            }
+            @SuppressWarnings("unchecked")
+            Collection<T> collection = (Collection<T>) arg;
+            List<A> list = collection.stream()
+                    .map(mapping)
+                    .collect(Collectors.toList());
+            return builder.setAttribute(attributeKey, list);
+        };
+    }
+
+    private static AttributeBinding objectConverter(String name) {
+        return (builder, arg) -> {
+            if (arg instanceof String) {
+                return builder.setAttribute(name, (String) arg);
+            } else if (arg instanceof Long) {
+                return builder.setAttribute(name, (Long) arg);
+            } else if (arg instanceof Integer) {
+                return builder.setAttribute(name, (Integer) arg);
+            } else if (arg instanceof Boolean) {
+                return builder.setAttribute(name, (Boolean) arg);
+            } else if (arg instanceof Double) {
+                return builder.setAttribute(name, (Double) arg);
+            } else if (arg instanceof Float) {
+                return builder.setAttribute(name, (Float) arg);
+            } else if (arg instanceof String[]) {
+                return builder.setAttribute(AttributeKey.stringArrayKey(name), Arrays.asList((String[]) arg));
+            } else if (arg instanceof Long[]) {
+                return builder.setAttribute(AttributeKey.longArrayKey(name), Arrays.asList((Long[]) arg));
+            } else if (arg instanceof Boolean[]) {
+                return builder.setAttribute(AttributeKey.booleanArrayKey(name), Arrays.asList((Boolean[]) arg));
+            } else if (arg instanceof Double[]) {
+                return builder.setAttribute(AttributeKey.doubleArrayKey(name), Arrays.asList((Double[]) arg));
+            } else if (arg instanceof long[]) {
+                return longArrayConverter(name).apply(builder, arg);
+            } else if (arg instanceof int[]) {
+                return intArrayConverter(name).apply(builder, arg);
+            } else if (arg instanceof Integer[]) {
+                return boxedIntegerArrayConverter(name).apply(builder, arg);
+            } else if (arg instanceof boolean[]) {
+                return booleanArrayConverter(name).apply(builder, arg);
+            } else if (arg instanceof double[]) {
+                return doubleArrayConverter(name).apply(builder, arg);
+            } else if (arg instanceof float[]) {
+                return floatArrayConverter(name).apply(builder, arg);
+            } else if (arg instanceof Float[]) {
+                return boxedFloatArrayConverter(name).apply(builder, arg);
+            } else if (arg instanceof Collection<?>) {
+                return objectCollectionConverter(name).apply(builder, arg);
+            }
+            return defaultConverter(name).apply(builder, arg);
+        };
+    }
+
+    private static AttributeBinding defaultConverter(String name) {
+        return (builder, arg) -> builder.setAttribute(name, arg.toString());
+    }
+
+    private static AttributeBinding intArrayConverter(String name) {
+        AttributeKey<List<Long>> key = AttributeKey.longArrayKey(name);
+        return (builder, arg) -> {
+            int[] array = (int[]) arg;
+            List<Long> list = new ArrayList<>(array.length);
+            for (int value : array) {
+                list.add((long) value);
+            }
+
+            return builder.setAttribute(key, list);
+        };
+    }
+
+    private static AttributeBinding boxedIntegerArrayConverter(String name) {
+        AttributeKey<List<Long>> key = AttributeKey.longArrayKey(name);
+        return (builder, arg) -> {
+            Integer[] array = (Integer[]) arg;
+            List<Long> list = new ArrayList<>(array.length);
+            for (Integer value : array) {
+                if (value != null) {
+                    list.add(value.longValue());
+                } else {
+                    list.add(null);
+                }
+            }
+
+            return builder.setAttribute(key, list);
+        };
+    }
+
+    private static AttributeBinding longArrayConverter(String name) {
+        AttributeKey<List<Long>> key = AttributeKey.longArrayKey(name);
+        return (builder, arg) -> {
+            long[] array = (long[]) arg;
+            List<Long> list = new ArrayList<>(array.length);
+            for (long value : array) {
+                list.add(value);
+            }
+
+            return builder.setAttribute(key, list);
+        };
+    }
+
+    private static AttributeBinding doubleArrayConverter(String name) {
+        AttributeKey<List<Double>> key = AttributeKey.doubleArrayKey(name);
+        return (builder, arg) -> {
+            double[] array = (double[]) arg;
+            List<Double> list = new ArrayList<>(array.length);
+            for (double value : array) {
+                list.add(value);
+            }
+
+            return builder.setAttribute(key, list);
+        };
+    }
+
+    private static AttributeBinding booleanArrayConverter(String name) {
+        AttributeKey<List<Boolean>> key = AttributeKey.booleanArrayKey(name);
+        return (builder, arg) -> {
+            boolean[] array = (boolean[]) arg;
+            List<Boolean> list = new ArrayList<>(array.length);
+            for (boolean value : array) {
+                list.add(value);
+            }
+
+            return builder.setAttribute(key, list);
+        };
+    }
+
+    private static AttributeBinding floatArrayConverter(String name) {
+        AttributeKey<List<Double>> key = AttributeKey.doubleArrayKey(name);
+        return (builder, arg) -> {
+            float[] array = (float[]) arg;
+            List<Double> list = new ArrayList<>(array.length);
+            for (float value : array) {
+                list.add((double) value);
+            }
+
+            return builder.setAttribute(key, list);
+        };
+    }
+
+    private static AttributeBinding boxedFloatArrayConverter(String name) {
+        AttributeKey<List<Double>> key = AttributeKey.doubleArrayKey(name);
+        return (builder, arg) -> {
+            Float[] array = (Float[]) arg;
+            List<Double> list = new ArrayList<>(array.length);
+            for (Float value : array) {
+                if (value != null) {
+                    list.add(value.doubleValue());
+                } else {
+                    list.add(null);
+                }
+            }
+
+            return builder.setAttribute(key, list);
+        };
+    }
+
+    private static AttributeBinding objectCollectionConverter(String name) {
+        AttributeKey<List<String>> key = AttributeKey.stringArrayKey(name);
+        return (builder, arg) -> {
+            Collection<?> collection = (Collection<?>) arg;
+            List<String> list = new ArrayList<>(collection.size());
+            for (Object value : collection) {
+                if (value != null) {
+                    list.add(value.toString());
+                } else {
+                    list.add(null);
+                }
+            }
+
+            return builder.setAttribute(key, list);
+        };
+    }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/AttributeBinding.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/AttributeBinding.java
@@ -1,0 +1,8 @@
+package io.opentelemetry.instrumentation.api.tracer.binding;
+
+import io.opentelemetry.api.trace.SpanBuilder;
+
+@FunctionalInterface
+public interface AttributeBinding {
+    SpanBuilder apply(SpanBuilder builder, Object arg);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/DefaultTraceBinder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/DefaultTraceBinder.java
@@ -1,0 +1,92 @@
+package io.opentelemetry.instrumentation.api.tracer.binding;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+import io.opentelemetry.api.trace.SpanBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.aspectj.lang.Signature;
+
+public enum DefaultTraceBinder implements TraceBinder {
+    INSTANCE;
+
+    private static final TraceAttributesBinding IDENTITY = (builder, args) -> builder;
+
+    public TraceBinding bind(Method method, WithSpan annotation) {
+
+        TraceBinding binding;
+        if (StringUtils.isNotBlank(annotation.value())) {
+            binding = (tracer, joinPoint) -> tracer.spanBuilder(annotation.value())
+                    .setSpanKind(annotation.kind());
+        } else {
+            binding = (tracer, joinPoint) -> {
+                Signature signature = joinPoint.getSignature();
+                Object target = joinPoint.getTarget();
+                String typeName = (target != null) ? target.getClass().getSimpleName() : signature.getDeclaringTypeName();
+                String spanName = typeName + "." + signature.getName();
+                return tracer.spanBuilder(spanName)
+                        .setSpanKind(annotation.kind());
+            };
+        }
+        return bindParameters(binding, method);
+    }
+
+    private static TraceBinding bindParameters(TraceBinding traceBinding, Method method) {
+
+        Parameter[] parameters = method.getParameters();
+        if (parameters == null || parameters.length == 0) {
+            return traceBinding;
+        }
+
+        TraceAttributesBinding attributesBinding = bindParameters(parameters, IDENTITY);
+        if (attributesBinding == IDENTITY) {
+            return traceBinding;
+        }
+        return (tracer, joinPoint) -> attributesBinding.apply(traceBinding.apply(tracer, joinPoint), joinPoint.getArgs());
+    }
+
+    private static TraceAttributesBinding bindParameters(Parameter[] parameters, TraceAttributesBinding attributesBinding) {
+
+        for (int i = 0; i < parameters.length; i++) {
+            attributesBinding = bindParameter(parameters[i], i, attributesBinding);
+        }
+        return attributesBinding;
+    }
+
+    private static TraceAttributesBinding bindParameter(Parameter parameter, int index, TraceAttributesBinding attributesBinding) {
+
+        Trace.Attribute annotation = parameter.getAnnotation(WithSpan.Attribute.class);
+        if (annotation == null) {
+            return attributesBinding;
+        }
+
+        String attributeName;
+        if (StringUtils.isNotBlank(annotation.value())) {
+            attributeName = annotation.value();
+        } else if (parameter.isNamePresent()) {
+            attributeName = parameter.getName();
+        } else {
+            return attributesBinding;
+        }
+
+        AttributeBinding converter = AttributeBinder
+                .bind(attributeName, parameter.getParameterizedType());
+        if (converter == null) {
+            return attributesBinding;
+        }
+
+        return (spanBuilder, args) -> {
+            SpanBuilder next = attributesBinding.apply(spanBuilder, args);
+            Object arg = args[index];
+            if (arg == null) {
+                return next;
+            }
+            return converter.apply(next, arg);
+        };
+    }
+
+    @FunctionalInterface
+    private interface TraceAttributesBinding {
+        SpanBuilder apply(SpanBuilder spanBuilder, Object[] args);
+    }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/MethodSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/MethodSpan.java
@@ -1,0 +1,23 @@
+package io.opentelemetry.instrumentation.api.tracer.binding;
+
+import io.opentelemetry.api.trace.Span;
+
+/**
+ * Represents the invocation of a traced method.  The {@link MethodSpan#complete}
+ * method is called when the method completes either successfully or by throwing
+ * an exception.
+ */
+@FunctionalInterface
+public interface MethodSpan {
+    /**
+     * Called to indicate that the traced method has completed, either successfully
+     * or by throwing an exception.
+     * @param result the successful result of the traced method
+     * @param error the exception thrown by the traced method
+     * @param finish the {@link SpanFinisher} to be used to finish tracing {@link Span}s.
+     * @return the result of the method span which may decorate the successful
+     *         result of the traced method to allow the {@link SpanStrategy} to
+     *         optionally register for completion of an asynchronous result
+     */
+    Object complete(Object result, Throwable error, SpanFinisher finish);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/Proceeder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/Proceeder.java
@@ -1,0 +1,6 @@
+package io.opentelemetry.instrumentation.api.tracer.binding;
+
+@FunctionalInterface
+public interface Proceeder {
+  Object proceed() throws Throwable;
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/SpanFinisher.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/SpanFinisher.java
@@ -1,0 +1,22 @@
+package io.opentelemetry.instrumentation.api.tracer.binding;
+
+import io.opentelemetry.api.trace.Span;
+
+/**
+ * Abstracts how a method span should be finished based on the result
+ * of the traced method.  The success of the traced method is determined
+ * by the presence (or lack thereof) of an {@link Throwable} instance
+ * passed to the {@code error} parameter of the
+ * {@link SpanFinisher#finish} method.
+ */
+@FunctionalInterface
+public interface SpanFinisher {
+    /**
+     *
+     * @param span the {@link Span} to finish
+     * @param result the successful result of the method being traced
+     * @param error the unsuccessful result of the method being traced
+     * @return the successful result of the method
+     */
+    Object finish(Span span, Object result, Throwable error);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/TraceBinder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/TraceBinder.java
@@ -1,0 +1,7 @@
+package io.opentelemetry.instrumentation.api.tracer.binding;
+
+import java.lang.reflect.Method;
+
+public interface TraceBinder {
+    TraceBinding bind(Method method, WithSpan annotation);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/TraceBinding.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/binding/TraceBinding.java
@@ -1,0 +1,10 @@
+package io.opentelemetry.instrumentation.api.tracer.binding;
+
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+import org.aspectj.lang.ProceedingJoinPoint;
+
+@FunctionalInterface
+public interface TraceBinding {
+  SpanBuilder apply(Tracer tracer, ProceedingJoinPoint joinPoint);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/SpanStrategy.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/SpanStrategy.java
@@ -1,0 +1,19 @@
+package io.opentelemetry.instrumentation.api.tracer.strategy;
+
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.tracer.binding.MethodSpan;
+
+/**
+ * Represents a strategy for tracing spans around method calls.
+ */
+@FunctionalInterface
+public interface SpanStrategy {
+    /**
+     * Starts a span around the method being traced.
+     * @param currentContext the context for the current thread
+     * @param spanBuilder a span builder used to create spans
+     * @return a {@link MethodSpan} used as a callback for when the method completes
+     */
+    MethodSpan startMethodSpan(Context currentContext, SpanBuilder spanBuilder);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/SpanStrategyFactory.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/SpanStrategyFactory.java
@@ -1,0 +1,50 @@
+package io.opentelemetry.instrumentation.api.tracer.strategy;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import io.opentelemetry.instrumentation.api.tracer.strategy.async.CompletableFutureSpanStrategy;
+import io.opentelemetry.instrumentation.api.tracer.strategy.async.CompletionStageSpanStrategy;
+
+
+/**
+ * Registers strategies for tracing spans around traced methods based on the
+ * return type of the method being traced.
+ */
+public class SpanStrategyFactory {
+
+    private final Map<Class<?>, SpanStrategy> strategies;
+    private final SpanStrategy defaultStrategy;
+
+    /**
+     * Creates a new instance of the factory with the default strategies.
+     */
+    public SpanStrategyFactory() {
+        strategies = new HashMap<>();
+        defaultStrategy = new SynchronousSpanStrategy();
+        register(CompletionStage.class, new CompletionStageSpanStrategy());
+        register(CompletableFuture.class, new CompletableFutureSpanStrategy());
+    }
+
+    /**
+     * Registers a strategy for tracing spans around a traced method.
+     * @param returnClass return type of the method being traced
+     * @param strategy strategy to use when tracing the method
+     * @return this factory
+     */
+    public SpanStrategyFactory register(Class<?> returnClass, SpanStrategy strategy) {
+        strategies.put(returnClass, strategy);
+        return this;
+    }
+
+    /**
+     * Returns the span strategy used for tracing a traced method based
+     * on the return type of the method.
+     * @param returnClass return type of the method being traced
+     * @return the strategy to use when tracing the method
+     */
+    public SpanStrategy createSpanStrategy(Class<?> returnClass) {
+        return strategies.getOrDefault(returnClass, defaultStrategy);
+    }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/SynchronousSpanStrategy.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/SynchronousSpanStrategy.java
@@ -1,0 +1,24 @@
+package io.opentelemetry.instrumentation.api.tracer.strategy;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.tracer.binding.MethodSpan;
+
+/**
+ * Strategy to trace methods that execute synchronously and where the tracing span
+ * is to be finished immediately on completion of the method invocation.
+ */
+public class SynchronousSpanStrategy implements SpanStrategy {
+
+    @Override
+    public MethodSpan startMethodSpan(Context currentContext, SpanBuilder spanBuilder) {
+        Span span = spanBuilder.startSpan();
+        Scope scope = currentContext.with(span).makeCurrent();
+        return (result, exception, finisher) -> {
+            scope.close();
+            return finisher.finish(span, result, exception);
+        };
+    }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/async/CompletableFutureSpanStrategy.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/async/CompletableFutureSpanStrategy.java
@@ -1,0 +1,40 @@
+package io.opentelemetry.instrumentation.api.tracer.strategy.async;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.tracer.binding.MethodSpan;
+import io.opentelemetry.instrumentation.api.tracer.binding.SpanFinisher;
+import io.opentelemetry.instrumentation.api.tracer.strategy.SpanStrategy;
+
+/**
+ * Strategy to trace methods that return {@link CompletableFuture} instances that
+ * represent an asynchronous operation in-flight.  The {@link Span} traced for the
+ * method will not be finished until the future is completed.
+ */
+public class CompletableFutureSpanStrategy implements SpanStrategy {
+
+    @Override
+    public MethodSpan startMethodSpan(Context currentContext, SpanBuilder spanBuilder) {
+        Span span = spanBuilder.startSpan();
+        Scope scope = currentContext.with(span).makeCurrent();
+        return (result, error, finisher) -> {
+            try (Scope ignored = scope) {
+                if (result instanceof CompletableFuture) {
+                    CompletableFuture<?> future = (CompletableFuture<?>) result;
+                    return future.whenComplete(finishSpan(span, finisher));
+                } else {
+                    return finisher.finish(span, result, error);
+                }
+            }
+        };
+    }
+
+    private BiConsumer<Object, Throwable> finishSpan(Span span, SpanFinisher finisher) {
+        return (result, error) -> finisher.finish(span, result, error);
+    }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/async/CompletionStageSpanStrategy.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/async/CompletionStageSpanStrategy.java
@@ -1,0 +1,40 @@
+package io.opentelemetry.instrumentation.api.tracer.strategy.async;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.tracer.binding.MethodSpan;
+import io.opentelemetry.instrumentation.api.tracer.binding.SpanFinisher;
+import io.opentelemetry.instrumentation.api.tracer.strategy.SpanStrategy;
+
+/**
+ * Strategy to trace methods that return {@link CompletionStage} instances that
+ * represent an asynchronous operation in-flight.  The {@link Span} traced for the
+ * method will not be finished until the future is completed.
+ */
+public class CompletionStageSpanStrategy implements SpanStrategy {
+
+    @Override
+    public MethodSpan startMethodSpan(Context currentContext, SpanBuilder spanBuilder) {
+        Span span = spanBuilder.startSpan();
+        Scope scope = currentContext.with(span).makeCurrent();
+        return (result, error, finisher) -> {
+            try (Scope ignored = scope) {
+                if (result instanceof CompletionStage) {
+                    CompletionStage<?> stage = (CompletionStage<?>) result;
+                    return stage.whenComplete(finishSpan(span, finisher));
+                } else {
+                    return finisher.finish(span, result, error);
+                }
+            }
+        };
+    }
+
+    private BiConsumer<Object, Throwable> finishSpan(Span span, SpanFinisher finisher) {
+        return (result, error) -> finisher.finish(span, result, error);
+    }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/reactor/FluxSpanStrategy.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/reactor/FluxSpanStrategy.java
@@ -1,0 +1,48 @@
+package io.opentelemetry.instrumentation.api.tracer.strategy.reactor;
+
+import java.util.function.Function;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.tracer.binding.MethodSpan;
+import io.opentelemetry.instrumentation.api.tracer.binding.SpanFinisher;
+import io.opentelemetry.instrumentation.api.tracer.strategy.SpanStrategy;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+
+/**
+ * Strategy to trace methods that return a reactive {@link Flux} instance representing
+ * an asynchronous operation.  The {@link Flux} traced for the method isn't finished
+ * until an observer subscribes to the {@link Mono} and the publisher completes.  If
+ * subsequent observers subscribe additional {@link Span} instances are traced.
+ */
+public class FluxSpanStrategy extends ReactiveSpanStrategy implements SpanStrategy {
+
+    @Override
+    public MethodSpan startMethodSpan(Context currentContext, SpanBuilder spanBuilder) {
+
+        Span span = spanBuilder.startSpan();
+        Scope scope = currentContext.with(span).makeCurrent();
+        return (result, error, finisher) -> {
+            try (Scope ignored = scope) {
+                if (result instanceof Flux) {
+                    Flux<?> flux = (Flux<?>) result;
+                    return createSpanMono(spanBuilder, span)
+                            .flatMapMany(recordFluxCompletion(flux, finisher));
+                } else {
+                    return finisher.finish(span, result, error);
+                }
+            }
+        };
+    }
+
+    private Function<Span, Flux<?>> recordFluxCompletion(Flux<?> flux, SpanFinisher finisher) {
+        return span -> flux.transform(withCheckpoint(span, Flux::checkpoint))
+                .doOnError(exception -> finisher.finish(span, null, exception))
+                .doOnCancel(() -> finisher.finish(span, null, null))
+                .doOnComplete(() -> finisher.finish(span, null, null));
+    }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/reactor/MonoSpanStrategy.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/reactor/MonoSpanStrategy.java
@@ -1,0 +1,45 @@
+package io.opentelemetry.instrumentation.api.tracer.strategy.reactor;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import java.util.function.Function;
+import io.opentelemetry.instrumentation.api.tracer.binding.MethodSpan;
+import io.opentelemetry.instrumentation.api.tracer.binding.SpanFinisher;
+import io.opentelemetry.instrumentation.api.tracer.strategy.SpanStrategy;
+import reactor.core.publisher.Mono;
+
+/**
+ * Strategy to trace methods that return a reactive {@link Mono} instance representing
+ * an asynchronous operation.  The {@link Span} traced for the method isn't finished
+ * until an observer subscribes to the {@link Mono} and the publisher completes.  If
+ * subsequent observers subscribe additional {@link Span} instances are traced.
+ */
+public class MonoSpanStrategy extends ReactiveSpanStrategy implements SpanStrategy {
+
+    @Override
+    public MethodSpan startMethodSpan(Context currentContext, SpanBuilder spanBuilder) {
+
+        Span span = spanBuilder.startSpan();
+        Scope scope = currentContext.with(span).makeCurrent();
+        return (result, error, finisher) -> {
+            try (Scope ignored = scope) {
+                if (result instanceof Mono) {
+                    Mono<?> mono = (Mono<?>) result;
+                    return createSpanMono(spanBuilder, span)
+                            .flatMap(recordMonoCompletion(mono, finisher));
+                } else {
+                    return finisher.finish(span, result, error);
+                }
+            }
+        };
+    }
+
+    private Function<Span, Mono<?>> recordMonoCompletion(Mono<?> mono, SpanFinisher finisher) {
+        return span -> mono.transform(withCheckpoint(span, Mono::checkpoint))
+                .doOnError(error -> finisher.finish(span, null, error))
+                .doOnSuccess(result -> finisher.finish(span, result, null))
+                .doOnCancel(() -> finisher.finish(span, null, null));
+    }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/reactor/ReactiveSpanStrategy.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/strategy/reactor/ReactiveSpanStrategy.java
@@ -1,0 +1,43 @@
+package io.opentelemetry.instrumentation.api.tracer.strategy.reactor;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.instrumentation.api.tracer.strategy.SpanStrategy;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Base class for strategies that trace methods that return reactive
+ * publishers, e.g. {@link Mono} or {@link Flux}.  These publishers can
+ * support multiple subscriptions which are each traced as a separate span.
+ */
+public abstract class ReactiveSpanStrategy implements SpanStrategy {
+
+    protected  <T, P extends Publisher<T>> Function<P, P> withCheckpoint(Span span, BiFunction<P, String, P> checkpoint) {
+        return publisher -> checkpoint.apply(publisher, span.toString());
+    }
+
+    /**
+     * Creates a {@link Mono} of the {@link Span} for the current subscription.
+     * @param spanBuilder used to create new {@link Span} instances
+     * @param existingSpan the initial {@link Span} used to trace the method invocation
+     *                     and the first subscription
+     * @return a {@link Mono} wrapping the {@link Span}
+     */
+    protected Mono<Span> createSpanMono(SpanBuilder spanBuilder, Span existingSpan) {
+        AtomicBoolean flag = new AtomicBoolean(false);
+
+        return Mono.defer(() -> {
+            if (flag.compareAndSet(false, true)) {
+                return Mono.just(existingSpan);
+            } else {
+                return Mono.just(spanBuilder.startSpan());
+            }
+        });
+    }
+}

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/WithSpanAspect.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/WithSpanAspect.java
@@ -6,12 +6,22 @@
 package io.opentelemetry.instrumentation.spring.autoconfigure.aspects;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.extension.annotations.WithSpan;
 import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import io.opentelemetry.instrumentation.api.tracer.binding.DefaultTraceBinder;
+import io.opentelemetry.instrumentation.api.tracer.binding.MethodSpan;
+import io.opentelemetry.instrumentation.api.tracer.binding.SpanFinisher;
+import io.opentelemetry.instrumentation.api.tracer.binding.TraceBinder;
+import io.opentelemetry.instrumentation.api.tracer.binding.TraceBinding;
+import io.opentelemetry.instrumentation.api.tracer.strategy.SpanStrategy;
+import io.opentelemetry.instrumentation.api.tracer.strategy.SpanStrategyFactory;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -31,9 +41,19 @@ import org.aspectj.lang.reflect.MethodSignature;
 public class WithSpanAspect {
 
   private final Tracer tracer;
+  private final SpanStrategyFactory spanStrategyFactory;
+  private final TraceBinder traceBinder;
+  private final ConcurrentMap<Method, TraceBinding> traceBindingsMap;
 
   public WithSpanAspect(Tracer tracer) {
+    this(tracer, new SpanStrategyFactory(), DefaultTraceBinder.INSTANCE);
+  }
+
+  public WithSpanAspect(Tracer tracer, SpanStrategyFactory spanStrategyFactory, TraceBinder traceBinder) {
     this.tracer = tracer;
+    this.spanStrategyFactory = spanStrategyFactory;
+    this.traceBinder = traceBinder;
+    this.traceBindingsMap = new ConcurrentHashMap<>();
   }
 
   @Around("@annotation(io.opentelemetry.extension.annotations.WithSpan)")
@@ -41,6 +61,19 @@ public class WithSpanAspect {
     MethodSignature signature = (MethodSignature) pjp.getSignature();
     Method method = signature.getMethod();
     WithSpan withSpan = method.getAnnotation(WithSpan.class);
+
+    TraceBinding binding = traceBindingsMap.computeIfAbsent(method, key -> traceBinder.bind(method, withSpan));
+    SpanBuilder spanBuilder = binding.apply(tracer, pjp::getArgs, pjp::proceed);
+    SpanStrategy strategy = spanStrategyFactory.createSpanStrategy(signature.getReturnType());
+    MethodSpan methodSpan = strategy.startMethodSpan(Context.current(), spanBuilder);
+
+    try {
+      Object result = pjp.proceed();
+      return methodSpan.complete(result, null, endSpan(annotation));
+    } catch (Exception exception) {
+      methodSpan.complete(null, exception, endSpan(annotation));
+      throw exception;
+    }
 
     Context parent = Context.current();
     Span span =
@@ -58,6 +91,30 @@ public class WithSpanAspect {
     } finally {
       span.end();
     }
+  }
+
+  private SpanFinisher endSpan(WithSpan annotation) {
+    return (span, result, error) -> {
+      if (error == null || ignoreException(error, annotation.ignoredExceptions())) {
+        span.setStatus(StatusCode.OK);
+      } else {
+        span.setStatus(StatusCode.ERROR, error.getMessage());
+        span.recordException(error);
+      }
+      span.end();
+      return result;
+    };
+  }
+
+  private boolean ignoreException(Throwable error, Class<? extends Exception>[] ignoredExceptions) {
+    if (error instanceof Exception) {
+      for (Class<? extends Exception> ignoredException : ignoredExceptions) {
+        if (ignoredException.isInstance(error)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private String getSpanName(WithSpan withSpan, Method method) {


### PR DESCRIPTION
This is an early draft of a proposal to extend the `@WithSpan` annotation aspects to support the following features ported from a Comcast flavor of this aspect used in a number of Spring WebFlux applications:

1. Supporting asynchronous return values
2. Map method parameters to span attributes
3. Treat specific thrown exceptions as not errors

I've tried to dump most of what we have into the repo as-is for the sake of discussion.  It does not build due to an assortment of missing dependencies and bits of this would certainly have to be broken up and refactored for a number of different reasons.  I also see a number of places I would like to refactor the API for the sake of simplifying it and unifying the behavior behind specific interfaces to keep much of the logic out of the different specific AOP implementations.