### PR TITLE
cassandra table name should split out keyspace (#1298)

### DIFF
--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraDatabaseClientTracer.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraDatabaseClientTracer.java
@@ -131,6 +131,11 @@ public class CassandraDatabaseClientTracer extends DatabaseClientTracer<CqlSessi
     super.onStatement(span, statement);
     String table = SqlStatementSanitizer.sanitize(statement).getTable();
     if (table != null) {
+      // account for splitting out the keyspace, <keyspace>.<table>
+      int i = table.indexOf('.');
+      if (i > -1 && i + 1 < table.length()) {
+        table = table.substring(i + 1);
+      }
       span.setAttribute(SemanticAttributes.DB_CASSANDRA_TABLE, table);
     }
   }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/test/groovy/CassandraClientTest.groovy
@@ -119,8 +119,8 @@ class CassandraClientTest extends AgentInstrumentationSpecification {
         "$SemanticAttributes.DB_CASSANDRA_IDEMPOTENCE.key" Boolean
         "$SemanticAttributes.DB_CASSANDRA_PAGE_SIZE.key" 5000
         "$SemanticAttributes.DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT.key" 0
-        // the SqlStatementSanitizer can't handle CREATE statements or splitting out the keyspace
-        "$SemanticAttributes.DB_CASSANDRA_TABLE.key" { table -> (statement.contains("CREATE") || keyspace == null ? true : table.endsWith("users")) }
+        // the SqlStatementSanitizer can't handle CREATE statements yet
+        "$SemanticAttributes.DB_CASSANDRA_TABLE.key" { table -> (statement.contains("CREATE") || keyspace == null ? true : table == "users") }
       }
     }
   }


### PR DESCRIPTION
This addresses an issue in PR #1314 https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1314#issuecomment-771552383 to split the keyspace out from the table name if needed.

@mateuszrzeszutek 