### PR TITLE
Close response to avoid warning about leaked response

### DIFF
--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -92,6 +92,9 @@ abstract class AppServerTest extends SmokeTest {
       .findAny()
       .isPresent()
 
+    cleanup:
+    response?.close()
+
     where:
     [appServer, jdk] << getTestParams()
   }
@@ -132,6 +135,9 @@ abstract class AppServerTest extends SmokeTest {
       .findAny()
       .isPresent()
 
+    cleanup:
+    response?.close()
+
     where:
     [appServer, jdk] << getTestParams()
   }
@@ -170,6 +176,9 @@ abstract class AppServerTest extends SmokeTest {
       .map { it.stringValue }
       .findAny()
       .isPresent()
+
+    cleanup:
+    response?.close()
 
     where:
     [appServer, jdk] << getTestParams()
@@ -211,6 +220,9 @@ abstract class AppServerTest extends SmokeTest {
       .map { it.stringValue }
       .findAny()
       .isPresent()
+
+    cleanup:
+    response?.close()
 
     where:
     [appServer, jdk] << getTestParams()
@@ -256,6 +268,9 @@ abstract class AppServerTest extends SmokeTest {
       .findAny()
       .isPresent()
 
+    cleanup:
+    response?.close()
+
     where:
     [appServer, jdk] << getTestParams()
   }
@@ -294,6 +309,9 @@ abstract class AppServerTest extends SmokeTest {
       .map { it.stringValue }
       .findAny()
       .isPresent()
+
+    cleanup:
+    response?.close()
 
     where:
     [appServer, jdk] << getTestParams()
@@ -340,6 +358,9 @@ abstract class AppServerTest extends SmokeTest {
       .map { it.stringValue }
       .findAny()
       .isPresent()
+
+    cleanup:
+    response?.close()
 
     where:
     [appServer, jdk] << getTestParams()


### PR DESCRIPTION
Smoke tests have a bunch of tests that don't read response body which causes okhttp to log warnings about leaked responses.