### PR TITLE
testing-common refactoring: replace direct AgentTestRunner usage with…

### DIFF
--- a/docs/contributing/writing-instrumentation.md
+++ b/docs/contributing/writing-instrumentation.md
@@ -91,8 +91,8 @@ After writing a test or two, go back to the `library` package, make sure it has 
 `testing` submodule and add a test that inherits from the abstract test class. You should implement
 the method to initialize the client using the library's mechanism to register interceptors, perhaps
 a method like `registerInterceptor` or wrapping the result of a library factory when delegating. The
-test should implement the `InstrumentationTestRunner` trait for common setup logic. If the tests
-pass, library instrumentation is working OK.
+test should implement the `LibraryTestTrait` trait for common setup logic. If the tests pass,
+library instrumentation is working OK.
 
 ## Writing Java agent instrumentation
 
@@ -110,7 +110,7 @@ initializing the instrumentation library, so a user doesn't have to.
 With that written, let's add tests for the agent instrumentation. We basically want to ensure that
 the instrumentation works without the user knowing about the instrumentation. Add a test that extends
 the base class you wrote earlier, but in this, create a client using none of the APIs in our project,
-only the ones offered by the library. Implement the `AgentTestRunner` trait for common setup logic,
+only the ones offered by the library. Implement the `AgentTestTrait` trait for common setup logic,
 and try running. All the tests should pass for agent instrumentation too.
 
 Note that all the tests inside the `javaagent` module will be run using the shaded `-javaagent`

--- a/instrumentation-core/reactor-3.1/src/test/groovy/io/opentelemetry/instrumentation/reactor/HooksTest.groovy
+++ b/instrumentation-core/reactor-3.1/src/test/groovy/io/opentelemetry/instrumentation/reactor/HooksTest.groovy
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.reactor
 
-import io.opentelemetry.instrumentation.test.InstrumentationTestRunner
+import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import java.util.concurrent.atomic.AtomicReference
 import reactor.core.CoreSubscriber
 import reactor.core.publisher.Mono
 
