### PR TITLE
Fix Operation name logging for Netty based applications

### DIFF
--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
@@ -45,7 +45,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
 
     HttpRequest request = (HttpRequest) message;
 
-    Context context = tracer().startSpan(request, ctx.getChannel(), channelTraceContext, request.getUri().split("\\?")[0]);
+    Context context = tracer().startSpan(request, ctx.getChannel(), channelTraceContext, "HTTP " + request.getMethod());
     try (Scope ignored = context.makeCurrent()) {
       ctx.sendUpstream(event);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
@@ -45,7 +45,10 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
 
     HttpRequest request = (HttpRequest) message;
 
-    Context context = tracer().startSpan(request, ctx.getChannel(), channelTraceContext, "HTTP " + request.getMethod());
+    Context context =
+        tracer()
+            .startSpan(
+                request, ctx.getChannel(), channelTraceContext, "HTTP " + request.getMethod());
     try (Scope ignored = context.makeCurrent()) {
       ctx.sendUpstream(event);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
@@ -46,7 +46,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
     HttpRequest request = (HttpRequest) message;
 
     Context context =
-        tracer().startSpan(request, ctx.getChannel(), channelTraceContext, "netty.request");
+        tracer().startSpan(request, ctx.getChannel(), channelTraceContext, request.getMethod() + " " + request.getUri());
     try (Scope ignored = context.makeCurrent()) {
       ctx.sendUpstream(event);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
@@ -45,8 +45,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
 
     HttpRequest request = (HttpRequest) message;
 
-    Context context =
-        tracer().startSpan(request, ctx.getChannel(), channelTraceContext, request.getUri().split("\\?")[0]);
+    Context context = tracer().startSpan(request, ctx.getChannel(), channelTraceContext, request.getUri().split("\\?")[0]);
     try (Scope ignored = context.makeCurrent()) {
       ctx.sendUpstream(event);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
@@ -46,7 +46,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
     HttpRequest request = (HttpRequest) message;
 
     Context context =
-        tracer().startSpan(request, ctx.getChannel(), channelTraceContext, request.getMethod() + " " + request.getUri());
+        tracer().startSpan(request, ctx.getChannel(), channelTraceContext, request.getUri().split("\\?")[0]);
     try (Scope ignored = context.makeCurrent()) {
       ctx.sendUpstream(event);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
@@ -141,8 +141,8 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> implements Agent
     server?.shutdown()
   }
 
-  @Override
+  /*@Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
-    return "netty.request"
-  }
+    return "GET /exception"
+  }*/
 }

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
@@ -141,8 +141,4 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> implements Agent
     server?.shutdown()
   }
 
-  /*@Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
-    return "GET /exception"
-  }*/
 }

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
@@ -141,4 +141,8 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> implements Agent
     server?.shutdown()
   }
 
+  @Override
+  String expectedServerSpanName(ServerEndpoint endpoint) {
+    return "HTTP GET"
+  }
 }

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
@@ -33,7 +33,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     }
 
     HttpRequest request = (HttpRequest) msg;
-    Context context = tracer().startSpan(request, channel, channel, request.getUri().split("\\?")[0]);
+    Context context = tracer().startSpan(request, channel, channel, "HTTP " + request.getMethod());
     try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
@@ -32,7 +32,8 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       return;
     }
 
-    Context context = tracer().startSpan((HttpRequest) msg, channel, channel, "netty.request");
+    HttpRequest request = (HttpRequest) msg;
+    Context context = tracer().startSpan(request, channel, channel, request.getMethod() + " " + request.getUri());
     try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
@@ -33,7 +33,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     }
 
     HttpRequest request = (HttpRequest) msg;
-    Context context = tracer().startSpan(request, channel, channel, request.getMethod() + " " + request.getUri());
+    Context context = tracer().startSpan(request, channel, channel, request.getUri().split("\\?")[0]);
     try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
@@ -113,4 +113,8 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup> implements AgentT
     server?.shutdownGracefully()
   }
 
+  @Override
+  String expectedServerSpanName(ServerEndpoint endpoint) {
+    return "HTTP GET"
+  }
 }

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
@@ -113,8 +113,4 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup> implements AgentT
     server?.shutdownGracefully()
   }
 
-  @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
-    return "netty.request"
-  }
 }

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
@@ -32,7 +32,8 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       return;
     }
 
-    Context context = tracer().startSpan((HttpRequest) msg, channel, channel, "netty.request");
+    HttpRequest request = (HttpRequest) msg;
+    Context context = tracer().startSpan(request, channel, channel, request.method() + " " + request.uri());
     try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
@@ -33,7 +33,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     }
 
     HttpRequest request = (HttpRequest) msg;
-    Context context = tracer().startSpan(request, channel, channel, request.uri().split("\\?")[0]);
+    Context context = tracer().startSpan(request, channel, channel, "HTTP " + request.method());
     try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
@@ -33,7 +33,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     }
 
     HttpRequest request = (HttpRequest) msg;
-    Context context = tracer().startSpan(request, channel, channel, request.getUri().split("\\?")[0]);
+    Context context = tracer().startSpan(request, channel, channel, request.uri().split("\\?")[0]);
     try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
@@ -33,7 +33,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     }
 
     HttpRequest request = (HttpRequest) msg;
-    Context context = tracer().startSpan(request, channel, channel, request.method() + " " + request.uri());
+    Context context = tracer().startSpan(request, channel, channel, request.getUri().split("\\?")[0]);
     try (Scope ignored = context.makeCurrent()) {
       ctx.fireChannelRead(msg);
       // the span is ended normally in HttpServerResponseTracingHandler

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ServerTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ServerTest.groovy
@@ -111,4 +111,9 @@ class Netty41ServerTest extends HttpServerTest<EventLoopGroup> implements AgentT
   void stopServer(EventLoopGroup server) {
     server?.shutdownGracefully()
   }
+
+  @Override
+  String expectedServerSpanName(ServerEndpoint endpoint) {
+    return "HTTP GET"
+  }
 }

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ServerTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ServerTest.groovy
@@ -111,9 +111,4 @@ class Netty41ServerTest extends HttpServerTest<EventLoopGroup> implements AgentT
   void stopServer(EventLoopGroup server) {
     server?.shutdownGracefully()
   }
-
-  @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
-    return "netty.request"
-  }
 }


### PR DESCRIPTION
Fix Operation name logging for Netty based applications

(@trask Report of PR #1494 on ApplicationInsights-Java repo)