### PR TITLE
Don't String.format when determining if instrumentation is enabled.

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
@@ -142,7 +142,7 @@ public abstract class Config {
     // if default is disabled, we want to disable individually.
     boolean anyEnabled = defaultEnabled;
     for (String name : instrumentationNames) {
-      String propertyName = String.format("otel.instrumentation.%s.%s", name, suffix);
+      String propertyName = "otel.instrumentation." + name + '.' + suffix;
       boolean enabled = getBooleanProperty(propertyName, defaultEnabled);
 
       if (defaultEnabled) {


### PR DESCRIPTION
Randomly found this - we should never use the slow `String.format` in non-error code. This usage I guess has some impact on startup time.