### PR TITLE
Mark all non-javaagent artifacts as -alpha version.

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -26,6 +26,13 @@ publishing {
         from components.java
       }
 
+      def stable = findProperty("otel.stable") ?: false
+      if (!stable) {
+        def versionParts = version.split('-')
+        versionParts[0] += '-alpha'
+        version = versionParts.join('-')
+      }
+
       afterEvaluate {
         def mavenGroupId = project.findProperty('mavenGroupId')
         if (mavenGroupId) {

--- a/javaagent/gradle.properties
+++ b/javaagent/gradle.properties
@@ -1,0 +1,1 @@
+otel.stable=true


### PR DESCRIPTION
Similar to SDK 

https://github.com/open-telemetry/opentelemetry-java/blob/main/build.gradle.kts#L427

but opt-out of alpha instead of opt-in.

Fixes #2252