### PR TITLE
Clean up BaseTracer, part 1

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/context/ContextPropagationDebug.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/context/ContextPropagationDebug.java
@@ -5,18 +5,26 @@
 
 package io.opentelemetry.instrumentation.api.context;
 
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
+import java.util.Iterator;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ContextPropagationDebug {
+  private static final Logger log = LoggerFactory.getLogger(ContextPropagationDebug.class);
 
   // locations where the context was propagated to another thread (tracking multiple steps is
   // helpful in akka where there is so much recursive async spawning of new work)
   private static final ContextKey<List<StackTraceElement[]>> THREAD_PROPAGATION_LOCATIONS =
       ContextKey.named("thread-propagation-locations");
+
   private static final boolean THREAD_PROPAGATION_DEBUGGER =
       Boolean.getBoolean("otel.threadPropagationDebugger");
+  private static final boolean FAIL_ON_CONTEXT_LEAK =
+      Boolean.getBoolean("otel.internal.failOnContextLeak");
 
   public static boolean isThreadPropagationDebuggerEnabled() {
     return THREAD_PROPAGATION_DEBUGGER;
@@ -28,6 +36,40 @@ public final class ContextPropagationDebug {
 
   public static Context withLocations(List<StackTraceElement[]> locations, Context context) {
     return context.with(THREAD_PROPAGATION_LOCATIONS, locations);
+  }
+
+  public static void debugContextLeakIfEnabled() {
+    if (!isThreadPropagationDebuggerEnabled()) {
+      return;
+    }
+
+    Context current = Context.current();
+    if (current != Context.root()) {
+      log.error("Unexpected non-root current context found when extracting remote context!");
+      Span currentSpan = Span.fromContextOrNull(current);
+      if (currentSpan != null) {
+        log.error("It contains this span: {}", currentSpan);
+      }
+      List<StackTraceElement[]> locations = ContextPropagationDebug.getLocations(current);
+      if (locations != null) {
+        StringBuilder sb = new StringBuilder();
+        Iterator<StackTraceElement[]> i = locations.iterator();
+        while (i.hasNext()) {
+          for (StackTraceElement ste : i.next()) {
+            sb.append("\n");
+            sb.append(ste);
+          }
+          if (i.hasNext()) {
+            sb.append("\nwhich was propagated from:");
+          }
+        }
+        log.error("a context leak was detected. it was propagated from:{}", sb);
+      }
+
+      if (FAIL_ON_CONTEXT_LEAK) {
+        throw new IllegalStateException("Context leak detected");
+      }
+    }
   }
 
   private ContextPropagationDebug() {}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
@@ -51,15 +51,6 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
     return withClientSpan(parentContext, span);
   }
 
-  @Override
-  public Span getCurrentSpan() {
-    return Span.current();
-  }
-
-  public void end(Context context) {
-    Span.fromContext(context).end();
-  }
-
   public void endExceptionally(Context context, Throwable throwable) {
     Span span = Span.fromContext(context);
     onError(span, throwable);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
@@ -103,11 +103,6 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     super.end(span, endTimeNanos);
   }
 
-  public void end(Context context) {
-    Span span = Span.fromContext(context);
-    super.end(span);
-  }
-
   public void endExceptionally(Context context, RESPONSE response, Throwable throwable) {
     endExceptionally(context, response, throwable, -1);
   }
@@ -117,11 +112,6 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     Span span = Span.fromContext(context);
     onResponse(span, response);
     super.endExceptionally(span, throwable, endTimeNanos);
-  }
-
-  public void endExceptionally(Context context, Throwable throwable) {
-    Span span = Span.fromContext(context);
-    super.endExceptionally(span, throwable, -1);
   }
 
   // TODO (trask) see if we can reduce the number of end..() variants

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelRoutePolicy.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelRoutePolicy.java
@@ -38,7 +38,7 @@ final class CamelRoutePolicy extends RoutePolicySupport {
 
   private Span spanOnExchangeBegin(
       Route route, Exchange exchange, SpanDecorator sd, Span.Kind spanKind) {
-    Span activeSpan = CamelTracer.TRACER.getCurrentSpan();
+    Span activeSpan = Span.current();
     String name = sd.getOperationName(exchange, route.getEndpoint(), CamelDirection.INBOUND);
     SpanBuilder builder = CamelTracer.TRACER.spanBuilder(name);
     builder.setSpanKind(spanKind);
@@ -52,7 +52,7 @@ final class CamelRoutePolicy extends RoutePolicySupport {
   }
 
   private Span.Kind spanKind(SpanDecorator sd) {
-    Span activeSpan = CamelTracer.TRACER.getCurrentSpan();
+    Span activeSpan = Span.current();
     // if there's an active span, this is not a root span which we always mark as INTERNAL
     return (activeSpan.getSpanContext().isValid() ? Span.Kind.INTERNAL : sd.getReceiverSpanKind());
   }

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/chunk/ChunkExecutionTracer.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/chunk/ChunkExecutionTracer.java
@@ -43,14 +43,6 @@ public class ChunkExecutionTracer extends BaseTracer {
     }
   }
 
-  public void end(Context context) {
-    end(Span.fromContext(context));
-  }
-
-  public void endExceptionally(Context context, Throwable throwable) {
-    endExceptionally(Span.fromContext(context), throwable);
-  }
-
   @Override
   protected String getInstrumentationName() {
     return "io.opentelemetry.javaagent.spring-batch";

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/item/ItemTracer.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/item/ItemTracer.java
@@ -68,14 +68,6 @@ public class ItemTracer extends BaseTracer {
     return currentContext.with(span);
   }
 
-  public void end(Context context) {
-    end(Span.fromContext(context));
-  }
-
-  public void endExceptionally(Context context, Throwable throwable) {
-    endExceptionally(Span.fromContext(context), throwable);
-  }
-
   @Override
   protected String getInstrumentationName() {
     return "io.opentelemetry.javaagent.spring-batch";

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/job/JobExecutionTracer.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/job/JobExecutionTracer.java
@@ -25,10 +25,6 @@ public class JobExecutionTracer extends BaseTracer {
     return Context.current().with(span);
   }
 
-  public void end(Context context) {
-    end(Span.fromContext(context));
-  }
-
   @Override
   protected String getInstrumentationName() {
     return "io.opentelemetry.javaagent.spring-batch";

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/step/StepExecutionTracer.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/step/StepExecutionTracer.java
@@ -26,10 +26,6 @@ public class StepExecutionTracer extends BaseTracer {
     return Context.current().with(span);
   }
 
-  public void end(Context context) {
-    end(Span.fromContext(context));
-  }
-
   @Override
   protected String getInstrumentationName() {
     return "io.opentelemetry.javaagent.spring-batch";

--- a/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioTracer.java
+++ b/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioTracer.java
@@ -100,10 +100,6 @@ public class TwilioTracer extends BaseTracer {
     super.end(span);
   }
 
-  public void endExceptionally(Context context, Throwable throwable) {
-    super.endExceptionally(Span.fromContext(context), throwable);
-  }
-
   /**
    * Helper method for calling a getter using reflection. This will be slow, so only use when
    * required.


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2129

* Move context leak debugging to ContextPropagationDebug
* Remove getCurrentSpan()
* Add end(Context, ...) & endExceptionally(Context, ...) methods - they're supposed to replace the ones that accept Spans in the future