### PR TITLE
Improve stability of elasticsearch tests

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -10,6 +10,7 @@ import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.env.Environment
@@ -51,6 +52,8 @@ class Elasticsearch53NodeClientTest extends AgentInstrumentationSpecification {
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call
       // into a top level trace to get exactly one trace in the result.
       testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
+      // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
+      testNode.client().admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
     testWriter.waitForTraces(1)
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -10,6 +10,7 @@ import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -68,6 +69,8 @@ class Elasticsearch53TransportClientTest extends AgentInstrumentationSpecificati
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call
       // into a top level trace to get exactly one trace in the result.
       client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
+      // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
+      client.admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
     testWriter.waitForTraces(1)
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Config.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Config.groovy
@@ -5,6 +5,7 @@
 
 package springdata
 
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.env.Environment
@@ -28,8 +29,8 @@ class Config {
     return new NodeBuilder()
   }
 
-  @Bean
-  ElasticsearchOperations elasticsearchTemplate() {
+  @Bean(destroyMethod = "close")
+  Node elasticSearchNode() {
     def tmpDir = File.createTempFile("test-es-working-dir-", "")
     tmpDir.delete()
     tmpDir.mkdir()
@@ -53,6 +54,16 @@ class Config {
 
     println "ES work dir: $tmpDir"
 
-    return new ElasticsearchTemplate(new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin]).start().client())
+    def testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
+    testNode.start()
+    // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
+    testNode.client().admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
+
+    return testNode
+  }
+
+  @Bean
+  ElasticsearchOperations elasticsearchTemplate(Node node) {
+    return new ElasticsearchTemplate(node.client())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -12,6 +12,7 @@ import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.atomic.AtomicLong
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -31,11 +32,6 @@ import spock.lang.Shared
 
 class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecification {
   public static final long TIMEOUT = 10000 // 10 seconds
-
-  // Some ES actions are not caused by clients and seem to just happen from time to time.
-  // We will just ignore these actions in traces.
-  // TODO: check if other ES tests need this protection and potentially pull this into global class
-  public static final Set<String> IGNORED_ACTIONS = ["NodesStatsAction", "IndicesStatsAction"] as Set
 
   @Shared
   Node testNode
@@ -67,6 +63,8 @@ class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecificatio
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call
       // into a top level trace to get exactly one trace in the result.
       testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
+      // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
+      testNode.client().admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
     testWriter.waitForTraces(1)
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -10,6 +10,7 @@ import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.index.IndexNotFoundException
@@ -48,6 +49,8 @@ class Elasticsearch6NodeClientTest extends AgentInstrumentationSpecification {
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call
       // into a top level trace to get exactly one trace in the result.
       testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
+      // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
+      testNode.client().admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
     testWriter.waitForTraces(1)
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -10,6 +10,7 @@ import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
@@ -63,6 +64,8 @@ class Elasticsearch6TransportClientTest extends AgentInstrumentationSpecificatio
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call
       // into a top level trace to get exactly one trace in the result.
       client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
+      // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
+      client.admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
     testWriter.waitForTraces(1)
   }


### PR DESCRIPTION
- Disables background job that creates spans not expected by tests. Currently failure can be forced by adding a sleep (I used 30s) before asserting traces.
- shut down spring and elasticsearch in Elasticsearch53SpringRepositoryTest, without shutting it down it seems to interfere with other tests