### PR TITLE
Don't hardcode agent-for-testing archive filename so it can be publis…

### DIFF
--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -104,9 +104,11 @@ shadowJar {
   relocate "application.io.opentelemetry", "io.opentelemetry"
 }
 
+evaluationDependsOn(":testing:agent-for-testing")
+
 tasks.withType(Test).configureEach {
   jvmArgs "-Dotel.javaagent.debug=true"
-  jvmArgs "-javaagent:${project(":testing:agent-for-testing").buildDir}/libs/javaagent-for-testing.jar"
+  jvmArgs "-javaagent:${project(":testing:agent-for-testing").tasks.shadowJar.archiveFile.get().asFile.absolutePath}"
   jvmArgs "-Dotel.initializer.jar=${shadowJar.archiveFile.get().asFile.absolutePath}"
   jvmArgs "-Dinternal.testing.disable.global.library.ignores=true"
 

--- a/instrumentation/instrumentation.gradle
+++ b/instrumentation/instrumentation.gradle
@@ -46,8 +46,9 @@ configurations {
 }
 
 shadowJar {
-
   mergeServiceFiles()
+
+  archiveClassifier.set("")
 
   exclude '**/module-info.class'
 

--- a/instrumentation/instrumentation.gradle
+++ b/instrumentation/instrumentation.gradle
@@ -48,8 +48,6 @@ configurations {
 shadowJar {
   mergeServiceFiles()
 
-  archiveClassifier.set("")
-
   exclude '**/module-info.class'
 
   // Prevents conflict with other SLF4J instances. Important for premain.

--- a/testing/agent-for-testing/agent-for-testing.gradle
+++ b/testing/agent-for-testing/agent-for-testing.gradle
@@ -80,9 +80,11 @@ dependencies {
   testImplementation deps.opentelemetryApi
 }
 
-tasks.withType(Test).configureEach {
-  jvmArgs "-Dotel.javaagent.debug=true"
-  jvmArgs "-javaagent:${shadowJar.archiveFile.get().asFile.absolutePath}"
+afterEvaluate {
+  tasks.withType(Test).configureEach {
+    jvmArgs "-Dotel.javaagent.debug=true"
+    jvmArgs "-javaagent:${shadowJar.archiveFile.get().asFile.absolutePath}"
 
-  dependsOn shadowJar
+    dependsOn shadowJar
+  }
 }

--- a/testing/agent-for-testing/agent-for-testing.gradle
+++ b/testing/agent-for-testing/agent-for-testing.gradle
@@ -41,7 +41,7 @@ evaluationDependsOn(":testing:agent-exporter")
 shadowJar {
   configurations = [project.configurations.shadowInclude]
 
-  classifier = null
+  archiveClassifier.set("")
 
   dependsOn ':testing:agent-exporter:shadowJar'
   with isolateSpec([project(':testing:agent-exporter').tasks.shadowJar])

--- a/testing/agent-for-testing/agent-for-testing.gradle
+++ b/testing/agent-for-testing/agent-for-testing.gradle
@@ -36,9 +36,12 @@ configurations {
   shadowInclude
 }
 
+evaluationDependsOn(":testing:agent-exporter")
+
 shadowJar {
   configurations = [project.configurations.shadowInclude]
-  archiveFileName = 'javaagent-for-testing.jar'
+
+  classifier = null
 
   dependsOn ':testing:agent-exporter:shadowJar'
   with isolateSpec([project(':testing:agent-exporter').tasks.shadowJar])


### PR DESCRIPTION
…hed.

While I'm not a huge fan of `evaluationDependsOn` can't find a way to code this otherwise.