### PR TITLE
Match classloader when applying netty instrumentation.

### DIFF
--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/NettyInstrumentationModule.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/NettyInstrumentationModule.java
@@ -5,17 +5,27 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v4_0;
 
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.ClassLoaderMatcher.hasClassesNamed;
 import static java.util.Arrays.asList;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class NettyInstrumentationModule extends InstrumentationModule {
   public NettyInstrumentationModule() {
     super("netty", "netty-4.0");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    // Class added in 4.1.0 and not in 4.0.56 to avoid resolving this instrumentation completely
+    // when using 4.1.
+    return not(hasClassesNamed("io.netty.handler.codec.http.CombinedHttpHeaders"));
   }
 
   @Override

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyInstrumentationModule.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyInstrumentationModule.java
@@ -5,17 +5,26 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.ClassLoaderMatcher.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class NettyInstrumentationModule extends InstrumentationModule {
   public NettyInstrumentationModule() {
     super("netty", "netty-4.1");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    // Class added in 4.1.0 and not in 4.0.56 to avoid resolving this instrumentation completely
+    // when using 4.0.
+    return hasClassesNamed("io.netty.handler.codec.http.CombinedHttpHeaders");
   }
 
   @Override


### PR DESCRIPTION
Currently, both netty 4.0 and 4.1 are attempted to be applied on every classload because 4.0 does not fail type matching, only muzzle reference check. I'm not sure if this is a bug or not in our muzzle reference check handling, presumably it should only do so once. Either way, it seems like good practice to explicitly check where we can when targeting multiple versions.

This makes debug logs much more readable since previously every successful 4.1 transformation was also accompanied by a mysterious failure of the 4.0 instrumentation. Presumably some speed boost too.