### PR TITLE
Allow Gradle build without JDK/bin in PATH

### DIFF
--- a/instrumentation/rmi/javaagent/rmi-javaagent.gradle
+++ b/instrumentation/rmi/javaagent/rmi-javaagent.gradle
@@ -8,7 +8,14 @@ muzzle {
 
 task "rmic", dependsOn: testClasses {
   def clazz = 'rmi.app.ServerLegacy'
-  String command = """rmic -g -keep -classpath ${sourceSets.test.output.classesDirs.asPath} -d ${buildDir}/classes/java/test ${clazz}"""
+
+  // Try one level up too in case java.home refers to jre directory inside jdk directory
+  def rmicBinaryPath = ['/bin/rmic', '/../bin/rmic'].findResult {
+    def path = new File(System.getProperty("java.home"), it).getAbsoluteFile()
+    path.isFile() ? path.toString() : null
+  } ?: "rmic"
+
+  String command = """$rmicBinaryPath -g -keep -classpath ${sourceSets.test.output.classesDirs.asPath} -d ${buildDir}/classes/java/test ${clazz}"""
   command.execute().text
 }
 


### PR DESCRIPTION
Currently when running a Gradle build (also when importing in IDE), the RMI module invokes the `rmic` binary, assuming it is in `PATH`. This does not work in cases where no JDK `bin` directory is in `PATH`, but `JAVA_HOME` is used instead to tell Gradle where the JDK is.

Added looking for the `rmic` binary in `${java.home}/bin` (or `${java.home}/../bin`) before falling back to invoking it without specifying its full path.