### PR TITLE
Fix warning on agent startup

### DIFF
--- a/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodInstrumentationModule.java
+++ b/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodInstrumentationModule.java
@@ -56,7 +56,9 @@ public class MethodInstrumentationModule extends InstrumentationModule {
   // generate any TypeInstrumentation for muzzle to analyze
   @Override
   protected String[] additionalHelperClassNames() {
-    return new String[] {"io.opentelemetry.javaagent.instrumentation.methods.MethodTracer"};
+    return typeInstrumentations.isEmpty()
+        ? new String[0]
+        : new String[] {"io.opentelemetry.javaagent.instrumentation.methods.MethodTracer"};
   }
 
   @Override


### PR DESCRIPTION
On startup agent currently emits the following warning
```
[opentelemetry.auto.trace 2021-01-25 11:49:12:313 +0200] [main] WARN io.opentelemetry.javaagent.tooling.InstrumentationModule - Helper classes and resources won't be injected if no types are instrumented: methods
```