-class HooksTest extends InstrumentationTestRunner {
+class HooksTest extends LibraryInstrumentationSpecification {
 
   def "can reset out hooks"() {
     setup:

--- a/instrumentation-core/reactor-3.1/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorCoreTest.groovy
+++ b/instrumentation-core/reactor-3.1/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorCoreTest.groovy
@@ -6,9 +6,9 @@
 package io.opentelemetry.instrumentation.reactor
 
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 import io.opentelemetry.api.GlobalOpenTelemetry
-import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.TraceUtils
@@ -19,13 +19,12 @@ import org.reactivestreams.Subscription
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import spock.lang.Shared
+import spock.lang.Unroll
 
+@Unroll
 class ReactorCoreTest extends LibraryInstrumentationSpecification {
 
   public static final String EXCEPTION_MESSAGE = "test exception"
-
-  private static final Tracer testTracer =
-    GlobalOpenTelemetry.getTracer("io.opentelemetry.auto.reactor")
 
   def setupSpec() {
     TracingOperator.registerOnEachOperator()
@@ -50,7 +49,7 @@ class ReactorCoreTest extends LibraryInstrumentationSpecification {
     throw new RuntimeException(EXCEPTION_MESSAGE)
   }
 
-  def "Publisher '#name' test"() {
+  def "Publisher '#paramName' test"() {
     when:
     def result = runUnderTrace(publisherSupplier)
 
@@ -94,7 +93,7 @@ class ReactorCoreTest extends LibraryInstrumentationSpecification {
     }
   }
 
-  def "Publisher error '#name' test"() {
+  def "Publisher error '#paramName' test"() {
     when:
     runUnderTrace(publisherSupplier)
 
@@ -125,7 +124,7 @@ class ReactorCoreTest extends LibraryInstrumentationSpecification {
     "flux"    | { -> Flux.error(new RuntimeException(EXCEPTION_MESSAGE)) }
   }
 
-  def "Publisher step '#name' test"() {
+  def "Publisher step '#paramName' test"() {
     when:
     runUnderTrace(publisherSupplier)
 
@@ -167,7 +166,7 @@ class ReactorCoreTest extends LibraryInstrumentationSpecification {
     }
   }
 
-  def "Publisher '#name' cancel"() {
+  def "Publisher '#paramName' cancel"() {
     when:
     cancelUnderTrace(publisherSupplier)
 
@@ -191,7 +190,7 @@ class ReactorCoreTest extends LibraryInstrumentationSpecification {
     "basic flux" | { -> Flux.fromIterable([5, 6]) }
   }
 
-  def "Publisher chain spans have the correct parent for '#name'"() {
+  def "Publisher chain spans have the correct parent for '#paramName'"() {
     when:
     runUnderTrace(publisherSupplier)
 
@@ -228,7 +227,7 @@ class ReactorCoreTest extends LibraryInstrumentationSpecification {
     }
   }
 
-  def "Publisher chain spans have the correct parents from assembly time '#name'"() {
+  def "Publisher chain spans have the correct parents from assembly time '#paramName'"() {
     when:
     runUnderTrace {
       // The "add one" operations in the publisher created here should be children of the publisher-parent
@@ -321,12 +320,12 @@ class ReactorCoreTest extends LibraryInstrumentationSpecification {
   }
 
   static addOneFunc(int i) {
-    testTracer.spanBuilder("add one").startSpan().end()
+    runInternalSpan("add one")
     return i + 1
   }
 
   static addTwoFunc(int i) {
-    testTracer.spanBuilder("add two").startSpan().end()
+    runInternalSpan("add two")
     return i + 2
   }
 }

--- a/instrumentation-core/reactor-3.1/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorCoreTest.groovy
+++ b/instrumentation-core/reactor-3.1/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorCoreTest.groovy
@@ -8,10 +8,9 @@ package io.opentelemetry.instrumentation.reactor
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 
 import io.opentelemetry.api.GlobalOpenTelemetry
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
-import io.opentelemetry.instrumentation.test.InstrumentationTestRunner
+import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.TraceUtils
 import java.time.Duration
 import org.reactivestreams.Publisher
@@ -21,7 +20,7 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import spock.lang.Shared
 
-class ReactorCoreTest extends InstrumentationTestRunner {
+class ReactorCoreTest extends LibraryInstrumentationSpecification {
 
   public static final String EXCEPTION_MESSAGE = "test exception"
 

--- a/instrumentation/akka-actor-2.5/javaagent/src/test/groovy/AkkaActorTest.groovy
+++ b/instrumentation/akka-actor-2.5/javaagent/src/test/groovy/AkkaActorTest.groovy
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 
-class AkkaActorTest extends AgentTestRunner {
+class AkkaActorTest extends AgentInstrumentationSpecification {
 
   // TODO this test doesn't really depend on otel.instrumentation.akka-actor.enabled=true
   //  but setting this property here is needed when running both this test

--- a/instrumentation/akka-actor-2.5/javaagent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/instrumentation/akka-actor-2.5/javaagent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -7,7 +7,7 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTra
 
 import akka.dispatch.forkjoin.ForkJoinPool
 import akka.dispatch.forkjoin.ForkJoinTask
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ArrayBlockingQueue
@@ -22,7 +22,7 @@ import spock.lang.Shared
  * Test executor instrumentation for Akka specific classes.
  * This is to large extent a copy of ExecutorInstrumentationTest.
  */
-class AkkaExecutorInstrumentationTest extends AgentTestRunner {
+class AkkaExecutorInstrumentationTest extends AgentInstrumentationSpecification {
 
   @Shared
   def executeRunnable = { e, c -> e.execute((Runnable) c) }
@@ -58,11 +58,11 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
       }
     }.run()
 
-    TEST_WRITER.waitForTraces(1)
-    List<SpanData> trace = TEST_WRITER.traces[0]
+    testWriter.waitForTraces(1)
+    List<SpanData> trace = testWriter.traces[0]
 
     expect:
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
     trace.size() == 2
     trace.get(0).name == "parent"
     trace.get(1).name == "asyncChild"
@@ -129,10 +129,10 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
       }
     }.run()
 
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
 
     expect:
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
 
     where:
     name              | method         | poolImpl

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/DirectCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/DirectCamelTest.groovy
@@ -7,14 +7,14 @@ package test
 
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.apache.camel.CamelContext
 import org.apache.camel.ProducerTemplate
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import spock.lang.Shared
 
-class DirectCamelTest extends AgentTestRunner {
+class DirectCamelTest extends AgentInstrumentationSpecification {
 
     @Shared
     ConfigurableApplicationContext server

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/MulticastDirectCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/MulticastDirectCamelTest.groovy
@@ -7,14 +7,14 @@ package test
 
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.apache.camel.CamelContext
 import org.apache.camel.ProducerTemplate
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import spock.lang.Shared
 
-class MulticastDirectCamelTest extends AgentTestRunner {
+class MulticastDirectCamelTest extends AgentInstrumentationSpecification {
 
   @Shared
   ConfigurableApplicationContext server

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/RestCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/RestCamelTest.groovy
@@ -9,7 +9,7 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.RetryOnAddressAlreadyInUseTrait
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -19,7 +19,7 @@ import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import spock.lang.Shared
 
-class RestCamelTest extends AgentTestRunner implements RetryOnAddressAlreadyInUseTrait {
+class RestCamelTest extends AgentInstrumentationSpecification implements RetryOnAddressAlreadyInUseTrait {
 
   @Shared
   ConfigurableApplicationContext server

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SingleServiceCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SingleServiceCamelTest.groovy
@@ -7,7 +7,7 @@ package test
 
 import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.RetryOnAddressAlreadyInUseTrait
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -20,7 +20,7 @@ import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import spock.lang.Shared
 
-class SingleServiceCamelTest extends AgentTestRunner implements RetryOnAddressAlreadyInUseTrait {
+class SingleServiceCamelTest extends AgentInstrumentationSpecification implements RetryOnAddressAlreadyInUseTrait {
 
   @Shared
   ConfigurableApplicationContext server

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/SqsCamelTest.groovy
@@ -10,8 +10,8 @@ import static io.opentelemetry.api.trace.Span.Kind.CONSUMER
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.apache.camel.CamelContext
 import org.apache.camel.ProducerTemplate
 import org.elasticmq.rest.sqs.SQSRestServerBuilder
@@ -20,7 +20,7 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap
 import spock.lang.Shared
 
-class SqsCamelTest extends AgentTestRunner {
+class SqsCamelTest extends AgentInstrumentationSpecification {
 
   @Shared
   ConfigurableApplicationContext server

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/TwoServicesWithDirectClientCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/test/TwoServicesWithDirectClientCamelTest.groovy
@@ -9,7 +9,7 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.RetryOnAddressAlreadyInUseTrait
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -21,7 +21,7 @@ import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import spock.lang.Shared
 
-class TwoServicesWithDirectClientCamelTest extends AgentTestRunner implements RetryOnAddressAlreadyInUseTrait {
+class TwoServicesWithDirectClientCamelTest extends AgentInstrumentationSpecification implements RetryOnAddressAlreadyInUseTrait {
 
   @Shared
   int portOne

--- a/instrumentation/armeria-1.3/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaTest.groovy
+++ b/instrumentation/armeria-1.3/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaTest.groovy
@@ -21,11 +21,11 @@ class ArmeriaTest extends AbstractArmeriaTest implements AgentTestTrait {
     return clientBuilder
   }
 
-  def childSetupSpec() {
+  def setupSpec() {
     server.before()
   }
 
-  def childCleanupSpec() {
+  def cleanupSpec() {
     server.after()
   }
 }

--- a/instrumentation/armeria-1.3/library/src/test/groovy/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTest.groovy
+++ b/instrumentation/armeria-1.3/library/src/test/groovy/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTest.groovy
@@ -9,9 +9,9 @@ import com.linecorp.armeria.client.WebClientBuilder
 import com.linecorp.armeria.server.ServerBuilder
 import io.opentelemetry.instrumentation.armeria.v1_3.client.OpenTelemetryClient
 import io.opentelemetry.instrumentation.armeria.v1_3.server.OpenTelemetryService
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
 
-class ArmeriaTest extends AbstractArmeriaTest implements InstrumentationTestTrait {
+class ArmeriaTest extends AbstractArmeriaTest implements LibraryTestTrait {
   @Override
   ServerBuilder configureServer(ServerBuilder sb) {
     return sb.decorator(OpenTelemetryService.newDecorator())
@@ -22,7 +22,7 @@ class ArmeriaTest extends AbstractArmeriaTest implements InstrumentationTestTrai
     return clientBuilder.decorator(OpenTelemetryClient.newDecorator())
   }
 
-  def childSetupSpec() {
+  def setupSpec() {
     server.before()
   }
 

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsHandlerTest.groovy
@@ -8,9 +8,9 @@ package io.opentelemetry.instrumentation.awslambda.v1_0
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
 
-class AwsLambdaSqsHandlerTest extends AbstractAwsLambdaSqsHandlerTest implements InstrumentationTestTrait {
+class AwsLambdaSqsHandlerTest extends AbstractAwsLambdaSqsHandlerTest implements LibraryTestTrait {
 
   static class TestHandler extends TracingSqsEventHandler {
     @Override

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsMessageHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsMessageHandlerTest.groovy
@@ -10,11 +10,10 @@ import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import io.opentelemetry.instrumentation.test.InstrumentationSpecification
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
-class AwsLambdaSqsMessageHandlerTest extends InstrumentationSpecification implements InstrumentationTestTrait {
+class AwsLambdaSqsMessageHandlerTest extends LibraryInstrumentationSpecification {
 
   private static final String AWS_TRACE_HEADER1 = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"
   private static final String AWS_TRACE_HEADER2 = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad9;Sampled=1"

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTest.groovy
@@ -7,9 +7,9 @@ package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
 
-class AwsLambdaTest extends AbstractAwsLambdaRequestHandlerTest implements InstrumentationTestTrait {
+class AwsLambdaTest extends AbstractAwsLambdaRequestHandlerTest implements LibraryTestTrait {
 
   def cleanup() {
     assert forceFlushCalled()

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
@@ -11,15 +11,14 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.opentelemetry.instrumentation.test.InstrumentationSpecification
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.nio.charset.Charset
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Shared
 
-class TracingRequestStreamWrapperPropagationTest extends InstrumentationSpecification implements InstrumentationTestTrait {
+class TracingRequestStreamWrapperPropagationTest extends LibraryInstrumentationSpecification {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
 
@@ -48,7 +47,7 @@ class TracingRequestStreamWrapperPropagationTest extends InstrumentationSpecific
   @Shared
   TracingRequestStreamWrapper wrapper
 
-  def childSetup() {
+  def setup() {
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, "io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestStreamWrapperPropagationTest\$TestRequestHandler::handleRequest")
     TracingRequestStreamWrapper.WRAPPED_LAMBDA = WrappedLambda.fromConfiguration()
     wrapper = new TracingRequestStreamWrapper()

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
@@ -9,15 +9,14 @@ import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler
-import io.opentelemetry.instrumentation.test.InstrumentationSpecification
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.nio.charset.Charset
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Shared
 
-class TracingRequestStreamWrapperTest extends InstrumentationSpecification implements InstrumentationTestTrait {
+class TracingRequestStreamWrapperTest extends LibraryInstrumentationSpecification {
 
   @Rule
   public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
@@ -43,7 +42,7 @@ class TracingRequestStreamWrapperTest extends InstrumentationSpecification imple
   @Shared
   TracingRequestStreamWrapper wrapper
 
-  def childSetup() {
+  def setup() {
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, "io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestStreamWrapperTest\$TestRequestHandler::handleRequest")
     TracingRequestStreamWrapper.WRAPPED_LAMBDA = WrappedLambda.fromConfiguration()
     wrapper = new TracingRequestStreamWrapper()

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
@@ -6,13 +6,12 @@
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import com.amazonaws.services.lambda.runtime.Context
-import io.opentelemetry.instrumentation.test.InstrumentationSpecification
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Shared
 
-class TracingRequestWrapperTestBase extends InstrumentationSpecification implements InstrumentationTestTrait {
+class TracingRequestWrapperTestBase extends LibraryInstrumentationSpecification {
 
   @Rule
   public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
@@ -23,7 +22,7 @@ class TracingRequestWrapperTestBase extends InstrumentationSpecification impleme
   @Shared
   Context context
 
-  def childSetupSpec() {
+  def setup() {
     context = Mock(Context)
     context.getFunctionName() >> "my_function"
     context.getAwsRequestId() >> "1-22-333"

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/Aws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/Aws1ClientTest.groovy
@@ -39,13 +39,13 @@ import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import com.amazonaws.services.sqs.model.CreateQueueRequest
 import com.amazonaws.services.sqs.model.SendMessageRequest
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import java.util.concurrent.atomic.AtomicReference
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
-class Aws1ClientTest extends AgentTestRunner {
+class Aws1ClientTest extends AgentInstrumentationSpecification {
 
   private static final CREDENTIALS_PROVIDER_CHAIN = new AWSCredentialsProviderChain(
     new EnvironmentVariableCredentialsProvider(),
@@ -164,18 +164,18 @@ class Aws1ClientTest extends AgentTestRunner {
     server.lastRequest.headers.get("traceparent") == null
 
     where:
-    service      | operation         | method | path                  | handlerCount | client                                                                                                                                             | call                                                                            | additionalAttributes              | body
-    "S3"         | "CreateBucket"    | "PUT"  | "/testbucket/"        | 1            | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.createBucket("testbucket") }                                 | ["aws.bucket.name": "testbucket"] | ""
-    "S3"         | "GetObject"       | "GET"  | "/someBucket/someKey" | 1            | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.getObject("someBucket", "someKey") }                         | ["aws.bucket.name": "someBucket"] | ""
-    "DynamoDBv2" | "CreateTable"     | "POST" | "/"                   | 1            | AmazonDynamoDBClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                            | { c -> c.createTable(new CreateTableRequest("sometable", null)) }               | ["aws.table.name": "sometable"]   | ""
-    "Kinesis"    | "DeleteStream"    | "POST" | "/"                   | 1            | AmazonKinesisClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                             | { c -> c.deleteStream(new DeleteStreamRequest().withStreamName("somestream")) } | ["aws.stream.name": "somestream"] | ""
-    "SQS"        | "CreateQueue"     | "POST" | "/"                   | 4            | AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.createQueue(new CreateQueueRequest("somequeue")) }                     | ["aws.queue.name": "somequeue"]   | """
+    service      | operation           | method | path                  | handlerCount                                   | client                                                                                                                                             | call                                                                            | additionalAttributes              | body
+    "S3"         | "CreateBucket"      | "PUT"  | "/testbucket/"        | 1                                              | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.createBucket("testbucket") }                                 | ["aws.bucket.name": "testbucket"] | ""
+    "S3"         | "GetObject"         | "GET"  | "/someBucket/someKey" | 1                                              | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true).withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.getObject("someBucket", "someKey") }                         | ["aws.bucket.name": "someBucket"] | ""
+    "DynamoDBv2" | "CreateTable"       | "POST" | "/"                   | 1                                              | AmazonDynamoDBClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                            | { c -> c.createTable(new CreateTableRequest("sometable", null)) }               | ["aws.table.name": "sometable"]   | ""
+    "Kinesis"    | "DeleteStream"      | "POST" | "/"                   | 1                                              | AmazonKinesisClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                             | { c -> c.deleteStream(new DeleteStreamRequest().withStreamName("somestream")) } | ["aws.stream.name": "somestream"] | ""
+    "SQS"        | "CreateQueue"       | "POST" | "/"                   | 4                                              | AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.createQueue(new CreateQueueRequest("somequeue")) }                     | ["aws.queue.name": "somequeue"]   | """
         <CreateQueueResponse>
             <CreateQueueResult><QueueUrl>https://queue.amazonaws.com/123456789012/MyQueue</QueueUrl></CreateQueueResult>
             <ResponseMetadata><RequestId>7a62c49f-347e-4fc4-9331-6e8e7a96aa73</RequestId></ResponseMetadata>
         </CreateQueueResponse>
       """
-    "SQS"        | "SendMessage"     | "POST" | "/someurl"            | 4            | AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.sendMessage(new SendMessageRequest("someurl", "")) }                   | ["aws.queue.url": "someurl"]      | """
+    "SQS"        | "SendMessage"       | "POST" | "/someurl"            | 4                                              | AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { c -> c.sendMessage(new SendMessageRequest("someurl", "")) }                   | ["aws.queue.url": "someurl"]      | """
         <SendMessageResponse>
             <SendMessageResult>
                 <MD5OfMessageBody>d41d8cd98f00b204e9800998ecf8427e</MD5OfMessageBody>
@@ -185,14 +185,14 @@ class Aws1ClientTest extends AgentTestRunner {
             <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId></ResponseMetadata>
         </SendMessageResponse>
       """
-    "EC2"        | "AllocateAddress" | "POST" | "/"                   | 4            | AmazonEC2ClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { client -> client.allocateAddress() }                                          | [:]                               | """
+    "EC2"        | "AllocateAddress"   | "POST" | "/"                   | 4                                              | AmazonEC2ClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { client -> client.allocateAddress() }                                          | [:]                               | """
         <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
            <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
            <publicIp>192.0.2.1</publicIp>
            <domain>standard</domain>
         </AllocateAddressResponse>
       """
-    "RDS" | "DeleteOptionGroup" | "POST" | "/" | (Boolean.getBoolean("testLatestDeps") ? 6 : 5) | AmazonRDSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build() | { client -> client.deleteOptionGroup(new DeleteOptionGroupRequest()) } | [:] | """
+    "RDS"        | "DeleteOptionGroup" | "POST" | "/"                   | (Boolean.getBoolean("testLatestDeps") ? 6 : 5) | AmazonRDSClientBuilder.standard().withEndpointConfiguration(endpoint).withCredentials(credentialsProvider).build()                                 | { client -> client.deleteOptionGroup(new DeleteOptionGroupRequest()) }          | [:]                               | """
         <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
           <ResponseMetadata>
             <RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId>

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -25,13 +25,13 @@ import com.amazonaws.services.rds.model.DeleteOptionGroupRequest
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.S3ClientOptions
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import java.util.concurrent.atomic.AtomicReference
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
-class Aws0ClientTest extends AgentTestRunner {
+class Aws0ClientTest extends AgentInstrumentationSpecification {
 
   private static final CREDENTIALS_PROVIDER_CHAIN = new AWSCredentialsProviderChain(
     new EnvironmentVariableCredentialsProvider(),

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/Aws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/Aws2ClientTest.groovy
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2
 
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
 import software.amazon.awssdk.core.client.builder.SdkClientBuilder
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 
-class Aws2ClientTest extends AbstractAws2ClientTest implements InstrumentationTestTrait {
+class Aws2ClientTest extends AbstractAws2ClientTest implements LibraryTestTrait {
   @Override
   void configureSdkClient(SdkClientBuilder builder) {
     builder.overrideConfiguration(ClientOverrideConfiguration.builder()

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/groovy/CassandraClientTest.groovy
@@ -9,10 +9,10 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTra
 
 import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.Session
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
@@ -22,7 +22,7 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
 
-class CassandraClientTest extends AgentTestRunner {
+class CassandraClientTest extends AgentInstrumentationSpecification {
   private static final Logger log = LoggerFactory.getLogger(CassandraClientTest)
 
   @Shared

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/test/groovy/CassandraClientTest.groovy
@@ -11,10 +11,10 @@ import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -22,7 +22,7 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
 
-class CassandraClientTest extends AgentTestRunner {
+class CassandraClientTest extends AgentInstrumentationSpecification {
   private static final Logger log = LoggerFactory.getLogger(CassandraClientTest)
 
   @Shared

--- a/instrumentation/cdi-testing/src/test/groovy/CDIContainerTest.groovy
+++ b/instrumentation/cdi-testing/src/test/groovy/CDIContainerTest.groovy
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.jboss.weld.environment.se.Weld
 import org.jboss.weld.environment.se.WeldContainer
 import org.jboss.weld.environment.se.threading.RunnableDecorator
 
-class CDIContainerTest extends AgentTestRunner {
+class CDIContainerTest extends AgentInstrumentationSpecification {
 
   def "CDI container starts with agent"() {
     given:

--- a/instrumentation/classloaders/javaagent/jboss-testing/src/test/groovy/JBossClassloadingTest.groovy
+++ b/instrumentation/classloaders/javaagent/jboss-testing/src/test/groovy/JBossClassloadingTest.groovy
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.jboss.modules.ModuleFinder
 import org.jboss.modules.ModuleIdentifier
 import org.jboss.modules.ModuleLoadException
 import org.jboss.modules.ModuleLoader
 import org.jboss.modules.ModuleSpec
 
-class JBossClassloadingTest extends AgentTestRunner {
+class JBossClassloadingTest extends AgentInstrumentationSpecification {
   def "delegates to bootstrap class loader for agent classes"() {
     setup:
     def moduleFinders = new ModuleFinder[1]

--- a/instrumentation/classloaders/javaagent/osgi-testing/src/test/groovy/OSGIClassloadingTest.groovy
+++ b/instrumentation/classloaders/javaagent/osgi-testing/src/test/groovy/OSGIClassloadingTest.groovy
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.apache.felix.framework.BundleWiringImpl
 import org.eclipse.osgi.internal.debug.Debug
 import org.eclipse.osgi.internal.framework.EquinoxConfiguration
@@ -12,7 +12,7 @@ import org.eclipse.osgi.internal.loader.ModuleClassLoader
 import org.eclipse.osgi.internal.loader.classpath.ClasspathManager
 import org.eclipse.osgi.storage.BundleInfo
 
-class OSGIClassloadingTest extends AgentTestRunner {
+class OSGIClassloadingTest extends AgentInstrumentationSpecification {
   def "OSGI delegates to bootstrap class loader for agent classes"() {
     when:
     def clazz

--- a/instrumentation/classloaders/javaagent/src/test/groovy/ClassLoadingTest.groovy
+++ b/instrumentation/classloaders/javaagent/src/test/groovy/ClassLoadingTest.groovy
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 
-class ClassLoadingTest extends AgentTestRunner {
+class ClassLoadingTest extends AgentInstrumentationSpecification {
   def "delegates to bootstrap class loader for agent classes"() {
     setup:
     def classLoader = new NonDelegatingURLClassLoader()

--- a/instrumentation/classloaders/javaagent/src/test/groovy/ResourceInjectionTest.groovy
+++ b/instrumentation/classloaders/javaagent/src/test/groovy/ResourceInjectionTest.groovy
@@ -5,12 +5,12 @@
 
 import static io.opentelemetry.instrumentation.test.utils.GcUtils.awaitGc
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.javaagent.testing.common.HelperInjectorAccess
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicReference
 
-class ResourceInjectionTest extends AgentTestRunner {
+class ResourceInjectionTest extends AgentInstrumentationSpecification {
 
   def "resources injected to non-delegating classloader"() {
     setup:

--- a/instrumentation/classloaders/javaagent/tomcat-testing/src/test/groovy/TomcatClassloadingTest.groovy
+++ b/instrumentation/classloaders/javaagent/tomcat-testing/src/test/groovy/TomcatClassloadingTest.groovy
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.apache.catalina.WebResource
 import org.apache.catalina.WebResourceRoot
 import org.apache.catalina.loader.ParallelWebappClassLoader
 
-class TomcatClassloadingTest extends AgentTestRunner {
+class TomcatClassloadingTest extends AgentInstrumentationSpecification {
 
   WebResourceRoot resources = Mock(WebResourceRoot) {
     getResource(_) >> Mock(WebResource)

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringRepositoryTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringRepositoryTest.groovy
@@ -103,9 +103,9 @@ abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouchbaseTe
     }
 
     cleanup:
-    TEST_WRITER.clear()
+    testWriter.clear()
     repo.deleteAll()
-    TEST_WRITER.waitForTraces(2)
+    testWriter.waitForTraces(2)
   }
 
   def "test save and retrieve"() {
@@ -130,9 +130,9 @@ abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouchbaseTe
     }
 
     cleanup:
-    TEST_WRITER.clear()
+    testWriter.clear()
     repo.deleteAll()
-    TEST_WRITER.waitForTraces(2)
+    testWriter.waitForTraces(2)
   }
 
   def "test save and update"() {
@@ -157,9 +157,9 @@ abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouchbaseTe
     }
 
     cleanup:
-    TEST_WRITER.clear()
+    testWriter.clear()
     repo.deleteAll()
-    TEST_WRITER.waitForTraces(2)
+    testWriter.waitForTraces(2)
   }
 
   def "save and delete"() {

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringTemplateTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringTemplateTest.groovy
@@ -111,7 +111,7 @@ class AbstractCouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
     }
 
     when:
-    TEST_WRITER.clear()
+    testWriter.clear()
     def result = template.findById("1", Doc)
 
     then:

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/util/AbstractCouchbaseTest.groovy
@@ -17,15 +17,15 @@ import com.couchbase.mock.Bucket
 import com.couchbase.mock.BucketConfiguration
 import com.couchbase.mock.CouchbaseMock
 import com.couchbase.mock.http.query.QueryServer
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.TimeUnit
 import spock.lang.Shared
 
-abstract class AbstractCouchbaseTest extends AgentTestRunner {
+abstract class AbstractCouchbaseTest extends AgentInstrumentationSpecification {
 
   static final USERNAME = "Administrator"
   static final PASSWORD = "password"

--- a/instrumentation/dropwizard-views-0.7/javaagent/src/test/groovy/ViewRenderTest.groovy
+++ b/instrumentation/dropwizard-views-0.7/javaagent/src/test/groovy/ViewRenderTest.groovy
@@ -9,10 +9,10 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTra
 import io.dropwizard.views.View
 import io.dropwizard.views.freemarker.FreemarkerViewRenderer
 import io.dropwizard.views.mustache.MustacheViewRenderer
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.nio.charset.StandardCharsets
 
-class ViewRenderTest extends AgentTestRunner {
+class ViewRenderTest extends AgentInstrumentationSpecification {
 
   def "render #template succeeds with span"() {
     setup:

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -6,8 +6,8 @@
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
 import groovy.json.JsonSlurper
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -23,7 +23,7 @@ import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty4Plugin
 import spock.lang.Shared
 
-class Elasticsearch6RestClientTest extends AgentTestRunner {
+class Elasticsearch6RestClientTest extends AgentInstrumentationSpecification {
   @Shared
   TransportAddress httpTransportAddress
   @Shared

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -7,8 +7,8 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 import groovy.json.JsonSlurper
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -25,7 +25,7 @@ import org.elasticsearch.node.internal.InternalSettingsPreparer
 import org.elasticsearch.transport.Netty3Plugin
 import spock.lang.Shared
 
-class Elasticsearch5RestClientTest extends AgentTestRunner {
+class Elasticsearch5RestClientTest extends AgentInstrumentationSpecification {
   @Shared
   TransportAddress httpTransportAddress
   @Shared

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -6,8 +6,8 @@
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
 import groovy.json.JsonSlurper
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -26,7 +26,7 @@ import org.elasticsearch.plugins.Plugin
 import org.elasticsearch.transport.Netty4Plugin
 import spock.lang.Shared
 
-class Elasticsearch6RestClientTest extends AgentTestRunner {
+class Elasticsearch6RestClientTest extends AgentInstrumentationSpecification {
 
   @Shared
   TransportAddress httpTransportAddress

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -6,8 +6,8 @@
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
 import groovy.json.JsonSlurper
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -23,7 +23,7 @@ import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty4Plugin
 import spock.lang.Shared
 
-class Elasticsearch6RestClientTest extends AgentTestRunner {
+class Elasticsearch6RestClientTest extends AgentInstrumentationSpecification {
   @Shared
   TransportAddress httpTransportAddress
   @Shared

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -7,8 +7,8 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -19,7 +19,7 @@ import org.elasticsearch.node.internal.InternalSettingsPreparer
 import org.elasticsearch.transport.Netty3Plugin
 import spock.lang.Shared
 
-class Elasticsearch5NodeClientTest extends AgentTestRunner {
+class Elasticsearch5NodeClientTest extends AgentInstrumentationSpecification {
   public static final long TIMEOUT = 10000 // 10 seconds
 
   @Shared
@@ -52,7 +52,7 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
       // into a top level trace to get exactly one trace in the result.
       testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
     }
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
   }
 
   def cleanupSpec() {
@@ -122,13 +122,13 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER.traces == []
+    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
 
     when:
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -7,8 +7,8 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
@@ -24,7 +24,7 @@ import org.elasticsearch.transport.TransportService
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Shared
 
-class Elasticsearch5TransportClientTest extends AgentTestRunner {
+class Elasticsearch5TransportClientTest extends AgentInstrumentationSpecification {
   public static final long TIMEOUT = 10000 // 10 seconds
 
   @Shared
@@ -68,7 +68,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
       // into a top level trace to get exactly one trace in the result.
       client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
     }
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
   }
 
   def cleanupSpec() {
@@ -141,13 +141,13 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER.traces == []
+    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -7,8 +7,8 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -19,7 +19,7 @@ import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty3Plugin
 import spock.lang.Shared
 
-class Elasticsearch53NodeClientTest extends AgentTestRunner {
+class Elasticsearch53NodeClientTest extends AgentInstrumentationSpecification {
   public static final long TIMEOUT = 10000 // 10 seconds
 
   @Shared
@@ -52,7 +52,7 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
       // into a top level trace to get exactly one trace in the result.
       testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
     }
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
   }
 
   def cleanupSpec() {
@@ -122,13 +122,13 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER.traces == []
+    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
 
     when:
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -7,8 +7,8 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
@@ -24,7 +24,7 @@ import org.elasticsearch.transport.TransportService
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Shared
 
-class Elasticsearch53TransportClientTest extends AgentTestRunner {
+class Elasticsearch53TransportClientTest extends AgentInstrumentationSpecification {
   public static final long TIMEOUT = 10000 // 10 seconds
 
   @Shared
@@ -69,7 +69,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
       // into a top level trace to get exactly one trace in the result.
       client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
     }
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
   }
 
   def cleanupSpec() {
@@ -142,13 +142,13 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER.traces == []
+    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -9,15 +9,15 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
 
-class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
+class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecification {
   // Setting up appContext & repo with @Shared doesn't allow
   // spring-data instrumentation to applied.
   // To change the timing without adding ugly checks everywhere -
@@ -51,12 +51,12 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
 
   def setup() {
     repo.refresh()
-    TEST_WRITER.clear()
+    testWriter.clear()
     runUnderTrace("delete") {
       repo.deleteAll()
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
   }
 
   def "test empty repo"() {
@@ -158,7 +158,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     and:
     repo.findById("1").get() == doc
@@ -189,7 +189,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     doc.data = "other data"
@@ -265,7 +265,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     repo.deleteById("1")

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -9,7 +9,7 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.atomic.AtomicLong
 import org.elasticsearch.action.search.SearchResponse
@@ -29,7 +29,7 @@ import org.springframework.data.elasticsearch.core.query.NativeSearchQuery
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder
 import spock.lang.Shared
 
-class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
+class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecification {
   public static final long TIMEOUT = 10000 // 10 seconds
 
   // Some ES actions are not caused by clients and seem to just happen from time to time.
@@ -68,7 +68,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
       // into a top level trace to get exactly one trace in the result.
       testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
     }
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
 
     template = new ElasticsearchTemplate(testNode.client())
   }
@@ -267,8 +267,8 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
       .withId("b")
       .build())
     template.refresh(indexName)
-    TEST_WRITER.waitForTraces(5)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(5)
+    testWriter.clear()
 
     and:
     def query = new NativeSearchQueryBuilder().withIndices(indexName).build()

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -7,8 +7,8 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -18,7 +18,7 @@ import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty4Plugin
 import spock.lang.Shared
 
-class Elasticsearch6NodeClientTest extends AgentTestRunner {
+class Elasticsearch6NodeClientTest extends AgentInstrumentationSpecification {
   public static final long TIMEOUT = 10000 // 10 seconds
 
   @Shared
@@ -49,7 +49,7 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
       // into a top level trace to get exactly one trace in the result.
       testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
     }
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
   }
 
   def cleanupSpec() {
@@ -119,13 +119,13 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER.traces == []
+    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
 
     expect:
     indexResult.index() == indexName
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -7,8 +7,8 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
@@ -23,7 +23,7 @@ import org.elasticsearch.transport.TransportService
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Shared
 
-class Elasticsearch6TransportClientTest extends AgentTestRunner {
+class Elasticsearch6TransportClientTest extends AgentInstrumentationSpecification {
   public static final long TIMEOUT = 10000 // 10 seconds
 
   @Shared
@@ -64,7 +64,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
       // into a top level trace to get exactly one trace in the result.
       client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
     }
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
   }
 
   def cleanupSpec() {
@@ -137,13 +137,13 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER.traces == []
+    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
 
     expect:
     indexResult.index() == indexName
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()

--- a/instrumentation/executors/javaagent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/instrumentation/executors/javaagent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -5,7 +5,7 @@
 
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.AbstractExecutorService
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import spock.lang.Shared
 
-class ExecutorInstrumentationTest extends AgentTestRunner {
+class ExecutorInstrumentationTest extends AgentInstrumentationSpecification {
 
   @Shared
   def executeRunnable = { e, c -> e.execute((Runnable) c) }
@@ -72,11 +72,11 @@ class ExecutorInstrumentationTest extends AgentTestRunner {
       }
     }.run()
 
-    TEST_WRITER.waitForTraces(1)
-    List<SpanData> trace = TEST_WRITER.traces[0]
+    testWriter.waitForTraces(1)
+    List<SpanData> trace = testWriter.traces[0]
 
     expect:
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
     trace.size() == 2
     trace.get(0).name == "parent"
     trace.get(1).name == "asyncChild"
@@ -153,11 +153,11 @@ class ExecutorInstrumentationTest extends AgentTestRunner {
     child.unblock()
     child.waitForCompletion()
 
-    TEST_WRITER.waitForTraces(1)
-    List<SpanData> trace = TEST_WRITER.traces[0]
+    testWriter.waitForTraces(1)
+    List<SpanData> trace = testWriter.traces[0]
 
     expect:
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
     trace.size() == 2
     trace.get(0).name == "parent"
     trace.get(1).name == "asyncChild"
@@ -216,10 +216,10 @@ class ExecutorInstrumentationTest extends AgentTestRunner {
       }
     }.run()
 
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
 
     expect:
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
 
     where:
     name                | method           | poolImpl

--- a/instrumentation/executors/javaagent/src/test/groovy/ModuleInjectionTest.groovy
+++ b/instrumentation/executors/javaagent/src/test/groovy/ModuleInjectionTest.groovy
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import javax.swing.*
 
 /**
  * This class tests that we correctly add module references when instrumenting
  */
-class ModuleInjectionTest extends AgentTestRunner {
+class ModuleInjectionTest extends AgentInstrumentationSpecification {
   /**
    * There's nothing special about RepaintManager other than
    * it's in a module (java.desktop) that doesn't read the "unnamed module" and it

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.test.annotation.SayTracedHello
 import java.util.concurrent.Callable
 
-class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
+class ConfiguredTraceAnnotationsTest extends AgentInstrumentationSpecification {
 
   def "method with disabled NewRelic annotation should be ignored"() {
     setup:
     SayTracedHello.fromCallableWhenDisabled()
 
     expect:
-    TEST_WRITER.traces == []
+    testWriter.traces == []
   }
 
   def "method with custom annotation should be traced"() {

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/TraceAnnotationsTest.groovy
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.test.annotation.SayTracedHello
 import io.opentracing.contrib.dropwizard.Trace
 import java.util.concurrent.Callable
 
-class TraceAnnotationsTest extends AgentTestRunner {
+class TraceAnnotationsTest extends AgentInstrumentationSpecification {
 
   def "test simple case annotations"() {
     setup:

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/TraceProvidersTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/TraceProvidersTest.groovy
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.test.annotation.SayTracedHello
 
 /**
  * This test verifies that Otel supports various 3rd-party trace annotations
  */
-class TraceProvidersTest extends AgentTestRunner {
+class TraceProvidersTest extends AgentInstrumentationSpecification {
 
   def "should support #provider"(String provider) {
     setup:

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/TracedMethodsExclusionTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/TracedMethodsExclusionTest.groovy
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentracing.contrib.dropwizard.Trace
 
-class TracedMethodsExclusionTest extends AgentTestRunner {
+class TracedMethodsExclusionTest extends AgentInstrumentationSpecification {
 
   static class TestClass {
     //This method is not mentioned in any configuration

--- a/instrumentation/geode-1.4/javaagent/src/test/groovy/PutGetTest.groovy
+++ b/instrumentation/geode-1.4/javaagent/src/test/groovy/PutGetTest.groovy
@@ -7,8 +7,8 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.apache.geode.DataSerializable
 import org.apache.geode.cache.client.ClientCacheFactory
 import org.apache.geode.cache.client.ClientRegionShortcut
@@ -16,7 +16,7 @@ import spock.lang.Shared
 import spock.lang.Unroll
 
 @Unroll
-class PutGetTest extends AgentTestRunner {
+class PutGetTest extends AgentInstrumentationSpecification {
   @Shared
   def cache = new ClientCacheFactory().create()
 
@@ -158,8 +158,8 @@ class PutGetTest extends AgentTestRunner {
 
     region.clear()
     region.put(1, value)
-    TEST_WRITER.waitForTraces(2)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(2)
+    testWriter.clear()
 
     when:
     def results = region.query("SELECT * FROM /test-region p WHERE p.expDate = '10/2020'")

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/GoogleHttpClientAsyncTest.groovy
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/GoogleHttpClientAsyncTest.groovy
@@ -10,7 +10,7 @@ import spock.lang.Timeout
 @Timeout(5)
 class GoogleHttpClientAsyncTest extends AbstractGoogleHttpClientTest {
   def setup() {
-    TEST_WRITER.clear()
+    testWriter.clear()
   }
 
   @Override

--- a/instrumentation/grpc-1.5/library/src/test/groovy/io/opentelemetry/instrumentation/grpc/v1_5/GrpcStreamingTest.groovy
+++ b/instrumentation/grpc-1.5/library/src/test/groovy/io/opentelemetry/instrumentation/grpc/v1_5/GrpcStreamingTest.groovy
@@ -9,9 +9,9 @@ import io.grpc.ManagedChannelBuilder
 import io.grpc.ServerBuilder
 import io.opentelemetry.instrumentation.grpc.v1_5.client.TracingClientInterceptor
 import io.opentelemetry.instrumentation.grpc.v1_5.server.TracingServerInterceptor
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
 
-class GrpcStreamingTest extends AbstractGrpcStreamingTest implements InstrumentationTestTrait {
+class GrpcStreamingTest extends AbstractGrpcStreamingTest implements LibraryTestTrait {
   @Override
   ServerBuilder configureServer(ServerBuilder server) {
     return server.intercept(TracingServerInterceptor.newInterceptor())

--- a/instrumentation/grpc-1.5/library/src/test/groovy/io/opentelemetry/instrumentation/grpc/v1_5/GrpcTest.groovy
+++ b/instrumentation/grpc-1.5/library/src/test/groovy/io/opentelemetry/instrumentation/grpc/v1_5/GrpcTest.groovy
@@ -9,9 +9,9 @@ import io.grpc.ManagedChannelBuilder
 import io.grpc.ServerBuilder
 import io.opentelemetry.instrumentation.grpc.v1_5.client.TracingClientInterceptor
 import io.opentelemetry.instrumentation.grpc.v1_5.server.TracingServerInterceptor
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
 
-class GrpcTest extends AbstractGrpcTest implements InstrumentationTestTrait {
+class GrpcTest extends AbstractGrpcTest implements LibraryTestTrait {
   @Override
   ServerBuilder configureServer(ServerBuilder server) {
     return server.intercept(TracingServerInterceptor.newInterceptor())

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/AbstractHibernateTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/AbstractHibernateTest.groovy
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.hibernate.Session
 import org.hibernate.SessionFactory
 import org.hibernate.cfg.AnnotationConfiguration
 import spock.lang.Shared
 
-abstract class AbstractHibernateTest extends AgentTestRunner {
+abstract class AbstractHibernateTest extends AgentInstrumentationSpecification {
 
   @Shared
   protected SessionFactory sessionFactory

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/AbstractHibernateTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/AbstractHibernateTest.groovy
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.hibernate.Session
 import org.hibernate.SessionFactory
 import org.hibernate.cfg.Configuration
 import spock.lang.Shared
 
-abstract class AbstractHibernateTest extends AgentTestRunner {
+abstract class AbstractHibernateTest extends AgentInstrumentationSpecification {
 
   @Shared
   protected SessionFactory sessionFactory

--- a/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/groovy/ProcedureCallTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/groovy/ProcedureCallTest.groovy
@@ -6,8 +6,8 @@
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.Statement
@@ -19,7 +19,7 @@ import org.hibernate.exception.SQLGrammarException
 import org.hibernate.procedure.ProcedureCall
 import spock.lang.Shared
 
-class ProcedureCallTest extends AgentTestRunner {
+class ProcedureCallTest extends AgentInstrumentationSpecification {
 
 
   @Shared

--- a/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/groovy/SpringJpaTest.groovy
@@ -5,8 +5,8 @@
 
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
 import spring.jpa.Customer
@@ -16,7 +16,7 @@ import spring.jpa.PersistenceConfig
 /**
  * Unfortunately this test verifies that our hibernate instrumentation doesn't currently work with Spring Data Repositories.
  */
-class SpringJpaTest extends AgentTestRunner {
+class SpringJpaTest extends AgentInstrumentationSpecification {
 
   @Shared
   def context = new AnnotationConfigApplicationContext(PersistenceConfig)
@@ -47,7 +47,7 @@ class SpringJpaTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     repo.save(customer)
@@ -56,7 +56,7 @@ class SpringJpaTest extends AgentTestRunner {
     then:
     customer.id != null
     // Behavior changed in new version:
-    def extraTrace = TEST_WRITER.traces.size() == 2
+    def extraTrace = testWriter.traces.size() == 2
     assertTraces(extraTrace ? 2 : 1) {
       if (extraTrace) {
         trace(0, 1) {
@@ -87,7 +87,7 @@ class SpringJpaTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     customer.firstName = "Bill"
@@ -123,7 +123,7 @@ class SpringJpaTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     customer = repo.findByLastName("Anonymous")[0]
@@ -146,7 +146,7 @@ class SpringJpaTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     repo.delete(customer)
@@ -180,6 +180,6 @@ class SpringJpaTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
   }
 }

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/UrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/UrlConnectionTest.groovy
@@ -8,10 +8,10 @@ import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_POR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 
-class UrlConnectionTest extends AgentTestRunner {
+class UrlConnectionTest extends AgentInstrumentationSpecification {
 
   def "trace request with connection failure #scheme"() {
     when:

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
@@ -4,14 +4,15 @@
  */
 
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import com.netflix.hystrix.HystrixObservableCommand
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import rx.Observable
 import rx.schedulers.Schedulers
 
-class HystrixObservableChainTest extends AgentTestRunner {
+class HystrixObservableChainTest extends AgentInstrumentationSpecification {
 
   def "test command #action"() {
     setup:
@@ -19,7 +20,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
     def result = runUnderTrace("parent") {
       def val = new HystrixObservableCommand<String>(asKey("ExampleGroup")) {
         private String tracedMethod() {
-          getTestTracer().spanBuilder("tracedMethod").startSpan().end()
+          runInternalSpan("tracedMethod")
           return "Hello"
         }
 
@@ -37,7 +38,7 @@ class HystrixObservableChainTest extends AgentTestRunner {
         }.flatMap { str ->
         new HystrixObservableCommand<String>(asKey("OtherGroup")) {
           private String anotherTracedMethod() {
-            getTestTracer().spanBuilder("anotherTracedMethod").startSpan().end()
+            runInternalSpan("anotherTracedMethod")
             return "$str!"
           }
 

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
@@ -4,18 +4,19 @@
  */
 
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import com.netflix.hystrix.HystrixObservable
 import com.netflix.hystrix.HystrixObservableCommand
 import com.netflix.hystrix.exception.HystrixRuntimeException
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import rx.Observable
 import rx.schedulers.Schedulers
 
-class HystrixObservableTest extends AgentTestRunner {
+class HystrixObservableTest extends AgentInstrumentationSpecification {
 
   def "test command #action"() {
     setup:
@@ -24,7 +25,7 @@ class HystrixObservableTest extends AgentTestRunner {
     def result = runUnderTrace("parent") {
       def val = operation new HystrixObservableCommand<String>(asKey("ExampleGroup")) {
         private String tracedMethod() {
-          getTestTracer().spanBuilder("tracedMethod").startSpan().end()
+          runInternalSpan("tracedMethod")
           return "Hello!"
         }
 

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
@@ -4,16 +4,17 @@
  */
 
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import com.netflix.hystrix.HystrixCommand
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import spock.lang.Timeout
 
 @Timeout(10)
-class HystrixTest extends AgentTestRunner {
+class HystrixTest extends AgentInstrumentationSpecification {
 
   def "test command #action"() {
     setup:
@@ -24,7 +25,7 @@ class HystrixTest extends AgentTestRunner {
       }
 
       private String tracedMethod() {
-        getTestTracer().spanBuilder("tracedMethod").startSpan().end()
+        runInternalSpan("tracedMethod")
         return "Hello!"
       }
     }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxMultithreadedClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxMultithreadedClientTest.groovy
@@ -5,14 +5,14 @@
 
 import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.httpServer
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import javax.ws.rs.client.Client
 import org.glassfish.jersey.client.JerseyClientBuilder
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
 
-class JaxMultithreadedClientTest extends AgentTestRunner {
+class JaxMultithreadedClientTest extends AgentInstrumentationSpecification {
 
   @AutoCleanup
   @Shared

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.utils.ClassUtils.getClassName
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import javax.ws.rs.DELETE
 import javax.ws.rs.GET
 import javax.ws.rs.HEAD
@@ -14,7 +15,7 @@ import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
 
-class JaxRsAnnotations1InstrumentationTest extends AgentTestRunner {
+class JaxRsAnnotations1InstrumentationTest extends AgentInstrumentationSpecification {
 
   def "instrumentation can be used as root span and resource is set to METHOD PATH"() {
     setup:

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JerseyTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JerseyTest.groovy
@@ -7,11 +7,11 @@ import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
 import io.dropwizard.testing.junit.ResourceTestRule
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.junit.ClassRule
 import spock.lang.Shared
 
-class JerseyTest extends AgentTestRunner {
+class JerseyTest extends AgentInstrumentationSpecification {
 
   @Shared
   @ClassRule

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.utils.ClassUtils.getClassName
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import javax.ws.rs.DELETE
 import javax.ws.rs.GET
 import javax.ws.rs.HEAD
@@ -15,7 +16,7 @@ import javax.ws.rs.PUT
 import javax.ws.rs.Path
 import spock.lang.Unroll
 
-abstract class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
+abstract class JaxRsAnnotationsInstrumentationTest extends AgentInstrumentationSpecification {
 
   def "instrumentation can be used as root span and resource is set to METHOD PATH"() {
     setup:

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsFilterTest.groovy
@@ -6,7 +6,7 @@
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import javax.ws.rs.container.ContainerRequestContext
 import javax.ws.rs.container.ContainerRequestFilter
 import javax.ws.rs.container.PreMatching
@@ -17,7 +17,7 @@ import spock.lang.Shared
 import spock.lang.Unroll
 
 @Unroll
-abstract class JaxRsFilterTest extends AgentTestRunner {
+abstract class JaxRsFilterTest extends AgentInstrumentationSpecification {
 
   @Shared
   SimpleRequestFilter simpleRequestFilter = new SimpleRequestFilter()

--- a/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
+++ b/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
@@ -10,8 +10,8 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTra
 import com.mchange.v2.c3p0.ComboPooledDataSource
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import java.sql.CallableStatement
 import java.sql.Connection
 import java.sql.PreparedStatement
@@ -28,7 +28,7 @@ import spock.lang.Unroll
 import test.TestConnection
 import test.TestDriver
 
-class JdbcInstrumentationTest extends AgentTestRunner {
+class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
 
   @Shared
   def dbName = "jdbcUnitTest"
@@ -526,8 +526,8 @@ class JdbcInstrumentationTest extends AgentTestRunner {
     datasource.getConnection().close()
 
     then:
-    !TEST_WRITER.traces.any { it.any { it.name == "database.connection" } }
-    TEST_WRITER.clear()
+    !testWriter.traces.any { it.any { it.name == "database.connection" } }
+    testWriter.clear()
 
     when:
     runUnderTrace("parent") {

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/test/groovy/JedisClientTest.groovy
@@ -5,14 +5,14 @@
 
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import redis.clients.jedis.Jedis
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
-class JedisClientTest extends AgentTestRunner {
+class JedisClientTest extends AgentInstrumentationSpecification {
 
   @Shared
   int port = PortUtils.randomOpenPort()
@@ -39,7 +39,7 @@ class JedisClientTest extends AgentTestRunner {
 
   def setup() {
     jedis.flushAll()
-    TEST_WRITER.clear()
+    testWriter.clear()
   }
 
   def "set command"() {

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/test/groovy/Jedis30ClientTest.groovy
@@ -5,14 +5,14 @@
 
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import redis.clients.jedis.Jedis
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
-class Jedis30ClientTest extends AgentTestRunner {
+class Jedis30ClientTest extends AgentInstrumentationSpecification {
 
   @Shared
   int port = PortUtils.randomOpenPort()
@@ -39,7 +39,7 @@ class Jedis30ClientTest extends AgentTestRunner {
 
   def setup() {
     jedis.flushAll()
-    TEST_WRITER.clear()
+    testWriter.clear()
   }
 
   def "set command"() {

--- a/instrumentation/jetty-8.0/javaagent/src/test/groovy/JettyContinuationHandlerTest.groovy
+++ b/instrumentation/jetty-8.0/javaagent/src/test/groovy/JettyContinuationHandlerTest.groovy
@@ -48,9 +48,9 @@ abstract class JettyContinuationHandlerTest extends JettyHandlerTest {
 //    final Closure spec) {
 //
 //    // If this is failing, make sure HttpServerTestAdvice is applied correctly.
-//    TEST_WRITER.waitForTraces(size * 3)
-//    // TEST_WRITER is a CopyOnWriteArrayList, which doesn't support remove()
-//    def toRemove = TEST_WRITER.findAll {
+//    testWriter.waitForTraces(size * 3)
+//    // testWriter is a CopyOnWriteArrayList, which doesn't support remove()
+//    def toRemove = testWriter.findAll {
 //      it.size() == 1 && it.get(0).name == "TEST_SPAN"
 //    }
 //    toRemove.each {
@@ -59,7 +59,7 @@ abstract class JettyContinuationHandlerTest extends JettyHandlerTest {
 //      }
 //    }
 //    assert toRemove.size() == size * 2
-//    TEST_WRITER.removeAll(toRemove)
+//    testWriter.removeAll(toRemove)
 //
 //    assertTraces(size, spec)
 //  }

--- a/instrumentation/jetty-8.0/javaagent/src/test/groovy/QueuedThreadPoolTest.groovy
+++ b/instrumentation/jetty-8.0/javaagent/src/test/groovy/QueuedThreadPoolTest.groovy
@@ -6,12 +6,12 @@
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.junit.Assume.assumeTrue
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.javaagent.instrumentation.jetty.JavaLambdaMaker
 import io.opentelemetry.sdk.trace.data.SpanData
 import org.eclipse.jetty.util.thread.QueuedThreadPool
 
-class QueuedThreadPoolTest extends AgentTestRunner {
+class QueuedThreadPoolTest extends AgentInstrumentationSpecification {
 
   def "QueueThreadPool 'dispatch' propagates"() {
     setup:
@@ -37,11 +37,11 @@ class QueuedThreadPoolTest extends AgentTestRunner {
       }
     }.run()
 
-    TEST_WRITER.waitForTraces(1)
-    List<SpanData> trace = TEST_WRITER.traces[0]
+    testWriter.waitForTraces(1)
+    List<SpanData> trace = testWriter.traces[0]
 
     expect:
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
     trace.size() == 2
     trace.get(0).traceId == trace.get(1).traceId
     trace.get(0).name == "parent"
@@ -73,11 +73,11 @@ class QueuedThreadPoolTest extends AgentTestRunner {
     child.unblock()
     child.waitForCompletion()
 
-    TEST_WRITER.waitForTraces(1)
-    List<SpanData> trace = TEST_WRITER.traces[0]
+    testWriter.waitForTraces(1)
+    List<SpanData> trace = testWriter.traces[0]
 
     expect:
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
     trace.size() == 2
     trace.get(0).traceId == trace.get(1).traceId
     trace.get(0).name == "parent"

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
@@ -7,10 +7,10 @@ import static io.opentelemetry.api.trace.Span.Kind.CONSUMER
 import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 
 import com.google.common.io.Files
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
 import javax.jms.Message
@@ -31,7 +31,7 @@ import org.hornetq.core.server.HornetQServers
 import org.hornetq.jms.client.HornetQTextMessage
 import spock.lang.Shared
 
-class Jms2Test extends AgentTestRunner {
+class Jms2Test extends AgentInstrumentationSpecification {
   @Shared
   HornetQServer server
   @Shared

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/SpringListenerJms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/SpringListenerJms2Test.groovy
@@ -6,13 +6,13 @@
 import static Jms2Test.consumerSpan
 import static Jms2Test.producerSpan
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import javax.jms.ConnectionFactory
 import listener.Config
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.jms.core.JmsTemplate
 
-class SpringListenerJms2Test extends AgentTestRunner {
+class SpringListenerJms2Test extends AgentInstrumentationSpecification {
   def "receiving message in spring listener generates spans"() {
     setup:
     def context = new AnnotationConfigApplicationContext(Config)

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/SpringTemplateJms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/SpringTemplateJms2Test.groovy
@@ -7,7 +7,7 @@ import static Jms2Test.consumerSpan
 import static Jms2Test.producerSpan
 
 import com.google.common.io.Files
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -27,7 +27,7 @@ import org.hornetq.core.server.HornetQServers
 import org.springframework.jms.core.JmsTemplate
 import spock.lang.Shared
 
-class SpringTemplateJms2Test extends AgentTestRunner {
+class SpringTemplateJms2Test extends AgentInstrumentationSpecification {
   @Shared
   HornetQServer server
   @Shared

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
@@ -6,10 +6,10 @@
 import static io.opentelemetry.api.trace.Span.Kind.CONSUMER
 import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
 import javax.jms.Connection
@@ -25,7 +25,7 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
 
-class Jms1Test extends AgentTestRunner {
+class Jms1Test extends AgentInstrumentationSpecification {
 
   private static final Logger logger = LoggerFactory.getLogger(Jms1Test)
 

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringListenerJms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringListenerJms1Test.groovy
@@ -6,13 +6,13 @@
 import static Jms1Test.consumerSpan
 import static Jms1Test.producerSpan
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import javax.jms.ConnectionFactory
 import listener.Config
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.jms.core.JmsTemplate
 
-class SpringListenerJms1Test extends AgentTestRunner {
+class SpringListenerJms1Test extends AgentInstrumentationSpecification {
 
   def "receiving message in spring listener generates spans"() {
     setup:

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringTemplateJms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringTemplateJms1Test.groovy
@@ -7,7 +7,7 @@ import static Jms1Test.consumerSpan
 import static Jms1Test.producerSpan
 
 import com.google.common.base.Stopwatch
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import javax.jms.Connection
@@ -21,7 +21,7 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
 
-class SpringTemplateJms1Test extends AgentTestRunner {
+class SpringTemplateJms1Test extends AgentInstrumentationSpecification {
   private static final Logger logger = LoggerFactory.getLogger(SpringTemplateJms1Test)
 
   private static final GenericContainer broker = new GenericContainer("rmohr/activemq:latest")
@@ -43,7 +43,7 @@ class SpringTemplateJms1Test extends AgentTestRunner {
     session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
 
     template = new JmsTemplate(connectionFactory)
-    // Make this longer than timeout on TEST_WRITER.waitForTraces
+    // Make this longer than timeout on testWriter.waitForTraces
     // Otherwise caller might give up waiting before callee has a chance to respond.
     template.receiveTimeout = TimeUnit.SECONDS.toMillis(21)
   }

--- a/instrumentation/jsf/jsf-testing-common/src/main/groovy/BaseJsfTest.groovy
+++ b/instrumentation/jsf/jsf-testing-common/src/main/groovy/BaseJsfTest.groovy
@@ -6,7 +6,7 @@
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -22,7 +22,7 @@ import org.eclipse.jetty.webapp.WebAppContext
 import org.jsoup.Jsoup
 import spock.lang.Unroll
 
-abstract class BaseJsfTest extends AgentTestRunner implements HttpServerTestTrait<Server> {
+abstract class BaseJsfTest extends AgentInstrumentationSpecification implements HttpServerTestTrait<Server> {
 
   @Override
   Server startServer(int port) {
@@ -108,7 +108,7 @@ abstract class BaseJsfTest extends AgentTestRunner implements HttpServerTestTrai
         basicSpan(it, 0, getContextPath() + "/greeting.xhtml", null)
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     // extract parameters needed to post back form
@@ -168,7 +168,7 @@ abstract class BaseJsfTest extends AgentTestRunner implements HttpServerTestTrai
         basicSpan(it, 0, getContextPath() + "/greeting.xhtml", null)
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     // extract parameters needed to post back form

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
@@ -5,7 +5,7 @@
 
 import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -22,7 +22,7 @@ import spock.lang.Shared
 import spock.lang.Unroll
 
 //TODO should this be HttpServerTest?
-class JspInstrumentationBasicTests extends AgentTestRunner {
+class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
 
   @Shared
   int port

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
@@ -5,7 +5,7 @@
 
 import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -19,7 +19,7 @@ import org.apache.jasper.JasperException
 import spock.lang.Shared
 import spock.lang.Unroll
 
-class JspInstrumentationForwardTests extends AgentTestRunner {
+class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
 
   @Shared
   int port

--- a/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientBaseTest.groovy
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientBaseTest.groovy
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -18,7 +18,7 @@ import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Unroll
 
-abstract class KafkaClientBaseTest extends AgentTestRunner {
+abstract class KafkaClientBaseTest extends AgentInstrumentationSpecification {
 
   protected static final SHARED_TOPIC = "shared.topic"
 

--- a/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
@@ -53,7 +53,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
     container.setupMessageListener(new MessageListener<String, String>() {
       @Override
       void onMessage(ConsumerRecord<String, String> record) {
-        TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
+        testWriter.waitForTraces(1) // ensure consistent ordering of traces
         records.add(record)
       }
     })
@@ -315,7 +315,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
     producer.send(new ProducerRecord<Integer, String>(SHARED_TOPIC, kafkaPartition, null, greeting))
 
     then:
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
     def records = new LinkedBlockingQueue<ConsumerRecord<String, String>>()
     def pollResult = KafkaTestUtils.getRecords(consumer)
 

--- a/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
@@ -7,11 +7,11 @@ import static io.opentelemetry.api.trace.Span.Kind.CONSUMER
 import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.TextMapPropagator
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -31,7 +31,7 @@ import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Shared
 
-class KafkaStreamsTest extends AgentTestRunner {
+class KafkaStreamsTest extends AgentInstrumentationSpecification {
 
   static final STREAM_PENDING = "test.pending"
   static final STREAM_PROCESSED = "test.processed"
@@ -222,8 +222,8 @@ class KafkaStreamsTest extends AgentTestRunner {
       }
     })
     def spanContext = Span.fromContext(context).getSpanContext()
-    spanContext.traceIdAsHexString == TEST_WRITER.traces[0][3].traceId
-    spanContext.spanIdAsHexString == TEST_WRITER.traces[0][3].spanId
+    spanContext.traceIdAsHexString == testWriter.traces[0][3].traceId
+    spanContext.spanIdAsHexString == testWriter.traces[0][3].spanId
 
 
     cleanup:

--- a/instrumentation/kotlinx-coroutines/javaagent/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
+++ b/instrumentation/kotlinx-coroutines/javaagent/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
@@ -4,11 +4,11 @@
  */
 
 import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ThreadPoolDispatcherKt
 
-class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
+class KotlinCoroutineInstrumentationTest extends AgentInstrumentationSpecification {
 
   static dispatchersToTest = [
     Dispatchers.Default,

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -15,9 +15,9 @@ import com.lambdaworks.redis.api.async.RedisAsyncCommands
 import com.lambdaworks.redis.api.sync.RedisCommands
 import com.lambdaworks.redis.codec.Utf8StringCodec
 import com.lambdaworks.redis.protocol.AsyncCommand
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.CancellationException
 import java.util.concurrent.TimeUnit
 import java.util.function.BiConsumer
@@ -28,7 +28,7 @@ import redis.embedded.RedisServer
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
 
-class LettuceAsyncClientTest extends AgentTestRunner {
+class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
   public static final String HOST = "localhost"
   public static final int DB_INDEX = 0
   // Disable autoreconnect so we do not get stray traces popping up on server shutdown
@@ -92,8 +92,8 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     syncCommands.set("TESTKEY", "TESTVAL")
 
     // 1 set + 1 connect trace
-    TEST_WRITER.waitForTraces(2)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(2)
+    testWriter.clear()
   }
 
   def cleanup() {
@@ -308,7 +308,7 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     hmsetFuture.thenApplyAsync(new Function<String, Object>() {
       @Override
       Object apply(String setResult) {
-        TEST_WRITER.waitForTraces(1) // Wait for 'hmset' trace to get written
+        testWriter.waitForTraces(1) // Wait for 'hmset' trace to get written
         conds.evaluate {
           assert setResult == "OK"
         }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -10,13 +10,13 @@ import com.lambdaworks.redis.RedisClient
 import com.lambdaworks.redis.RedisConnectionException
 import com.lambdaworks.redis.api.StatefulConnection
 import com.lambdaworks.redis.api.sync.RedisCommands
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
-class LettuceSyncClientTest extends AgentTestRunner {
+class LettuceSyncClientTest extends AgentInstrumentationSpecification {
   public static final String HOST = "localhost"
   public static final int DB_INDEX = 0
   // Disable autoreconnect so we do not get stray traces popping up on server shutdown
@@ -76,8 +76,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
     syncCommands.hmset("TESTHM", testHashMap)
 
     // 2 sets + 1 connect trace
-    TEST_WRITER.waitForTraces(3)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(3)
+    testWriter.clear()
   }
 
   def cleanup() {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -15,9 +15,9 @@ import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.codec.StringCodec
 import io.lettuce.core.protocol.AsyncCommand
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletionException
 import java.util.concurrent.ExecutionException
@@ -30,7 +30,7 @@ import redis.embedded.RedisServer
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
 
-class LettuceAsyncClientTest extends AgentTestRunner {
+class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
   public static final String PEER_NAME = "localhost"
   public static final String PEER_IP = "127.0.0.1"
   public static final int DB_INDEX = 0
@@ -95,8 +95,8 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     syncCommands.set("TESTKEY", "TESTVAL")
 
     // 1 set + 1 connect trace
-    TEST_WRITER.waitForTraces(2)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(2)
+    testWriter.clear()
   }
 
   def cleanup() {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -11,16 +11,16 @@ import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.api.reactive.RedisReactiveCommands
 import io.lettuce.core.api.sync.RedisCommands
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.function.Consumer
 import reactor.core.scheduler.Schedulers
 import redis.embedded.RedisServer
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
 
-class LettuceReactiveClientTest extends AgentTestRunner {
+class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
   public static final String PEER_HOST = "localhost"
   public static final String PEER_IP = "127.0.0.1"
   public static final int DB_INDEX = 0
@@ -65,8 +65,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
     syncCommands.set("TESTKEY", "TESTVAL")
 
     // 1 set + 1 connect trace
-    TEST_WRITER.waitForTraces(2)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(2)
+    testWriter.clear()
   }
 
   def cleanup() {
@@ -245,7 +245,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
 
     then:
     res != null
-    TEST_WRITER.traces.size() == 0
+    testWriter.traces.size() == 0
   }
 
   def "debug segfault command (returns mono void) with no argument should produce span"() {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -10,14 +10,14 @@ import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisConnectionException
 import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.api.sync.RedisCommands
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.CompletionException
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
-class LettuceSyncClientTest extends AgentTestRunner {
+class LettuceSyncClientTest extends AgentInstrumentationSpecification {
   public static final String PEER_NAME = "localhost"
   public static final String PEER_IP = "127.0.0.1"
   public static final int DB_INDEX = 0
@@ -78,8 +78,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
     syncCommands.hmset("TESTHM", testHashMap)
 
     // 2 sets + 1 connect trace
-    TEST_WRITER.waitForTraces(3)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(3)
+    testWriter.clear()
   }
 
   def cleanup() {

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceAsyncClientTest.groovy
@@ -16,9 +16,9 @@ import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.codec.StringCodec
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.function.BiConsumer
@@ -29,7 +29,7 @@ import redis.embedded.RedisServer
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
 
-class LettuceAsyncClientTest extends AgentTestRunner {
+class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
   public static final String HOST = "127.0.0.1"
   public static final int DB_INDEX = 0
   // Disable autoreconnect so we do not get stray traces popping up on server shutdown
@@ -93,8 +93,8 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     syncCommands.set("TESTKEY", "TESTVAL")
 
     // 1 set
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
   }
 
   def cleanup() {

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
@@ -13,16 +13,16 @@ import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.api.reactive.RedisReactiveCommands
 import io.lettuce.core.api.sync.RedisCommands
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.function.Consumer
 import reactor.core.scheduler.Schedulers
 import redis.embedded.RedisServer
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
 
-class LettuceReactiveClientTest extends AgentTestRunner {
+class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
   public static final String HOST = "127.0.0.1"
   public static final int DB_INDEX = 0
   // Disable autoreconnect so we do not get stray traces popping up on server shutdown
@@ -68,8 +68,8 @@ class LettuceReactiveClientTest extends AgentTestRunner {
     syncCommands.set("TESTKEY", "TESTVAL")
 
     // 1 set
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
   }
 
   def cleanup() {
@@ -275,7 +275,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
 
     then:
     res != null
-    TEST_WRITER.traces.size() == 0
+    testWriter.traces.size() == 0
   }
 
   def "blocking subscriber"() {

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceSyncClientAuthTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceSyncClientAuthTest.groovy
@@ -9,13 +9,13 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
-class LettuceSyncClientAuthTest extends AgentTestRunner {
+class LettuceSyncClientAuthTest extends AgentInstrumentationSpecification {
   public static final String HOST = "127.0.0.1"
   public static final int DB_INDEX = 0
   // Disable autoreconnect so we do not get stray traces popping up on server shutdown

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceSyncClientTest.groovy
@@ -14,13 +14,13 @@ import io.lettuce.core.RedisConnectionException
 import io.lettuce.core.ScriptOutputType
 import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.api.sync.RedisCommands
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
-class LettuceSyncClientTest extends AgentTestRunner {
+class LettuceSyncClientTest extends AgentInstrumentationSpecification {
   public static final String HOST = "127.0.0.1"
   public static final int DB_INDEX = 0
   // Disable autoreconnect so we do not get stray traces popping up on server shutdown
@@ -83,8 +83,8 @@ class LettuceSyncClientTest extends AgentTestRunner {
     syncCommands.hmset("TESTHM", testHashMap)
 
     // 2 sets
-    TEST_WRITER.waitForTraces(2)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(2)
+    testWriter.clear()
   }
 
   def cleanup() {

--- a/instrumentation/log4j/log4j-1.2/javaagent/src/test/groovy/Log4j1MdcTest.groovy
+++ b/instrumentation/log4j/log4j-1.2/javaagent/src/test/groovy/Log4j1MdcTest.groovy
@@ -4,11 +4,11 @@
  */
 
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.TraceUtils
 import org.apache.log4j.LogManager
 
-class Log4j1MdcTest extends AgentTestRunner {
+class Log4j1MdcTest extends AgentInstrumentationSpecification {
   def cleanup() {
     ListAppender.clearEvents()
   }

--- a/instrumentation/log4j/log4j-2.13.2/library/src/test/groovy/LibraryLog4j2Test.groovy
+++ b/instrumentation/log4j/log4j-2.13.2/library/src/test/groovy/LibraryLog4j2Test.groovy
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
 
-class LibraryLog4j2Test extends Log4j2Test implements InstrumentationTestTrait {
+class LibraryLog4j2Test extends Log4j2Test implements LibraryTestTrait {
 }

--- a/instrumentation/logback/logback-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/logback/v1_0/LogbackTest.groovy
+++ b/instrumentation/logback/logback-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/logback/v1_0/LogbackTest.groovy
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.logback.v1_0
 
-import io.opentelemetry.instrumentation.test.InstrumentationTestTrait
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
 
-class LogbackTest extends AbstractLogbackTest implements InstrumentationTestTrait {
+class LogbackTest extends AbstractLogbackTest implements LibraryTestTrait {
 }

--- a/instrumentation/methods/javaagent/src/test/groovy/MethodTest.groovy
+++ b/instrumentation/methods/javaagent/src/test/groovy/MethodTest.groovy
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.Callable
 
-class MethodTest extends AgentTestRunner {
+class MethodTest extends AgentInstrumentationSpecification {
 
   static class ConfigTracedCallable implements Callable<String> {
     @Override

--- a/instrumentation/mongo/mongo-3.1/javaagent/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/javaagent/src/test/groovy/MongoClientTest.groovy
@@ -123,8 +123,8 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     collection.insertOne(new Document("password", "SECRET"))
@@ -154,8 +154,8 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def result = collection.updateOne(
@@ -188,8 +188,8 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def result = collection.deleteOne(new BsonDocument("password", new BsonString("SECRET")))
@@ -219,8 +219,8 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertMany([new Document("_id", 0), new Document("_id", 1), new Document("_id", 2)])
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     collection.find().filter(new Document("_id", new Document('$gte', 0)))
@@ -248,8 +248,8 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     collection.updateOne(new BsonDocument(), new BsonDocument())

--- a/instrumentation/mongo/mongo-3.7/javaagent/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/javaagent/src/test/groovy/MongoClientTest.groovy
@@ -133,8 +133,8 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     collection.insertOne(new Document("password", "SECRET"))
@@ -164,8 +164,8 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def result = collection.updateOne(
@@ -198,8 +198,8 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def result = collection.deleteOne(new BsonDocument("password", new BsonString("SECRET")))
@@ -229,8 +229,8 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertMany([new Document("_id", 0), new Document("_id", 1), new Document("_id", 2)])
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     collection.find().filter(new Document("_id", new Document('$gte', 0)))
@@ -258,8 +258,8 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     collection.updateOne(new BsonDocument(), new BsonDocument())

--- a/instrumentation/mongo/mongo-4.0-testing/src/test/groovy/Mongo4ReactiveClientTest.groovy
+++ b/instrumentation/mongo/mongo-4.0-testing/src/test/groovy/Mongo4ReactiveClientTest.groovy
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.api.trace.Span.Kind.CLIENT
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.reactivestreams.client.MongoClient
@@ -12,6 +15,8 @@ import com.mongodb.reactivestreams.client.MongoDatabase
 import io.opentelemetry.api.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
 import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
@@ -19,12 +24,6 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import spock.lang.Shared
 import spock.lang.Timeout
-
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CountDownLatch
-
-import static io.opentelemetry.api.trace.Span.Kind.CLIENT
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 @Timeout(10)
 class Mongo4ReactiveClientTest extends MongoBaseTest {
@@ -122,8 +121,8 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
       latch1.await()
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(2)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(2)
+    testWriter.clear()
 
     when:
     def count = new CompletableFuture()
@@ -168,8 +167,8 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
       latch2.await()
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def result = new CompletableFuture<UpdateResult>()
@@ -219,8 +218,8 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
       latch2.await()
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def result = new CompletableFuture<DeleteResult>()

--- a/instrumentation/mongo/mongo-4.0-testing/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-4.0-testing/src/test/groovy/MongoClientTest.groovy
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import com.mongodb.MongoTimeoutException
-import org.bson.BsonDocument
-import org.bson.BsonString
-
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+
+import com.mongodb.MongoTimeoutException
 import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
+import org.bson.BsonDocument
+import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
 
@@ -95,8 +95,8 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     collection.insertOne(new Document("password", "SECRET"))
@@ -126,8 +126,8 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def result = collection.updateOne(
@@ -160,8 +160,8 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def result = collection.deleteOne(new BsonDocument("password", new BsonString("SECRET")))
@@ -190,8 +190,8 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     collection.updateOne(new BsonDocument(), new BsonDocument())

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/src/test/groovy/MongoAsyncClientTest.groovy
@@ -16,9 +16,9 @@ import com.mongodb.async.client.MongoDatabase
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.connection.ClusterSettings
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import org.bson.BsonDocument
@@ -157,8 +157,8 @@ class MongoAsyncClientTest extends MongoBaseTest {
       latch1.await()
       return db.getCollection(collectionName)
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def count = new CompletableFuture()
@@ -203,8 +203,8 @@ class MongoAsyncClientTest extends MongoBaseTest {
       latch2.await()
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def result = new CompletableFuture<UpdateResult>()
@@ -254,8 +254,8 @@ class MongoAsyncClientTest extends MongoBaseTest {
       latch2.await()
       return coll
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
 
     when:
     def result = new CompletableFuture<DeleteResult>()

--- a/instrumentation/mongo/mongo-testing/src/main/groovy/MongoBaseTest.groovy
+++ b/instrumentation/mongo/mongo-testing/src/main/groovy/MongoBaseTest.groovy
@@ -13,11 +13,11 @@ import de.flapdoodle.embed.mongo.config.MongodConfigBuilder
 import de.flapdoodle.embed.mongo.config.Net
 import de.flapdoodle.embed.mongo.distribution.Version
 import de.flapdoodle.embed.process.runtime.Network
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Shared
 
 /**
@@ -25,7 +25,7 @@ import spock.lang.Shared
  * If tests in multiple different projects are using embedded mongo,
  * they downloader is at risk of a race condition.
  */
-class MongoBaseTest extends AgentTestRunner {
+class MongoBaseTest extends AgentInstrumentationSpecification {
   // https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo#executable-collision
   private static final MongodStarter STARTER = MongodStarter.getDefaultInstance()
 

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -8,13 +8,13 @@ import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.test.annotation.TracedWithSpan
 
 /**
  * This test verifies that auto instrumentation supports {@link io.opentelemetry.extension.annotations.WithSpan} contrib annotation.
  */
-class WithSpanInstrumentationTest extends AgentTestRunner {
+class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
 
   def "should derive automatic name"() {
     setup:

--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/ContextBridgeTest.groovy
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/ContextBridgeTest.groovy
@@ -9,12 +9,12 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
 import io.opentelemetry.extension.annotations.WithSpan
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
 
-class ContextBridgeTest extends AgentTestRunner {
+class ContextBridgeTest extends AgentInstrumentationSpecification {
 
   private static final ContextKey<String> ANIMAL = ContextKey.named("animal")
 

--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/ContextTest.groovy
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/ContextTest.groovy
@@ -6,9 +6,9 @@
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 
-class ContextTest extends AgentTestRunner {
+class ContextTest extends AgentInstrumentationSpecification {
 
   def "Span.current() should return invalid"() {
     when:

--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/TracerTest.groovy
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/TracerTest.groovy
@@ -11,10 +11,10 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.Scope
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
-class TracerTest extends AgentTestRunner {
+class TracerTest extends AgentInstrumentationSpecification {
 
   def "capture span, kind, attributes, and status"() {
     when:

--- a/instrumentation/opentelemetry-api-metrics-1.0/javaagent/src/test/groovy/MeterTest.groovy
+++ b/instrumentation/opentelemetry-api-metrics-1.0/javaagent/src/test/groovy/MeterTest.groovy
@@ -14,12 +14,12 @@ import com.google.common.base.Stopwatch
 import io.opentelemetry.api.common.Labels
 import io.opentelemetry.api.metrics.AsynchronousInstrument
 import io.opentelemetry.api.metrics.GlobalMetricsProvider
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.sdk.metrics.data.MetricData
 import io.opentelemetry.sdk.metrics.data.Point
 import java.util.function.Consumer
 
-class MeterTest extends AgentTestRunner {
+class MeterTest extends AgentInstrumentationSpecification {
 
   def "test counter #builderMethod bound=#bind"() {
     given:
@@ -253,7 +253,7 @@ class MeterTest extends AgentTestRunner {
   def findMetric(instrumentationName, metricName) {
     Stopwatch stopwatch = Stopwatch.createStarted()
     while (stopwatch.elapsed(SECONDS) < 10) {
-      def allMetrics = TEST_WRITER.getMetrics()
+      def allMetrics = testWriter.getMetrics()
       for (def metric : allMetrics) {
         if (metric.instrumentationLibraryInfo.name == instrumentationName && metric.name == metricName) {
           return metric

--- a/instrumentation/opentelemetry-sdk-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/opentelemetrysdk/OpenTelemetrySdkTest.groovy
+++ b/instrumentation/opentelemetry-sdk-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/opentelemetrysdk/OpenTelemetrySdkTest.groovy
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.opentelemetrysdk
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.sdk.OpenTelemetrySdk
 
-class OpenTelemetrySdkTest extends AgentTestRunner {
+class OpenTelemetrySdkTest extends AgentInstrumentationSpecification {
 
   def "direct access to sdk should not fail"() {
     when:

--- a/instrumentation/oshi/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/oshi/OshiTest.groovy
+++ b/instrumentation/oshi/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/oshi/OshiTest.groovy
@@ -8,11 +8,11 @@ package io.opentelemetry.javaagent.instrumentation.oshi
 import static java.util.concurrent.TimeUnit.SECONDS
 
 import com.google.common.base.Stopwatch
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import oshi.PlatformEnum
 import oshi.SystemInfo
 
-class OshiTest extends AgentTestRunner {
+class OshiTest extends AgentInstrumentationSpecification {
 
   def "test system metrics is enabled"() {
     setup:
@@ -33,7 +33,7 @@ class OshiTest extends AgentTestRunner {
   def findMetric(instrumentationName, metricName) {
     Stopwatch stopwatch = Stopwatch.createStarted()
     while (stopwatch.elapsed(SECONDS) < 10) {
-      def allMetrics = TEST_WRITER.getMetrics()
+      def allMetrics = testWriter.getMetrics()
       for (def metric : allMetrics) {
         if (metric.instrumentationLibraryInfo.name == instrumentationName && metric.name == metricName) {
           return metric

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMQTest.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMQTest.groovy
@@ -18,10 +18,10 @@ import com.rabbitmq.client.Envelope
 import com.rabbitmq.client.GetResponse
 import com.rabbitmq.client.ShutdownSignalException
 import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.time.Duration
 import org.springframework.amqp.core.AmqpAdmin
 import org.springframework.amqp.core.AmqpTemplate
@@ -32,7 +32,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.testcontainers.containers.GenericContainer
 import spock.lang.Shared
 
-class RabbitMQTest extends AgentTestRunner {
+class RabbitMQTest extends AgentInstrumentationSpecification {
 
   @Shared
   def rabbitMQContainer

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/RatpackOtherTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/RatpackOtherTest.groovy
@@ -6,16 +6,16 @@
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import ratpack.groovy.test.embed.GroovyEmbeddedApp
 import ratpack.path.PathBinding
 
-class RatpackOtherTest extends AgentTestRunner {
+class RatpackOtherTest extends AgentInstrumentationSpecification {
 
   OkHttpClient client = OkHttpUtils.client()
 

--- a/instrumentation/reactor-3.1/javaagent/src/test/groovy/ReactorCoreTest.groovy
+++ b/instrumentation/reactor-3.1/javaagent/src/test/groovy/ReactorCoreTest.groovy
@@ -4,10 +4,11 @@
  */
 
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.context.Context
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.TraceUtils
 import java.time.Duration
 import org.reactivestreams.Publisher
@@ -17,7 +18,7 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import spock.lang.Shared
 
-class ReactorCoreTest extends AgentTestRunner {
+class ReactorCoreTest extends AgentInstrumentationSpecification {
 
   public static final String EXCEPTION_MESSAGE = "test exception"
 
@@ -344,12 +345,12 @@ class ReactorCoreTest extends AgentTestRunner {
   }
 
   static addOneFunc(int i) {
-    getTestTracer().spanBuilder("add one").startSpan().end()
+    runInternalSpan("add one")
     return i + 1
   }
 
   static addTwoFunc(int i) {
-    getTestTracer().spanBuilder("add two").startSpan().end()
+    runInternalSpan("add two")
     return i + 2
   }
 }

--- a/instrumentation/reactor-3.1/javaagent/src/test/groovy/SubscriptionTest.groovy
+++ b/instrumentation/reactor-3.1/javaagent/src/test/groovy/SubscriptionTest.groovy
@@ -7,11 +7,11 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.api.GlobalOpenTelemetry
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.CountDownLatch
 import reactor.core.publisher.Mono
 
-class SubscriptionTest extends AgentTestRunner {
+class SubscriptionTest extends AgentInstrumentationSpecification {
 
   def "subscription test"() {
     when:

--- a/instrumentation/reactor-netty-0.9/javaagent/src/test/groovy/HttpClientTest.groovy
+++ b/instrumentation/reactor-netty-0.9/javaagent/src/test/groovy/HttpClientTest.groovy
@@ -8,10 +8,10 @@ import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.h
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import reactor.netty.http.client.HttpClient
@@ -19,7 +19,7 @@ import reactor.netty.http.client.HttpClientResponse
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
-class HttpClientTest extends AgentTestRunner {
+class HttpClientTest extends AgentInstrumentationSpecification {
   @AutoCleanup
   @Shared
   def server = httpServer {

--- a/instrumentation/rediscala-1.8/javaagent/src/test/groovy/RediscalaClientTest.groovy
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/groovy/RediscalaClientTest.groovy
@@ -6,9 +6,9 @@
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
 import akka.actor.ActorSystem
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import redis.ByteStringDeserializerDefault
 import redis.ByteStringSerializerLowPriority
 import redis.RedisClient
@@ -19,7 +19,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import spock.lang.Shared
 
-class RediscalaClientTest extends AgentTestRunner {
+class RediscalaClientTest extends AgentInstrumentationSpecification {
 
   @Shared
   int port = PortUtils.randomOpenPort()

--- a/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonAsyncClientTest.groovy
+++ b/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonAsyncClientTest.groovy
@@ -5,9 +5,9 @@
 
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.TimeUnit
 import org.redisson.Redisson
 import org.redisson.api.RBucket
@@ -19,7 +19,7 @@ import org.redisson.config.Config
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
-class RedissonAsyncClientTest extends AgentTestRunner {
+class RedissonAsyncClientTest extends AgentInstrumentationSpecification {
 
   @Shared
   int port = PortUtils.randomOpenPort()
@@ -54,7 +54,7 @@ class RedissonAsyncClientTest extends AgentTestRunner {
     Config config = new Config()
     config.useSingleServer().setAddress(address)
     redisson = Redisson.create(config)
-    TEST_WRITER.clear()
+    testWriter.clear()
   }
 
   def "test future set"() {

--- a/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonClientTest.groovy
+++ b/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonClientTest.groovy
@@ -7,9 +7,9 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static java.util.regex.Pattern.compile
 import static java.util.regex.Pattern.quote
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.redisson.Redisson
 import org.redisson.api.RAtomicLong
 import org.redisson.api.RBatch
@@ -24,7 +24,7 @@ import org.redisson.config.Config
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
-class RedissonClientTest extends AgentTestRunner {
+class RedissonClientTest extends AgentInstrumentationSpecification {
 
   @Shared
   int port = PortUtils.randomOpenPort()
@@ -59,7 +59,7 @@ class RedissonClientTest extends AgentTestRunner {
     Config config = new Config()
     config.useSingleServer().setAddress(address)
     redisson = Redisson.create(config)
-    TEST_WRITER.clear()
+    testWriter.clear()
   }
 
   def "test string command"() {

--- a/instrumentation/rmi/javaagent/src/test/groovy/RmiTest.groovy
+++ b/instrumentation/rmi/javaagent/src/test/groovy/RmiTest.groovy
@@ -8,16 +8,16 @@ import static io.opentelemetry.api.trace.Span.Kind.SERVER
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.rmi.registry.LocateRegistry
 import java.rmi.server.UnicastRemoteObject
 import rmi.app.Greeter
 import rmi.app.Server
 import rmi.app.ServerLegacy
 
-class RmiTest extends AgentTestRunner {
+class RmiTest extends AgentInstrumentationSpecification {
   def registryPort = PortUtils.randomOpenPort()
   def serverRegistry = LocateRegistry.createRegistry(registryPort)
   def clientRegistry = LocateRegistry.getRegistry("localhost", registryPort)

--- a/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
@@ -5,10 +5,10 @@
 
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 
-class SlickTest extends AgentTestRunner {
+class SlickTest extends AgentInstrumentationSpecification {
 
   // Can't be @Shared, otherwise the work queue is initialized before the instrumentation is applied
   def database = new SlickUtils()

--- a/instrumentation/scala-executors/javaagent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/instrumentation/scala-executors/javaagent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -5,7 +5,7 @@
 
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ArrayBlockingQueue
@@ -22,7 +22,7 @@ import spock.lang.Shared
  * Test executor instrumentation for Scala specific classes.
  * This is to large extent a copy of ExecutorInstrumentationTest.
  */
-class ScalaExecutorInstrumentationTest extends AgentTestRunner {
+class ScalaExecutorInstrumentationTest extends AgentInstrumentationSpecification {
 
   @Shared
   def executeRunnable = { e, c -> e.execute((Runnable) c) }
@@ -58,11 +58,11 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
       }
     }.run()
 
-    TEST_WRITER.waitForTraces(1)
-    List<SpanData> trace = TEST_WRITER.traces[0]
+    testWriter.waitForTraces(1)
+    List<SpanData> trace = testWriter.traces[0]
 
     expect:
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
     trace.size() == 2
     trace.get(0).name == "parent"
     trace.get(1).name == "asyncChild"
@@ -128,10 +128,10 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
       }
     }.run()
 
-    TEST_WRITER.waitForTraces(1)
+    testWriter.waitForTraces(1)
 
     expect:
-    TEST_WRITER.traces.size() == 1
+    testWriter.traces.size() == 1
 
     where:
     name              | method         | poolImpl

--- a/instrumentation/scala-executors/javaagent/src/test/groovy/ScalaInstrumentationTest.groovy
+++ b/instrumentation/scala-executors/javaagent/src/test/groovy/ScalaInstrumentationTest.groovy
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 
-class ScalaInstrumentationTest extends AgentTestRunner {
+class ScalaInstrumentationTest extends AgentInstrumentationSpecification {
 
   def "scala futures and callbacks"() {
     setup:

--- a/instrumentation/servlet/servlet-common/javaagent/src/test/groovy/HttpServletResponseTest.groovy
+++ b/instrumentation/servlet/servlet-common/javaagent/src/test/groovy/HttpServletResponseTest.groovy
@@ -8,7 +8,7 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTra
 import static java.util.Collections.emptyEnumeration
 
 import groovy.servlet.AbstractHttpServlet
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import javax.servlet.ServletOutputStream
 import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
@@ -17,7 +17,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import spock.lang.Subject
 
-class HttpServletResponseTest extends AgentTestRunner {
+class HttpServletResponseTest extends AgentInstrumentationSpecification {
 
   @Subject
   def response = new TestResponse()
@@ -32,7 +32,7 @@ class HttpServletResponseTest extends AgentTestRunner {
     def servlet = new AbstractHttpServlet() {}
     // We need to call service so HttpServletAdvice can link the request to the response.
     servlet.service((ServletRequest) request, (ServletResponse) response)
-    TEST_WRITER.clear()
+    testWriter.clear()
   }
 
   def "test send no-parent"() {
@@ -91,7 +91,7 @@ class HttpServletResponseTest extends AgentTestRunner {
     def servlet = new AbstractHttpServlet() {}
     // We need to call service so HttpServletAdvice can link the request to the response.
     servlet.service((ServletRequest) request, (ServletResponse) response)
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     runUnderTrace("parent") {

--- a/instrumentation/servlet/servlet-common/javaagent/src/test/groovy/RequestDispatcherTest.groovy
+++ b/instrumentation/servlet/servlet-common/javaagent/src/test/groovy/RequestDispatcherTest.groovy
@@ -7,12 +7,12 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.context.Context
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import javax.servlet.ServletException
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-class RequestDispatcherTest extends AgentTestRunner {
+class RequestDispatcherTest extends AgentInstrumentationSpecification {
 
   def request = Mock(HttpServletRequest)
   def response = Mock(HttpServletResponse)

--- a/instrumentation/spark-2.3/javaagent/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/instrumentation/spark-2.3/javaagent/src/test/groovy/SparkJavaBasedTest.groovy
@@ -5,16 +5,16 @@
 
 import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import spark.Spark
 import spock.lang.Shared
 
-class SparkJavaBasedTest extends AgentTestRunner {
+class SparkJavaBasedTest extends AgentInstrumentationSpecification {
 
   @Shared
   int port

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ChunkRootSpanTest.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ChunkRootSpanTest.groovy
@@ -6,13 +6,13 @@
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static java.util.Collections.emptyMap
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.springframework.batch.core.JobParameter
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.support.ClassPathXmlApplicationContext
 
-abstract class ChunkRootSpanTest extends AgentTestRunner {
+abstract class ChunkRootSpanTest extends AgentInstrumentationSpecification {
 
   abstract runJob(String jobName, Map<String, JobParameter> params = emptyMap())
 

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ItemLevelSpanTest.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ItemLevelSpanTest.groovy
@@ -6,13 +6,13 @@
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static java.util.Collections.emptyMap
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.springframework.batch.core.JobParameter
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.support.ClassPathXmlApplicationContext
 
-abstract class ItemLevelSpanTest extends AgentTestRunner {
+abstract class ItemLevelSpanTest extends AgentInstrumentationSpecification {
   abstract runJob(String jobName, Map<String, JobParameter> params = emptyMap())
 
   def "should trace item read, process and write calls"() {
@@ -269,7 +269,7 @@ class XmlConfigItemLevelSpanTest extends ItemLevelSpanTest implements Applicatio
 // JsrChunkProcessor works a bit differently than the "standard" one and does not read the whole
 // chunk at once, it reads every item separately; it results in a different span ordering, that's
 // why it has a completely separate test class
-class JsrConfigItemLevelSpanTest extends AgentTestRunner implements JavaxBatchConfigTrait {
+class JsrConfigItemLevelSpanTest extends AgentInstrumentationSpecification implements JavaxBatchConfigTrait {
   def "should trace item read, process and write calls"() {
     when:
     runJob("itemsAndTaskletJob", [:])

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/SpringBatchTest.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/SpringBatchTest.groovy
@@ -6,13 +6,13 @@
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static java.util.Collections.emptyMap
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.springframework.batch.core.JobParameter
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.support.ClassPathXmlApplicationContext
 
-abstract class SpringBatchTest extends AgentTestRunner {
+abstract class SpringBatchTest extends AgentInstrumentationSpecification {
 
   abstract runJob(String jobName, Map<String, JobParameter> params = emptyMap())
 

--- a/instrumentation/spring/spring-core-2.0/javaagent/src/test/groovy/SimpleAsyncTaskExecutorInstrumentationTest.groovy
+++ b/instrumentation/spring/spring-core-2.0/javaagent/src/test/groovy/SimpleAsyncTaskExecutorInstrumentationTest.groovy
@@ -7,14 +7,14 @@ import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.api.GlobalOpenTelemetry
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
 import org.springframework.core.task.SimpleAsyncTaskExecutor
 import spock.lang.Shared
 import spock.lang.Unroll
 
-class SimpleAsyncTaskExecutorInstrumentationTest extends AgentTestRunner {
+class SimpleAsyncTaskExecutorInstrumentationTest extends AgentInstrumentationSpecification {
 
   @Shared
   def executeRunnable = { e, c -> e.execute((Runnable) c) }

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/test/groovy/SpringJpaTest.groovy
@@ -7,21 +7,21 @@ import static io.opentelemetry.api.trace.Span.Kind.CLIENT
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spring.jpa.JpaCustomer
 import spring.jpa.JpaCustomerRepository
 import spring.jpa.JpaPersistenceConfig
 
-class SpringJpaTest extends AgentTestRunner {
+class SpringJpaTest extends AgentInstrumentationSpecification {
   def "test object method"() {
     setup:
     def context = new AnnotationConfigApplicationContext(JpaPersistenceConfig)
     def repo = context.getBean(JpaCustomerRepository)
 
     // when Spring JPA sets up, it issues metadata queries -- clear those traces
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     runUnderTrace("toString test") {
@@ -47,7 +47,7 @@ class SpringJpaTest extends AgentTestRunner {
     def repo = context.getBean(JpaCustomerRepository)
 
     // when Spring JPA sets up, it issues metadata queries -- clear those traces
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     setup:
     def customer = new JpaCustomer("Bob", "Anonymous")
@@ -79,7 +79,7 @@ class SpringJpaTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     repo.save(customer) // insert
@@ -110,7 +110,7 @@ class SpringJpaTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     customer.firstName = "Bill"
@@ -153,7 +153,7 @@ class SpringJpaTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     customer = repo.findByLastName("Anonymous")[0] // select
@@ -182,7 +182,7 @@ class SpringJpaTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
 
     when:
     repo.delete(customer) // delete
@@ -223,6 +223,6 @@ class SpringJpaTest extends AgentTestRunner {
         }
       }
     }
-    TEST_WRITER.clear()
+    testWriter.clear()
   }
 }

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.TimeUnit
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
-class SpringSchedulingTest extends AgentTestRunner {
+class SpringSchedulingTest extends AgentInstrumentationSpecification {
 
   def "schedule trigger test according to cron expression"() {
     setup:

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -6,10 +6,10 @@
 import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.api.trace.Span.Kind.SERVER
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.api.config.Config
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
@@ -25,7 +25,7 @@ import server.SpringWebFluxTestApplication
 import server.TestController
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [SpringWebFluxTestApplication, ForceNettyAutoConfiguration])
-class SpringWebfluxTest extends AgentTestRunner {
+class SpringWebfluxTest extends AgentInstrumentationSpecification {
   static Config previousConfig
 
   @TestConfiguration

--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/test/groovy/test/boot/SpringWsTest.groovy
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/test/groovy/test/boot/SpringWsTest.groovy
@@ -6,7 +6,7 @@
 package test.boot
 
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -26,7 +26,7 @@ import org.springframework.ws.soap.client.SoapFaultClientException
 import org.springframework.ws.soap.client.core.SoapActionCallback
 import spock.lang.Shared
 
-class SpringWsTest extends AgentTestRunner implements HttpServerTestTrait<ConfigurableApplicationContext> {
+class SpringWsTest extends AgentInstrumentationSpecification implements HttpServerTestTrait<ConfigurableApplicationContext> {
 
   @Shared
   private Jaxb2Marshaller marshaller = new Jaxb2Marshaller()

--- a/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
@@ -8,10 +8,10 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTra
 import static net.spy.memcached.ConnectionFactoryBuilder.Protocol.BINARY
 
 import com.google.common.util.concurrent.MoreExecutors
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.javaagent.instrumentation.spymemcached.CompletionListener
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.time.Duration
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.BlockingQueue
@@ -28,7 +28,7 @@ import net.spy.memcached.ops.OperationQueueFactory
 import org.testcontainers.containers.GenericContainer
 import spock.lang.Shared
 
-class SpymemcachedTest extends AgentTestRunner {
+class SpymemcachedTest extends AgentInstrumentationSpecification {
 
   @Shared
   def parentOperation = "parent-span"
@@ -116,8 +116,8 @@ class SpymemcachedTest extends AgentTestRunner {
     runUnderTrace("setup") {
       valuesToSet.each { k, v -> assert memcached.set(key(k), expiration, v).get() }
     }
-    TEST_WRITER.waitForTraces(1)
-    TEST_WRITER.clear()
+    testWriter.waitForTraces(1)
+    testWriter.clear()
   }
 
   def "test get hit"() {

--- a/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
@@ -18,7 +18,7 @@ import com.twilio.http.TwilioRestClient
 import com.twilio.rest.api.v2010.account.Call
 import com.twilio.rest.api.v2010.account.Message
 import com.twilio.type.PhoneNumber
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import org.apache.http.HttpEntity
@@ -28,7 +28,7 @@ import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.impl.client.HttpClientBuilder
 
-class TwilioClientTest extends AgentTestRunner {
+class TwilioClientTest extends AgentInstrumentationSpecification {
   final static String ACCOUNT_SID = "abc"
   final static String AUTH_TOKEN = "efg"
 

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/VertxReactivePropagationTest.groovy
@@ -8,16 +8,16 @@ import static io.opentelemetry.api.trace.Span.Kind.SERVER
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.vertx.reactivex.core.Vertx
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import spock.lang.Shared
 
-class VertxReactivePropagationTest extends AgentTestRunner {
+class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
   @Shared
   OkHttpClient client = OkHttpUtils.client()
 

--- a/testing-common/integration-tests/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/AgentTestRunnerTest.groovy
@@ -6,7 +6,7 @@
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import com.google.common.reflect.ClassPath
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.ClasspathUtils
 import io.opentelemetry.javaagent.tooling.Constants
 import java.util.concurrent.TimeoutException
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory
 // this test is run using
 //   -Dotel.javaagent.exclude-classes=config.exclude.packagename.*,config.exclude.SomeClass,config.exclude.SomeClass$NestedClass
 // (see integration-tests.gradle)
-class AgentTestRunnerTest extends AgentTestRunner {
+class AgentTestRunnerTest extends AgentInstrumentationSpecification {
   private static final ClassLoader BOOTSTRAP_CLASSLOADER = null
 
   def "classpath setup"() {
@@ -48,7 +48,7 @@ class AgentTestRunnerTest extends AgentTestRunner {
   def "waiting for child spans times out"() {
     when:
     runUnderTrace("parent") {
-      TEST_WRITER.waitForTraces(1)
+      testWriter.waitForTraces(1)
     }
 
     then:

--- a/testing-common/integration-tests/src/test/groovy/InstrumentOldBytecode.groovy
+++ b/testing-common/integration-tests/src/test/groovy/InstrumentOldBytecode.groovy
@@ -4,9 +4,9 @@
  */
 
 import com.ibm.as400.resource.ResourceLevel
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 
-class InstrumentOldBytecode extends AgentTestRunner {
+class InstrumentOldBytecode extends AgentInstrumentationSpecification {
   def "can instrument old bytecode"() {
     expect:
     new ResourceLevel().toString() == "instrumented"

--- a/testing-common/integration-tests/src/test/groovy/context/FieldBackedProviderTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/context/FieldBackedProviderTest.groovy
@@ -5,6 +5,7 @@
 
 package context
 
+
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import io.opentelemetry.instrumentation.test.utils.ClasspathUtils
 import io.opentelemetry.instrumentation.test.utils.GcUtils

--- a/testing-common/integration-tests/src/test/groovy/context/FieldInjectionDisabledTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/context/FieldInjectionDisabledTest.groovy
@@ -5,6 +5,7 @@
 
 package context
 
+
 import io.opentelemetry.instrumentation.test.AgentTestRunner
 import java.lang.reflect.Field
 import java.util.function.BiFunction

--- a/testing-common/integration-tests/src/test/groovy/server/ServerTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/server/ServerTest.groovy
@@ -7,13 +7,13 @@ package server
 
 import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.httpServer
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils
 import okhttp3.MultipartBody
 import okhttp3.Request
 import spock.lang.Shared
 
-class ServerTest extends AgentTestRunner {
+class ServerTest extends AgentInstrumentationSpecification {
   @Shared
   def client = OkHttpUtils.client()
 

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentInstrumentationSpecification.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentInstrumentationSpecification.groovy
@@ -1,0 +1,9 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.test
+
+abstract class AgentInstrumentationSpecification extends InstrumentationSpecification implements AgentTestTrait {
+}

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestRunner.java
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestRunner.java
@@ -11,9 +11,7 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
 import groovy.transform.stc.SimpleType;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.instrumentation.test.asserts.InMemoryExporterAssert;
 import io.opentelemetry.javaagent.testing.common.AgentTestingExporterAccess;
 import io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess;
@@ -53,17 +51,9 @@ public abstract class AgentTestRunner extends Specification {
    */
   public static final InMemoryExporter TEST_WRITER = new InMemoryExporter();
 
-  protected static final Tracer TEST_TRACER;
-
   static {
     ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.WARN);
     ((Logger) LoggerFactory.getLogger("io.opentelemetry")).setLevel(Level.DEBUG);
-
-    TEST_TRACER = GlobalOpenTelemetry.getTracer("io.opentelemetry.auto");
-  }
-
-  protected static Tracer getTestTracer() {
-    return TEST_TRACER;
   }
 
   /**
@@ -119,19 +109,5 @@ public abstract class AgentTestRunner extends Specification {
           @DelegatesTo(value = InMemoryExporterAssert.class, strategy = Closure.DELEGATE_FIRST)
           Closure spec) {
     InMemoryExporterAssert.assertTraces(AgentTestingExporterAccess::getExportedSpans, size, spec);
-  }
-
-  protected static String getClassName(Class clazz) {
-    String className = clazz.getSimpleName();
-    if (className.isEmpty()) {
-      className = clazz.getName();
-      if (clazz.getPackage() != null) {
-        String pkgName = clazz.getPackage().getName();
-        if (!pkgName.isEmpty()) {
-          className = clazz.getName().replace(pkgName, "").substring(1);
-        }
-      }
-    }
-    return className;
   }
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestTrait.groovy
@@ -19,44 +19,20 @@ trait AgentTestTrait {
   static AgentTestRunner agentTestRunner
   static InMemoryExporter testWriter
 
-  def setupSpec() {
+  void runnerSetupSpec() {
     agentTestRunner = new AgentTestRunnerImpl()
     testWriter = AgentTestRunner.TEST_WRITER
 
     agentTestRunner.setupBeforeTests()
-
-    childSetupSpec()
   }
 
-  def setup() {
+  void runnerSetup() {
     agentTestRunner.beforeTest()
-
-    childSetup()
   }
 
-  def cleanupSpec() {
+  void runnerCleanupSpec() {
     AgentTestRunner.agentCleanup()
-
-    childCleanupSpec()
   }
-
-  /**
-   * Initialization method called once per individual test. Equivalent to Spock's {@code setup} which
-   * we can't use because of https://stackoverflow.com/questions/56464191/public-groovy-method-must-be-public-says-the-compiler
-   */
-  def childSetup() {}
-
-  /**
-   * Initialization method called once per test class. Equivalent to Spock's {@code setupSpec} which
-   * we can't use because of https://stackoverflow.com/questions/56464191/public-groovy-method-must-be-public-says-the-compiler
-   */
-  def childSetupSpec() {}
-
-  /**
-   * Cleanup method called once per test class. Equivalent to Spock's {@code cleanupSpec} which
-   * we can't use because of https://stackoverflow.com/questions/56464191/public-groovy-method-must-be-public-says-the-compiler
-   */
-  def childCleanupSpec() {}
 
   void assertTraces(final int size,
                     @ClosureParams(

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/InstrumentationSpecification.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/InstrumentationSpecification.groovy
@@ -14,9 +14,27 @@ import spock.lang.Specification
 /**
  * Base class for test specifications that are shared between instrumentation libraries and agent.
  * The methods in this class are implemented by {@link AgentTestTrait} and
- * {@link InstrumentationTestTrait}.
+ * {@link LibraryTestTrait}.
  */
 abstract class InstrumentationSpecification extends Specification {
+  def setupSpec() {
+    runnerSetupSpec()
+  }
+
+  abstract void runnerSetupSpec()
+
+  def setup() {
+    runnerSetup()
+  }
+
+  abstract void runnerSetup()
+
+  def cleanupSpec() {
+    runnerCleanupSpec()
+  }
+
+  abstract void runnerCleanupSpec()
+
   abstract void assertTraces(
     final int size,
     @ClosureParams(

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryInstrumentationSpecification.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryInstrumentationSpecification.groovy
@@ -1,0 +1,9 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.test
+
+abstract class LibraryInstrumentationSpecification extends InstrumentationSpecification implements LibraryTestTrait {
+}

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
@@ -15,39 +15,26 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
  * A trait which initializes instrumentation library tests, including a test span exporter. All
  * library tests should implement this trait.
  */
-trait InstrumentationTestTrait {
+trait LibraryTestTrait {
 
   static InstrumentationTestRunner instrumentationTestRunner
   static InMemorySpanExporter testWriter
 
-  def setupSpec() {
+  void runnerSetupSpec() {
     instrumentationTestRunner = new InstrumentationTestRunnerImpl()
     testWriter = InstrumentationTestRunner.testExporter
-
-    childSetupSpec()
   }
 
-  def setup() {
+  void runnerSetup() {
     instrumentationTestRunner.beforeTest()
+  }
 
-    childSetup()
+  void runnerCleanupSpec() {
   }
 
   boolean forceFlushCalled() {
     return instrumentationTestRunner.forceFlushCalled()
   }
-
-  /**
-   * Initialization method called once per test class. Equivalent to Spock's {@code setupSpec} which
-   * we can't use because of https://stackoverflow.com/questions/56464191/public-groovy-method-must-be-public-says-the-compiler
-   */
-  def childSetupSpec() {}
-
-  /**
-   * Initialization method called once per individual test. Equivalent to Spock's {@code setup} which
-   * we can't use because of https://stackoverflow.com/questions/56464191/public-groovy-method-must-be-public-says-the-compiler
-   */
-  def childSetup() {}
 
   void assertTraces(final int size,
                     @ClosureParams(

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/AbstractPromiseTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/AbstractPromiseTest.groovy
@@ -8,10 +8,10 @@ package io.opentelemetry.instrumentation.test.base
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 
 // TODO: add a test for a longer chain of promises
-abstract class AbstractPromiseTest<P, M> extends AgentTestRunner {
+abstract class AbstractPromiseTest<P, M> extends AgentInstrumentationSpecification {
 
   abstract P newPromise()
 

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -14,7 +14,7 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTra
 import static org.junit.Assume.assumeTrue
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.concurrent.ExecutionException
@@ -24,7 +24,7 @@ import spock.lang.Shared
 import spock.lang.Unroll
 
 @Unroll
-abstract class HttpClientTest extends AgentTestRunner {
+abstract class HttpClientTest extends AgentInstrumentationSpecification {
   protected static final BODY_METHODS = ["POST", "PUT"]
   protected static final CONNECT_TIMEOUT_MS = 5000
   protected static final BASIC_AUTH_KEY = "custom-authorization-header"

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
@@ -17,7 +17,7 @@ import static org.junit.Assume.assumeTrue
 
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.concurrent.Callable
@@ -28,7 +28,7 @@ import okhttp3.Response
 import spock.lang.Unroll
 
 @Unroll
-abstract class HttpServerTest<SERVER> extends AgentTestRunner implements HttpServerTestTrait<SERVER> {
+abstract class HttpServerTest<SERVER> extends AgentInstrumentationSpecification implements HttpServerTestTrait<SERVER> {
 
   String expectedServerSpanName(ServerEndpoint endpoint) {
     return endpoint == PATH_PARAM ? getContextPath() + "/path/:id/param" : endpoint.resolvePath(address).path

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/utils/TraceUtils.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/utils/TraceUtils.groovy
@@ -44,6 +44,10 @@ class TraceUtils {
     }
   }
 
+  static void runInternalSpan(String spanName) {
+    tracer.spanBuilder(spanName).startSpan().end()
+  }
+
   static basicSpan(TraceAssert trace, int index, String operation, Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
       if (parentSpan == null) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/ClassUtils.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/test/utils/ClassUtils.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.test.utils;
+
+public final class ClassUtils {
+
+  public static String getClassName(Class<?> clazz) {
+    if (!clazz.isAnonymousClass()) {
+      return clazz.getSimpleName();
+    }
+    String className = clazz.getName();
+    if (clazz.getPackage() != null) {
+      String pkgName = clazz.getPackage().getName();
+      if (!pkgName.isEmpty()) {
+        className = clazz.getName().replace(pkgName, "").substring(1);
+      }
+    }
+    return className;
+  }
+
+  private ClassUtils() {}
+}


### PR DESCRIPTION
… spock spec

Another part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1644

I've replaced direct `AgentTestRunner` usages with `AgentInstrumentationSpecification`, which is based on @anuraaga's `InstrumentationSpecification` & agent/library traits idea. The aim of this whole refactoring is to make `AgentTestRunner` (and other crucial test code) Java-only - and thus usable in non-spock tests.

This PR is pretty big but it's mostly imports & renaming things.