### PR TITLE
Add constructors/methods to the base tracers to enable injecting an OpenTelemetry instance

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
@@ -205,16 +205,14 @@ public abstract class BaseTracer {
     return extract(GlobalOpenTelemetry.getPropagators(), carrier, getter);
   }
 
-  public static <C> Context extract(ContextPropagators propagators, C carrier,
-      TextMapPropagator.Getter<C> getter) {
+  public static <C> Context extract(
+      ContextPropagators propagators, C carrier, TextMapPropagator.Getter<C> getter) {
     ContextPropagationDebug.debugContextLeakIfEnabled();
 
     // Using Context.ROOT here may be quite unexpected, but the reason is simple.
     // We want either span context extracted from the carrier or invalid one.
     // We DO NOT want any span context potentially lingering in the current context.
-    return propagators
-        .getTextMapPropagator()
-        .extract(Context.root(), carrier, getter);
+    return propagators.getTextMapPropagator().extract(Context.root(), carrier, getter);
   }
 
   /** Returns span of type SERVER from the current context or <code>null</code> if not found. */
@@ -226,5 +224,4 @@ public abstract class BaseTracer {
   public static Span getCurrentServerSpan(Context context) {
     return context.get(CONTEXT_SERVER_SPAN_KEY);
   }
-
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
@@ -45,6 +45,8 @@ public abstract class BaseTracer {
     propagators = GlobalOpenTelemetry.getPropagators();
   }
 
+  /** @deprecated prefer to pass in an OpenTelemetry instance, instead. */
+  @Deprecated
   public BaseTracer(Tracer tracer) {
     this.tracer = tracer;
     this.propagators = GlobalOpenTelemetry.getPropagators();
@@ -201,11 +203,18 @@ public abstract class BaseTracer {
     span.recordException(throwable);
   }
 
-  public static <C> Context extract(C carrier, TextMapPropagator.Getter<C> getter) {
+  /** @deprecated We should eliminate all static usages so we can use the non-global propagators. */
+  @Deprecated
+  public static <C> Context extractWithGlobalPropagators(
+      C carrier, TextMapPropagator.Getter<C> getter) {
     return extract(GlobalOpenTelemetry.getPropagators(), carrier, getter);
   }
 
-  public static <C> Context extract(
+  public <C> Context extract(C carrier, TextMapPropagator.Getter<C> getter) {
+    return extract(propagators, carrier, getter);
+  }
+
+  private static <C> Context extract(
       ContextPropagators propagators, C carrier, TextMapPropagator.Getter<C> getter) {
     ContextPropagationDebug.debugContextLeakIfEnabled();
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
@@ -45,7 +45,12 @@ public abstract class BaseTracer {
     propagators = GlobalOpenTelemetry.getPropagators();
   }
 
-  /** @deprecated prefer to pass in an OpenTelemetry instance, instead. */
+  /**
+   * Prefer to pass in an OpenTelemetry instance, rather than just a Tracer, so you don't have to
+   * use the GlobalOpenTelemetry Propagator instance.
+   *
+   * @deprecated prefer to pass in an OpenTelemetry instance, instead.
+   */
   @Deprecated
   public BaseTracer(Tracer tracer) {
     this.tracer = tracer;
@@ -203,7 +208,11 @@ public abstract class BaseTracer {
     span.recordException(throwable);
   }
 
-  /** @deprecated We should eliminate all static usages so we can use the non-global propagators. */
+  /**
+   * Do extraction with the propagators from the GlobalOpenTelemetry instance. Not recommended.
+   *
+   * @deprecated We should eliminate all static usages so we can use the non-global propagators.
+   */
   @Deprecated
   public static <C> Context extractWithGlobalPropagators(
       C carrier, TextMapPropagator.Getter<C> getter) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
@@ -7,7 +7,7 @@ package io.opentelemetry.instrumentation.api.tracer;
 
 import static io.opentelemetry.api.trace.Span.Kind.CLIENT;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Span.Kind;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -32,6 +32,18 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
 
   protected static final String USER_AGENT = "User-Agent";
 
+  protected HttpClientTracer() {
+    super();
+  }
+
+  protected HttpClientTracer(Tracer tracer) {
+    super(tracer);
+  }
+
+  protected HttpClientTracer(OpenTelemetry openTelemetry) {
+    super(openTelemetry);
+  }
+
   protected abstract String method(REQUEST request);
 
   @Nullable
@@ -52,14 +64,6 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
   protected abstract String responseHeader(RESPONSE response, String name);
 
   protected abstract TextMapPropagator.Setter<CARRIER> getSetter();
-
-  protected HttpClientTracer() {
-    super();
-  }
-
-  protected HttpClientTracer(Tracer tracer) {
-    super(tracer);
-  }
 
   public boolean shouldStartSpan(Context parentContext) {
     return shouldStartSpan(CLIENT, parentContext);
@@ -90,7 +94,7 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
       throw new IllegalStateException(
           "getSetter() not defined but calling startScope(), either getSetter must be implemented or the scope should be setup manually");
     }
-    GlobalOpenTelemetry.getPropagators().getTextMapPropagator().inject(context, carrier, setter);
+    propagators.getTextMapPropagator().inject(context, carrier, setter);
   }
 
   public void end(Context context, RESPONSE response) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
@@ -36,6 +36,8 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     super();
   }
 
+  /** @deprecated prefer to pass in an OpenTelemetry instance, instead. */
+  @Deprecated
   protected HttpClientTracer(Tracer tracer) {
     super(tracer);
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
@@ -36,7 +36,12 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
     super();
   }
 
-  /** @deprecated prefer to pass in an OpenTelemetry instance, instead. */
+  /**
+   * Prefer to pass in an OpenTelemetry instance, rather than just a Tracer, so you don't have to
+   * use the GlobalOpenTelemetry Propagator instance.
+   *
+   * @deprecated prefer to pass in an OpenTelemetry instance, instead.
+   */
   @Deprecated
   protected HttpClientTracer(Tracer tracer) {
     super(tracer);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
@@ -43,7 +43,12 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
     super();
   }
 
-  /** @deprecated prefer to pass in an OpenTelemetry instance, instead. */
+  /**
+   * Prefer to pass in an OpenTelemetry instance, rather than just a Tracer, so you don't have to
+   * use the GlobalOpenTelemetry Propagator instance.
+   *
+   * @deprecated prefer to pass in an OpenTelemetry instance, instead.
+   */
   @Deprecated
   public HttpServerTracer(Tracer tracer) {
     super(tracer);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
@@ -43,6 +43,8 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
     super();
   }
 
+  /** @deprecated prefer to pass in an OpenTelemetry instance, instead. */
+  @Deprecated
   public HttpServerTracer(Tracer tracer) {
     super(tracer);
   }
@@ -74,7 +76,7 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
     // also we can't conditionally start a span in this method, because the caller won't know
     // whether to call end() or not on the Span in the returned Context
 
-    Context parentContext = extract(propagators, request, getGetter());
+    Context parentContext = extract(request, getGetter());
     SpanBuilder builder = tracer.spanBuilder(spanName).setSpanKind(SERVER).setParent(parentContext);
 
     if (startTimestamp >= 0) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.tracer;
 
 import static io.opentelemetry.api.trace.Span.Kind.SERVER;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
@@ -46,6 +47,10 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
     super(tracer);
   }
 
+  public HttpServerTracer(OpenTelemetry openTelemetry) {
+    super(openTelemetry);
+  }
+
   public Context startSpan(REQUEST request, CONNECTION connection, STORAGE storage, Method origin) {
     String spanName = spanNameForMethod(origin);
     return startSpan(request, connection, storage, spanName);
@@ -69,7 +74,7 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
     // also we can't conditionally start a span in this method, because the caller won't know
     // whether to call end() or not on the Span in the returned Context
 
-    Context parentContext = extract(request, getGetter());
+    Context parentContext = extract(propagators, request, getGetter());
     SpanBuilder builder = tracer.spanBuilder(spanName).setSpanKind(SERVER).setParent(parentContext);
 
     if (startTimestamp >= 0) {

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -110,7 +110,8 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
     @Override
     public HttpRequest generateRequest() throws IOException, HttpException {
       HttpRequest request = delegate.generateRequest();
-      tracer().getPropagators()
+      tracer()
+          .getPropagators()
           .getTextMapPropagator()
           .inject(context, request, tracer().getSetter());
       Span span = Span.fromContext(context);

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -15,7 +15,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -111,7 +110,7 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
     @Override
     public HttpRequest generateRequest() throws IOException, HttpException {
       HttpRequest request = delegate.generateRequest();
-      GlobalOpenTelemetry.getPropagators()
+      tracer().getPropagators()
           .getTextMapPropagator()
           .inject(context, request, tracer().getSetter());
       Span span = Span.fromContext(context);

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/server/ContextDispatcher.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/server/ContextDispatcher.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.rmi.context.server;
 
-import static io.opentelemetry.instrumentation.api.tracer.BaseTracer.extract;
+import static io.opentelemetry.instrumentation.api.tracer.BaseTracer.extractWithGlobalPropagators;
 import static io.opentelemetry.javaagent.instrumentation.api.rmi.ThreadLocalContext.THREAD_LOCAL_CONTEXT;
 import static io.opentelemetry.javaagent.instrumentation.rmi.context.ContextPayload.GETTER;
 import static io.opentelemetry.javaagent.instrumentation.rmi.context.ContextPropagator.CONTEXT_CALL_ID;
@@ -50,7 +50,7 @@ public class ContextDispatcher implements Dispatcher {
     if (PROPAGATOR.isOperationWithPayload(operationId)) {
       ContextPayload payload = ContextPayload.read(in);
       if (payload != null) {
-        Context context = extract(payload, GETTER);
+        Context context = extractWithGlobalPropagators(payload, GETTER);
         SpanContext spanContext = Span.fromContext(context).getSpanContext();
         if (spanContext.isValid()) {
           THREAD_LOCAL_CONTEXT.set(context);


### PR DESCRIPTION
I haven't gone and updated any of the many other sub-tracers to inject the global, but having the capability means we can start migrating toward that model. This will enable the spring sleuth integration to not have to mess around with the global instance during startup.