### PR TITLE
Move slf4j-simple initialization from bootstrap into tooling

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
@@ -10,8 +10,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Agent start up logic.
@@ -23,78 +21,30 @@ import org.slf4j.LoggerFactory;
  */
 public class AgentInitializer {
 
-  private static final String SIMPLE_LOGGER_SHOW_DATE_TIME_PROPERTY =
-      "io.opentelemetry.javaagent.slf4j.simpleLogger.showDateTime";
-  private static final String SIMPLE_LOGGER_DATE_TIME_FORMAT_PROPERTY =
-      "io.opentelemetry.javaagent.slf4j.simpleLogger.dateTimeFormat";
-  private static final String SIMPLE_LOGGER_DATE_TIME_FORMAT_DEFAULT =
-      "'[opentelemetry.auto.trace 'yyyy-MM-dd HH:mm:ss:SSS Z']'";
-  private static final String SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY =
-      "io.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel";
-  private static final String SIMPLE_LOGGER_PREFIX =
-      "io.opentelemetry.javaagent.slf4j.simpleLogger.log.";
-
-  private static final Logger log;
-
-  static {
-    // We can configure logger here because io.opentelemetry.auto.AgentBootstrap doesn't touch
-    // it.
-    configureLogger();
-    log = LoggerFactory.getLogger(AgentInitializer.class);
-  }
-
   // Accessed via reflection from tests.
   // fields must be managed under class lock
   private static ClassLoader AGENT_CLASSLOADER = null;
 
-  public static void initialize(Instrumentation inst, URL bootstrapUrl) {
+  public static void initialize(Instrumentation inst, URL bootstrapUrl) throws Exception {
     startAgent(inst, bootstrapUrl);
   }
 
-  private static synchronized void startAgent(Instrumentation inst, URL bootstrapUrl) {
+  private static synchronized void startAgent(Instrumentation inst, URL bootstrapUrl)
+      throws Exception {
     if (AGENT_CLASSLOADER == null) {
+      ClassLoader agentClassLoader = createAgentClassLoader("inst", bootstrapUrl);
+      Class<?> agentInstallerClass =
+          agentClassLoader.loadClass("io.opentelemetry.javaagent.tooling.AgentInstaller");
+      Method agentInstallerMethod =
+          agentInstallerClass.getMethod("installBytebuddyAgent", Instrumentation.class);
+      ClassLoader savedContextClassLoader = Thread.currentThread().getContextClassLoader();
       try {
-        ClassLoader agentClassLoader = createAgentClassLoader("inst", bootstrapUrl);
-        Class<?> agentInstallerClass =
-            agentClassLoader.loadClass("io.opentelemetry.javaagent.tooling.AgentInstaller");
-        Method agentInstallerMethod =
-            agentInstallerClass.getMethod("installBytebuddyAgent", Instrumentation.class);
-        ClassLoader savedContextClassLoader = Thread.currentThread().getContextClassLoader();
-        try {
-          Thread.currentThread().setContextClassLoader(AGENT_CLASSLOADER);
-          agentInstallerMethod.invoke(null, inst);
-        } finally {
-          Thread.currentThread().setContextClassLoader(savedContextClassLoader);
-        }
-        AGENT_CLASSLOADER = agentClassLoader;
-      } catch (Throwable ex) {
-        log.error("Throwable thrown while installing the agent", ex);
+        Thread.currentThread().setContextClassLoader(AGENT_CLASSLOADER);
+        agentInstallerMethod.invoke(null, inst);
+      } finally {
+        Thread.currentThread().setContextClassLoader(savedContextClassLoader);
       }
-    }
-  }
-
-  private static void configureLogger() {
-    setSystemPropertyDefault(SIMPLE_LOGGER_SHOW_DATE_TIME_PROPERTY, "true");
-    setSystemPropertyDefault(
-        SIMPLE_LOGGER_DATE_TIME_FORMAT_PROPERTY, SIMPLE_LOGGER_DATE_TIME_FORMAT_DEFAULT);
-
-    if (isDebugMode()) {
-      setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, "DEBUG");
-      // suppress a couple of verbose ClassNotFoundException stack traces logged at debug level
-      setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "io.perfmark.PerfMark", "INFO");
-      setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "io.grpc.Context", "INFO");
-      setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "io.grpc.internal.ServerImplBuilder", "INFO");
-      setSystemPropertyDefault(
-          SIMPLE_LOGGER_PREFIX + "io.grpc.internal.ManagedChannelImplBuilder", "INFO");
-    } else {
-      // by default muzzle warnings are turned off
-      setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "muzzleMatcher", "OFF");
-    }
-  }
-
-  private static void setSystemPropertyDefault(String property, String value) {
-    if (System.getProperty(property) == null) {
-      System.setProperty(property, value);
+      AGENT_CLASSLOADER = agentClassLoader;
     }
   }
 
