### PR TITLE
Add OpenTelemetry parameter constructors to all api Tracer classes

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
@@ -20,9 +20,7 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
 
   protected static final String DB_QUERY = "DB Query";
 
-  public DatabaseClientTracer() {
-    super();
-  }
+  public DatabaseClientTracer() {}
 
   public DatabaseClientTracer(OpenTelemetry openTelemetry) {
     super(openTelemetry);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
@@ -7,10 +7,9 @@ package io.opentelemetry.instrumentation.api.tracer;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -21,10 +20,12 @@ public abstract class DatabaseClientTracer<CONNECTION, QUERY> extends BaseTracer
 
   protected static final String DB_QUERY = "DB Query";
 
-  protected final Tracer tracer;
-
   public DatabaseClientTracer() {
-    tracer = GlobalOpenTelemetry.getTracer(getInstrumentationName(), getVersion());
+    super();
+  }
+
+  public DatabaseClientTracer(OpenTelemetry openTelemetry) {
+    super(openTelemetry);
   }
 
   public boolean shouldStartSpan(Context parentContext) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/RpcClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/RpcClientTracer.java
@@ -9,9 +9,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 
 public abstract class RpcClientTracer extends BaseTracer {
-  protected RpcClientTracer() {
-    super();
-  }
+  protected RpcClientTracer() {}
 
   /**
    * Prefer to pass in an OpenTelemetry instance, rather than just a Tracer, so you don't have to

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/RpcClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/RpcClientTracer.java
@@ -5,13 +5,27 @@
 
 package io.opentelemetry.instrumentation.api.tracer;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 
 public abstract class RpcClientTracer extends BaseTracer {
-  protected RpcClientTracer() {}
+  protected RpcClientTracer() {
+    super();
+  }
 
+  /**
+   * Prefer to pass in an OpenTelemetry instance, rather than just a Tracer, so you don't have to
+   * use the GlobalOpenTelemetry Propagator instance.
+   *
+   * @deprecated prefer to pass in an OpenTelemetry instance, instead.
+   */
+  @Deprecated
   protected RpcClientTracer(Tracer tracer) {
     super(tracer);
+  }
+
+  protected RpcClientTracer(OpenTelemetry openTelemetry) {
+    super(openTelemetry);
   }
 
   protected abstract String getRpcSystem();

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/RpcServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/RpcServerTracer.java
@@ -5,15 +5,27 @@
 
 package io.opentelemetry.instrumentation.api.tracer;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 
 public abstract class RpcServerTracer<REQUEST> extends BaseTracer {
 
-  protected RpcServerTracer() {}
+  protected RpcServerTracer() { super(); }
 
+  /**
+   * Prefer to pass in an OpenTelemetry instance, rather than just a Tracer, so you don't have to
+   * use the GlobalOpenTelemetry Propagator instance.
+   *
+   * @deprecated prefer to pass in an OpenTelemetry instance, instead.
+   */
+  @Deprecated
   protected RpcServerTracer(Tracer tracer) {
     super(tracer);
+  }
+
+  protected RpcServerTracer(OpenTelemetry openTelemetry) {
+    super(openTelemetry);
   }
 
   protected abstract TextMapPropagator.Getter<REQUEST> getGetter();

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/RpcServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/RpcServerTracer.java
@@ -11,7 +11,7 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 
 public abstract class RpcServerTracer<REQUEST> extends BaseTracer {
 
-  protected RpcServerTracer() { super(); }
+  protected RpcServerTracer() {}
 
   /**
    * Prefer to pass in an OpenTelemetry instance, rather than just a Tracer, so you don't have to


### PR DESCRIPTION
Add an `OpenTelemetry` parameter to api RPC and DatabaseTracer constructors, to match the same constructor that was added to `BaseTracer`.

Ensure all the constructors call `super(..)` so that they take on the behavior of `BaseTracer` where context propagators and tracer are automatically initialized.