### PR TITLE
fixing nightly fail - elasticmq version fix

### DIFF
--- a/instrumentation/apache-camel-2.20/javaagent/apache-camel-2.20-javaagent.gradle
+++ b/instrumentation/apache-camel-2.20/javaagent/apache-camel-2.20-javaagent.gradle
@@ -12,35 +12,38 @@ muzzle {
   }
 }
 
-dependencies {
-  library group: 'org.apache.camel', name: 'camel-core', version: '2.20.1'
+ext {
+  camelversion = '2.20.1'
+}
 
-  testLibrary group: 'org.apache.camel', name: 'camel-spring-boot-starter', version: '2.20.1'
-  testLibrary group: 'org.apache.camel', name: 'camel-jetty-starter', version: '2.20.1'
-  testLibrary group: 'org.apache.camel', name: 'camel-http-starter', version: '2.20.1'
-  testLibrary group: 'org.apache.camel', name: 'camel-jaxb-starter', version: '2.20.1'
-  testLibrary group: 'org.apache.camel', name: 'camel-undertow', version: '2.20.1'
-  testLibrary group: 'org.apache.camel', name: 'camel-aws', version: '2.20.1'
+dependencies {
+  library group: 'org.apache.camel', name: 'camel-core', version: "$camelversion"
 
   testInstrumentation project(':instrumentation:apache-httpclient:apache-httpclient-2.0:javaagent')
   testInstrumentation project(':instrumentation:servlet:servlet-3.0:javaagent')
   testInstrumentation project(':instrumentation:aws-sdk:aws-sdk-1.11:javaagent')
 
-  testImplementation group: 'org.spockframework', name: 'spock-spring', version: "$versions.spock"
+  testLibrary group: 'org.apache.camel', name: 'camel-spring-boot-starter', version: "$camelversion"
+  testLibrary group: 'org.apache.camel', name: 'camel-jetty-starter', version: "$camelversion"
+  testLibrary group: 'org.apache.camel', name: 'camel-http-starter', version: "$camelversion"
+  testLibrary group: 'org.apache.camel', name: 'camel-jaxb-starter', version: "$camelversion"
+  testLibrary group: 'org.apache.camel', name: 'camel-undertow', version: "$camelversion"
+  testLibrary group: 'org.apache.camel', name: 'camel-aws', version: "$camelversion"
 
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '1.5.17.RELEASE'
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter', version: '1.5.17.RELEASE'
 
+  testImplementation group: 'org.spockframework', name: 'spock-spring', version: "$versions.spock"
   testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
-
+  testImplementation group: 'org.elasticmq', name: 'elasticmq-rest-sqs_2.12', version: '1.0.0'
   /**
-  testImplementation deps.testcontainers
-  testImplementation "org.testcontainers:localstack:1.15.0-rc2"**/
-
-  testLibrary group: 'org.elasticmq', name: 'elasticmq-rest-sqs_2.12', version: '1.0.0'
+   *    Temporarily using emq instead of localstack till the latter supports AWS trace propagation
+   *
+   *    testImplementation deps.testcontainers
+   *    testImplementation "org.testcontainers:localstack:1.15.0-rc2"
+   **/
 
   latestDepTestLibrary group: 'org.apache.camel', name: 'camel-core', version: '2.+'
-
   latestDepTestLibrary group: 'org.apache.camel', name: 'camel-spring-boot-starter', version: '2.+'
   latestDepTestLibrary group: 'org.apache.camel', name: 'camel-jetty-starter', version: '2.+'
   latestDepTestLibrary group: 'org.apache.camel', name: 'camel-http-starter', version: '2.+'


### PR DESCRIPTION
Fixing nightly fail #2144 - elasticmq test dependency should not be a library (fix version @1.0.0)