### PR TITLE
Correct hibernate dtd address

### DIFF
--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/resources/hibernate.cfg.xml
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/resources/hibernate.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE hibernate-configuration PUBLIC
   "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-  "https://hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+  "http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">
 
 <hibernate-configuration>
 

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/resources/hibernate.cfg.xml
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/resources/hibernate.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE hibernate-configuration PUBLIC
   "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-  "https://hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+  "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
 
 <hibernate-configuration>
 

--- a/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/resources/hibernate.cfg.xml
+++ b/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/resources/hibernate.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE hibernate-configuration PUBLIC
   "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-  "https://hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+  "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
 
 <hibernate-configuration>
 


### PR DESCRIPTION
Dtd address should be what the framework expects so that it could use the copy of dtd that is bundled inside the jar instead of downloading it.