### PR TITLE
Update MDC docs to reflect log spec naming

### DIFF
--- a/docs/logger-mdc-instrumentation.md
+++ b/docs/logger-mdc-instrumentation.md
@@ -19,13 +19,15 @@ event's MDC copy:
   (same as `Span.current().getSpanContext().isSampled()`).
 
 Those three pieces of information can be included in log statements produced by the logging library
-by specifying them in the pattern/format. Example for Spring Boot configuration (which uses logback):
+by specifying them in the pattern/format. Example for Spring Boot configuration (which uses
+logback):
 
 ```properties
-logging.pattern.console = %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg t:%X{traceId} s:%X{spanId} %n
+logging.pattern.console = %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg trace_id=%X{traceId} span_id=%X{spanId} %n
 ```
 
-This way any services or tools that parse the application logs can correlate traces/spans with log statements.
+This way any services or tools that parse the application logs can correlate traces/spans with log
+statements.
 
 ## Supported logging libraries
 

--- a/instrumentation/log4j/log4j-2.13.2/library/README.md
+++ b/instrumentation/log4j/log4j-2.13.2/library/README.md
@@ -1,13 +1,15 @@
 # Log4j 2 Integration
 
 This module integrates instrumentation with Log4j 2 by injecting the trace ID and span ID from a
-mounted span into Log4j's [context data](https://logging.apache.org/log4j/2.x/manual/thread-context.html).
+mounted span into
+Log4j's [context data](https://logging.apache.org/log4j/2.x/manual/thread-context.html).
 
 To use it, just add the module to your application's runtime classpath.
 
 **Maven**
 
 ```xml
+
 <dependencies>
   <dependency>
     <groupId>io.opentelemetry.instrumentation</groupId>
@@ -40,12 +42,13 @@ You can use these keys when defining an appender in your `log4j.xml` configurati
 <Configuration>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} traceId: %X{traceId} spanId: %X{spanId} - %msg%n" />
+      <PatternLayout
+          pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} trace_id=%X{traceId} span_id=%X{spanId} - %msg%n"/>
     </Console>
   </Appenders>
   <Loggers>
     <Root>
-      <AppenderRef ref="Console" level="All" />
+      <AppenderRef ref="Console" level="All"/>
     </Root>
   </Loggers>
 </Configuration>

--- a/instrumentation/logback/logback-1.0/library/README.md
+++ b/instrumentation/logback/logback-1.0/library/README.md
@@ -9,6 +9,7 @@ To use it, add the module to your application's runtime classpath and add the ap
 **Maven**
 
 ```xml
+
 <dependencies>
   <dependency>
     <groupId>io.opentelemetry.instrumentation</groupId>
@@ -34,13 +35,13 @@ dependencies {
 <configuration>
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %X{traceId} %X{spanId} %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} trace_id=%X{traceId} span_id=%X{spanId} %msg%n</pattern>
     </encoder>
   </appender>
 
   <!-- Just wrap your logging appender, for example ConsoleAppender, with OpenTelemetryAppender -->
   <appender name="OTEL" class="io.opentelemetry.instrumentation.logback.v1_0.OpenTelemetryAppender">
-    <appender-ref ref="CONSOLE" />
+    <appender-ref ref="CONSOLE"/>
   </appender>
   ...
 </configuration>


### PR DESCRIPTION
It's not required, but seems to make sense to start reflecting the logging spec recommendation in our examples:

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/overview.md#trace-context-in-legacy-formats
