### PR TITLE
Fix references of otel.trace. to otel.traces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Configuration parameters are passed as Java system properties (`-D` flags) or
 as environment variables. See below for a full list of environment variables. For example:
 ```
 java -javaagent:path/to/opentelemetry-javaagent-all.jar \
-     -Dotel.trace.exporter=zipkin \
+     -Dotel.traces.exporter=zipkin \
      -jar myapp.jar
 ```
 

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
@@ -58,7 +58,7 @@ public class HttpBenchmark {
   @Fork(
       jvmArgsAppend = {
         "-javaagent:/path/to/opentelemetry-java-instrumentation/java-agent/build/libs/opentelemetry-javaagent.jar",
-        "-Dotel.trace.exporter=logging"
+        "-Dotel.traces.exporter=logging"
       })
   public static class WithAgent extends ClassRetransformingBenchmark {}
 }

--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -123,20 +123,20 @@ The [peer service name](https://github.com/open-telemetry/opentelemetry-specific
 
 | System property                 | Environment variable            | Description                                                  |
 |---------------------------------|---------------------------------|--------------------------------------------------------------|
-| otel.trace.sampler              | OTEL_TRACE_SAMPLER              | The sampler to use for tracing. Defaults to `parentbased_always_on` |
-| otel.trace.sampler.arg          | OTEL_TRACE_SAMPLER_ARG          | An argument to the configured tracer if supported, for example a ratio. |
+| otel.traces.sampler             | OTEL_TRACES_SAMPLER              | The sampler to use for tracing. Defaults to `parentbased_always_on` |
+| otel.traces.sampler.arg         | OTEL_TRACES_SAMPLER_ARG          | An argument to the configured tracer if supported, for example a ratio. |
 | otel.span.attribute.count.limit | OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT | The maximum number of attributes per span. Default is `32`.  |
 | otel.span.event.count.limit     | OTEL_SPAN_EVENT_COUNT_LIMIT     | The maximum number of events per span. Default is `128`.     |
 | otel.span.link.count.limit      | OTEL_SPAN_LINK_COUNT_LIMIT      | The maximum number of links per span. Default is `32`        |
 
-Supported values for `otel.trace.sampler` are
+Supported values for `otel.traces.sampler` are
 
 - "always_on": AlwaysOnSampler
 - "always_off": AlwaysOffSampler
-- "traceidratio": TraceIdRatioBased. `otel.trace.sampler.arg` sets the ratio.
+- "traceidratio": TraceIdRatioBased. `otel.traces.sampler.arg` sets the ratio.
 - "parentbased_always_on": ParentBased(root=AlwaysOnSampler)
 - "parentbased_always_off": ParentBased(root=AlwaysOffSampler)
-- "parentbased_traceidratio": ParentBased(root=TraceIdRatioBased). `otel.trace.sampler.arg` sets the ratio.
+- "parentbased_traceidratio": ParentBased(root=TraceIdRatioBased). `otel.traces.sampler.arg` sets the ratio.
 
 ## Interval metric reader
 

--- a/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/config/PropertySource.java
+++ b/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/config/PropertySource.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public interface PropertySource {
   /**
    * Returns all properties whose default values are overridden by this property source. Key of the
-   * map is the propertyName (same as system property name, e.g. {@code otel.trace.exporter}), value
+   * map is the propertyName (same as system property name, e.g. {@code otel.traces.exporter}), value
    * is the property value.
    */
   Map<String, String> getProperties();

--- a/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/config/PropertySource.java
+++ b/javaagent-spi/src/main/java/io/opentelemetry/javaagent/spi/config/PropertySource.java
@@ -16,8 +16,8 @@ import java.util.Map;
 public interface PropertySource {
   /**
    * Returns all properties whose default values are overridden by this property source. Key of the
-   * map is the propertyName (same as system property name, e.g. {@code otel.traces.exporter}), value
-   * is the property value.
+   * map is the propertyName (same as system property name, e.g. {@code otel.traces.exporter}),
+   * value is the property value.
    */
   Map<String, String> getProperties();
 }

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingExporterPropertySource.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingExporterPropertySource.java
@@ -15,7 +15,7 @@ public class AgentTestingExporterPropertySource implements PropertySource {
   @Override
   public Map<String, String> getProperties() {
     Map<String, String> properties = new HashMap<>();
-    properties.put("otel.trace.exporter", "none");
+    properties.put("otel.traces.exporter", "none");
     properties.put("otel.metrics.exporter", "none");
     return properties;
   }


### PR DESCRIPTION
This was recent-ish spec change, and was changed already in underlying SDK releases.