### PR TITLE
Filter out library jar from tests since it's shadowed into the agent …

### DIFF
--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -125,7 +125,7 @@ tasks.withType(Test).configureEach {
     }
     // If agent depends on library instrumentation, it will be packaged into the testing jar so we
     // need to make sure to exclude from the test classpath.
-    if (it.absolutePath.startsWith(file("${projectDir.parent}/library").absolutePath)) {
+    if (it.absolutePath.startsWith(file("${projectDir.parent}/library/build/libs").absolutePath)) {
       return false
     }
     return true

--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -115,10 +115,17 @@ tasks.withType(Test).configureEach {
   dependsOn shadowJar
   dependsOn ":testing:agent-for-testing:shadowJar"
 
-  // The sources are packaged into the testing jar so we need to make sure to exclude from the test
-  // classpath, which automatically inherits them, to ensure our shaded versions are used.
+  // We do fine-grained filtering of the classpath of this codebase's sources since Gradle's
+  // configurations will include transitive dependencies as well, which tests do often need.
   classpath = classpath.filter {
+    // The sources are packaged into the testing jar so we need to make sure to exclude from the test
+    // classpath, which automatically inherits them, to ensure our shaded versions are used.
     if (file("$buildDir/resources/main").equals(it) || file("$buildDir/classes/java/main").equals(it)) {
+      return false
+    }
+    // If agent depends on library instrumentation, it will be packaged into the testing jar so we
+    // need to make sure to exclude from the test classpath.
+    if (it.absolutePath.startsWith(file("${projectDir.parent}/library").absolutePath)) {
       return false
     }
     return true


### PR DESCRIPTION
…/ agent-testing jar.

Found this when debugging the dubbo test failure, which is having unintended influence from the library jar on the test classpath. 

As with the previous classpath filtering, I can't come up with a clean check, but the heuristic is relatively safe (I guess?).