### PR TITLE
Disable retry on connection failure for okhttp3 tests

### DIFF
--- a/instrumentation/okhttp/okhttp-3.0/javaagent/src/test/groovy/OkHttp3Test.groovy
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/src/test/groovy/OkHttp3Test.groovy
@@ -18,6 +18,7 @@ class OkHttp3Test extends HttpClientTest {
 
   def client = new OkHttpClient.Builder()
     .connectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    .retryOnConnectionFailure(false)
     .build()
 
   @Override


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2153
`OkHttp3AsyncTest` waits for request to complete with `latch.await(30, SECONDS)` if response or failure is not received in this time then the request will fail with `NullPointerException` by reading response that it has not received yet. 
`HttpClientTest "connection error dropped request"` expects the request to fail, connection timeout is set to `5s`. Usually it completes in ~10s without retry it completes in `~5s`. Same test with okhttp2 does not retry the request and completes in `5s`.
This PR removes retry from okhttp3 in the hopes that this makes test less flaky. I have seen this failure multiple times, but I have not seen a similar failure for okhttp2.