### PR TITLE
Remove kotlin core libs from javaagent distro

### DIFF
--- a/instrumentation/kotlinx-coroutines/javaagent/kotlinx-coroutines-javaagent.gradle
+++ b/instrumentation/kotlinx-coroutines/javaagent/kotlinx-coroutines-javaagent.gradle
@@ -16,11 +16,9 @@ muzzle {
   }
 }
 dependencies {
-  implementation deps.opentelemetryKotlin
+  compileOnly deps.opentelemetryKotlin
 
-  compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72'
-  compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7'
-
+  testImplementation deps.opentelemetryKotlin
   testImplementation deps.kotlin
   testImplementation deps.coroutines
 }


### PR DESCRIPTION
They either came back, or more likely I did a poor job of testing (see #2206)