### PR TITLE
Update smoke tests to 0.16.0-SNAPSHOT

### DIFF
--- a/smoke-tests/grpc/build.gradle
+++ b/smoke-tests/grpc/build.gradle
@@ -11,7 +11,7 @@ repositories {
   jcenter()
   // this is only needed for the working against unreleased otel-java snapshots
   maven {
-    url "https://oss.jfrog.org/artifactory/oss-snapshot-local"
+    url "https://oss.sonatype.org/content/repositories/snapshots"
     content {
       includeGroup "io.opentelemetry"
     }
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
   implementation platform("io.grpc:grpc-bom:1.33.1")
-  implementation platform("io.opentelemetry:opentelemetry-bom:0.15.0")
+  implementation platform("io.opentelemetry:opentelemetry-bom:0.16.0-SNAPSHOT")
   implementation platform("org.apache.logging.log4j:log4j-bom:2.13.3")
 
   implementation "io.grpc:grpc-netty-shaded"

--- a/smoke-tests/springboot/build.gradle
+++ b/smoke-tests/springboot/build.gradle
@@ -13,7 +13,7 @@ repositories {
   jcenter()
   // this is only needed for the working against unreleased otel-java snapshots
   maven {
-    url "https://oss.jfrog.org/artifactory/oss-snapshot-local"
+    url "https://oss.sonatype.org/content/repositories/snapshots"
     content {
       includeGroup "io.opentelemetry"
     }
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-  implementation platform("io.opentelemetry:opentelemetry-bom:0.15.0")
+  implementation platform("io.opentelemetry:opentelemetry-bom:0.16.0-SNAPSHOT")
 
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'io.opentelemetry:opentelemetry-extension-annotations'


### PR DESCRIPTION
No more breaking changes, so using unversioned SNAPSHOT should be fine and will let us release more smoothly,