### PR TITLE
Fix JSP 2.3 muzzle

### DIFF
--- a/instrumentation/jsp-2.3/javaagent/jsp-2.3-javaagent.gradle
+++ b/instrumentation/jsp-2.3/javaagent/jsp-2.3-javaagent.gradle
@@ -6,7 +6,8 @@ muzzle {
     module = "tomcat-jasper"
     // range [7.0.0,7.0.19) and version 8.0.9 missing from maven
     // tomcat 10 uses JSP 3.0
-    versions = "[7.0.19,8.0.9),(8.0.9,10)"
+    versions = "[7.0.19,10)"
+    skipVersions += '8.0.9'
   }
 }
 

--- a/instrumentation/jsp-2.3/javaagent/jsp-2.3-javaagent.gradle
+++ b/instrumentation/jsp-2.3/javaagent/jsp-2.3-javaagent.gradle
@@ -5,7 +5,8 @@ muzzle {
     group = "org.apache.tomcat"
     module = "tomcat-jasper"
     // range [7.0.0,7.0.19) and version 8.0.9 missing from maven
-    versions = "[7.0.19,8.0.9),(8.0.9,)"
+    // tomcat 10 uses JSP 3.0
+    versions = "[7.0.19,8.0.9),(8.0.9,10)"
   }
 }
 


### PR DESCRIPTION
Tomcat 10.0.2 was released just today; version 10.0.x is supposed to use JSP 3.0 (and servlet 5.0) so this broke the muzzle task.