### PR TITLE
Publish agent-for-testing and testing-common

### DIFF
--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -55,7 +55,6 @@ afterEvaluate {
     testImplementation project(':testing-common')
     testAnnotationProcessor deps.autoservice
     testCompileOnly deps.autoservice
-    testImplementation project(':utils:test-utils')
 
     testImplementation deps.testcontainers
 

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -7,7 +7,10 @@
 
   <Match>
     <!-- forced GC only used in testing -->
-    <Class name="io.opentelemetry.instrumentation.util.gc.GcUtils"/>
+    <Or>
+      <Class name="io.opentelemetry.instrumentation.test.utils.GcUtils"/>
+      <Class name="io.opentelemetry.javaagent.util.GcUtils"/>
+    </Or>
     <Bug pattern="DM_GC"/>
   </Match>
 

--- a/instrumentation/classloaders/javaagent/src/test/groovy/ResourceInjectionTest.groovy
+++ b/instrumentation/classloaders/javaagent/src/test/groovy/ResourceInjectionTest.groovy
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.util.gc.GcUtils.awaitGc
+import static io.opentelemetry.instrumentation.test.utils.GcUtils.awaitGc
 
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import io.opentelemetry.javaagent.testing.common.HelperInjectorAccess

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/test/HelperInjectionTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/test/HelperInjectionTest.groovy
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.test
 
 import static io.opentelemetry.instrumentation.test.utils.ClasspathUtils.isClassLoaded
-import static io.opentelemetry.instrumentation.util.gc.GcUtils.awaitGc
+import static io.opentelemetry.instrumentation.test.utils.GcUtils.awaitGc
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.ClassLoaderMatcher.BOOTSTRAP_CLASSLOADER
 
 import io.opentelemetry.javaagent.tooling.AgentInstaller

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/PeriodicSchedulingTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/PeriodicSchedulingTest.groovy
@@ -7,7 +7,7 @@ package io.opentelemetry.javaagent.tooling
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
-import io.opentelemetry.instrumentation.util.gc.GcUtils
+import io.opentelemetry.instrumentation.test.utils.GcUtils
 import java.lang.ref.WeakReference
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/WeakConcurrentSupplierTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/WeakConcurrentSupplierTest.groovy
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.tooling
 
-import io.opentelemetry.instrumentation.util.gc.GcUtils
+import io.opentelemetry.instrumentation.test.utils.GcUtils
 import io.opentelemetry.javaagent.instrumentation.api.WeakMap
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit

--- a/javaagent/javaagent.gradle
+++ b/javaagent/javaagent.gradle
@@ -96,7 +96,6 @@ dependencies {
   testCompileOnly project(':javaagent-bootstrap')
   testCompileOnly project(':javaagent-api')
 
-  testImplementation project(':utils:test-utils')
   testImplementation deps.guava
 
   testImplementation 'io.opentracing.contrib.dropwizard:dropwizard-opentracing:0.2.2'

--- a/javaagent/src/test/groovy/io/opentelemetry/javaagent/classloading/ClassLoadingTest.groovy
+++ b/javaagent/src/test/groovy/io/opentelemetry/javaagent/classloading/ClassLoadingTest.groovy
@@ -7,9 +7,9 @@ package io.opentelemetry.javaagent.classloading
 
 import static io.opentelemetry.javaagent.IntegrationTestUtils.createJarWithClasses
 
-import io.opentelemetry.instrumentation.util.gc.GcUtils
 import io.opentelemetry.javaagent.ClassToInstrument
 import io.opentelemetry.javaagent.ClassToInstrumentChild
+import io.opentelemetry.javaagent.util.GcUtils
 import java.lang.ref.WeakReference
 import spock.lang.Specification
 import spock.lang.Timeout

--- a/javaagent/src/test/java/io/opentelemetry/javaagent/util/GcUtils.java
+++ b/javaagent/src/test/java/io/opentelemetry/javaagent/util/GcUtils.java
@@ -3,19 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.util.gc;
+package io.opentelemetry.javaagent.util;
 
 import java.lang.ref.WeakReference;
 
-public abstract class GcUtils {
-
-  public static void awaitGc() throws InterruptedException {
-    Object obj = new Object();
-    WeakReference<Object> ref = new WeakReference<>(obj);
-    obj = null;
-    awaitGc(ref);
-  }
-
+public final class GcUtils {
   public static void awaitGc(WeakReference<?> ref) throws InterruptedException {
     while (ref.get() != null) {
       if (Thread.interrupted()) {
@@ -25,4 +17,6 @@ public abstract class GcUtils {
       System.runFinalization();
     }
   }
+
+  private GcUtils() {}
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -49,7 +49,6 @@ include ':testing:agent-for-testing'
 include ':testing-common'
 include ':testing-common:integration-tests'
 include ':testing-common:library-for-integration-tests'
-include ':utils:test-utils'
 
 // smoke tests
 include ':smoke-tests'

--- a/testing-common/integration-tests/integration-tests.gradle
+++ b/testing-common/integration-tests/integration-tests.gradle
@@ -9,6 +9,9 @@ dependencies {
   testCompileOnly project(':javaagent-api')
   testCompileOnly project(':javaagent-tooling')
 
+  testImplementation deps.bytebuddy
+  testImplementation deps.bytebuddyagent
+
   testImplementation deps.guava
   testImplementation deps.opentelemetryExtAnnotations
 

--- a/testing-common/integration-tests/src/test/groovy/context/FieldBackedProviderTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/context/FieldBackedProviderTest.groovy
@@ -7,7 +7,7 @@ package context
 
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import io.opentelemetry.instrumentation.test.utils.ClasspathUtils
-import io.opentelemetry.instrumentation.util.gc.GcUtils
+import io.opentelemetry.instrumentation.test.utils.GcUtils
 import java.lang.instrument.ClassDefinition
 import java.lang.ref.WeakReference
 import java.lang.reflect.Field

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/GcUtils.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/GcUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.test.utils;
+
+import java.lang.ref.WeakReference;
+
+public final class GcUtils {
+
+  public static void awaitGc() throws InterruptedException {
+    Object obj = new Object();
+    WeakReference<Object> ref = new WeakReference<>(obj);
+    obj = null;
+    awaitGc(ref);
+  }
+
+  public static void awaitGc(WeakReference<?> ref) throws InterruptedException {
+    while (ref.get() != null) {
+      if (Thread.interrupted()) {
+        throw new InterruptedException();
+      }
+      System.gc();
+      System.runFinalization();
+    }
+  }
+
+  private GcUtils() {}
+}

--- a/testing-common/src/test/java/muzzle/MuzzleWeakReferenceTest.java
+++ b/testing-common/src/test/java/muzzle/MuzzleWeakReferenceTest.java
@@ -5,7 +5,7 @@
 
 package muzzle;
 
-import io.opentelemetry.instrumentation.util.gc.GcUtils;
+import io.opentelemetry.instrumentation.test.utils.GcUtils;
 import io.opentelemetry.javaagent.tooling.muzzle.Reference;
 import io.opentelemetry.javaagent.tooling.muzzle.collector.ReferenceCollector;
 import io.opentelemetry.javaagent.tooling.muzzle.matcher.ReferenceMatcher;

--- a/testing-common/testing-common.gradle
+++ b/testing-common/testing-common.gradle
@@ -1,6 +1,11 @@
+description = 'OpenTelemetry Javaagent testing commons'
+group = 'io.opentelemetry.javaagent'
+
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/publish.gradle"
 
 dependencies {
+  api deps.groovy
   api deps.spock
 
   api deps.opentelemetryApi
@@ -24,12 +29,8 @@ dependencies {
   //TODO replace with Servlet API?
   implementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '8.0.0.v20110901'
 
-  api project(':utils:test-utils')
-
   annotationProcessor deps.autoservice
   compileOnly deps.autoservice
-
-  api deps.groovy
 
   testImplementation project(':instrumentation-api')
   testImplementation project(':javaagent-api')

--- a/testing/agent-for-testing/agent-for-testing.gradle
+++ b/testing/agent-for-testing/agent-for-testing.gradle
@@ -2,7 +2,11 @@ plugins {
   id "com.github.johnrengelman.shadow"
 }
 
+description = 'OpenTelemetry Javaagent for testing'
+group = 'io.opentelemetry.javaagent'
+
 apply from: "$rootDir/gradle/java.gradle"
+apply from: "$rootDir/gradle/publish.gradle"
 
 jar {
   manifest {

--- a/utils/test-utils/test-utils.gradle
+++ b/utils/test-utils/test-utils.gradle
@@ -1,9 +1,0 @@
-apply from: "$rootDir/gradle/java.gradle"
-
-dependencies {
-  api deps.groovy
-  api deps.spock
-
-  api deps.bytebuddy
-  api deps.bytebuddyagent
-}


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1644. There's Groovy/Spock -> Java refactoring left, but it's better to leave that for another PR (or a series of them).

Published `agent-for-testing` (which includes `agent-exporter`) and `testing-common`.
I've removed `test-utils` module because it only contained one small class -- less artifacts to publish.