### PR TITLE
Add Netty instrumentation handlers after matched handler rather than at end of pipeline.

### DIFF
--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
@@ -81,7 +81,6 @@ public class NettyChannelPipelineInstrumentation implements TypeInstrumentation 
       // initializers would not be considered.
       // Using the specific handler key instead of the generic ChannelPipeline.class will help us
       // both to handle such cases and avoid adding our additional handlers in case of internal
-      // calls of `addLast` to other method overloads with a compatible signature.
       return CallDepthThreadLocalMap.incrementCallDepth(handler.getClass());
     }
 
@@ -90,6 +89,7 @@ public class NettyChannelPipelineInstrumentation implements TypeInstrumentation 
         @Advice.Enter int callDepth,
         @Advice.This ChannelPipeline pipeline,
         @Advice.Argument(2) ChannelHandler handler) {
+      // calls of `addLast` to other method overloads with a compatible signature.
       if (callDepth > 0) {
         return;
       }

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
@@ -82,6 +82,7 @@ public class NettyChannelPipelineInstrumentation implements TypeInstrumentation 
       // initializers would not be considered.
       // Using the specific handler key instead of the generic ChannelPipeline.class will help us
       // both to handle such cases and avoid adding our additional handlers in case of internal
+      // calls of `addLast` to other method overloads with a compatible signature.
       return CallDepthThreadLocalMap.incrementCallDepth(handler.getClass());
     }
 
@@ -91,7 +92,6 @@ public class NettyChannelPipelineInstrumentation implements TypeInstrumentation 
         @Advice.This ChannelPipeline pipeline,
         @Advice.Argument(1) String name,
         @Advice.Argument(2) ChannelHandler handler) {
-      // calls of `addLast` to other method overloads with a compatible signature.
       if (callDepth > 0) {
         return;
       }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/spring-webflux-5.0-javaagent.gradle
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/spring-webflux-5.0-javaagent.gradle
@@ -48,14 +48,11 @@ dependencies {
   testLibrary group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.0.0.RELEASE'
   testLibrary group: 'org.springframework.boot', name: 'spring-boot-starter-reactor-netty', version: '2.0.0.RELEASE'
   testImplementation group: 'org.spockframework', name: 'spock-spring', version: '1.1-groovy-2.4'
-
-  // FIXME: reactor-netty packages have changed so test imports are failing
-  latestDepTestLibrary group: 'org.springframework.boot', name: 'spring-boot-starter-webflux', version: '2.0.+'
-  latestDepTestLibrary group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.0.+'
-  latestDepTestLibrary group: 'org.springframework.boot', name: 'spring-boot-starter-reactor-netty', version: '2.0.+'
 }
 
 tasks.withType(Test) {
   // TODO run tests both with and without experimental span attributes
   jvmArgs '-Dotel.instrumentation.spring-webflux.experimental-span-attributes=true'
+
+  systemProperty "testLatestDeps", testLatestDeps
 }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SingleThreadedSpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SingleThreadedSpringWebfluxTest.groovy
@@ -29,7 +29,7 @@ class SingleThreadedSpringWebfluxTest extends SpringWebfluxTest {
 
   static NettyServerCustomizer customizer() {
     if (Boolean.getBoolean("testLatestDeps")) {
-      return { builder -> builder.loopResources(reactor.netty.resources.LoopResources.create("my-http", 1, true)) }
+      return { builder -> builder.runOn(reactor.netty.resources.LoopResources.create("my-http", 1, true)) }
     }
     return { builder -> builder.loopResources(reactor.ipc.netty.resources.LoopResources.create("my-http", 1, true)) }
   }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SingleThreadedSpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SingleThreadedSpringWebfluxTest.groovy
@@ -8,9 +8,7 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory
 import org.springframework.boot.web.embedded.netty.NettyServerCustomizer
 import org.springframework.context.annotation.Bean
-import reactor.ipc.netty.resources.LoopResources
 import server.SpringWebFluxTestApplication
-
 /**
  * Run all Webflux tests under netty event loop having only 1 thread.
  * Some of the bugs are better visible in this setup because same thread is reused
@@ -24,10 +22,15 @@ class SingleThreadedSpringWebfluxTest extends SpringWebfluxTest {
     @Bean
     NettyReactiveWebServerFactory nettyFactory() {
       def factory = new NettyReactiveWebServerFactory()
-      NettyServerCustomizer customizer = { builder -> builder.loopResources(LoopResources.create("my-http", 1, true)) }
-      factory.addServerCustomizers(customizer)
+      factory.addServerCustomizers(customizer())
       return factory
     }
   }
 
+  static NettyServerCustomizer customizer() {
+    if (Boolean.getBoolean("testLatestDeps")) {
+      return { builder -> builder.loopResources(reactor.netty.resources.LoopResources.create("my-http", 1, true)) }
+    }
+    return { builder -> builder.loopResources(reactor.ipc.netty.resources.LoopResources.create("my-http", 1, true)) }
+  }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -132,7 +132,9 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       if (name.startsWith("org.springframework.core.")) {
         if (name.startsWith("org.springframework.core.task.")
             || name.equals("org.springframework.core.DecoratingClassLoader")
-            || name.equals("org.springframework.core.OverridingClassLoader")) {
+            || name.equals("org.springframework.core.OverridingClassLoader")
+            || name.equals(
+                "org.springframework.core.ReactiveAdapterRegistry$EmptyCompletableFuture")) {
           return false;
         }
         return true;

--- a/smoke-tests/smoke-tests.gradle
+++ b/smoke-tests/smoke-tests.gradle
@@ -1,3 +1,5 @@
+import java.time.Duration
+
 ext {
   // we only need to run the Spock test itself under a single Java version, and the Spock test in
   // turn is parameterized and runs the test using different docker containers that run different
@@ -30,6 +32,8 @@ test {
   inputs.files(tasks.findByPath(':javaagent:shadowJar').outputs.files)
   maxParallelForks = 2
 
+  timeout = Duration.ofMinutes(30)
+  
   doFirst {
     jvmArgs "-Dio.opentelemetry.smoketest.agent.shadowJar.path=${project(':javaagent').tasks.shadowJar.archivePath}"
   }


### PR DESCRIPTION
While I think it's generally a bug, in practice we can't be sure that the pipeline will propagate events we need through to the end because who knows what the user's handlers will be doing. We can be sure that Netty's default handlers do though, so `addAfter` is safer than `addLast`.

Fixes #2098 

This is close, tests pass but I get this mysterious error. @trask do you know the magic?

```
Transformed classes match global libraries ignore matcher: [org.springframework.core.ReactiveAdapterRegistry$EmptyCompletableFuture]
java.lang.AssertionError: Transformed classes match global libraries ignore matcher: [org.springframework.core.ReactiveAdapterRegistry$EmptyCompletableFuture]
	at io.opentelemetry.instrumentation.test.AgentTestRunner.agentCleanup(AgentTestRunner.java:111)
	at org.spockframework.util.ReflectionUtil.invokeMethod(ReflectionUtil.java:200)
	at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:113)
	at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:98)
	at org.spockframework.spring.SpringInterceptor.interceptCleanupSpecMethod(SpringInterceptor.java:82)
	at org.spockframework.runtime.extension.AbstractMethodInterceptor.intercept(AbstractMethodInterceptor.java:39)
	at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:97)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:43)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:82)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:73)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:87)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:53)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:66)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:51)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:87)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:66)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.stop(TestWorker.java:133)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:414)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.base/java.lang.Thread.run(Thread.java:834)
```