### PR TITLE
Improve stability of jms-1.1 tests

### DIFF
--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringListenerJms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringListenerJms1Test.groovy
@@ -5,6 +5,7 @@
 
 import static Jms1Test.consumerSpan
 import static Jms1Test.producerSpan
+import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import javax.jms.ConnectionFactory
@@ -19,15 +20,20 @@ class SpringListenerJms1Test extends AgentInstrumentationSpecification {
     def context = new AnnotationConfigApplicationContext(Config)
     def factory = context.getBean(ConnectionFactory)
     def template = new JmsTemplate(factory)
-    // TODO(anuraaga): There is no defined order between when JMS starts receiving and our attempt
-    // to send/receive. Sleep a bit to let JMS start to receive first. Ideally, we would not have
-    // an ordering constraint in our assertTraces for when there is no defined ordering like this
-    // test case.
-    sleep(500)
+
     template.convertAndSend("SpringListenerJms1", "a message")
 
     expect:
     assertTraces(2) {
+      sortTraces {
+        // ensure that traces appear in expected order
+        if (traces[0][0].kind == PRODUCER) {
+          def tmp = traces[0]
+          traces[0] = traces[1]
+          traces[1] = tmp
+        }
+      }
+
       trace(0, 1) {
         consumerSpan(it, 0, "queue", "SpringListenerJms1", "", null, "receive")
       }

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/listener/Config.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/listener/Config.groovy
@@ -5,6 +5,7 @@
 
 package listener
 
+import java.time.Duration
 import javax.annotation.PreDestroy
 import javax.jms.ConnectionFactory
 import org.apache.activemq.ActiveMQConnectionFactory
@@ -15,6 +16,7 @@ import org.springframework.jms.annotation.EnableJms
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory
 import org.springframework.jms.config.JmsListenerContainerFactory
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
 
 @Configuration
 @ComponentScan
@@ -23,6 +25,8 @@ class Config {
 
   private static GenericContainer broker = new GenericContainer("rmohr/activemq:latest")
     .withExposedPorts(61616, 8161)
+    .waitingFor(Wait.forLogMessage(".*Apache ActiveMQ .* started.*", 1))
+    .withStartupTimeout(Duration.ofMinutes(2))
 
   static {
     broker.start()


### PR DESCRIPTION
- sort traces to be in expected order
- increase timeout for starting activemq container