### PR TITLE
Include status code for HttpUrlConnection exceptions

### DIFF
--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentationModule.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentationModule.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
@@ -162,8 +161,7 @@ public class HttpUrlConnectionInstrumentationModule extends InstrumentationModul
 
     @Advice.OnMethodExit
     public static void methodExit(
-        @Advice.This HttpURLConnection connection,
-        @Advice.Return(typing = Assigner.Typing.DYNAMIC) int returnValue) {
+        @Advice.This HttpURLConnection connection, @Advice.Return int returnValue) {
 
       ContextStore<HttpURLConnection, HttpUrlState> storage =
           InstrumentationContext.get(HttpURLConnection.class, HttpUrlState.class);

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentationModule.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentationModule.java
@@ -139,11 +139,9 @@ public class HttpUrlConnectionInstrumentationModule extends InstrumentationModul
         @Advice.Return(typing = Assigner.Typing.DYNAMIC) Object returnValue) {
 
       if (methodName.equals("getResponseCode")) {
-        if (httpUrlState == null) {
-          ContextStore<HttpURLConnection, HttpUrlState> storage =
-              InstrumentationContext.get(HttpURLConnection.class, HttpUrlState.class);
-          httpUrlState = storage.get(connection);
-        }
+        ContextStore<HttpURLConnection, HttpUrlState> storage =
+            InstrumentationContext.get(HttpURLConnection.class, HttpUrlState.class);
+        httpUrlState = storage.get(connection);
         if (httpUrlState != null) {
           Span span = Span.fromContext(httpUrlState.context);
           span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, (int) returnValue);
@@ -180,7 +178,6 @@ public class HttpUrlConnectionInstrumentationModule extends InstrumentationModul
   public static class HttpUrlState {
     public final Context context;
     public boolean finished;
-    public int responseCode = -1;
 
     public HttpUrlState(Context context) {
       this.context = context;

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentationModule.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentationModule.java
@@ -28,10 +28,10 @@ import io.opentelemetry.javaagent.instrumentation.api.ContextStore;
 import io.opentelemetry.javaagent.instrumentation.api.InstrumentationContext;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.Map;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -90,10 +90,9 @@ public class HttpUrlConnectionInstrumentationModule extends InstrumentationModul
         @Advice.Local("otelHttpUrlState") HttpUrlState httpUrlState,
         @Advice.Local("otelScope") Scope scope,
         @Advice.Local("otelCallDepth") CallDepth callDepth,
-        @Advice.Origin("#m") String methodName
-        ) {
+        @Advice.Origin("#m") String methodName) {
 
-      if(methodName.equals("getResponseCode")){
+      if (methodName.equals("getResponseCode")) {
         // Nothing to do here, prevent changing/impacting
         return;
       }
@@ -139,16 +138,16 @@ public class HttpUrlConnectionInstrumentationModule extends InstrumentationModul
         @Advice.Local("otelCallDepth") CallDepth callDepth,
         @Advice.Return(typing = Assigner.Typing.DYNAMIC) Object returnValue) {
 
-      if(methodName.equals("getResponseCode")){
-        if(httpUrlState == null){
+      if (methodName.equals("getResponseCode")) {
+        if (httpUrlState == null) {
           ContextStore<HttpURLConnection, HttpUrlState> storage =
               InstrumentationContext.get(HttpURLConnection.class, HttpUrlState.class);
           httpUrlState = storage.get(connection);
         }
-        if(httpUrlState != null){
+        if (httpUrlState != null) {
           Span span = Span.fromContext(httpUrlState.context);
-          span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, (int)returnValue);
-          if((int)returnValue >= 400){
+          span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, (int) returnValue);
+          if ((int) returnValue >= 400) {
             span.setStatus(StatusCode.ERROR);
           }
         }

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -299,7 +299,7 @@ class HttpUrlConnectionTest extends HttpClientTest {
     when:
     def url = uri.toURL()
     runUnderTrace("parent") {
-      doRequest(method, uri, ["is-test-server": "false"])
+      doRequest(method, uri)
     }
 
     then:

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -306,9 +306,10 @@ class HttpUrlConnectionTest extends HttpClientTest {
     def expectedException = new IOException("Server returned HTTP response code: 500 for URL: $url")
     thrown(IOException)
     assertTraces(1) {
-      trace(0, 2 + extraClientSpans()) {
+      trace(0, 3 + extraClientSpans()) {
         basicSpan(it, 0, "parent", null, expectedException)
         clientSpan(it, 1, span(0), method, uri, 500, expectedException)
+        serverSpan(it, 2 + extraClientSpans(), span(1 + extraClientSpans()))
       }
     }
 

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.api.trace.Span
@@ -291,6 +292,28 @@ class HttpUrlConnectionTest extends HttpClientTest {
         }
       }
     }
+  }
+
+  def "error span"(){
+    def uri = server.address.resolve("/error")
+    when:
+    def url = uri.toURL()
+    runUnderTrace("parent") {
+      doRequest(method, uri, ["is-test-server": "false"])
+    }
+
+    then:
+    def expectedException = new IOException("Server returned HTTP response code: 500 for URL: $url")
+    thrown(IOException)
+    assertTraces(1) {
+      trace(0, 2 + extraClientSpans()) {
+        basicSpan(it, 0, "parent", null, expectedException)
+        clientSpan(it, 1, span(0), method, uri, 500, expectedException)
+      }
+    }
+
+    where:
+    method = "GET"
   }
 
   // This test makes no sense on IBM JVM because there is no HttpsURLConnectionImpl class there


### PR DESCRIPTION
Resolves #2244 

The `HttpUrlConnection` implementation is highly complex.  There are code paths that generate and throw an exception, which causes inconsistency around `responseCode` being populated or not (since it is both a method an a field).

There's also a neat note in the instrumentation module that says:
```
        // responseCode field is sometimes not populated.
        // We can't call getResponseCode() due to some unwanted side-effects
        // (e.g. breaks getOutputStream).
```

So this adds instrumentation around `HttpUrlConnection.getResponseCode()`.  Method enter is effectively a no-op, but on exit we get the span and add in the status code and mark it as an error if it's 400/500 level.