### PR TITLE
Remove all remaining direct AgentTestRunner usages

### DIFF
--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/SqsCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/SqsCamelTest.groovy
@@ -11,7 +11,7 @@ import static io.opentelemetry.api.trace.Span.Kind.INTERNAL
 import static io.opentelemetry.api.trace.Span.Kind.PRODUCER
 
 import com.amazonaws.services.sqs.model.SendMessageRequest
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import org.apache.camel.CamelContext
 import org.apache.camel.ProducerTemplate
@@ -21,7 +21,7 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap
 import spock.lang.Shared
 
-class SqsCamelTest extends AgentTestRunner {
+class SqsCamelTest extends AgentInstrumentationSpecification {
 
   @Shared
   ConfigurableApplicationContext server

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SqsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SqsTracingTest.groovy
@@ -12,12 +12,12 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.amazonaws.services.sqs.model.SendMessageRequest
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import org.elasticmq.rest.sqs.SQSRestServerBuilder
 import spock.lang.Shared
 
-class SqsTracingTest extends AgentTestRunner {
+class SqsTracingTest extends AgentInstrumentationSpecification {
 
   @Shared
   def sqs

--- a/instrumentation/jaxws/jaxws-2.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/jaxws/v2_0/JaxWsAnnotationsTest.groovy
+++ b/instrumentation/jaxws/jaxws-2.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/jaxws/v2_0/JaxWsAnnotationsTest.groovy
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxws.v2_0
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 
-class JaxWsAnnotationsTest extends AgentTestRunner {
+class JaxWsAnnotationsTest extends AgentInstrumentationSpecification {
 
   def "Web service providers generate spans"() {
     when:

--- a/instrumentation/jaxws/jws-1.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/jaxws/jws/v1_1/JwsAnnotationsTest.groovy
+++ b/instrumentation/jaxws/jws-1.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/jaxws/jws/v1_1/JwsAnnotationsTest.groovy
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxws.jws.v1_1
 
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import java.lang.reflect.Proxy
 
-class JwsAnnotationsTest extends AgentTestRunner {
+class JwsAnnotationsTest extends AgentInstrumentationSpecification {
 
   def "WebService on a class generates spans only for public methods"() {
     when:

--- a/testing-common/integration-tests/src/test/groovy/context/FieldBackedProviderTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/context/FieldBackedProviderTest.groovy
@@ -5,18 +5,16 @@
 
 package context
 
-
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.ClasspathUtils
 import io.opentelemetry.instrumentation.test.utils.GcUtils
+import io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess
 import java.lang.instrument.ClassDefinition
 import java.lang.ref.WeakReference
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.util.concurrent.atomic.AtomicReference
-import java.util.function.BiFunction
-import java.util.function.Function
 import library.IncorrectCallUsageKeyClass
 import library.IncorrectContextClassUsageKeyClass
 import library.IncorrectKeyClassUsageKeyClass
@@ -30,28 +28,15 @@ import net.sf.cglib.proxy.MethodProxy
 // this test is run using
 //   -Dotel.instrumentation.context-test-instrumentation.enabled=true
 // (see integration-tests.gradle)
-class FieldBackedProviderTest extends AgentTestRunner {
+class FieldBackedProviderTest extends AgentInstrumentationSpecification {
 
-  @Override
-  protected List<BiFunction<String, Throwable, Boolean>> skipErrorConditions() {
-    return [
-      new BiFunction<String, Throwable, Boolean>() {
-        @Override
-        Boolean apply(String typeName, Throwable throwable) {
-          return typeName.startsWith('library.Incorrect') &&
-            throwable.getMessage().startsWith("Incorrect Context Api Usage detected.")
-        }
-      }
-    ]
-  }
-
-  @Override
-  protected List<Function<String, Boolean>> skipTransformationConditions() {
-    return Collections.singletonList(new Function<String, Boolean>() {
-      @Override
-      Boolean apply(String typeName) {
-        return typeName != null && typeName.endsWith("UntransformableKeyClass")
-      }
+  def setupSpec() {
+    TestAgentListenerAccess.addSkipErrorCondition({ typeName, throwable ->
+      return typeName.startsWith('library.Incorrect') &&
+        throwable.getMessage().startsWith("Incorrect Context Api Usage detected.")
+    })
+    TestAgentListenerAccess.addSkipTransformationCondition({ typeName ->
+      return typeName != null && typeName.endsWith("UntransformableKeyClass")
     })
   }
 

--- a/testing-common/integration-tests/src/test/groovy/context/FieldInjectionDisabledTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/context/FieldInjectionDisabledTest.groovy
@@ -5,28 +5,21 @@
 
 package context
 
-
-import io.opentelemetry.instrumentation.test.AgentTestRunner
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess
 import java.lang.reflect.Field
-import java.util.function.BiFunction
 import library.DisabledKeyClass
 
 // this test is run using:
 //   -Dotel.javaagent.runtime.context.field.injection=false
 //   -Dotel.instrumentation.context-test-instrumentation.enabled=true
 // (see integration-tests.gradle)
-class FieldInjectionDisabledTest extends AgentTestRunner {
+class FieldInjectionDisabledTest extends AgentInstrumentationSpecification {
 
-  @Override
-  protected List<BiFunction<String, Throwable, Boolean>> skipErrorConditions() {
-    return [
-      new BiFunction<String, Throwable, Boolean>() {
-        @Override
-        Boolean apply(String typeName, Throwable throwable) {
-          return typeName.startsWith(ContextTestInstrumentationModule.getName() + '$Incorrect') && throwable.getMessage().startsWith("Incorrect Context Api Usage detected.")
-        }
-      }
-    ]
+  def setupSpec() {
+    TestAgentListenerAccess.addSkipErrorCondition({ typeName, throwable ->
+      return typeName.startsWith(ContextTestInstrumentationModule.getName() + '$Incorrect') && throwable.getMessage().startsWith("Incorrect Context Api Usage detected.")
+    })
   }
 
   def "Check that structure is not modified when structure modification is disabled"() {

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentInstrumentationSpecification.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentInstrumentationSpecification.groovy
@@ -5,5 +5,8 @@
 
 package io.opentelemetry.instrumentation.test
 
+/**
+ * Base class for spock specifications that test javaagent instrumentations.
+ */
 abstract class AgentInstrumentationSpecification extends InstrumentationSpecification implements AgentTestTrait {
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestRunner.java
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestRunner.java
@@ -15,26 +15,9 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.test.asserts.InMemoryExporterAssert;
 import io.opentelemetry.javaagent.testing.common.AgentTestingExporterAccess;
 import io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.slf4j.LoggerFactory;
-import org.spockframework.runtime.model.SpecMetadata;
-import spock.lang.Specification;
 
-/**
- * A spock test runner which automatically applies instrumentation and exposes a global trace
- * writer.
- *
- * <p>To use, write a regular spock test, but extend this class instead of {@link
- * spock.lang.Specification}.
- */
-@SpecMetadata(filename = "AgentTestRunner.java", line = 0)
-public abstract class AgentTestRunner extends Specification {
+public final class AgentTestRunner {
 
   static {
     // always run with the thread propagation debugger to help track down sporadic test failures
@@ -56,41 +39,16 @@ public abstract class AgentTestRunner extends Specification {
     ((Logger) LoggerFactory.getLogger("io.opentelemetry")).setLevel(Level.DEBUG);
   }
 
-  /**
-   * Returns conditions for the classname for a class for which transformation should be skipped.
-   */
-  protected List<Function<String, Boolean>> skipTransformationConditions() {
-    return Collections.emptyList();
-  }
-
-  /**
-   * Returns conditions for the classname for a class and throwable of an error for which errors
-   * should be ignored.
-   */
-  protected List<BiFunction<String, Throwable, Boolean>> skipErrorConditions() {
-    return Collections.emptyList();
-  }
-
-  /**
-   * Normally {@code @BeforeClass} is run only on static methods, but spock allows us to run it on
-   * instance methods. Note: this means there is a 'special' instance of test class that is not used
-   * to run any tests, but instead is just used to run this method once.
-   */
-  @BeforeClass
   public void setupBeforeTests() {
     TestAgentListenerAccess.reset();
-    skipTransformationConditions().forEach(TestAgentListenerAccess::addSkipTransformationCondition);
-    skipErrorConditions().forEach(TestAgentListenerAccess::addSkipErrorCondition);
   }
 
-  @Before
   public void beforeTest() {
     assert !Span.current().getSpanContext().isValid()
         : "Span is active before test has started: " + Span.current();
     AgentTestingExporterAccess.reset();
   }
 
-  @AfterClass
   public static synchronized void agentCleanup() {
     // Cleanup before assertion.
     assert TestAgentListenerAccess.getInstrumentationErrorCount() == 0

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestTrait.groovy
@@ -20,7 +20,7 @@ trait AgentTestTrait {
   static InMemoryExporter testWriter
 
   void runnerSetupSpec() {
-    agentTestRunner = new AgentTestRunnerImpl()
+    agentTestRunner = new AgentTestRunner()
     testWriter = AgentTestRunner.TEST_WRITER
 
     agentTestRunner.setupBeforeTests()
@@ -43,5 +43,4 @@ trait AgentTestTrait {
     AgentTestRunner.assertTraces(size, spec)
   }
 
-  static class AgentTestRunnerImpl extends AgentTestRunner {}
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryInstrumentationSpecification.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryInstrumentationSpecification.groovy
@@ -5,5 +5,8 @@
 
 package io.opentelemetry.instrumentation.test
 
+/**
+ * Base class for spock specifications that test library instrumentations.
+ */
 abstract class LibraryInstrumentationSpecification extends InstrumentationSpecification implements LibraryTestTrait {
 }


### PR DESCRIPTION
Now everybody's forced to use `AgentInstrumentationSpecification` when testing agent instrumentations