### PR TITLE
Elasticsearch: fix unexpected spans for ConnectException: Connection refused

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -44,6 +44,7 @@ class Elasticsearch5NodeClientTest extends AgentInstrumentationSpecification {
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
       .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
+      .put("discovery.type", "local")
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -50,6 +50,7 @@ class Elasticsearch5TransportClientTest extends AgentInstrumentationSpecificatio
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
       .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
+      .put("discovery.type", "local")
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -45,6 +45,7 @@ class Elasticsearch53NodeClientTest extends AgentInstrumentationSpecification {
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
       .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
+      .put("discovery.type", "single-node")
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -52,6 +52,7 @@ class Elasticsearch53TransportClientTest extends AgentInstrumentationSpecificati
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
       .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
+      .put("discovery.type", "single-node")
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()
@@ -76,6 +77,7 @@ class Elasticsearch53TransportClientTest extends AgentInstrumentationSpecificati
   }
 
   def cleanupSpec() {
+    client?.close()
     testNode?.close()
     if (esWorkingDir != null) {
       FileSystemUtils.deleteSubDirectories(esWorkingDir.toPath())

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Config.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Config.groovy
@@ -50,6 +50,7 @@ class Config {
       .put("thread_pool.listener.size", 1)
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
+      .put("discovery.type", "single-node")
       .build()
 
     println "ES work dir: $tmpDir"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -56,6 +56,7 @@ class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecificatio
       .put("transport.type", "netty3")
       .put("http.type", "netty3")
       .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
+      .put("discovery.type", "single-node")
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
     testNode.start()

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -42,6 +42,7 @@ class Elasticsearch6NodeClientTest extends AgentInstrumentationSpecification {
     // Since we use listeners to close spans this should make our span closing deterministic which is good for tests
       .put("thread_pool.listener.size", 1)
       .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
+      .put("discovery.type", "single-node")
       .build()
     testNode = new Node(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])
     testNode.start()

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -47,6 +47,7 @@ class Elasticsearch6TransportClientTest extends AgentInstrumentationSpecificatio
     def settings = Settings.builder()
       .put("path.home", esWorkingDir.path)
       .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
+      .put("discovery.type", "single-node")
       .build()
     testNode = new Node(InternalSettingsPreparer.prepareEnvironment(settings, null), [Netty4Plugin])
     testNode.start()
@@ -71,6 +72,7 @@ class Elasticsearch6TransportClientTest extends AgentInstrumentationSpecificatio
   }
 
   def cleanupSpec() {
+    client?.close()
     testNode?.close()
     if (esWorkingDir != null) {
       FileSystemUtils.deleteSubDirectories(esWorkingDir.toPath())


### PR DESCRIPTION
- Configure elasticsearch to run in a single node cluster. This skips discovery of other cluster nodes. Currently this discovery process doesn't always complete before tests start to run so tests may fail because there is an unexpected span for `java.net.ConnectException: Connection refused`
- Shut down `PreBuiltTransportClient` to avoid it attempting to reconnect with a shut down node which can produce unexpected span for `java.net.ConnectException: Connection refused` in subsequent test
