### PR TITLE
Remove afterburner from aws-lambda tests

### DIFF
--- a/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
+++ b/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
@@ -27,7 +27,6 @@ dependencies {
 
   compileOnly(
     'com.fasterxml.jackson.core:jackson-databind:2.10.5.1',
-    'com.fasterxml.jackson.module:jackson-module-afterburner:2.9.10',
     'commons-io:commons-io:2.2')
   compileOnly deps.slf4j
 
@@ -38,7 +37,6 @@ dependencies {
 
   testImplementation(
     'com.fasterxml.jackson.core:jackson-databind:2.10.5.1',
-    'com.fasterxml.jackson.module:jackson-module-afterburner:2.9.10',
     'commons-io:commons-io:2.2')
 
   testImplementation deps.opentelemetryTraceProps

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/HeadersFactory.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/HeadersFactory.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.awslambda.v1_0;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import java.io.InputStream;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -20,10 +19,6 @@ class HeadersFactory {
   private static final Logger log = LoggerFactory.getLogger(HeadersFactory.class);
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-  static {
-    OBJECT_MAPPER.registerModule(new AfterburnerModule());
-  }
 
   @Nullable
   static Map<String, String> ofStream(InputStream inputStream) {

--- a/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractorTest.java
+++ b/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractorTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import java.util.Map;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,12 +28,18 @@ public class ParentContextExtractorTest {
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
-  @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+  @Rule
+  public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   @BeforeClass
   public static void setUp() {
     GlobalOpenTelemetry.set(
         OpenTelemetry.getPropagating(ContextPropagators.create(B3Propagator.getInstance())));
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    GlobalOpenTelemetry.resetForTest();
   }
 
   @Test

--- a/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractorTest.java
+++ b/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractorTest.java
@@ -28,8 +28,7 @@ public class ParentContextExtractorTest {
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
-  @Rule
-  public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+  @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   @BeforeClass
   public static void setUp() {


### PR DESCRIPTION
Also added `GlobalOpenTelemetry.resetForTest()` to make tests pass without relying on retries.

EDIT: this is a follow-up, see https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2251#discussion_r574271966