### PR TITLE
Implement spanName for MongoClientTracer

### DIFF
--- a/instrumentation/mongo/mongo-3.1/javaagent/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/javaagent/src/test/groovy/MongoClientTest.groovy
@@ -37,6 +37,7 @@ class MongoClientTest extends MongoBaseTest {
   def "test create collection"() {
     setup:
     MongoDatabase db = client.getDatabase(dbName)
+    client.listDatabaseNames()
 
     when:
     db.createCollection(collectionName)

--- a/instrumentation/mongo/mongo-3.1/javaagent/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/javaagent/src/test/groovy/MongoClientTest.groovy
@@ -37,7 +37,6 @@ class MongoClientTest extends MongoBaseTest {
   def "test create collection"() {
     setup:
     MongoDatabase db = client.getDatabase(dbName)
-    client.listDatabaseNames()
 
     when:
     db.createCollection(collectionName)

--- a/instrumentation/mongo/mongo-4.0-testing/src/test/groovy/Mongo4ReactiveClientTest.groovy
+++ b/instrumentation/mongo/mongo-4.0-testing/src/test/groovy/Mongo4ReactiveClientTest.groovy
@@ -281,7 +281,7 @@ class Mongo4ReactiveClientTest extends MongoBaseTest {
                 String dbName, Closure<Boolean> statementEval,
                 Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
-      name statementEval
+      name { operation + " " + dbName + "." + collection }
       kind CLIENT
       if (parentSpan == null) {
         hasNoParent()

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/src/test/groovy/MongoAsyncClientTest.groovy
@@ -305,7 +305,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
                 String dbName, Closure<Boolean> statementEval,
                 Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
-      name statementEval
+      name { operation + " " + dbName + "." collection }
       kind CLIENT
       if (parentSpan == null) {
         hasNoParent()

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/src/test/groovy/MongoAsyncClientTest.groovy
@@ -305,7 +305,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
                 String dbName, Closure<Boolean> statementEval,
                 Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
-      name { operation + " " + dbName + "." collection }
+      name { operation + " " + dbName + "." + collection }
       kind CLIENT
       if (parentSpan == null) {
         hasNoParent()

--- a/instrumentation/mongo/mongo-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/MongoClientTracer.java
+++ b/instrumentation/mongo/mongo-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/MongoClientTracer.java
@@ -85,8 +85,7 @@ public class MongoClientTracer extends DatabaseClientTracer<CommandStartedEvent,
   }
 
   @Override
-  public String spanName(
-      CommandStartedEvent event, BsonDocument document, String normalizedQuery) {
+  public String spanName(CommandStartedEvent event, BsonDocument document, String normalizedQuery) {
     String dbName = dbName(event);
     if (event.getCommandName() == null) {
       return dbName == null ? DB_QUERY : dbName;

--- a/instrumentation/mongo/mongo-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/MongoClientTracer.java
+++ b/instrumentation/mongo/mongo-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/MongoClientTracer.java
@@ -85,6 +85,29 @@ public class MongoClientTracer extends DatabaseClientTracer<CommandStartedEvent,
   }
 
   @Override
+  protected String spanName(
+      CommandStartedEvent event, BsonDocument document, String normalizedQuery) {
+    String dbName = dbName(event);
+    if (event.getCommandName() == null) {
+      return dbName == null ? DB_QUERY : dbName;
+    }
+
+    String collectionName = collectionName(event);
+    StringBuilder name = new StringBuilder();
+    name.append(event.getCommandName()).append(' ');
+    if (dbName != null) {
+      name.append(dbName);
+      if (collectionName != null) {
+        name.append('.');
+      }
+    }
+    if (collectionName != null) {
+      name.append(collectionName);
+    }
+    return name.toString();
+  }
+
+  @Override
   protected String dbConnectionString(CommandStartedEvent event) {
     ConnectionDescription connectionDescription = event.getConnectionDescription();
     if (connectionDescription != null) {

--- a/instrumentation/mongo/mongo-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/MongoClientTracer.java
+++ b/instrumentation/mongo/mongo-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/MongoClientTracer.java
@@ -85,7 +85,7 @@ public class MongoClientTracer extends DatabaseClientTracer<CommandStartedEvent,
   }
 
   @Override
-  protected String spanName(
+  public String spanName(
       CommandStartedEvent event, BsonDocument document, String normalizedQuery) {
     String dbName = dbName(event);
     if (event.getCommandName() == null) {
@@ -94,7 +94,10 @@ public class MongoClientTracer extends DatabaseClientTracer<CommandStartedEvent,
 
     String collectionName = collectionName(event);
     StringBuilder name = new StringBuilder();
-    name.append(event.getCommandName()).append(' ');
+    name.append(event.getCommandName());
+    if (dbName != null || collectionName != null) {
+      name.append(' ');
+    }
     if (dbName != null) {
       name.append(dbName);
       if (collectionName != null) {

--- a/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
+++ b/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import com.mongodb.event.CommandStartedEvent
 
 import static java.util.Arrays.asList

--- a/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
+++ b/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
@@ -78,17 +78,16 @@ class MongoClientTracerTest extends Specification {
     setup:
     def tracer = new MongoClientTracer()
     def event = new CommandStartedEvent(
-      0, null, null, command, new BsonDocument(command, new BsonString(collection)))
+      0, null, null, command, new BsonDocument(command, new BsonInt32(1)))
 
     when:
     def spanName = tracer.spanName(event, null, null);
 
     then:
-    spanName == command + " " + collection;
+    spanName == command;
 
     where:
-    command = "findAndModify";
-    collection = "collection";
+    command = "listDatabases";
   }
 
   def normalizeQueryAcrossVersions(MongoClientTracer tracer, BsonDocument query) {

--- a/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
+++ b/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import com.mongodb.event.CommandStartedEvent
+
 import static java.util.Arrays.asList
 
 import io.opentelemetry.javaagent.instrumentation.mongo.MongoClientTracer
@@ -69,6 +72,23 @@ class MongoClientTracerTest extends Specification {
     expect:
     // this can vary because of different whitespace for different mongo versions
     normalized == '{"cmd": "c", "f1": ["?", "?' || normalized == '{"cmd": "c", "f1": ["?",'
+  }
+
+  def 'test span name with no dbName'() {
+    setup:
+    def tracer = new MongoClientTracer()
+    def event = new CommandStartedEvent(
+      0, null, null, command, new BsonDocument(command, new BsonString(collection)))
+
+    when:
+    def spanName = tracer.spanName(event, null, null);
+
+    then:
+    spanName == command + " " + collection;
+
+    where:
+    command = "findAndModify";
+    collection = "collection";
   }
 
   def normalizeQueryAcrossVersions(MongoClientTracer tracer, BsonDocument query) {

--- a/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
+++ b/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
@@ -81,13 +81,13 @@ class MongoClientTracerTest extends Specification {
       0, null, null, command, new BsonDocument(command, new BsonInt32(1)))
 
     when:
-    def spanName = tracer.spanName(event, null, null);
+    def spanName = tracer.spanName(event, null, null)
 
     then:
-    spanName == command;
+    spanName == command
 
     where:
-    command = "listDatabases";
+    command = "listDatabases"
   }
 
   def normalizeQueryAcrossVersions(MongoClientTracer tracer, BsonDocument query) {

--- a/instrumentation/mongo/mongo-testing/src/main/groovy/MongoBaseTest.groovy
+++ b/instrumentation/mongo/mongo-testing/src/main/groovy/MongoBaseTest.groovy
@@ -77,7 +77,7 @@ class MongoBaseTest extends AgentInstrumentationSpecification {
                 String dbName, String statement,
                 Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
-      name { it.replace(" ", "") == statement }
+      name { operation + " " + dbName + "." + collection }
       kind CLIENT
       if (parentSpan == null) {
         hasNoParent()


### PR DESCRIPTION
Adds a basic implementation for spanName in MongoClientTracer that uses the recommended  name from the specification.

Please let me know if this is not the right way to solve this and I'm happy to iterate on it. :)

Fixes #2306 