### PR TITLE
Use ClassRule in armeria tests

### DIFF
--- a/instrumentation/armeria-1.3/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaTest.groovy
+++ b/instrumentation/armeria-1.3/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaTest.groovy
@@ -20,12 +20,4 @@ class ArmeriaTest extends AbstractArmeriaTest implements AgentTestTrait {
   WebClientBuilder configureClient(WebClientBuilder clientBuilder) {
     return clientBuilder
   }
-
-  def setupSpec() {
-    server.before()
-  }
-
-  def cleanupSpec() {
-    server.after()
-  }
 }

--- a/instrumentation/armeria-1.3/library/src/test/groovy/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTest.groovy
+++ b/instrumentation/armeria-1.3/library/src/test/groovy/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTest.groovy
@@ -21,12 +21,4 @@ class ArmeriaTest extends AbstractArmeriaTest implements LibraryTestTrait {
   WebClientBuilder configureClient(WebClientBuilder clientBuilder) {
     return clientBuilder.decorator(OpenTelemetryClient.newDecorator())
   }
-
-  def setupSpec() {
-    server.before()
-  }
-
-  def cleanupSpec() {
-    server.after()
-  }
 }

--- a/instrumentation/armeria-1.3/testing/src/main/groovy/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaTest.groovy
+++ b/instrumentation/armeria-1.3/testing/src/main/groovy/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaTest.groovy
@@ -20,9 +20,10 @@ import com.linecorp.armeria.server.ServerBuilder
 import com.linecorp.armeria.server.ServiceRequestContext
 import com.linecorp.armeria.testing.junit4.server.ServerRule
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.function.Function
+import org.junit.ClassRule
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -33,9 +34,8 @@ abstract class AbstractArmeriaTest extends InstrumentationSpecification {
 
   abstract WebClientBuilder configureClient(WebClientBuilder clientBuilder)
 
-  // We cannot annotate with @ClassRule since then Armeria will be class loaded before bytecode
-  // instrumentation is set up by the Spock trait.
   @Shared
+  @ClassRule
   protected ServerRule server = new ServerRule() {
     @Override
     protected void configure(ServerBuilder sb) throws Exception {


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/765

There's no longer any problem with using `@ClassRule`s after https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1643 was implemented - we no longer do any code transformations in test code (not directly at least)