### PR TITLE
Remove Hibernate from javaagent jar

### DIFF
--- a/instrumentation/hibernate/hibernate-4.3/javaagent/hibernate-4.3-javaagent.gradle
+++ b/instrumentation/hibernate/hibernate-4.3/javaagent/hibernate-4.3-javaagent.gradle
@@ -26,7 +26,7 @@ testSets {
 test.dependsOn version5Test, version6Test
 
 dependencies {
-  implementation group: 'org.hibernate', name: 'hibernate-core', version: '4.3.0.Final'
+  library group: 'org.hibernate', name: 'hibernate-core', version: '4.3.0.Final'
 
   implementation project(':instrumentation:hibernate:hibernate-common:javaagent')
 


### PR DESCRIPTION
I've noticed that we bundle entire Hibernate 4.3 + its dependencies in the javaagent jar - which is not likely to be needed.