### PR TITLE
Hide the context keys in the BaseTracer.

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
@@ -33,12 +33,11 @@ public abstract class BaseTracer {
   // Keeps track of the server span for the current trace.
   // TODO(anuraaga): Should probably be renamed to local root key since it could be a consumer span
   // or other non-server root.
-  public static final ContextKey<Span> CONTEXT_SERVER_SPAN_KEY =
+  private static final ContextKey<Span> CONTEXT_SERVER_SPAN_KEY =
       ContextKey.named("opentelemetry-trace-server-span-key");
 
   // Keeps track of the client span in a subtree corresponding to a client request.
-  // Visible for testing
-  public static final ContextKey<Span> CONTEXT_CLIENT_SPAN_KEY =
+  private final ContextKey<Span> CONTEXT_CLIENT_SPAN_KEY =
       ContextKey.named("opentelemetry-trace-auto-client-span-key");
 
   protected final Tracer tracer;
@@ -65,14 +64,16 @@ public abstract class BaseTracer {
     return tracer.spanBuilder(spanName).setSpanKind(kind).startSpan();
   }
 
-  // TODO (trask) make the key private
   protected final boolean inClientSpan(Context parentContext) {
     return parentContext.get(CONTEXT_CLIENT_SPAN_KEY) != null;
   }
 
-  // TODO (trask) make the key private
   protected final Context withClientSpan(Context parentContext, Span span) {
     return parentContext.with(span).with(CONTEXT_CLIENT_SPAN_KEY, span);
+  }
+
+  protected final Context withServerSpan(Context parentContext, Span span) {
+    return parentContext.with(span).with(CONTEXT_SERVER_SPAN_KEY, span);
   }
 
   public Scope startScope(Span span) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
@@ -37,7 +37,7 @@ public abstract class BaseTracer {
       ContextKey.named("opentelemetry-trace-server-span-key");
 
   // Keeps track of the client span in a subtree corresponding to a client request.
-  private final ContextKey<Span> CONTEXT_CLIENT_SPAN_KEY =
+  private static final ContextKey<Span> CONTEXT_CLIENT_SPAN_KEY =
       ContextKey.named("opentelemetry-trace-auto-client-span-key");
 
   protected final Tracer tracer;

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
@@ -28,7 +28,7 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
   }
 
   public boolean shouldStartSpan(Context parentContext) {
-    return parentContext.get(CONTEXT_CLIENT_SPAN_KEY) == null;
+    return !inClientSpan(parentContext);
   }
 
   public Context startSpan(Context parentContext, CONNECTION connection, QUERY query) {
@@ -48,17 +48,12 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
     }
     onStatement(span, normalizedQuery);
 
-    return parentContext.with(span).with(CONTEXT_CLIENT_SPAN_KEY, span);
+    return withClientSpan(parentContext, span);
   }
 
   @Override
   public Span getCurrentSpan() {
     return Span.current();
-  }
-
-  public Span getClientSpan() {
-    Context context = Context.current();
-    return context.get(CONTEXT_CLIENT_SPAN_KEY);
   }
 
   public void end(Context context) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
@@ -81,7 +81,7 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
     onRequest(span, request);
     onConnectionAndRequest(span, connection, request);
 
-    Context context = parentContext.with(CONTEXT_SERVER_SPAN_KEY, span).with(span);
+    Context context = withServerSpan(parentContext, span);
     attachServerContext(context, storage);
 
     return context;
@@ -137,7 +137,7 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
 
   public Span getServerSpan(STORAGE storage) {
     Context attachedContext = getServerContext(storage);
-    return attachedContext == null ? null : attachedContext.get(CONTEXT_SERVER_SPAN_KEY);
+    return attachedContext == null ? null : getCurrentServerSpan(attachedContext);
   }
 
   /**

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/HttpSpanDecorator.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/HttpSpanDecorator.java
@@ -87,7 +87,7 @@ class HttpSpanDecorator extends BaseSpanDecorator {
 
     span.setAttribute(SemanticAttributes.HTTP_METHOD, getHttpMethod(exchange, endpoint));
 
-    Span serverSpan = Context.current().get(BaseTracer.CONTEXT_SERVER_SPAN_KEY);
+    Span serverSpan = BaseTracer.getCurrentServerSpan();
     if (shouldUpdateServerSpanName(serverSpan, camelDirection)) {
       updateServerSpanName(serverSpan, exchange, endpoint);
     }

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/HttpSpanDecorator.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/HttpSpanDecorator.java
@@ -24,7 +24,6 @@
 package io.opentelemetry.javaagent.instrumentation.apachecamel.decorators;
 
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.javaagent.instrumentation.apachecamel.CamelDirection;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientTracer.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientTracer.java
@@ -39,7 +39,7 @@ public class ApacheHttpAsyncClientTracer
             .setSpanKind(CLIENT)
             .setParent(parentContext)
             .startSpan();
-    return parentContext.with(span).with(CONTEXT_CLIENT_SPAN_KEY, span);
+    return withClientSpan(parentContext, span);
   }
 
   @Override

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
@@ -159,9 +159,8 @@ public class AwsLambdaTracer extends BaseTracer {
   /** Creates new scoped context with the given span. */
   @Override
   public Scope startScope(Span span) {
-    // TODO we could do this in one go, but TracingContextUtils.CONTEXT_SPAN_KEY is private
     io.opentelemetry.context.Context newContext =
-        io.opentelemetry.context.Context.current().with(CONTEXT_SERVER_SPAN_KEY, span).with(span);
+        withServerSpan(io.opentelemetry.context.Context.current(), span);
     return newContext.makeCurrent();
   }
 

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientTracer.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientTracer.java
@@ -37,7 +37,7 @@ public class KubernetesClientTracer extends HttpClientTracer<Request, Request, R
             .setAttribute("namespace", digest.getResourceMeta().getNamespace())
             .setAttribute("name", digest.getResourceMeta().getName())
             .startSpan();
