### PR TITLE
Avoid NoSuchMethodError on shutdown

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/PatchLogger.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/PatchLogger.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.bootstrap;
 
 import java.text.MessageFormat;
 import java.util.ResourceBundle;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -326,6 +327,10 @@ public class PatchLogger {
   public void setParent(PatchLogger parent) {}
 
   public void setLevel(Level newLevel) {}
+
+  public Handler[] getHandlers() {
+    return new Handler[0];
+  }
 
   public static PatchLogger getAnonymousLogger() {
     return getLogger("");


### PR DESCRIPTION
Currently at the end of test output there is
```
Exception in thread "Thread-0" java.lang.NoSuchMethodError: io.opentelemetry.javaagent.bootstrap.PatchLogger.getHandlers()[Ljava/util/logging/Handler;
	at io.opentelemetry.exporter.logging.LoggingSpanExporter.flush(LoggingSpanExporter.java:58)
	at io.opentelemetry.exporter.logging.LoggingSpanExporter.shutdown(LoggingSpanExporter.java:70)
	at io.opentelemetry.sdk.trace.export.SimpleSpanProcessor.shutdown(SimpleSpanProcessor.java:89)
	at io.opentelemetry.sdk.trace.MultiSpanProcessor.shutdown(MultiSpanProcessor.java:68)
	at io.opentelemetry.sdk.trace.TracerSharedState.shutdown(TracerSharedState.java:96)
	at io.opentelemetry.sdk.trace.SdkTracerProvider.shutdown(SdkTracerProvider.java:107)
	at java.base/java.lang.Thread.run(Thread.java:834)
```