### PR TITLE
Allow getting current call depth

### DIFF
--- a/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/CallDepth.java
+++ b/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/CallDepth.java
@@ -20,6 +20,10 @@ public final class CallDepth {
     return --this.depth;
   }
 
+  public int get() {
+    return depth;
+  }
+
   void reset() {
     depth = 0;
   }

--- a/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/CallDepth.java
+++ b/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/CallDepth.java
@@ -20,6 +20,10 @@ public final class CallDepth {
     return --this.depth;
   }
 
+  /**
+   * Get current call depth. This method may be used by vendor distributions to extend existing
+   * instrumentations.
+   */
   public int get() {
     return depth;
   }


### PR DESCRIPTION
That's a really minor thing, but it can be useful in vendor distributions when trying add some additional code to existing instrumentation.