### PR TITLE
Remove unused gradle config

### DIFF
--- a/instrumentation/opentelemetry-api-1.0/javaagent/opentelemetry-api-1.0-javaagent.gradle
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/opentelemetry-api-1.0-javaagent.gradle
@@ -29,7 +29,3 @@ dependencies {
   testImplementation deps.opentelemetryExtAnnotations
   testInstrumentation project(':instrumentation:opentelemetry-annotations-1.0:javaagent')
 }
-
-tasks.withType(Test) {
-  jvmArgs '-Dotel.trace.annotated.methods.exclude=io.opentelemetry.test.annotation.TracedWithSpan[ignored]'
-}


### PR DESCRIPTION
Looks like I forgot to remove this when moving splitting out opentelemetry-annotations as a separate module.