### PR TITLE
Refactor InMemoryExporter and move some of its methods …

### DIFF
--- a/instrumentation/akka-actor-2.5/javaagent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/instrumentation/akka-actor-2.5/javaagent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import akka.dispatch.forkjoin.ForkJoinPool
 import akka.dispatch.forkjoin.ForkJoinTask
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import io.opentelemetry.sdk.trace.data.SpanData
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.Callable
@@ -58,15 +58,13 @@ class AkkaExecutorInstrumentationTest extends AgentInstrumentationSpecification 
       }
     }.run()
 
-    testWriter.waitForTraces(1)
-    List<SpanData> trace = testWriter.traces[0]
-
     expect:
-    testWriter.traces.size() == 1
-    trace.size() == 2
-    trace.get(0).name == "parent"
-    trace.get(1).name == "asyncChild"
-    trace.get(1).parentSpanId == trace.get(0).spanId
+    assertTraces(1) {
+      trace(0, 2) {
+        basicSpan(it, 0, "parent")
+        basicSpan(it, 1, "asyncChild", span(0))
+      }
+    }
 
     cleanup:
     pool?.shutdown()
@@ -129,10 +127,8 @@ class AkkaExecutorInstrumentationTest extends AgentInstrumentationSpecification 
       }
     }.run()
 
-    testWriter.waitForTraces(1)
-
     expect:
-    testWriter.traces.size() == 1
+    waitForTraces(1).size() == 1
 
     where:
     name              | method         | poolImpl

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringRepositoryTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringRepositoryTest.groovy
@@ -103,9 +103,9 @@ abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouchbaseTe
     }
 
     cleanup:
-    testWriter.clear()
+    clearExportedData()
     repo.deleteAll()
-    testWriter.waitForTraces(2)
+    ignoreTracesAndClear(2)
   }
 
   def "test save and retrieve"() {
@@ -130,9 +130,9 @@ abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouchbaseTe
     }
 
     cleanup:
-    testWriter.clear()
+    clearExportedData()
     repo.deleteAll()
-    testWriter.waitForTraces(2)
+    ignoreTracesAndClear(2)
   }
 
   def "test save and update"() {
@@ -157,9 +157,9 @@ abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouchbaseTe
     }
 
     cleanup:
-    testWriter.clear()
+    clearExportedData()
     repo.deleteAll()
-    testWriter.waitForTraces(2)
+    ignoreTracesAndClear(2)
   }
 
   def "save and delete"() {

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringTemplateTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringTemplateTest.groovy
@@ -109,9 +109,9 @@ class AbstractCouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
         assertCouchbaseCall(it, 2, "Bucket.remove", name, span(0))
       }
     }
+    clearExportedData()
 
     when:
-    testWriter.clear()
     def result = template.findById("1", Doc)
 
     then:

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -53,7 +53,7 @@ class Elasticsearch5NodeClientTest extends AgentInstrumentationSpecification {
       // into a top level trace to get exactly one trace in the result.
       testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
     }
