### PR TITLE
Support library instrumentations with HttpServerTest & HttpClientTest

### DIFF
--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -11,12 +11,13 @@ import akka.http.javadsl.model.HttpMethods
 import akka.http.javadsl.model.HttpRequest
 import akka.http.javadsl.model.headers.RawHeader
 import akka.stream.ActorMaterializer
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class AkkaHttpClientInstrumentationTest extends HttpClientTest {
+class AkkaHttpClientInstrumentationTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   ActorSystem system = ActorSystem.create()

--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 

--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 
-abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> {
+abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> implements AgentTestTrait {
 
   @Override
   boolean testExceptionBody() {

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.CompletableFuture
 import org.apache.http.HttpResponse
@@ -15,7 +17,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class ApacheHttpAsyncClientCallbackTest extends HttpClientTest {
+class ApacheHttpAsyncClientCallbackTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   RequestConfig requestConfig = RequestConfig.custom()

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.CompletableFuture

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.Future
 import org.apache.http.client.config.RequestConfig
@@ -13,7 +15,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest {
+class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   RequestConfig requestConfig = RequestConfig.custom()

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.Future

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.CountDownLatch

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.CountDownLatch
 import org.apache.http.HttpResponse
@@ -15,7 +17,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class ApacheHttpAsyncClientTest extends HttpClientTest {
+class ApacheHttpAsyncClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   RequestConfig requestConfig = RequestConfig.custom()

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/test/groovy/CommonsHttpClientTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/test/groovy/CommonsHttpClientTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import org.apache.commons.httpclient.HttpClient
 import org.apache.commons.httpclient.HttpMethod
@@ -17,7 +18,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class CommonsHttpClientTest extends HttpClientTest {
+class CommonsHttpClientTest extends HttpClientTest implements AgentTestTrait {
   @Shared
   HttpClient client = new HttpClient()
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import org.apache.http.HttpResponse
 import org.apache.http.client.ResponseHandler
@@ -14,7 +15,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class ApacheHttpClientResponseHandlerTest extends HttpClientTest {
+class ApacheHttpClientResponseHandlerTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   def client = new DefaultHttpClient()

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/groovy/ApacheHttpClientTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import org.apache.http.HttpHost
 import org.apache.http.HttpRequest
@@ -16,7 +17,7 @@ import org.apache.http.protocol.BasicHttpContext
 import spock.lang.Shared
 import spock.lang.Timeout
 
-abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest {
+abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest implements AgentTestTrait {
   @Shared
   def client = new DefaultHttpClient()
 

--- a/instrumentation/async-http-client-1.9/javaagent/src/test/groovy/AsyncHttpClientTest.groovy
+++ b/instrumentation/async-http-client-1.9/javaagent/src/test/groovy/AsyncHttpClientTest.groovy
@@ -9,11 +9,12 @@ import com.ning.http.client.Request
 import com.ning.http.client.RequestBuilder
 import com.ning.http.client.Response
 import com.ning.http.client.uri.Uri
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
-class AsyncHttpClientTest extends HttpClientTest {
+class AsyncHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @AutoCleanup
   @Shared

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
@@ -18,18 +19,19 @@ import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
 import io.dropwizard.testing.ConfigOverride
 import io.dropwizard.testing.DropwizardTestSupport
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import javax.ws.rs.GET
 import javax.ws.rs.Path
 import javax.ws.rs.PathParam
 import javax.ws.rs.QueryParam
 import javax.ws.rs.core.Response
 
-class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
+class DropwizardTest extends HttpServerTest<DropwizardTestSupport> implements AgentTestTrait {
 
   @Override
   DropwizardTestSupport startServer(int port) {

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR

--- a/instrumentation/finatra-2.9/javaagent/src/latestDepTest/groovy/FinatraServerLatestTest.groovy
+++ b/instrumentation/finatra-2.9/javaagent/src/latestDepTest/groovy/FinatraServerLatestTest.groovy
@@ -13,11 +13,12 @@ import com.twitter.util.Await
 import com.twitter.util.Closable
 import com.twitter.util.Duration
 import com.twitter.util.Promise
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
 
-class FinatraServerLatestTest extends HttpServerTest<HttpServer> {
+class FinatraServerLatestTest extends HttpServerTest<HttpServer> implements AgentTestTrait {
   private static final Duration TIMEOUT = Duration.fromSeconds(5)
   private static final Duration STARTUP_TIMEOUT = Duration.fromSeconds(20)
 

--- a/instrumentation/finatra-2.9/javaagent/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/javaagent/src/test/groovy/FinatraServerTest.groovy
@@ -10,12 +10,13 @@ import com.twitter.finatra.http.HttpServer
 import com.twitter.util.Await
 import com.twitter.util.Closable
 import com.twitter.util.Duration
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.concurrent.TimeoutException
 
-class FinatraServerTest extends HttpServerTest<HttpServer> {
+class FinatraServerTest extends HttpServerTest<HttpServer> implements AgentTestTrait {
   private static final Duration TIMEOUT = Duration.fromSeconds(5)
   private static final long STARTUP_TIMEOUT = 40 * 1000
 

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -9,11 +9,12 @@ import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpRequest
 import com.google.api.client.http.HttpResponse
 import com.google.api.client.http.javanet.NetHttpTransport
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Shared
 
-abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
+abstract class AbstractGoogleHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   def requestFactory = new NetHttpTransport().createRequestFactory()

--- a/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyFilterchainServerTest.groovy
+++ b/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyFilterchainServerTest.groovy
@@ -16,6 +16,7 @@ import static java.nio.charset.Charset.defaultCharset
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static org.glassfish.grizzly.memory.Buffers.wrap
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import java.util.concurrent.Executors
 import org.glassfish.grizzly.filterchain.BaseFilter
@@ -36,7 +37,7 @@ import org.glassfish.grizzly.nio.transport.TCPNIOTransportBuilder
 import org.glassfish.grizzly.utils.DelayedExecutor
 import org.glassfish.grizzly.utils.IdleTimeoutFilter
 
-class GrizzlyFilterchainServerTest extends HttpServerTest<HttpServer> {
+class GrizzlyFilterchainServerTest extends HttpServerTest<HttpServer> implements AgentTestTrait {
 
   private TCPNIOTransport transport
   private TCPNIOServerConnection serverConnection

--- a/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyTest.groovy
+++ b/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyTest.groovy
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import javax.ws.rs.GET
 import javax.ws.rs.NotFoundException
@@ -22,7 +23,7 @@ import org.glassfish.grizzly.http.server.Request
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
 import org.glassfish.jersey.server.ResourceConfig
 
-class GrizzlyTest extends HttpServerTest<HttpServer> {
+class GrizzlyTest extends HttpServerTest<HttpServer> implements AgentTestTrait {
 
   @Override
   HttpServer startServer(int port) {

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import spock.lang.Timeout
 
 @Timeout(5)
-class HttpUrlConnectionResponseCodeOnlyTest extends HttpClientTest {
+class HttpUrlConnectionResponseCodeOnlyTest extends HttpClientTest implements AgentTestTrait {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -3,19 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Ignore
 import spock.lang.Requires
 import spock.lang.Timeout
 import sun.net.www.protocol.https.HttpsURLConnectionImpl
 
 @Timeout(5)
-class HttpUrlConnectionTest extends HttpClientTest {
+class HttpUrlConnectionTest extends HttpClientTest implements AgentTestTrait {
 
   static final RESPONSE = "Hello."
   static final STATUS = 200

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
@@ -4,11 +4,12 @@
  */
 
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import spock.lang.Timeout
 
 @Timeout(5)
-class HttpUrlConnectionUseCachesFalseTest extends HttpClientTest {
+class HttpUrlConnectionUseCachesFalseTest extends HttpClientTest implements AgentTestTrait {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/SpringRestTemplateTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -15,7 +16,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class SpringRestTemplateTest extends HttpClientTest {
+class SpringRestTemplateTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   ClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory()

--- a/instrumentation/java-httpclient/javaagent/src/test/groovy/JdkHttpClientTest.groovy
+++ b/instrumentation/java-httpclient/javaagent/src/test/groovy/JdkHttpClientTest.groovy
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
@@ -17,7 +19,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-abstract class JdkHttpClientTest extends HttpClientTest {
+abstract class JdkHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   def client = HttpClient.newBuilder().connectTimeout(Duration.of(CONNECT_TIMEOUT_MS,

--- a/instrumentation/java-httpclient/javaagent/src/test/groovy/JdkHttpClientTest.groovy
+++ b/instrumentation/java-httpclient/javaagent/src/test/groovy/JdkHttpClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import io.opentelemetry.instrumentation.test.AgentTestTrait

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/test/groovy/JaxRsClientV1Test.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/test/groovy/JaxRsClientV1Test.groovy
@@ -7,12 +7,13 @@ import com.sun.jersey.api.client.Client
 import com.sun.jersey.api.client.ClientResponse
 import com.sun.jersey.api.client.filter.GZIPContentEncodingFilter
 import com.sun.jersey.api.client.filter.LoggingFilter
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class JaxRsClientV1Test extends HttpClientTest {
+class JaxRsClientV1Test extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   Client client = Client.create()

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.CountDownLatch

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -21,7 +23,7 @@ import org.glassfish.jersey.client.JerseyClientBuilder
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
 import spock.lang.Timeout
 
-abstract class JaxRsClientAsyncTest extends HttpClientTest {
+abstract class JaxRsClientAsyncTest extends HttpClientTest implements AgentTestTrait {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import io.opentelemetry.instrumentation.test.AgentTestTrait

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.TimeUnit
 import javax.ws.rs.client.Client
 import javax.ws.rs.client.ClientBuilder
@@ -23,7 +25,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
 import spock.lang.Timeout
 import spock.lang.Unroll
 
-abstract class JaxRsClientTest extends HttpClientTest {
+abstract class JaxRsClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/ResteasyProxyClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/ResteasyProxyClientTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.nio.charset.StandardCharsets
 import javax.ws.rs.GET
@@ -16,7 +18,7 @@ import org.apache.http.client.utils.URLEncodedUtils
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
 import org.jboss.resteasy.specimpl.ResteasyUriBuilder
 
-class ResteasyProxyClientTest extends HttpClientTest {
+class ResteasyProxyClientTest extends HttpClientTest implements AgentTestTrait {
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
     def proxyMethodName = "${method}_${uri.path}".toLowerCase()

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/ResteasyProxyClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/ResteasyProxyClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.nio.charset.StandardCharsets

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -11,10 +12,11 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.junit.Assume.assumeTrue
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.CompletableFuture
 import okhttp3.Call
 import okhttp3.Callback
@@ -24,7 +26,7 @@ import okhttp3.Response
 import spock.lang.Timeout
 import spock.lang.Unroll
 
-abstract class JaxRsHttpServerTest<S> extends HttpServerTest<S> {
+abstract class JaxRsHttpServerTest<S> extends HttpServerTest<S> implements AgentTestTrait {
   @Timeout(10)
   @Unroll
   def "should handle #desc AsyncResponse"() {

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION

--- a/instrumentation/jetty-8.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty-8.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import javax.servlet.DispatcherType
@@ -23,7 +24,7 @@ import org.eclipse.jetty.server.handler.AbstractHandler
 import org.eclipse.jetty.server.handler.ErrorHandler
 import spock.lang.Shared
 
-class JettyHandlerTest extends HttpServerTest<Server> {
+class JettyHandlerTest extends HttpServerTest<Server> implements AgentTestTrait {
 
   @Shared
   ErrorHandler errorHandler = new ErrorHandler() {

--- a/instrumentation/khttp-0.1/javaagent/src/test/groovy/KHttpClientTest.groovy
+++ b/instrumentation/khttp-0.1/javaagent/src/test/groovy/KHttpClientTest.groovy
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import khttp.KHttp
 
-class KHttpClientTest extends HttpClientTest {
+class KHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {

--- a/instrumentation/netty/netty-3.8/javaagent/src/latestDepTest/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/latestDepTest/groovy/Netty38ClientTest.groovy
@@ -11,13 +11,14 @@ import com.ning.http.client.AsyncCompletionHandler
 import com.ning.http.client.AsyncHttpClient
 import com.ning.http.client.AsyncHttpClientConfig
 import com.ning.http.client.Response
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
-class Netty38ClientTest extends HttpClientTest {
+class Netty38ClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   def clientConfig = new AsyncHttpClientConfig.Builder()

--- a/instrumentation/netty/netty-3.8/javaagent/src/latestDepTest/groovy/Netty38ServerTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/latestDepTest/groovy/Netty38ServerTest.groovy
@@ -15,6 +15,7 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.LOCATION
 import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import org.jboss.netty.bootstrap.ServerBootstrap
 import org.jboss.netty.buffer.ChannelBuffer
@@ -41,7 +42,7 @@ import org.jboss.netty.logging.InternalLoggerFactory
 import org.jboss.netty.logging.Slf4JLoggerFactory
 import org.jboss.netty.util.CharsetUtil
 
-class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
+class Netty38ServerTest extends HttpServerTest<ServerBootstrap> implements AgentTestTrait {
 
   static final LoggingHandler LOGGING_HANDLER
   static {

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
@@ -11,13 +11,14 @@ import com.ning.http.client.AsyncCompletionHandler
 import com.ning.http.client.AsyncHttpClient
 import com.ning.http.client.AsyncHttpClientConfig
 import com.ning.http.client.Response
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
-class Netty38ClientTest extends HttpClientTest {
+class Netty38ClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   def clientConfig = new AsyncHttpClientConfig.Builder()

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
@@ -15,6 +15,7 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.LOCATION
 import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import org.jboss.netty.bootstrap.ServerBootstrap
 import org.jboss.netty.buffer.ChannelBuffer
@@ -41,7 +42,7 @@ import org.jboss.netty.logging.InternalLoggerFactory
 import org.jboss.netty.logging.Slf4JLoggerFactory
 import org.jboss.netty.util.CharsetUtil
 
-class Netty38ServerTest extends HttpServerTest<ServerBootstrap> {
+class Netty38ServerTest extends HttpServerTest<ServerBootstrap> implements AgentTestTrait {
 
   static final LoggingHandler LOGGING_HANDLER
   static {

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ClientTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ClientTest.groovy
@@ -8,6 +8,7 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.asynchttpclient.Dsl.asyncHttpClient
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
@@ -20,7 +21,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class Netty40ClientTest extends HttpClientTest {
+class Netty40ClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   def clientConfig = DefaultAsyncHttpClientConfig.Builder.newInstance().setRequestTimeout(TimeUnit.SECONDS.toMillis(10).toInteger())

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
@@ -34,9 +34,10 @@ import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 
-class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
+class Netty40ServerTest extends HttpServerTest<EventLoopGroup> implements AgentTestTrait {
 
   static final LoggingHandler LOGGING_HANDLER = new LoggingHandler(SERVER_LOGGER.name, LogLevel.DEBUG)
 

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.HttpClientCodec
 import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.HttpMethod
 import io.netty.handler.codec.http.HttpVersion
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.javaagent.instrumentation.netty.v4_1.client.HttpClientTracingHandler
 import java.util.concurrent.ExecutionException
@@ -40,7 +41,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class Netty41ClientTest extends HttpClientTest {
+class Netty41ClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   def clientConfig = DefaultAsyncHttpClientConfig.Builder.newInstance().setRequestTimeout(TimeUnit.SECONDS.toMillis(10).toInteger())

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ServerTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ServerTest.groovy
@@ -33,9 +33,10 @@ import io.netty.handler.codec.http.HttpServerCodec
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 
-class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
+class Netty41ServerTest extends HttpServerTest<EventLoopGroup> implements AgentTestTrait {
 
   static final LoggingHandler LOGGING_HANDLER = new LoggingHandler(SERVER_LOGGER.name, LogLevel.DEBUG)
 

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/test/groovy/OkHttp2Test.groovy
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/test/groovy/OkHttp2Test.groovy
@@ -9,13 +9,14 @@ import com.squareup.okhttp.OkHttpClient
 import com.squareup.okhttp.Request
 import com.squareup.okhttp.RequestBody
 import com.squareup.okhttp.internal.http.HttpMethod
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.TimeUnit
 import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class OkHttp2Test extends HttpClientTest {
+class OkHttp2Test extends HttpClientTest implements AgentTestTrait {
   @Shared
   def client = new OkHttpClient()
 

--- a/instrumentation/okhttp/okhttp-3.0/javaagent/src/test/groovy/OkHttp3Test.groovy
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/src/test/groovy/OkHttp3Test.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.TimeUnit
 import okhttp3.Headers
@@ -14,7 +15,7 @@ import okhttp3.internal.http.HttpMethod
 import spock.lang.Timeout
 
 @Timeout(5)
-class OkHttp3Test extends HttpClientTest {
+class OkHttp3Test extends HttpClientTest implements AgentTestTrait {
 
   def client = new OkHttpClient.Builder()
     .connectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)

--- a/instrumentation/play-ws/play-ws-testing/src/main/groovy/PlayWsClientTestBase.groovy
+++ b/instrumentation/play-ws/play-ws-testing/src/main/groovy/PlayWsClientTestBase.groovy
@@ -6,6 +6,7 @@
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.ActorMaterializerSettings
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import play.shaded.ahc.org.asynchttpclient.AsyncHttpClient
 import play.shaded.ahc.org.asynchttpclient.AsyncHttpClientConfig
@@ -13,7 +14,7 @@ import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClient
 import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClientConfig
 import spock.lang.Shared
 
-abstract class PlayWsClientTestBase extends HttpClientTest {
+abstract class PlayWsClientTestBase extends HttpClientTest implements AgentTestTrait {
   @Shared
   ActorSystem system
 

--- a/instrumentation/play/play-2.3/javaagent/src/test/groovy/client/PlayWsClientTest.groovy
+++ b/instrumentation/play/play-2.3/javaagent/src/test/groovy/client/PlayWsClientTest.groovy
@@ -5,6 +5,7 @@
 
 package client
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.util.concurrent.TimeUnit
 import play.GlobalSettings
@@ -13,7 +14,7 @@ import play.test.FakeApplication
 import play.test.Helpers
 import spock.lang.Shared
 
-class PlayWsClientTest extends HttpClientTest {
+class PlayWsClientTest extends HttpClientTest implements AgentTestTrait {
   @Shared
   def application = new FakeApplication(
     new File("."),

--- a/instrumentation/play/play-2.3/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.3/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -9,12 +9,13 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
 import play.api.test.TestServer
 
-class PlayServerTest extends HttpServerTest<TestServer> {
+class PlayServerTest extends HttpServerTest<TestServer> implements AgentTestTrait {
   @Override
   TestServer startServer(int port) {
     def server = SyncServer.server(port)

--- a/instrumentation/play/play-2.4/javaagent/src/test/groovy/client/PlayWsClientTest.groovy
+++ b/instrumentation/play/play-2.4/javaagent/src/test/groovy/client/PlayWsClientTest.groovy
@@ -5,6 +5,7 @@
 
 package client
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import play.libs.ws.WS
 import spock.lang.AutoCleanup
@@ -15,7 +16,7 @@ import spock.lang.Timeout
 // Play 2.6+ uses a separately versioned client that shades the underlying dependency
 // This means our built in instrumentation won't work.
 @Timeout(5)
-class PlayWsClientTest extends HttpClientTest {
+class PlayWsClientTest extends HttpClientTest implements AgentTestTrait {
   @Subject
   @Shared
   @AutoCleanup

--- a/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -20,7 +21,7 @@ import play.mvc.Results
 import play.routing.RoutingDsl
 import play.server.Server
 
-class PlayServerTest extends HttpServerTest<Server> {
+class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
   @Override
   Server startServer(int port) {
     def router =

--- a/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -22,7 +23,7 @@ import play.mvc.Results
 import play.routing.RoutingDsl
 import play.server.Server
 
-class PlayServerTest extends HttpServerTest<Server> {
+class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
   @Override
   Server startServer(int port) {
     return Server.forRouter(Mode.TEST, port) { BuiltInComponents components ->

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/client/RatpackHttpClientTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/client/RatpackHttpClientTest.groovy
@@ -5,6 +5,7 @@
 
 package client
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import java.time.Duration
 import ratpack.exec.ExecResult
@@ -15,7 +16,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class RatpackHttpClientTest extends HttpClientTest {
+class RatpackHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @AutoCleanup
   @Shared

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -13,6 +13,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -21,7 +22,7 @@ import ratpack.groovy.test.embed.GroovyEmbeddedApp
 import ratpack.handling.Context
 import ratpack.test.embed.EmbeddedApp
 
-class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
+class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> implements AgentTestTrait {
 
   @Override
   EmbeddedApp startServer(int bindPort) {

--- a/instrumentation/reactor-netty-0.9/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty-0.9/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import reactor.netty.http.client.HttpClient
 import reactor.netty.http.client.HttpClientResponse
 
-class ReactorNettyHttpClientTest extends HttpClientTest {
+class ReactorNettyHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Override
   boolean testRedirects() {

--- a/instrumentation/reactor-netty-0.9/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty-0.9/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import reactor.netty.http.client.HttpClient

--- a/instrumentation/reactor-netty-1.0/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty-1.0/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import reactor.netty.http.client.HttpClient
 import reactor.netty.http.client.HttpClientResponse
 
-class ReactorNettyHttpClientTest extends HttpClientTest {
+class ReactorNettyHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Override
   boolean testRedirects() {

--- a/instrumentation/reactor-netty-1.0/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty-1.0/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import reactor.netty.http.client.HttpClient

--- a/instrumentation/servlet/glassfish-testing/src/test/groovy/GlassFishServerTest.groovy
+++ b/instrumentation/servlet/glassfish-testing/src/test/groovy/GlassFishServerTest.groovy
@@ -7,6 +7,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import org.glassfish.embeddable.BootstrapProperties
@@ -21,7 +22,7 @@ import org.glassfish.embeddable.archive.ScatteredArchive
  * OSGi setup that requires {@link io.opentelemetry.javaagent.instrumentation.javaclassloader.ClassloadingInstrumentation}.
  */
 // TODO: Figure out a better way to test with OSGi included.
-class GlassFishServerTest extends HttpServerTest<GlassFish> {
+class GlassFishServerTest extends HttpServerTest<GlassFish> implements AgentTestTrait {
 
   @Override
   URI buildAddress() {

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/JettyServlet2Test.groovy
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/JettyServlet2Test.groovy
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -19,7 +20,7 @@ import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
 
-class JettyServlet2Test extends HttpServerTest<Server> {
+class JettyServlet2Test extends HttpServerTest<Server> implements AgentTestTrait {
 
   private static final CONTEXT = "ctx"
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
@@ -10,13 +10,14 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import javax.servlet.Servlet
 import okhttp3.Request
 import okhttp3.RequestBody
 
-abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERVER> {
+abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERVER> implements AgentTestTrait {
   @Override
   URI buildAddress() {
     return new URI("http://localhost:$port$contextPath/")

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/client/SpringWebfluxHttpClientTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/client/SpringWebfluxHttpClientTest.groovy
@@ -5,6 +5,7 @@
 
 package client
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import org.springframework.http.HttpMethod
 import org.springframework.web.reactive.function.client.ClientResponse
@@ -12,7 +13,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import spock.lang.Timeout
 
 @Timeout(5)
-class SpringWebfluxHttpClientTest extends HttpClientTest {
+class SpringWebfluxHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -14,6 +14,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -24,7 +25,7 @@ import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.web.servlet.view.RedirectView
 
-class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext> {
+class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext> implements AgentTestTrait {
 
   @Override
   ConfigurableApplicationContext startServer(int port) {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -19,7 +20,7 @@ import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import test.boot.SecurityConfig
 
-class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> {
+class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> implements AgentTestTrait {
 
   @Override
   ConfigurableApplicationContext startServer(int port) {

--- a/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
+++ b/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 
 import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -21,7 +22,7 @@ import org.eclipse.jetty.servlet.DefaultServlet
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.util.resource.FileResource
 
-class Struts2ActionSpanTest extends HttpServerTest<Server> {
+class Struts2ActionSpanTest extends HttpServerTest<Server> implements AgentTestTrait {
 
   @Override
   boolean testNotFound() {

--- a/instrumentation/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat7/TomcatHandlerTest.groovy
+++ b/instrumentation/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat7/TomcatHandlerTest.groovy
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -18,7 +19,7 @@ import org.apache.catalina.Context
 import org.apache.catalina.startup.Tomcat
 import org.apache.tomcat.util.descriptor.web.ErrorPage
 
-class TomcatHandlerTest extends HttpServerTest<Tomcat> {
+class TomcatHandlerTest extends HttpServerTest<Tomcat> implements AgentTestTrait {
 
   def "Tomcat starts"() {
     expect:

--- a/instrumentation/undertow/javaagent/src/test/groovy/UndertowServerTest.groovy
+++ b/instrumentation/undertow/javaagent/src/test/groovy/UndertowServerTest.groovy
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.undertow.Handlers
 import io.undertow.Undertow
@@ -16,7 +17,7 @@ import io.undertow.util.Headers
 import io.undertow.util.StatusCodes
 
 //TODO make test which mixes handlers and servlets
-class UndertowServerTest extends HttpServerTest<Undertow> {
+class UndertowServerTest extends HttpServerTest<Undertow> implements AgentTestTrait {
 
   @Override
   Undertow startServer(int port) {

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -5,6 +5,7 @@
 
 package client
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.vertx.circuitbreaker.CircuitBreakerOptions
 import io.vertx.core.VertxOptions
@@ -18,7 +19,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(10)
-class VertxRxCircuitBreakerWebClientTest extends HttpClientTest {
+class VertxRxCircuitBreakerWebClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   Vertx vertx = Vertx.vertx(new VertxOptions())

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/client/VertxRxWebClientTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/client/VertxRxWebClientTest.groovy
@@ -5,6 +5,7 @@
 
 package client
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpMethod
@@ -15,7 +16,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(10)
-class VertxRxWebClientTest extends HttpClientTest {
+class VertxRxWebClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   Vertx vertx = Vertx.vertx(new VertxOptions())

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/server/VertxRxHttpServerTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/server/VertxRxHttpServerTest.groovy
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.vertx.core.DeploymentOptions
 import io.vertx.core.Future
@@ -23,7 +24,7 @@ import io.vertx.reactivex.ext.web.Router
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
-class VertxRxHttpServerTest extends HttpServerTest<Vertx> {
+class VertxRxHttpServerTest extends HttpServerTest<Vertx> implements AgentTestTrait {
   public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port"
 
   @Override

--- a/instrumentation/vertx-web-3.0/src/test/groovy/client/VertxHttpClientTest.groovy
+++ b/instrumentation/vertx-web-3.0/src/test/groovy/client/VertxHttpClientTest.groovy
@@ -5,6 +5,7 @@
 
 package client
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
@@ -16,7 +17,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(10)
-class VertxHttpClientTest extends HttpClientTest {
+class VertxHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
   def vertx = Vertx.vertx(new VertxOptions())

--- a/instrumentation/vertx-web-3.0/src/test/groovy/server/VertxHttpServerTest.groovy
+++ b/instrumentation/vertx-web-3.0/src/test/groovy/server/VertxHttpServerTest.groovy
@@ -7,6 +7,7 @@ package server
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.DeploymentOptions
@@ -16,7 +17,7 @@ import io.vertx.core.json.JsonObject
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
-class VertxHttpServerTest extends HttpServerTest<Vertx> {
+class VertxHttpServerTest extends HttpServerTest<Vertx> implements AgentTestTrait {
   public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port"
 
   @Override

--- a/instrumentation/vertx-web-3.0/src/test/groovy/server/VertxHttpServerTest.groovy
+++ b/instrumentation/vertx-web-3.0/src/test/groovy/server/VertxHttpServerTest.groovy
@@ -18,8 +18,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 class VertxHttpServerTest extends HttpServerTest<Vertx> implements AgentTestTrait {
-  public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port"
-
   @Override
   Vertx startServer(int port) {
     Vertx server = Vertx.vertx(new VertxOptions()
@@ -29,7 +27,7 @@ class VertxHttpServerTest extends HttpServerTest<Vertx> implements AgentTestTrai
     CompletableFuture<Void> future = new CompletableFuture<>()
     server.deployVerticle(verticle().getName(),
       new DeploymentOptions()
-        .setConfig(new JsonObject().put(CONFIG_HTTP_SERVER_PORT, port))
+        .setConfig(new JsonObject().put(VertxWebServer.CONFIG_HTTP_SERVER_PORT, port))
         .setInstances(3)) { res ->
       if (!res.succeeded()) {
         throw new RuntimeException("Cannot deploy server Verticle", res.cause())

--- a/instrumentation/vertx-web-3.0/src/test/java/server/VertxWebServer.java
+++ b/instrumentation/vertx-web-3.0/src/test/java/server/VertxWebServer.java
@@ -20,10 +20,11 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
 public class VertxWebServer extends AbstractVerticle {
+  public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port";
 
   @Override
   public void start(Future<Void> startFuture) {
-    int port = config().getInteger(VertxHttpServerTest.CONFIG_HTTP_SERVER_PORT);
+    int port = config().getInteger(CONFIG_HTTP_SERVER_PORT);
     Router router = Router.router(vertx);
 
     //noinspection Convert2Lambda

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -16,7 +16,7 @@ import static org.junit.Assume.assumeTrue
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.AttributesAssert
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -30,7 +30,7 @@ import spock.lang.Shared
 import spock.lang.Unroll
 
 @Unroll
-abstract class HttpClientTest extends AgentInstrumentationSpecification {
+abstract class HttpClientTest extends InstrumentationSpecification {
   protected static final BODY_METHODS = ["POST", "PUT"]
   protected static final CONNECT_TIMEOUT_MS = 5000
   protected static final BASIC_AUTH_KEY = "custom-authorization-header"
@@ -498,7 +498,7 @@ abstract class HttpClientTest extends AgentInstrumentationSpecification {
       } else {
         childOf((SpanData) parentSpan)
       }
-      if(additionAttributesAssert != null){
+      if (additionAttributesAssert != null) {
         attributes(additionAttributesAssert)
       }
     }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
@@ -17,7 +17,7 @@ import static org.junit.Assume.assumeTrue
 
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -29,7 +29,7 @@ import okhttp3.Response
 import spock.lang.Unroll
 
 @Unroll
-abstract class HttpServerTest<SERVER> extends AgentInstrumentationSpecification implements HttpServerTestTrait<SERVER> {
+abstract class HttpServerTest<SERVER> extends InstrumentationSpecification implements HttpServerTestTrait<SERVER> {
 
   String expectedServerSpanName(ServerEndpoint endpoint) {
     return endpoint == PATH_PARAM ? getContextPath() + "/path/:id/param" : endpoint.resolvePath(address).path


### PR DESCRIPTION
It is now possible to use `HttpClientTest`/`HttpServerTest` in library instrumentations.

Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/779