### PR TITLE
Remove deps from javaagent

### DIFF
--- a/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
+++ b/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
@@ -25,11 +25,11 @@ dependencies {
   // in public API.
   library group: 'com.amazonaws', name: 'aws-lambda-java-events', version: '2.2.1'
 
-  implementation(
+  compileOnly(
     'com.fasterxml.jackson.core:jackson-databind:2.10.5.1',
     'com.fasterxml.jackson.module:jackson-module-afterburner:2.9.10',
     'commons-io:commons-io:2.2')
-  implementation deps.slf4j
+  compileOnly deps.slf4j
 
   implementation deps.opentelemetryExtAws
 

--- a/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
+++ b/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
@@ -36,6 +36,11 @@ dependencies {
   // 1.2.0 allows to get the function ARN
   testLibrary group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.0'
 
+  testImplementation(
+    'com.fasterxml.jackson.core:jackson-databind:2.10.5.1',
+    'com.fasterxml.jackson.module:jackson-module-afterburner:2.9.10',
+    'commons-io:commons-io:2.2')
+
   testImplementation deps.opentelemetryTraceProps
   testImplementation deps.guava
 

--- a/instrumentation/netty/netty-4.1/library/netty-4.1-library.gradle
+++ b/instrumentation/netty/netty-4.1/library/netty-4.1-library.gradle
@@ -1,5 +1,5 @@
 apply from: "$rootDir/gradle/instrumentation-library.gradle"
 
 dependencies {
-  implementation group: 'io.netty', name: 'netty-codec-http', version: '4.1.0.Final'
+  compileOnly group: 'io.netty', name: 'netty-codec-http', version: '4.1.0.Final'
 }


### PR DESCRIPTION
e.g. jackson is currently (unnecessarily) bundled under `inst/`

we already have netty under `inst/` due to the otlp/jaeger exporters, but is unnecessarily included if someone is not using netty in their javaagent exporter