### PR TITLE
Remove kotlin core libs from javaagent distro

### DIFF
--- a/javaagent-tooling/javaagent-tooling.gradle
+++ b/javaagent-tooling/javaagent-tooling.gradle
@@ -28,7 +28,12 @@ dependencies {
   implementation deps.opentelemetrySdk
   implementation deps.opentelemetrySdkAutoconfigure
   implementation deps.opentelemetrySdkMetrics
-  implementation deps.opentelemetryKotlin
+  implementation (deps.opentelemetryKotlin) {
+    // opentelemetry-extension-kotlin classes are injected into user classpath
+    // where kotlin core libraries are already present
+    exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-common'
+    exclude group: 'org.jetbrains.kotlinx', module: 'kotlinx-coroutines-core'
+  }
   implementation deps.opentelemetryTraceProps
   implementation(deps.opentelemetryResources) {
     // exclude sdk-common to avoid bumping guava version


### PR DESCRIPTION
these are adding ~3mb to the javaagent distro