@@ -132,28 +82,6 @@ public class AgentInitializer {
     */
     Method method = ClassLoader.class.getDeclaredMethod("getPlatformClassLoader");
     return (ClassLoader) method.invoke(null);
-  }
-
-  /**
-   * Determine if we should log in debug level according to otel.javaagent.debug
-   *
-   * @return true if we should
-   */
-  private static boolean isDebugMode() {
-    String tracerDebugLevelSysprop = "otel.javaagent.debug";
-    String tracerDebugLevelProp = System.getProperty(tracerDebugLevelSysprop);
-
-    if (tracerDebugLevelProp != null) {
-      return Boolean.parseBoolean(tracerDebugLevelProp);
-    }
-
-    String tracerDebugLevelEnv =
-        System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase());
-
-    if (tracerDebugLevelEnv != null) {
-      return Boolean.parseBoolean(tracerDebugLevelEnv);
-    }
-    return false;
   }
 
   public static boolean isJavaBefore9() {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -46,7 +46,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class AgentInstaller {
-  private static final Logger log = LoggerFactory.getLogger(AgentInstaller.class);
+
+  private static final Logger log;
 
   private static final String JAVAAGENT_ENABLED_CONFIG = "otel.javaagent.enabled";
   private static final String EXCLUDED_CLASSES_CONFIG = "otel.javaagent.exclude-classes";
@@ -65,6 +66,9 @@ public class AgentInstaller {
   }
 
   static {
+    LoggingConfigurer.configureLogger();
+    log = LoggerFactory.getLogger(AgentInstaller.class);
+
     addByteBuddyRawSetting();
     BootstrapPackagePrefixesHolder.setBoostrapPackagePrefixes(loadBootstrapPackagePrefixes());
     // WeakMap is used by other classes below, so we need to register the provider first.

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/LoggingConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/LoggingConfigurer.java
@@ -1,0 +1,62 @@
+package io.opentelemetry.javaagent.tooling;
+
+class LoggingConfigurer {
+
+  private static final String SIMPLE_LOGGER_SHOW_DATE_TIME_PROPERTY =
+      "io.opentelemetry.javaagent.slf4j.simpleLogger.showDateTime";
+  private static final String SIMPLE_LOGGER_DATE_TIME_FORMAT_PROPERTY =
+      "io.opentelemetry.javaagent.slf4j.simpleLogger.dateTimeFormat";
+  private static final String SIMPLE_LOGGER_DATE_TIME_FORMAT_DEFAULT =
+      "'[opentelemetry.auto.trace 'yyyy-MM-dd HH:mm:ss:SSS Z']'";
+  private static final String SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY =
+      "io.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel";
+  private static final String SIMPLE_LOGGER_PREFIX =
+      "io.opentelemetry.javaagent.slf4j.simpleLogger.log.";
+
+  static void configureLogger() {
+    setSystemPropertyDefault(SIMPLE_LOGGER_SHOW_DATE_TIME_PROPERTY, "true");
+    setSystemPropertyDefault(
+        SIMPLE_LOGGER_DATE_TIME_FORMAT_PROPERTY, SIMPLE_LOGGER_DATE_TIME_FORMAT_DEFAULT);
+
+    if (isDebugMode()) {
+      setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, "DEBUG");
+      // suppress a couple of verbose ClassNotFoundException stack traces logged at debug level
+      setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "io.perfmark.PerfMark", "INFO");
+      setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "io.grpc.Context", "INFO");
+      setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "io.grpc.internal.ServerImplBuilder", "INFO");
+      setSystemPropertyDefault(
+          SIMPLE_LOGGER_PREFIX + "io.grpc.internal.ManagedChannelImplBuilder", "INFO");
+    } else {
+      // by default muzzle warnings are turned off
+      setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "muzzleMatcher", "OFF");
+    }
+  }
+
+  private static void setSystemPropertyDefault(String property, String value) {
+    if (System.getProperty(property) == null) {
+      System.setProperty(property, value);
+    }
+  }
+
+  /**
+   * Determine if we should log in debug level according to otel.javaagent.debug
+   *
+   * @return true if we should
+   */
+  private static boolean isDebugMode() {
+    String tracerDebugLevelSysprop = "otel.javaagent.debug";
+    String tracerDebugLevelProp = System.getProperty(tracerDebugLevelSysprop);
+
+    if (tracerDebugLevelProp != null) {
+      return Boolean.parseBoolean(tracerDebugLevelProp);
+    }
+
+    String tracerDebugLevelEnv =
+        System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase());
+
+    if (tracerDebugLevelEnv != null) {
+      return Boolean.parseBoolean(tracerDebugLevelEnv);
+    }
+    return false;
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/LoggingConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/LoggingConfigurer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.tooling;
 
 class LoggingConfigurer {


### PR DESCRIPTION
In general, we want bootstrap init to be slim, just enough to get us over into the AgentClassLoader.

Also, this allows future vendor logging customization hooks to happen inside of tooling, which is where other vendor customization happens.

cc: @pavolloffay