### PR TITLE
Improved operation name logging for Netty based applications

### DIFF
--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
@@ -46,7 +46,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
     HttpRequest request = (HttpRequest) message;
 
     Context context =
-        tracer().startSpan(request, ctx.getChannel(), channelTraceContext, "netty.request");
+        tracer().startSpan(request, ctx.getChannel(), channelTraceContext, request.getMethod() + " " + request.getUri());
     try (Scope ignored = context.makeCurrent()) {
       ctx.sendUpstream(event);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
@@ -32,7 +32,8 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       return;
     }
 
-    Context context = tracer().startSpan((HttpRequest) msg, channel, channel, "netty.request");
+    HttpRequest req = (HttpRequest) msg;
+    Context context = tracer().startSpan(req, channel, channel, req.getMethod() + " " + req.getUri());
     try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
@@ -32,7 +32,9 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       return;
     }
 
-    Context context = tracer().startSpan((HttpRequest) msg, channel, channel, "netty.request");
+    HttpRequest req = (HttpRequest) msg;
+    Context context = tracer().startSpan(req, channel, channel, req.method() + " " + req.uri());
+    
     try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
       // the span is ended normally in HttpServerResponseTracingHandler


### PR DESCRIPTION
Fix Operation name logging for Netty based applications

(@trask Report of PR #1494 on ApplicationInsights-Java repo)