### PR TITLE
Instrument all jetty handlers

### DIFF
--- a/instrumentation/jetty-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/JettyHandlerAdvice.java
+++ b/instrumentation/jetty-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/JettyHandlerAdvice.java
@@ -55,8 +55,15 @@ public class JettyHandlerAdvice {
 
     tracer().setPrincipal(context, request);
 
-    if (throwable != null) {
-      tracer().endExceptionally(context, throwable, response);
+    // throwable is read-only, copy it to a new local that can be modified
+    Throwable exception = throwable;
+    if (exception == null) {
+      // on jetty versions before 9.4 exceptions from servlet don't propagate to this method
+      // check from request whether a throwable has been stored there
+      exception = (Throwable) request.getAttribute("javax.servlet.error.exception");
+    }
+    if (exception != null) {
+      tracer().endExceptionally(context, exception, response);
       return;
     }
 

--- a/instrumentation/jetty-8.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty-8.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
@@ -127,6 +127,6 @@ class JettyHandlerTest extends HttpServerTest<Server> implements AgentTestTrait 
 
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
-    "TestHandler.handle"
+    "HandlerWrapper.handle"
   }
 }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServlet3Test.groovy
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import javax.servlet.Servlet
 import javax.servlet.ServletException
 import javax.servlet.http.HttpServletRequest
@@ -27,6 +28,19 @@ abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletCon
   @Override
   Class<?> expectedExceptionClass() {
     ServletException
+  }
+
+  @Override
+  boolean hasResponseSpan(ServerEndpoint endpoint) {
+    return endpoint == EXCEPTION || super.hasResponseSpan(endpoint)
+  }
+
+  @Override
+  void responseSpan(TraceAssert trace, int index, Object controllerSpan, Object handlerSpan, String method, ServerEndpoint endpoint) {
+    if (endpoint == EXCEPTION) {
+      sendErrorSpan(trace, index, handlerSpan)
+    }
+    super.responseSpan(trace, index, controllerSpan, handlerSpan, method, endpoint)
   }
 
   @Override

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import javax.servlet.Servlet
 import javax.servlet.ServletException
 import javax.servlet.http.HttpServletRequest
@@ -11,6 +14,19 @@ import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.servlet.ServletHandler
 
 class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandler> {
+
+  @Override
+  boolean hasResponseSpan(ServerEndpoint endpoint) {
+    return endpoint == EXCEPTION || super.hasResponseSpan(endpoint)
+  }
+
+  @Override
+  void responseSpan(TraceAssert trace, int index, Object controllerSpan, Object handlerSpan, String method, ServerEndpoint endpoint) {
+    if (endpoint == EXCEPTION) {
+      sendErrorSpan(trace, index, handlerSpan)
+    }
+    super.responseSpan(trace, index, controllerSpan, handlerSpan, method, endpoint)
+  }
 
   @Override
   Server startServer(int port) {

--- a/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
+++ b/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
@@ -17,7 +17,6 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import javax.servlet.DispatcherType
 import org.apache.struts2.dispatcher.ng.filter.StrutsPrepareAndExecuteFilter
 import org.eclipse.jetty.server.Server
-import org.eclipse.jetty.server.handler.HandlerCollection
 import org.eclipse.jetty.servlet.DefaultServlet
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.util.resource.FileResource
@@ -101,11 +100,7 @@ class Struts2ActionSpanTest extends HttpServerTest<Server> implements AgentTestT
     context.setContextPath(getContextPath())
     def resource = new FileResource(getClass().getResource("/"))
     context.setBaseResource(resource)
-    // jetty integration is disabled for some handler classes, using HandlerCollection here
-    // enables jetty integration
-    HandlerCollection handlerCollection = new HandlerCollection()
-    handlerCollection.addHandler(context)
-    server.setHandler(handlerCollection)
+    server.setHandler(context)
 
     context.addServlet(DefaultServlet, "/")
     context.addFilter(StrutsPrepareAndExecuteFilter, "/*", EnumSet.of(DispatcherType.REQUEST))

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
@@ -16,7 +16,7 @@ class JettySmokeTest extends AppServerTest {
   }
 
   def getJettySpanName() {
-    return serverVersion.startsWith("10.") ? "HandlerList.handle" : "HandlerCollection.handle"
+    "HandlerWrapper.handle"
   }
 
   @Override


### PR DESCRIPTION
Due to the excluded handlers embedded jetty used in our tests usually runs without using jetty instrumentation even when test has a dependency to it.