-    Context context = parentContext.with(span).with(CONTEXT_CLIENT_SPAN_KEY, span);
+    Context context = withClientSpan(parentContext, span);
     GlobalOpenTelemetry.getPropagators()
         .getTextMapPropagator()
         .inject(context, request, getSetter());

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanTracer.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanTracer.java
@@ -31,8 +31,7 @@ public class WithSpanTracer extends BaseTracer {
       // don't create a nested SERVER span
       return false;
     }
-    if (kind == io.opentelemetry.api.trace.Span.Kind.CLIENT
-        && context.get(CONTEXT_CLIENT_SPAN_KEY) != null) {
+    if (kind == io.opentelemetry.api.trace.Span.Kind.CLIENT && inClientSpan(context)) {
       // don't create a nested CLIENT span
       return false;
     }
@@ -47,10 +46,10 @@ public class WithSpanTracer extends BaseTracer {
     io.opentelemetry.api.trace.Span span =
         startSpan(spanNameForMethodWithAnnotation(applicationAnnotation, method), kind);
     if (kind == io.opentelemetry.api.trace.Span.Kind.SERVER) {
-      context = context.with(CONTEXT_SERVER_SPAN_KEY, span);
+      return withServerSpan(context, span);
     }
     if (kind == io.opentelemetry.api.trace.Span.Kind.CLIENT) {
-      context = context.with(CONTEXT_CLIENT_SPAN_KEY, span);
+      return withClientSpan(context, span);
     }
     return context.with(span);
   }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/HandlerAdapterAdvice.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/HandlerAdapterAdvice.java
@@ -52,7 +52,8 @@ public class HandlerAdapterAdvice {
     }
 
     if (context != null) {
-      Span serverSpan = BaseTracer.getCurrentServerSpan(context);;
+      Span serverSpan = BaseTracer.getCurrentServerSpan(context);
+      ;
       PathPattern bestPattern =
           exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
       if (serverSpan != null && bestPattern != null) {

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/HandlerAdapterAdvice.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/HandlerAdapterAdvice.java
@@ -52,7 +52,7 @@ public class HandlerAdapterAdvice {
     }
 
     if (context != null) {
-      Span serverSpan = context.get(BaseTracer.CONTEXT_SERVER_SPAN_KEY);
+      Span serverSpan = BaseTracer.getCurrentServerSpan(context);;
       PathPattern bestPattern =
           exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
       if (serverSpan != null && bestPattern != null) {

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/HandlerAdapterAdvice.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/HandlerAdapterAdvice.java
@@ -53,7 +53,7 @@ public class HandlerAdapterAdvice {
 
     if (context != null) {
       Span serverSpan = BaseTracer.getCurrentServerSpan(context);
-      ;
+
       PathPattern bestPattern =
           exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
       if (serverSpan != null && bestPattern != null) {

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/RouteOnSuccessOrError.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/RouteOnSuccessOrError.java
@@ -43,7 +43,7 @@ public class RouteOnSuccessOrError implements BiConsumer<HandlerFunction<?>, Thr
             span.setAttribute("spring-webflux.request.predicate", predicateString);
           }
 
-          Span serverSpan = context.get(BaseTracer.CONTEXT_SERVER_SPAN_KEY);
+          Span serverSpan = BaseTracer.getCurrentServerSpan(context);
           if (serverSpan != null) {
             serverSpan.updateName(ServletContextPath.prepend(context, parseRoute(predicateString)));
           }

--- a/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioTracer.java
+++ b/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioTracer.java
@@ -29,7 +29,7 @@ public class TwilioTracer extends BaseTracer {
   }
 
   public boolean shouldStartSpan(Context parentContext) {
-    return parentContext.get(CONTEXT_CLIENT_SPAN_KEY) == null;
+    return !inClientSpan(parentContext);
   }
 
   public Context startSpan(Context parentContext, Object serviceExecutor, String methodName) {
@@ -39,7 +39,7 @@ public class TwilioTracer extends BaseTracer {
             .setSpanKind(CLIENT)
             .setParent(parentContext)
             .startSpan();
-    return parentContext.with(span).with(CONTEXT_CLIENT_SPAN_KEY, span);
+    return withClientSpan(parentContext, span);
   }
 
   /** Decorate trace based on service execution metadata. */


### PR DESCRIPTION
And, provide the appropriate methods to get access.