-    testWriter.waitForTraces(1)
+    ignoreTracesAndClear(1)
   }
 
   def cleanupSpec() {
@@ -123,13 +123,10 @@ class Elasticsearch5NodeClientTest extends AgentInstrumentationSpecification {
 
   def "test elasticsearch get"() {
     setup:
-    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    testWriter.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    testWriter.traces.size() == 1
 
     when:
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -69,7 +69,7 @@ class Elasticsearch5TransportClientTest extends AgentInstrumentationSpecificatio
       // into a top level trace to get exactly one trace in the result.
       client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
     }
-    testWriter.waitForTraces(1)
+    ignoreTracesAndClear(1)
   }
 
   def cleanupSpec() {
@@ -142,13 +142,10 @@ class Elasticsearch5TransportClientTest extends AgentInstrumentationSpecificatio
 
   def "test elasticsearch get"() {
     setup:
-    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    testWriter.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    testWriter.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -56,7 +56,7 @@ class Elasticsearch53NodeClientTest extends AgentInstrumentationSpecification {
       // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
       testNode.client().admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
-    testWriter.waitForTraces(1)
+    ignoreTracesAndClear(1)
   }
 
   def cleanupSpec() {
@@ -126,13 +126,10 @@ class Elasticsearch53NodeClientTest extends AgentInstrumentationSpecification {
 
   def "test elasticsearch get"() {
     setup:
-    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    testWriter.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    testWriter.traces.size() == 1
 
     when:
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -73,7 +73,7 @@ class Elasticsearch53TransportClientTest extends AgentInstrumentationSpecificati
       // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
       client.admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
-    testWriter.waitForTraces(1)
+    ignoreTracesAndClear(1)
   }
 
   def cleanupSpec() {
@@ -147,13 +147,10 @@ class Elasticsearch53TransportClientTest extends AgentInstrumentationSpecificati
 
   def "test elasticsearch get"() {
     setup:
-    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    testWriter.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    testWriter.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -59,12 +59,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
 
   def setup() {
     repo.refresh()
-    testWriter.clear()
+    clearExportedData()
     runUnderTrace("delete") {
       repo.deleteAll()
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
   }
 
   def cleanupSpec() {
@@ -170,7 +169,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     and:
     repo.findById("1").get() == doc
@@ -201,7 +200,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     doc.data = "other data"
@@ -277,7 +276,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     repo.deleteById("1")

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -67,7 +67,7 @@ class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecificatio
       // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
       testNode.client().admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
-    ignoreTracesAndClear(1)
+    waitForTraces(1)
 
     template = new ElasticsearchTemplate(testNode.client())
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -67,7 +67,7 @@ class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecificatio
       // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
       testNode.client().admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
-    testWriter.waitForTraces(1)
+    ignoreTracesAndClear(1)
 
     template = new ElasticsearchTemplate(testNode.client())
   }
@@ -266,8 +266,7 @@ class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecificatio
       .withId("b")
       .build())
     template.refresh(indexName)
-    testWriter.waitForTraces(5)
-    testWriter.clear()
+    ignoreTracesAndClear(5)
 
     and:
     def query = new NativeSearchQueryBuilder().withIndices(indexName).build()

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -53,7 +53,7 @@ class Elasticsearch6NodeClientTest extends AgentInstrumentationSpecification {
       // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
       testNode.client().admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
-    ignoreTracesAndClear(1)
+    waitForTraces(1)
   }
 
   def cleanupSpec() {

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -53,7 +53,7 @@ class Elasticsearch6NodeClientTest extends AgentInstrumentationSpecification {
       // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
       testNode.client().admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
-    testWriter.waitForTraces(1)
+    ignoreTracesAndClear(1)
   }
 
   def cleanupSpec() {
@@ -123,13 +123,10 @@ class Elasticsearch6NodeClientTest extends AgentInstrumentationSpecification {
 
   def "test elasticsearch get"() {
     setup:
-    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    testWriter.waitForTraces(1)
 
     expect:
     indexResult.index() == indexName
-    testWriter.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -68,7 +68,7 @@ class Elasticsearch6TransportClientTest extends AgentInstrumentationSpecificatio
       // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
       client.admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
-    ignoreTracesAndClear(1)
+    waitForTraces(1)
   }
 
   def cleanupSpec() {

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -68,7 +68,7 @@ class Elasticsearch6TransportClientTest extends AgentInstrumentationSpecificatio
       // disable periodic refresh in InternalClusterInfoService as it creates spans that tests don't expect
       client.admin().cluster().updateSettings(new ClusterUpdateSettingsRequest().transientSettings(["cluster.routing.allocation.disk.threshold_enabled": false]))
     }
-    testWriter.waitForTraces(1)
+    ignoreTracesAndClear(1)
   }
 
   def cleanupSpec() {
@@ -142,13 +142,10 @@ class Elasticsearch6TransportClientTest extends AgentInstrumentationSpecificatio
 
   def "test elasticsearch get"() {
     setup:
-    assert testWriter.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
-    testWriter.waitForTraces(1)
 
     expect:
     indexResult.index() == indexName
-    testWriter.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()

--- a/instrumentation/executors/javaagent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/instrumentation/executors/javaagent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import io.opentelemetry.sdk.trace.data.SpanData
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.AbstractExecutorService
 import java.util.concurrent.ArrayBlockingQueue
@@ -72,15 +72,13 @@ class ExecutorInstrumentationTest extends AgentInstrumentationSpecification {
       }
     }.run()
 
-    testWriter.waitForTraces(1)
-    List<SpanData> trace = testWriter.traces[0]
-
     expect:
-    testWriter.traces.size() == 1
-    trace.size() == 2
-    trace.get(0).name == "parent"
-    trace.get(1).name == "asyncChild"
-    trace.get(1).parentSpanId == trace.get(0).spanId
+    assertTraces(1) {
+      trace(0, 2) {
+        basicSpan(it, 0, "parent")
+        basicSpan(it, 1, "asyncChild", span(0))
+      }
+    }
 
     cleanup:
     if (pool?.hasProperty("shutdown")) {
@@ -153,15 +151,13 @@ class ExecutorInstrumentationTest extends AgentInstrumentationSpecification {
     child.unblock()
     child.waitForCompletion()
 
-    testWriter.waitForTraces(1)
-    List<SpanData> trace = testWriter.traces[0]
-
     expect:
-    testWriter.traces.size() == 1
-    trace.size() == 2
-    trace.get(0).name == "parent"
-    trace.get(1).name == "asyncChild"
-    trace.get(1).parentSpanId == trace.get(0).spanId
+    assertTraces(1) {
+      trace(0, 2) {
+        basicSpan(it, 0, "parent")
+        basicSpan(it, 1, "asyncChild", span(0))
+      }
+    }
 
     cleanup:
     pool?.shutdown()
@@ -216,10 +212,9 @@ class ExecutorInstrumentationTest extends AgentInstrumentationSpecification {
       }
     }.run()
 
-    testWriter.waitForTraces(1)
 
     expect:
-    testWriter.traces.size() == 1
+    waitForTraces(1).size() == 1
 
     where:
     name                | method           | poolImpl

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -14,7 +14,7 @@ class ConfiguredTraceAnnotationsTest extends AgentInstrumentationSpecification {
     SayTracedHello.fromCallableWhenDisabled()
 
     expect:
-    testWriter.traces == []
+    traces.empty
   }
 
   def "method with custom annotation should be traced"() {

--- a/instrumentation/geode-1.4/javaagent/src/test/groovy/PutGetTest.groovy
+++ b/instrumentation/geode-1.4/javaagent/src/test/groovy/PutGetTest.groovy
@@ -158,8 +158,7 @@ class PutGetTest extends AgentInstrumentationSpecification {
 
     region.clear()
     region.put(1, value)
-    testWriter.waitForTraces(2)
-    testWriter.clear()
+    ignoreTracesAndClear(2)
 
     when:
     def results = region.query("SELECT * FROM /test-region p WHERE p.expDate = '10/2020'")

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/GoogleHttpClientAsyncTest.groovy
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/GoogleHttpClientAsyncTest.groovy
@@ -9,10 +9,6 @@ import spock.lang.Timeout
 
 @Timeout(5)
 class GoogleHttpClientAsyncTest extends AbstractGoogleHttpClientTest {
-  def setup() {
-    testWriter.clear()
-  }
-
   @Override
   HttpResponse executeRequest(HttpRequest request) {
     return request.executeAsync().get()

--- a/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/groovy/SpringJpaTest.groovy
@@ -47,7 +47,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     repo.save(customer)
@@ -56,7 +56,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
     then:
     customer.id != null
     // Behavior changed in new version:
-    def extraTrace = testWriter.traces.size() == 2
+    def extraTrace = traces.size() == 2
     assertTraces(extraTrace ? 2 : 1) {
       if (extraTrace) {
         trace(0, 1) {
@@ -87,7 +87,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     customer.firstName = "Bill"
@@ -123,7 +123,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     customer = repo.findByLastName("Anonymous")[0]
@@ -146,7 +146,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     repo.delete(customer)
@@ -180,6 +180,5 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         }
       }
     }
-    testWriter.clear()
   }
 }

--- a/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
+++ b/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
@@ -526,8 +526,8 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
     datasource.getConnection().close()
 
     then:
-    !testWriter.traces.any { it.any { it.name == "database.connection" } }
-    testWriter.clear()
+    !traces.any { it.any { it.name == "database.connection" } }
+    clearExportedData()
 
     when:
     runUnderTrace("parent") {

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/test/groovy/JedisClientTest.groovy
@@ -39,7 +39,7 @@ class JedisClientTest extends AgentInstrumentationSpecification {
 
   def setup() {
     jedis.flushAll()
-    testWriter.clear()
+    clearExportedData()
   }
 
   def "set command"() {

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/test/groovy/Jedis30ClientTest.groovy
@@ -39,7 +39,7 @@ class Jedis30ClientTest extends AgentInstrumentationSpecification {
 
   def setup() {
     jedis.flushAll()
-    testWriter.clear()
+    clearExportedData()
   }
 
   def "set command"() {

--- a/instrumentation/jetty-8.0/javaagent/src/test/groovy/QueuedThreadPoolTest.groovy
+++ b/instrumentation/jetty-8.0/javaagent/src/test/groovy/QueuedThreadPoolTest.groovy
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.junit.Assume.assumeTrue
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.javaagent.instrumentation.jetty.JavaLambdaMaker
-import io.opentelemetry.sdk.trace.data.SpanData
 import org.eclipse.jetty.util.thread.QueuedThreadPool
 
 class QueuedThreadPoolTest extends AgentInstrumentationSpecification {
@@ -37,16 +37,13 @@ class QueuedThreadPoolTest extends AgentInstrumentationSpecification {
       }
     }.run()
 
-    testWriter.waitForTraces(1)
-    List<SpanData> trace = testWriter.traces[0]
-
     expect:
-    testWriter.traces.size() == 1
-    trace.size() == 2
-    trace.get(0).traceId == trace.get(1).traceId
-    trace.get(0).name == "parent"
-    trace.get(1).name == "asyncChild"
-    trace.get(1).parentSpanId == trace.get(0).spanId
+    assertTraces(1) {
+      trace(0, 2) {
+        basicSpan(it, 0, "parent")
+        basicSpan(it, 1, "asyncChild", span(0))
+      }
+    }
 
     cleanup:
     pool.stop()
@@ -73,16 +70,13 @@ class QueuedThreadPoolTest extends AgentInstrumentationSpecification {
     child.unblock()
     child.waitForCompletion()
 
-    testWriter.waitForTraces(1)
-    List<SpanData> trace = testWriter.traces[0]
-
     expect:
-    testWriter.traces.size() == 1
-    trace.size() == 2
-    trace.get(0).traceId == trace.get(1).traceId
-    trace.get(0).name == "parent"
-    trace.get(1).name == "asyncChild"
-    trace.get(1).parentSpanId == trace.get(0).spanId
+    assertTraces(1) {
+      trace(0, 2) {
+        basicSpan(it, 0, "parent")
+        basicSpan(it, 1, "asyncChild", span(0))
+      }
+    }
 
     cleanup:
     pool.stop()

--- a/instrumentation/jsf/jsf-testing-common/src/main/groovy/BaseJsfTest.groovy
+++ b/instrumentation/jsf/jsf-testing-common/src/main/groovy/BaseJsfTest.groovy
@@ -108,7 +108,7 @@ abstract class BaseJsfTest extends AgentInstrumentationSpecification implements 
         basicSpan(it, 0, getContextPath() + "/greeting.xhtml", null)
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     // extract parameters needed to post back form
@@ -168,7 +168,7 @@ abstract class BaseJsfTest extends AgentInstrumentationSpecification implements 
         basicSpan(it, 0, getContextPath() + "/greeting.xhtml", null)
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     // extract parameters needed to post back form

--- a/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
@@ -53,7 +53,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
     container.setupMessageListener(new MessageListener<String, String>() {
       @Override
       void onMessage(ConsumerRecord<String, String> record) {
-        testWriter.waitForTraces(1) // ensure consistent ordering of traces
+        waitForTraces(1) // ensure consistent ordering of traces
         records.add(record)
       }
     })
@@ -315,7 +315,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
     producer.send(new ProducerRecord<Integer, String>(SHARED_TOPIC, kafkaPartition, null, greeting))
 
     then:
-    testWriter.waitForTraces(1)
+    waitForTraces(1)
     def records = new LinkedBlockingQueue<ConsumerRecord<String, String>>()
     def pollResult = KafkaTestUtils.getRecords(consumer)
 

--- a/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
@@ -222,8 +222,9 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
       }
     })
     def spanContext = Span.fromContext(context).getSpanContext()
-    spanContext.traceId == testWriter.traces[0][3].traceId
-    spanContext.spanId == testWriter.traces[0][3].spanId
+    def streamSendSpan = traces[0][3]
+    spanContext.traceId == streamSendSpan.traceId
+    spanContext.spanId == streamSendSpan.spanId
 
 
     cleanup:

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -92,8 +92,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     syncCommands.set("TESTKEY", "TESTVAL")
 
     // 1 set + 1 connect trace
-    testWriter.waitForTraces(2)
-    testWriter.clear()
+    ignoreTracesAndClear(2)
   }
 
   def cleanup() {
@@ -308,7 +307,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     hmsetFuture.thenApplyAsync(new Function<String, Object>() {
       @Override
       Object apply(String setResult) {
-        testWriter.waitForTraces(1) // Wait for 'hmset' trace to get written
+        waitForTraces(1) // Wait for 'hmset' trace to get written
         conds.evaluate {
           assert setResult == "OK"
         }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -76,8 +76,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
     syncCommands.hmset("TESTHM", testHashMap)
 
     // 2 sets + 1 connect trace
-    testWriter.waitForTraces(3)
-    testWriter.clear()
+    ignoreTracesAndClear(3)
   }
 
   def cleanup() {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -95,8 +95,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     syncCommands.set("TESTKEY", "TESTVAL")
 
     // 1 set + 1 connect trace
-    testWriter.waitForTraces(2)
-    testWriter.clear()
+    ignoreTracesAndClear(2)
   }
 
   def cleanup() {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -65,8 +65,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
     syncCommands.set("TESTKEY", "TESTVAL")
 
     // 1 set + 1 connect trace
-    testWriter.waitForTraces(2)
-    testWriter.clear()
+    ignoreTracesAndClear(2)
   }
 
   def cleanup() {
@@ -237,15 +236,12 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
   }
 
   def "non reactive command should not produce span"() {
-    setup:
-    String res = null
-
     when:
-    res = reactiveCommands.digest(null)
+    def res = reactiveCommands.digest(null)
 
     then:
     res != null
-    testWriter.traces.size() == 0
+    traces.size() == 0
   }
 
   def "debug segfault command (returns mono void) with no argument should produce span"() {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -78,8 +78,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
     syncCommands.hmset("TESTHM", testHashMap)
 
     // 2 sets + 1 connect trace
-    testWriter.waitForTraces(3)
-    testWriter.clear()
+    ignoreTracesAndClear(3)
   }
 
   def cleanup() {

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceAsyncClientTest.groovy
@@ -93,8 +93,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     syncCommands.set("TESTKEY", "TESTVAL")
 
     // 1 set
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
   }
 
   def cleanup() {

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
@@ -68,8 +68,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
     syncCommands.set("TESTKEY", "TESTVAL")
 
     // 1 set
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
   }
 
   def cleanup() {
@@ -267,15 +266,12 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
   }
 
   def "non reactive command should not produce span"() {
-    setup:
-    String res = null
-
     when:
-    res = reactiveCommands.digest()
+    def res = reactiveCommands.digest()
 
     then:
     res != null
-    testWriter.traces.size() == 0
+    traces.size() == 0
   }
 
   def "blocking subscriber"() {

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceSyncClientTest.groovy
@@ -83,8 +83,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
     syncCommands.hmset("TESTHM", testHashMap)
 
     // 2 sets
-    testWriter.waitForTraces(2)
-    testWriter.clear()
+    ignoreTracesAndClear(2)
   }
 
   def cleanup() {

--- a/instrumentation/mongo/mongo-3.1/javaagent/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/javaagent/src/test/groovy/MongoClientTest.groovy
@@ -123,8 +123,7 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     collection.insertOne(new Document("password", "SECRET"))
@@ -154,8 +153,7 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def result = collection.updateOne(
@@ -188,8 +186,7 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def result = collection.deleteOne(new BsonDocument("password", new BsonString("SECRET")))
@@ -219,8 +216,7 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertMany([new Document("_id", 0), new Document("_id", 1), new Document("_id", 2)])
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     collection.find().filter(new Document("_id", new Document('$gte', 0)))
@@ -248,8 +244,7 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     collection.updateOne(new BsonDocument(), new BsonDocument())

--- a/instrumentation/mongo/mongo-3.7/javaagent/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/javaagent/src/test/groovy/MongoClientTest.groovy
@@ -133,8 +133,7 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     collection.insertOne(new Document("password", "SECRET"))
@@ -164,8 +163,7 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def result = collection.updateOne(
@@ -198,8 +196,7 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def result = collection.deleteOne(new BsonDocument("password", new BsonString("SECRET")))
@@ -229,8 +226,7 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertMany([new Document("_id", 0), new Document("_id", 1), new Document("_id", 2)])
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     collection.find().filter(new Document("_id", new Document('$gte', 0)))
@@ -258,8 +254,7 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     collection.updateOne(new BsonDocument(), new BsonDocument())

--- a/instrumentation/mongo/mongo-4.0-testing/src/test/groovy/Mongo4ReactiveClientTest.groovy
+++ b/instrumentation/mongo/mongo-4.0-testing/src/test/groovy/Mongo4ReactiveClientTest.groovy
@@ -121,8 +121,7 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
       latch1.await()
       return db.getCollection(collectionName)
     }
-    testWriter.waitForTraces(2)
-    testWriter.clear()
+    ignoreTracesAndClear(2)
 
     when:
     def count = new CompletableFuture()
@@ -167,8 +166,7 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
       latch2.await()
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def result = new CompletableFuture<UpdateResult>()
@@ -218,8 +216,7 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
       latch2.await()
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def result = new CompletableFuture<DeleteResult>()

--- a/instrumentation/mongo/mongo-4.0-testing/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-4.0-testing/src/test/groovy/MongoClientTest.groovy
@@ -95,8 +95,7 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     collection.insertOne(new Document("password", "SECRET"))
@@ -126,8 +125,7 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "OLDPW"))
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def result = collection.updateOne(
@@ -160,8 +158,7 @@ class MongoClientTest extends MongoBaseTest {
       coll.insertOne(new Document("password", "SECRET"))
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def result = collection.deleteOne(new BsonDocument("password", new BsonString("SECRET")))
@@ -190,8 +187,7 @@ class MongoClientTest extends MongoBaseTest {
       db.createCollection(collectionName)
       return db.getCollection(collectionName)
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     collection.updateOne(new BsonDocument(), new BsonDocument())

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/src/test/groovy/MongoAsyncClientTest.groovy
@@ -157,8 +157,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
       latch1.await()
       return db.getCollection(collectionName)
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def count = new CompletableFuture()
@@ -203,8 +202,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
       latch2.await()
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def result = new CompletableFuture<UpdateResult>()
@@ -254,8 +252,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
       latch2.await()
       return coll
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
 
     when:
     def result = new CompletableFuture<DeleteResult>()

--- a/instrumentation/opentelemetry-api-metrics-1.0/javaagent/src/test/groovy/MeterTest.groovy
+++ b/instrumentation/opentelemetry-api-metrics-1.0/javaagent/src/test/groovy/MeterTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.sdk.metrics.data.MetricDataType.DOUBLE_GAUGE
 import static io.opentelemetry.sdk.metrics.data.MetricDataType.DOUBLE_SUM
 import static io.opentelemetry.sdk.metrics.data.MetricDataType.LONG_GAUGE
@@ -11,9 +12,9 @@ import static io.opentelemetry.sdk.metrics.data.MetricDataType.SUMMARY
 import static java.util.concurrent.TimeUnit.SECONDS
 
 import com.google.common.base.Stopwatch
-import io.opentelemetry.api.metrics.common.Labels
 import io.opentelemetry.api.metrics.AsynchronousInstrument
 import io.opentelemetry.api.metrics.GlobalMetricsProvider
+import io.opentelemetry.api.metrics.common.Labels
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.sdk.metrics.data.MetricData
 import io.opentelemetry.sdk.metrics.data.PointData
@@ -253,8 +254,7 @@ class MeterTest extends AgentInstrumentationSpecification {
   def findMetric(instrumentationName, metricName) {
     Stopwatch stopwatch = Stopwatch.createStarted()
     while (stopwatch.elapsed(SECONDS) < 10) {
-      def allMetrics = testWriter.getMetrics()
-      for (def metric : allMetrics) {
+      for (def metric : metrics) {
         if (metric.instrumentationLibraryInfo.name == instrumentationName && metric.name == metricName) {
           return metric
         }

--- a/instrumentation/opentelemetry-api-metrics-1.0/javaagent/src/test/groovy/MeterTest.groovy
+++ b/instrumentation/opentelemetry-api-metrics-1.0/javaagent/src/test/groovy/MeterTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.sdk.metrics.data.MetricDataType.DOUBLE_GAUGE
 import static io.opentelemetry.sdk.metrics.data.MetricDataType.DOUBLE_SUM
 import static io.opentelemetry.sdk.metrics.data.MetricDataType.LONG_GAUGE

--- a/instrumentation/oshi/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/oshi/OshiTest.groovy
+++ b/instrumentation/oshi/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/oshi/OshiTest.groovy
@@ -33,8 +33,7 @@ class OshiTest extends AgentInstrumentationSpecification {
   def findMetric(instrumentationName, metricName) {
     Stopwatch stopwatch = Stopwatch.createStarted()
     while (stopwatch.elapsed(SECONDS) < 10) {
-      def allMetrics = testWriter.getMetrics()
-      for (def metric : allMetrics) {
+      for (def metric : metrics) {
         if (metric.instrumentationLibraryInfo.name == instrumentationName && metric.name == metricName) {
           return metric
         }

--- a/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonAsyncClientTest.groovy
+++ b/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonAsyncClientTest.groovy
@@ -54,7 +54,7 @@ class RedissonAsyncClientTest extends AgentInstrumentationSpecification {
     Config config = new Config()
     config.useSingleServer().setAddress(address)
     redisson = Redisson.create(config)
-    testWriter.clear()
+    clearExportedData()
   }
 
   def "test future set"() {

--- a/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonClientTest.groovy
+++ b/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonClientTest.groovy
@@ -59,7 +59,7 @@ class RedissonClientTest extends AgentInstrumentationSpecification {
     Config config = new Config()
     config.useSingleServer().setAddress(address)
     redisson = Redisson.create(config)
-    testWriter.clear()
+    clearExportedData()
   }
 
   def "test string command"() {

--- a/instrumentation/scala-executors/javaagent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/instrumentation/scala-executors/javaagent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import io.opentelemetry.sdk.trace.data.SpanData
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.Callable
@@ -58,15 +58,13 @@ class ScalaExecutorInstrumentationTest extends AgentInstrumentationSpecification
       }
     }.run()
 
-    testWriter.waitForTraces(1)
-    List<SpanData> trace = testWriter.traces[0]
-
     expect:
-    testWriter.traces.size() == 1
-    trace.size() == 2
-    trace.get(0).name == "parent"
-    trace.get(1).name == "asyncChild"
-    trace.get(1).parentSpanId == trace.get(0).spanId
+    assertTraces(1) {
+      trace(0, 2) {
+        basicSpan(it, 0, "parent")
+        basicSpan(it, 1, "asyncChild", span(0))
+      }
+    }
 
     cleanup:
     pool?.shutdown()
@@ -128,10 +126,8 @@ class ScalaExecutorInstrumentationTest extends AgentInstrumentationSpecification
       }
     }.run()
 
-    testWriter.waitForTraces(1)
-
     expect:
-    testWriter.traces.size() == 1
+    waitForTraces(1).size() == 1
 
     where:
     name              | method         | poolImpl

--- a/instrumentation/servlet/servlet-common/javaagent/src/test/groovy/HttpServletResponseTest.groovy
+++ b/instrumentation/servlet/servlet-common/javaagent/src/test/groovy/HttpServletResponseTest.groovy
@@ -32,7 +32,7 @@ class HttpServletResponseTest extends AgentInstrumentationSpecification {
     def servlet = new AbstractHttpServlet() {}
     // We need to call service so HttpServletAdvice can link the request to the response.
     servlet.service((ServletRequest) request, (ServletResponse) response)
-    testWriter.clear()
+    clearExportedData()
   }
 
   def "test send no-parent"() {
@@ -91,7 +91,7 @@ class HttpServletResponseTest extends AgentInstrumentationSpecification {
     def servlet = new AbstractHttpServlet() {}
     // We need to call service so HttpServletAdvice can link the request to the response.
     servlet.service((ServletRequest) request, (ServletResponse) response)
-    testWriter.clear()
+    clearExportedData()
 
     when:
     runUnderTrace("parent") {

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/test/groovy/SpringJpaTest.groovy
@@ -21,7 +21,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
     def repo = context.getBean(JpaCustomerRepository)
 
     // when Spring JPA sets up, it issues metadata queries -- clear those traces
-    testWriter.clear()
+    clearExportedData()
 
     when:
     runUnderTrace("toString test") {
@@ -47,7 +47,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
     def repo = context.getBean(JpaCustomerRepository)
 
     // when Spring JPA sets up, it issues metadata queries -- clear those traces
-    testWriter.clear()
+    clearExportedData()
 
     setup:
     def customer = new JpaCustomer("Bob", "Anonymous")
@@ -79,7 +79,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     repo.save(customer) // insert
@@ -110,7 +110,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     customer.firstName = "Bill"
@@ -153,7 +153,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     customer = repo.findByLastName("Anonymous")[0] // select
@@ -182,7 +182,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         }
       }
     }
-    testWriter.clear()
+    clearExportedData()
 
     when:
     repo.delete(customer) // delete
@@ -223,6 +223,5 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         }
       }
     }
-    testWriter.clear()
   }
 }

--- a/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
@@ -116,8 +116,7 @@ class SpymemcachedTest extends AgentInstrumentationSpecification {
     runUnderTrace("setup") {
       valuesToSet.each { k, v -> assert memcached.set(key(k), expiration, v).get() }
     }
-    testWriter.waitForTraces(1)
-    testWriter.clear()
+    ignoreTracesAndClear(1)
   }
 
   def "test get hit"() {

--- a/testing-common/integration-tests/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/AgentTestRunnerTest.groovy
@@ -48,7 +48,7 @@ class AgentTestRunnerTest extends AgentInstrumentationSpecification {
   def "waiting for child spans times out"() {
     when:
     runUnderTrace("parent") {
-      testWriter.waitForTraces(1)
+      waitForTraces(1)
     }
 
     then:

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestTrait.groovy
@@ -14,8 +14,7 @@ import io.opentelemetry.instrumentation.testing.InstrumentationTestRunner
  */
 trait AgentTestTrait {
 
-  static InstrumentationTestRunner agentTestRunner = AgentTestRunner.instance()
-  static InMemoryExporter testWriter = new InMemoryExporter()
+  static final InstrumentationTestRunner agentTestRunner = AgentTestRunner.instance()
 
   InstrumentationTestRunner testRunner() {
     agentTestRunner

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/AgentTestTrait.groovy
@@ -14,9 +14,7 @@ import io.opentelemetry.instrumentation.testing.InstrumentationTestRunner
  */
 trait AgentTestTrait {
 
-  static final InstrumentationTestRunner agentTestRunner = AgentTestRunner.instance()
-
   InstrumentationTestRunner testRunner() {
-    agentTestRunner
+    AgentTestRunner.instance()
   }
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/InstrumentationSpecification.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/InstrumentationSpecification.groovy
@@ -10,6 +10,9 @@ import groovy.transform.stc.SimpleType
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.test.asserts.InMemoryExporterAssert
 import io.opentelemetry.instrumentation.testing.InstrumentationTestRunner
+import io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil
+import io.opentelemetry.sdk.metrics.data.MetricData
+import io.opentelemetry.sdk.trace.data.SpanData
 import spock.lang.Specification
 
 /**
@@ -36,8 +39,40 @@ abstract class InstrumentationSpecification extends Specification {
     testRunner().afterTestClass()
   }
 
+  /** Return a list of all captured traces, where each trace is a sorted list of spans. */
+  List<List<SpanData>> getTraces() {
+    TelemetryDataUtil.groupTraces(testRunner().getExportedSpans())
+  }
+
+  /** Return a list of all captured metrics. */
+  List<MetricData> getMetrics() {
+    testRunner().getExportedMetrics()
+  }
+
+  /**
+   * Removes all captured telemetry data. After calling this method {@link #getTraces()} and
+   * {@link #getMetrics()} will return empty lists until more telemetry data is captured.
+   */
+  void clearExportedData() {
+    testRunner().clearAllExportedData()
+  }
+
   boolean forceFlushCalled() {
     return testRunner().forceFlushCalled()
+  }
+
+  /**
+   * Wait until at least {@code numberOfTraces} traces are completed and return all captured traces.
+   * Note that there may be more than {@code numberOfTraces} collected. By default this waits up to
+   * 20 seconds, then times out.
+   */
+  List<List<SpanData>> waitForTraces(int numberOfTraces) {
+    TelemetryDataUtil.waitForTraces({ testRunner().getExportedSpans() }, numberOfTraces)
+  }
+
+  void ignoreTracesAndClear(int numberOfTraces) {
+    waitForTraces(numberOfTraces)
+    clearExportedData()
   }
 
   void assertTraces(

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
@@ -13,8 +13,10 @@ import io.opentelemetry.instrumentation.testing.LibraryTestRunner
  * library tests should implement this trait.
  */
 trait LibraryTestTrait {
+  // library test runner has to be initialized statically so that GlobalOpenTelemetry is set as soon as possible
+  private static final InstrumentationTestRunner RUNNER = LibraryTestRunner.instance()
 
   InstrumentationTestRunner testRunner() {
-    LibraryTestRunner.instance()
+    RUNNER
   }
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
@@ -14,9 +14,7 @@ import io.opentelemetry.instrumentation.testing.LibraryTestRunner
  */
 trait LibraryTestTrait {
 
-  static final InstrumentationTestRunner instrumentationTestRunner = LibraryTestRunner.instance()
-
   InstrumentationTestRunner testRunner() {
-    instrumentationTestRunner
+    LibraryTestRunner.instance()
   }
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
@@ -14,11 +14,7 @@ import io.opentelemetry.instrumentation.testing.LibraryTestRunner
  */
 trait LibraryTestTrait {
 
-  static InstrumentationTestRunner instrumentationTestRunner = LibraryTestRunner.instance()
-
-  static {
-    instrumentationTestRunner = LibraryTestRunner.instance()
-  }
+  static final InstrumentationTestRunner instrumentationTestRunner = LibraryTestRunner.instance()
 
   InstrumentationTestRunner testRunner() {
     instrumentationTestRunner

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/InMemoryExporterAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/InMemoryExporterAssert.groovy
@@ -9,7 +9,7 @@ import static TraceAssert.assertTrace
 
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
-import io.opentelemetry.instrumentation.test.InMemoryExporter
+import io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.function.Supplier
 import org.codehaus.groovy.runtime.powerassert.PowerAssertionError
@@ -32,7 +32,7 @@ class InMemoryExporterAssert {
                            @ClosureParams(value = SimpleType, options = ['io.opentelemetry.instrumentation.test.asserts.ListWriterAssert'])
                            @DelegatesTo(value = InMemoryExporterAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
     try {
-      def traces = InMemoryExporter.waitForTraces(spanSupplier, expectedSize)
+      def traces = TelemetryDataUtil.waitForTraces(spanSupplier, expectedSize)
       assert traces.size() == expectedSize
       def asserter = new InMemoryExporterAssert(traces, spanSupplier)
       def clone = (Closure) spec.clone()

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/TraceAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/TraceAssert.groovy
@@ -9,7 +9,7 @@ import static SpanAssert.assertSpan
 
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
-import io.opentelemetry.instrumentation.test.InMemoryExporter
+import io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.concurrent.TimeUnit
 import java.util.function.Supplier
@@ -77,7 +77,7 @@ class TraceAssert {
   }
 
   private static List<SpanData> getTrace(Supplier<List<SpanData>> spanSupplier, String traceId) {
-    List<List<SpanData>> traces = InMemoryExporter.groupTraces(spanSupplier.get())
+    List<List<SpanData>> traces = TelemetryDataUtil.groupTraces(spanSupplier.get())
     for (List<SpanData> trace : traces) {
       if (trace[0].traceId == traceId) {
         return trace

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/InstrumentationExtension.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/InstrumentationExtension.java
@@ -6,9 +6,12 @@
 package io.opentelemetry.instrumentation.testing.junit;
 
 import io.opentelemetry.instrumentation.testing.InstrumentationTestRunner;
+import io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -16,6 +19,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 public abstract class InstrumentationExtension
     implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback {
+  private static final long DEFAULT_TRACE_WAIT_TIMEOUT_SECONDS = 20;
+
   private final InstrumentationTestRunner testRunner;
 
   protected InstrumentationExtension(InstrumentationTestRunner testRunner) {
@@ -37,11 +42,52 @@ public abstract class InstrumentationExtension
     testRunner.beforeTestClass();
   }
 
+  /** Return a list of all captured spans. */
   public List<SpanData> spans() {
     return testRunner.getExportedSpans();
   }
 
+  /** Return a list of all captured traces, where each trace is a sorted list of spans. */
+  public List<List<SpanData>> traces() {
+    return TelemetryDataUtil.groupTraces(spans());
+  }
+
+  /** Return a list of all captured metrics. */
   public List<MetricData> metrics() {
     return testRunner.getExportedMetrics();
+  }
+
+  /**
+   * Removes all captured telemetry data. After calling this method {@link #spans()}, {@link
+   * #traces()} and {@link #metrics()} will return empty lists until more telemetry data is
+   * captured.
+   */
+  public void clearData() {
+    testRunner.clearAllExportedData();
+  }
+
+  /**
+   * Wait until at least {@code numberOfTraces} traces are completed and return all captured traces.
+   * Note that there may be more than {@code numberOfTraces} collected. By default this waits up to
+   * 20 seconds, then times out.
+   *
+   * @throws TimeoutException when the operation times out
+   * @throws InterruptedException when the current thread is interrupted
+   */
+  public List<List<SpanData>> waitForTraces(int numberOfTraces)
+      throws TimeoutException, InterruptedException {
+    return waitForTraces(numberOfTraces, DEFAULT_TRACE_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Wait until at least {@code numberOfTraces} traces are completed and return all captured traces.
+   * Note that there may be more than {@code numberOfTraces} collected.
+   *
+   * @throws TimeoutException when the operation times out
+   * @throws InterruptedException when the current thread is interrupted
+   */
+  public List<List<SpanData>> waitForTraces(int numberOfTraces, long timeout, TimeUnit unit)
+      throws TimeoutException, InterruptedException {
+    return TelemetryDataUtil.waitForTraces(this::spans, numberOfTraces, timeout, unit);
   }
 }


### PR DESCRIPTION
…to spock base class & junit extension.

Additional methods in `InstrumentationExtension` will make unit testing in vendor distributions much easier and nicer - a small example of the extension (and sdk-testing assertions) in action can be found in `LibraryInstrumentationExtensionTest`.
Once 0.17.0/1.0.0 is released I'll also add an example of how to setup instrumentation tests in a distribution to `examples/distro`

And I guess it closes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1955 too