### PR TITLE
Inject OpenTelemetrySdk into lambda library instrumentation instead o…

### DIFF
--- a/instrumentation/aws-lambda-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambda/v1_0/AwsLambdaInstrumentationHelper.java
+++ b/instrumentation/aws-lambda-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambda/v1_0/AwsLambdaInstrumentationHelper.java
@@ -5,18 +5,21 @@
 
 package io.opentelemetry.javaagent.instrumentation.awslambda.v1_0;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.awslambda.v1_0.AwsLambdaMessageTracer;
 import io.opentelemetry.instrumentation.awslambda.v1_0.AwsLambdaTracer;
 
 public final class AwsLambdaInstrumentationHelper {
 
-  private static final AwsLambdaTracer FUNCTION_TRACER = new AwsLambdaTracer();
+  private static final AwsLambdaTracer FUNCTION_TRACER =
+      new AwsLambdaTracer(GlobalOpenTelemetry.get());
 
   public static AwsLambdaTracer functionTracer() {
     return FUNCTION_TRACER;
   }
 
-  private static final AwsLambdaMessageTracer MESSAGE_TRACER = new AwsLambdaMessageTracer();
+  private static final AwsLambdaMessageTracer MESSAGE_TRACER =
+      new AwsLambdaMessageTracer(GlobalOpenTelemetry.get());
 
   public static AwsLambdaMessageTracer messageTracer() {
     return MESSAGE_TRACER;

--- a/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
+++ b/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
@@ -17,6 +17,7 @@ apply from: "$rootDir/gradle/instrumentation-library.gradle"
 
 dependencies {
   compileOnly deps.opentelemetrySdk
+  compileOnly deps.opentelemetrySdkAutoconfigure
 
   library group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.0.0'
   // First version to includes support for SQSEvent, currently the most popular message queue used
@@ -39,6 +40,7 @@ dependencies {
     'com.fasterxml.jackson.core:jackson-databind:2.10.5.1',
     'commons-io:commons-io:2.2')
 
+  testImplementation deps.opentelemetrySdkAutoconfigure
   testImplementation deps.opentelemetryTraceProps
   testImplementation deps.guava
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaMessageTracer.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaMessageTracer.java
@@ -7,11 +7,11 @@ package io.opentelemetry.instrumentation.awslambda.v1_0;
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -20,10 +20,8 @@ public class AwsLambdaMessageTracer extends BaseTracer {
 
   private static final String AWS_TRACE_HEADER_SQS_ATTRIBUTE_KEY = "AWSTraceHeader";
 
-  public AwsLambdaMessageTracer() {}
-
-  public AwsLambdaMessageTracer(Tracer tracer) {
-    super(tracer);
+  public AwsLambdaMessageTracer(OpenTelemetry openTelemetry) {
+    super(openTelemetry);
   }
 
   public Context startSpan(SQSEvent event) {

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
@@ -13,10 +13,10 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.FAAS_
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes.FaasTriggerValues;
 import java.lang.invoke.MethodHandle;
@@ -47,10 +47,8 @@ public class AwsLambdaTracer extends BaseTracer {
   // cached accountId value
   private volatile String accountId;
 
-  public AwsLambdaTracer() {}
-
-  public AwsLambdaTracer(Tracer tracer) {
-    super(tracer);
+  public AwsLambdaTracer(OpenTelemetry openTelemetry) {
+    super(openTelemetry);
   }
 
   private void setAttributes(SpanBuilder span, Context context, Object input) {
@@ -118,7 +116,7 @@ public class AwsLambdaTracer extends BaseTracer {
 
   public io.opentelemetry.context.Context startSpan(
       Context awsContext, SpanKind kind, Object input, Map<String, String> headers) {
-    io.opentelemetry.context.Context parentContext = ParentContextExtractor.extract(headers);
+    io.opentelemetry.context.Context parentContext = ParentContextExtractor.extract(headers, this);
 
     SpanBuilder spanBuilder = tracer.spanBuilder(spanName(awsContext, input));
     setAttributes(spanBuilder, awsContext, input);

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractor.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractor.java
@@ -20,7 +20,7 @@ public class ParentContextExtractor {
 
   private static final String AWS_TRACE_HEADER_ENV_KEY = "_X_AMZN_TRACE_ID";
 
-  static Context extract(Map<String, String> headers) {
+  static Context extract(Map<String, String> headers, BaseTracer tracer) {
     Context parentContext = null;
     String parentTraceHeader = System.getenv(AWS_TRACE_HEADER_ENV_KEY);
     if (parentTraceHeader != null) {
@@ -28,7 +28,7 @@ public class ParentContextExtractor {
     }
     if (!isValidAndSampled(parentContext)) {
       // try http
-      parentContext = fromHttpHeaders(headers);
+      parentContext = fromHttpHeaders(headers, tracer);
     }
     return parentContext;
   }
@@ -42,8 +42,8 @@ public class ParentContextExtractor {
     return (parentSpanContext.isValid() && parentSpanContext.isSampled());
   }
 
-  private static Context fromHttpHeaders(Map<String, String> headers) {
-    return BaseTracer.extractWithGlobalPropagators(lowercaseMap(headers), MapGetter.INSTANCE);
+  private static Context fromHttpHeaders(Map<String, String> headers, BaseTracer tracer) {
+    return tracer.extract(lowercaseMap(headers), MapGetter.INSTANCE);
   }
 
   // lower-case map getter used for extraction

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapper.java
@@ -7,10 +7,21 @@ package io.opentelemetry.instrumentation.awslambda.v1_0;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 
 /**
  * Wrapper for {@link TracingRequestHandler}. Allows for wrapping a lambda proxied through API
  * Gateway, enabling single span tracing and HTTP context propagation.
  */
 public class TracingRequestApiGatewayWrapper
-    extends TracingRequestWrapperBase<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {}
+    extends TracingRequestWrapperBase<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+  public TracingRequestApiGatewayWrapper() {
+    super();
+  }
+
+  // Visible for testing
+  TracingRequestApiGatewayWrapper(OpenTelemetrySdk openTelemetrySdk) {
+    super(openTelemetrySdk);
+  }
+}

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestHandler.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestHandler.java
@@ -11,8 +11,11 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A base class similar to {@link RequestHandler} but will automatically trace invocations of {@link
@@ -21,38 +24,28 @@ import java.util.Map;
  */
 public abstract class TracingRequestHandler<I, O> implements RequestHandler<I, O> {
 
-  private static final long DEFAULT_FLUSH_TIMEOUT_SECONDS = 1;
+  protected static final Duration DEFAULT_FLUSH_TIMEOUT = Duration.ofSeconds(1);
 
   private final AwsLambdaTracer tracer;
-  private final long flushTimeout;
+  private final OpenTelemetrySdk openTelemetrySdk;
+  private final long flushTimeoutNanos;
 
   /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
-  protected TracingRequestHandler(long flushTimeout) {
-    this.tracer = new AwsLambdaTracer();
-    this.flushTimeout = flushTimeout;
+  protected TracingRequestHandler(OpenTelemetrySdk openTelemetrySdk) {
+    this(openTelemetrySdk, DEFAULT_FLUSH_TIMEOUT);
   }
 
   /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
-  protected TracingRequestHandler() {
-    this.tracer = new AwsLambdaTracer();
-    this.flushTimeout = DEFAULT_FLUSH_TIMEOUT_SECONDS;
+  protected TracingRequestHandler(OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout) {
+    this(openTelemetrySdk, flushTimeout, new AwsLambdaTracer(openTelemetrySdk));
   }
 
-  /**
-   * Creates a new {@link TracingRequestHandler} which traces using the specified {@link Tracer}.
-   */
-  protected TracingRequestHandler(Tracer tracer) {
-    this.tracer = new AwsLambdaTracer(tracer);
-    this.flushTimeout = DEFAULT_FLUSH_TIMEOUT_SECONDS;
-  }
-
-  /**
-   * Creates a new {@link TracingRequestHandler} which traces using the specified {@link
-   * AwsLambdaTracer}.
-   */
-  protected TracingRequestHandler(AwsLambdaTracer tracer) {
+  /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
+  protected TracingRequestHandler(
+      OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout, AwsLambdaTracer tracer) {
+    this.openTelemetrySdk = openTelemetrySdk;
+    this.flushTimeoutNanos = flushTimeout.toNanos();
     this.tracer = tracer;
-    this.flushTimeout = DEFAULT_FLUSH_TIMEOUT_SECONDS;
   }
 
   private Map<String, String> getHeaders(I input) {
@@ -81,7 +74,10 @@ public abstract class TracingRequestHandler<I, O> implements RequestHandler<I, O
       } else {
         tracer.end(otelContext);
       }
-      LambdaUtils.forceFlush();
+      openTelemetrySdk
+          .getSdkTracerProvider()
+          .forceFlush()
+          .join(flushTimeoutNanos, TimeUnit.NANOSECONDS);
     }
   }
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestHandler.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestHandler.java
@@ -9,7 +9,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.time.Duration;
@@ -30,17 +29,28 @@ public abstract class TracingRequestHandler<I, O> implements RequestHandler<I, O
   private final OpenTelemetrySdk openTelemetrySdk;
   private final long flushTimeoutNanos;
 
-  /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
+  /**
+   * Creates a new {@link TracingRequestHandler} which traces using the provided {@link
+   * OpenTelemetrySdk} and has a timeout of 1s when flushing at the end of an invocation.
+   */
   protected TracingRequestHandler(OpenTelemetrySdk openTelemetrySdk) {
     this(openTelemetrySdk, DEFAULT_FLUSH_TIMEOUT);
   }
 
-  /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
+  /**
+   * Creates a new {@link TracingRequestHandler} which traces using the provided {@link
+   * OpenTelemetrySdk} and has a timeout of {@code flushTimeout} when flushing at the end of an
+   * invocation.
+   */
   protected TracingRequestHandler(OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout) {
     this(openTelemetrySdk, flushTimeout, new AwsLambdaTracer(openTelemetrySdk));
   }
 
-  /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
+  /**
+   * Creates a new {@link TracingRequestHandler} which flushes the provided {@link
+   * OpenTelemetrySdk}, has a timeout of {@code flushTimeout} when flushing at the end of an
+   * invocation, and traces using the provided {@link AwsLambdaTracer}.
+   */
   protected TracingRequestHandler(
       OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout, AwsLambdaTracer tracer) {
     this.openTelemetrySdk = openTelemetrySdk;

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamHandler.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamHandler.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.awslambda.v1_0;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.io.IOException;
@@ -30,24 +29,26 @@ public abstract class TracingRequestStreamHandler implements RequestStreamHandle
   private final AwsLambdaTracer tracer;
 
   /**
-   * Creates a new {@link TracingRequestStreamHandler} which traces using the default {@link
-   * Tracer}.
+   * Creates a new {@link TracingRequestStreamHandler} which traces using the provided {@link
+   * OpenTelemetrySdk} and has a timeout of 1s when flushing at the end of an invocation.
    */
   protected TracingRequestStreamHandler(OpenTelemetrySdk openTelemetrySdk) {
     this(openTelemetrySdk, DEFAULT_FLUSH_TIMEOUT);
   }
 
   /**
-   * Creates a new {@link TracingRequestStreamHandler} which traces using the default {@link
-   * Tracer}.
+   * Creates a new {@link TracingRequestStreamHandler} which traces using the provided {@link
+   * OpenTelemetrySdk} and has a timeout of {@code flushTimeout} when flushing at the end of an
+   * invocation.
    */
   protected TracingRequestStreamHandler(OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout) {
     this(openTelemetrySdk, flushTimeout, new AwsLambdaTracer(openTelemetrySdk));
   }
 
   /**
-   * Creates a new {@link TracingRequestStreamHandler} which traces using the specified {@link
-   * Tracer}.
+   * Creates a new {@link TracingRequestStreamHandler} which flushes the provided {@link
+   * OpenTelemetrySdk}, has a timeout of {@code flushTimeout} when flushing at the end of an
+   * invocation, and traces using the provided {@link AwsLambdaTracer}.
    */
   protected TracingRequestStreamHandler(
       OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout, AwsLambdaTracer tracer) {

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapper.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.awslambda.v1_0;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -23,7 +25,12 @@ public class TracingRequestStreamWrapper extends TracingRequestStreamHandler {
   static WrappedLambda WRAPPED_LAMBDA = WrappedLambda.fromConfiguration();
 
   public TracingRequestStreamWrapper() {
-    super(WrapperConfiguration.flushTimeout());
+    this(OpenTelemetrySdkAutoConfiguration.initialize());
+  }
+
+  // Visible for testing
+  TracingRequestStreamWrapper(OpenTelemetrySdk openTelemetrySdk) {
+    super(openTelemetrySdk, WrapperConfiguration.flushTimeout());
   }
 
   @Override

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapper.java
@@ -5,8 +5,19 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0;
 
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+
 /**
  * Wrapper for {@link TracingRequestHandler}. Allows for wrapping a regular lambda, not proxied
  * through API Gateway. Therefore, HTTP headers propagation is not supported.
  */
-public class TracingRequestWrapper extends TracingRequestWrapperBase<Object, Object> {}
+public class TracingRequestWrapper extends TracingRequestWrapperBase<Object, Object> {
+  public TracingRequestWrapper() {
+    super();
+  }
+
+  // Visible for testing
+  TracingRequestWrapper(OpenTelemetrySdk openTelemetrySdk) {
+    super(openTelemetrySdk);
+  }
+}

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperBase.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperBase.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.awslambda.v1_0;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -16,7 +18,12 @@ import java.lang.reflect.Method;
 abstract class TracingRequestWrapperBase<I, O> extends TracingRequestHandler<I, O> {
 
   protected TracingRequestWrapperBase() {
-    super(WrapperConfiguration.flushTimeout());
+    this(OpenTelemetrySdkAutoConfiguration.initialize());
+  }
+
+  // Visible for testing
+  TracingRequestWrapperBase(OpenTelemetrySdk openTelemetrySdk) {
+    super(openTelemetrySdk, WrapperConfiguration.flushTimeout());
   }
 
   // visible for testing

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsEventHandler.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsEventHandler.java
@@ -7,31 +7,37 @@ package io.opentelemetry.instrumentation.awslambda.v1_0;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import java.time.Duration;
 
 public abstract class TracingSqsEventHandler extends TracingRequestHandler<SQSEvent, Void> {
 
   private final AwsLambdaMessageTracer tracer;
 
-  /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
-  protected TracingSqsEventHandler() {
-    this.tracer = new AwsLambdaMessageTracer();
-  }
-
   /**
-   * Creates a new {@link TracingRequestHandler} which traces using the specified {@link Tracer}.
+   * Creates a new {@link TracingRequestHandler} which traces using the specified {@link
+   * OpenTelemetrySdk}.
    */
-  protected TracingSqsEventHandler(Tracer tracer) {
-    super(tracer);
-    this.tracer = new AwsLambdaMessageTracer(tracer);
+  protected TracingSqsEventHandler(OpenTelemetrySdk openTelemetrySdk) {
+    this(openTelemetrySdk, DEFAULT_FLUSH_TIMEOUT);
   }
 
   /**
    * Creates a new {@link TracingRequestHandler} which traces using the specified {@link
-   * AwsLambdaMessageTracer}.
+   * OpenTelemetrySdk}.
    */
-  protected TracingSqsEventHandler(AwsLambdaMessageTracer tracer) {
+  protected TracingSqsEventHandler(OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout) {
+    this(openTelemetrySdk, flushTimeout, new AwsLambdaMessageTracer(openTelemetrySdk));
+  }
+
+  /**
+   * Creates a new {@link TracingRequestHandler} which traces using the specified {@link
+   * OpenTelemetrySdk}.
+   */
+  protected TracingSqsEventHandler(
+      OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout, AwsLambdaMessageTracer tracer) {
+    super(openTelemetrySdk, flushTimeout);
     this.tracer = tracer;
   }
 
@@ -50,7 +56,6 @@ public abstract class TracingSqsEventHandler extends TracingRequestHandler<SQSEv
       } else {
         tracer.end(otelContext);
       }
-      LambdaUtils.forceFlush();
     }
     return null;
   }

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsEventHandler.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsEventHandler.java
@@ -16,24 +16,26 @@ public abstract class TracingSqsEventHandler extends TracingRequestHandler<SQSEv
   private final AwsLambdaMessageTracer tracer;
 
   /**
-   * Creates a new {@link TracingRequestHandler} which traces using the specified {@link
-   * OpenTelemetrySdk}.
+   * Creates a new {@link TracingSqsEventHandler} which traces using the provided {@link
+   * OpenTelemetrySdk} and has a timeout of 1s when flushing at the end of an invocation.
    */
   protected TracingSqsEventHandler(OpenTelemetrySdk openTelemetrySdk) {
     this(openTelemetrySdk, DEFAULT_FLUSH_TIMEOUT);
   }
 
   /**
-   * Creates a new {@link TracingRequestHandler} which traces using the specified {@link
-   * OpenTelemetrySdk}.
+   * Creates a new {@link TracingSqsEventHandler} which traces using the provided {@link
+   * OpenTelemetrySdk} and has a timeout of {@code flushTimeout} when flushing at the end of an
+   * invocation.
    */
   protected TracingSqsEventHandler(OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout) {
     this(openTelemetrySdk, flushTimeout, new AwsLambdaMessageTracer(openTelemetrySdk));
   }
 
   /**
-   * Creates a new {@link TracingRequestHandler} which traces using the specified {@link
-   * OpenTelemetrySdk}.
+   * Creates a new {@link TracingSqsEventHandler} which flushes the provided {@link
+   * OpenTelemetrySdk}, has a timeout of {@code flushTimeout} when flushing at the end of an
+   * invocation, and traces using the provided {@link AwsLambdaTracer}.
    */
   protected TracingSqsEventHandler(
       OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout, AwsLambdaMessageTracer tracer) {

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsMessageHandler.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsMessageHandler.java
@@ -8,25 +8,33 @@ package io.opentelemetry.instrumentation.awslambda.v1_0;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.time.Duration;
 
 public abstract class TracingSqsMessageHandler extends TracingSqsEventHandler {
 
-  /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
+  /**
+   * Creates a new {@link TracingSqsMessageHandler} which traces using the provided {@link
+   * OpenTelemetrySdk} and has a timeout of 1s when flushing at the end of an invocation.
+   */
   protected TracingSqsMessageHandler(OpenTelemetrySdk openTelemetrySdk) {
     super(openTelemetrySdk);
   }
 
-  /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
+  /**
+   * Creates a new {@link TracingSqsMessageHandler} which traces using the provided {@link
+   * OpenTelemetrySdk} and has a timeout of {@code flushTimeout} when flushing at the end of an
+   * invocation.
+   */
   protected TracingSqsMessageHandler(OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout) {
     super(openTelemetrySdk, flushTimeout);
   }
 
   /**
-   * Creates a new {@link TracingRequestHandler} which traces using the specified {@link Tracer}.
+   * Creates a new {@link TracingSqsMessageHandler} which flushes the provided {@link
+   * OpenTelemetrySdk}, has a timeout of {@code flushTimeout} when flushing at the end of an
+   * invocation, and traces using the provided {@link AwsLambdaTracer}.
    */
   protected TracingSqsMessageHandler(
       OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout, AwsLambdaMessageTracer tracer) {

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsMessageHandler.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsMessageHandler.java
@@ -10,27 +10,27 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import java.time.Duration;
 
 public abstract class TracingSqsMessageHandler extends TracingSqsEventHandler {
 
   /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
-  protected TracingSqsMessageHandler() {
-    super(new AwsLambdaMessageTracer());
+  protected TracingSqsMessageHandler(OpenTelemetrySdk openTelemetrySdk) {
+    super(openTelemetrySdk);
+  }
+
+  /** Creates a new {@link TracingRequestHandler} which traces using the default {@link Tracer}. */
+  protected TracingSqsMessageHandler(OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout) {
+    super(openTelemetrySdk, flushTimeout);
   }
 
   /**
    * Creates a new {@link TracingRequestHandler} which traces using the specified {@link Tracer}.
    */
-  protected TracingSqsMessageHandler(Tracer tracer) {
-    super(new AwsLambdaMessageTracer(tracer));
-  }
-
-  /**
-   * Creates a new {@link TracingRequestHandler} which traces using the specified {@link
-   * AwsLambdaMessageTracer}.
-   */
-  protected TracingSqsMessageHandler(AwsLambdaMessageTracer tracer) {
-    super(tracer);
+  protected TracingSqsMessageHandler(
+      OpenTelemetrySdk openTelemetrySdk, Duration flushTimeout, AwsLambdaMessageTracer tracer) {
+    super(openTelemetrySdk, flushTimeout, tracer);
   }
 
   @Override

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/WrapperConfiguration.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/WrapperConfiguration.java
@@ -5,19 +5,21 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0;
 
+import java.time.Duration;
+
 public final class WrapperConfiguration {
 
   private WrapperConfiguration() {}
 
   public static final String OTEL_LAMBDA_FLUSH_TIMEOUT_ENV_KEY =
       "OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT";
-  public static final long OTEL_LAMBDA_FLUSH_TIMEOUT_DEFAULT = 1;
+  public static final Duration OTEL_LAMBDA_FLUSH_TIMEOUT_DEFAULT = Duration.ofSeconds(1);
 
-  public static final long flushTimeout() {
+  public static final Duration flushTimeout() {
     String lambdaFlushTimeout = System.getenv(OTEL_LAMBDA_FLUSH_TIMEOUT_ENV_KEY);
     if (lambdaFlushTimeout != null && !lambdaFlushTimeout.isEmpty()) {
       try {
-        return Long.parseLong(lambdaFlushTimeout);
+        return Duration.ofMillis(Long.parseLong(lambdaFlushTimeout));
       } catch (NumberFormatException nfe) {
         // ignored - default used
       }

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsHandlerTest.groovy
@@ -9,10 +9,16 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import io.opentelemetry.sdk.OpenTelemetrySdk
 
 class AwsLambdaSqsHandlerTest extends AbstractAwsLambdaSqsHandlerTest implements LibraryTestTrait {
 
   static class TestHandler extends TracingSqsEventHandler {
+
+    TestHandler(OpenTelemetrySdk openTelemetrySdk) {
+      super(openTelemetrySdk)
+    }
+
     @Override
     protected void handleEvent(SQSEvent event, Context context) {
     }
@@ -20,6 +26,6 @@ class AwsLambdaSqsHandlerTest extends AbstractAwsLambdaSqsHandlerTest implements
 
   @Override
   RequestHandler<SQSEvent, Void> handler() {
-    return new TestHandler()
+    return new TestHandler(testRunner().openTelemetrySdk)
   }
 }

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsMessageHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsMessageHandlerTest.groovy
@@ -11,6 +11,7 @@ import static io.opentelemetry.api.trace.SpanKind.SERVER
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
+import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 class AwsLambdaSqsMessageHandlerTest extends LibraryInstrumentationSpecification {
@@ -19,6 +20,11 @@ class AwsLambdaSqsMessageHandlerTest extends LibraryInstrumentationSpecification
   private static final String AWS_TRACE_HEADER2 = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad9;Sampled=1"
 
   static class TestHandler extends TracingSqsMessageHandler {
+
+    TestHandler(OpenTelemetrySdk openTelemetrySdk) {
+      super(openTelemetrySdk)
+    }
+
     @Override
     protected void handleMessage(SQSEvent.SQSMessage event, Context context) {
     }
@@ -43,7 +49,7 @@ class AwsLambdaSqsMessageHandlerTest extends LibraryInstrumentationSpecification
     def event = new SQSEvent()
     event.setRecords([message1, message2])
 
-    new TestHandler().handleRequest(event, context)
+    new TestHandler(testRunner().openTelemetrySdk).handleRequest(event, context)
 
     then:
     assertTraces(1) {

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTest.groovy
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.awslambda.v1_0
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import io.opentelemetry.sdk.OpenTelemetrySdk
 
 class AwsLambdaTest extends AbstractAwsLambdaRequestHandlerTest implements LibraryTestTrait {
 
@@ -17,6 +18,10 @@ class AwsLambdaTest extends AbstractAwsLambdaRequestHandlerTest implements Libra
 
   static class TestRequestHandler extends TracingRequestHandler<String, String> {
 
+    TestRequestHandler(OpenTelemetrySdk openTelemetrySdk) {
+      super(openTelemetrySdk)
+    }
+
     @Override
     protected String doHandleRequest(String input, Context context) {
       return AbstractAwsLambdaRequestHandlerTest.doHandleRequest(input, context)
@@ -25,6 +30,6 @@ class AwsLambdaTest extends AbstractAwsLambdaRequestHandlerTest implements Libra
 
   @Override
   RequestHandler<String, String> handler() {
-    return new TestRequestHandler()
+    return new TestRequestHandler(testRunner().openTelemetrySdk)
   }
 }

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapperTest.groovy
@@ -38,7 +38,7 @@ class TracingRequestApiGatewayWrapperTest extends TracingRequestWrapperTestBase 
 
   def "handler traced with trace propagation"() {
     given:
-    setLambda(TestApiGatewayHandler.getName() + "::handleRequest", TracingRequestApiGatewayWrapper)
+    setLambda(TestApiGatewayHandler.getName() + "::handleRequest", { new TracingRequestApiGatewayWrapper(it) })
 
     def headers = ImmutableMap.builder()
       .putAll(propagationHeaders())
@@ -83,7 +83,7 @@ class TracingRequestApiGatewayWrapperTest extends TracingRequestWrapperTestBase 
 
   def "test empty request & response"() {
     given:
-    setLambda(TestApiGatewayHandler.getName() + "::handleRequest", TracingRequestApiGatewayWrapper)
+    setLambda(TestApiGatewayHandler.getName() + "::handleRequest", { new TracingRequestApiGatewayWrapper(it) })
 
     def input = new APIGatewayProxyRequestEvent()
       .withBody("empty")

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
@@ -50,7 +50,7 @@ class TracingRequestStreamWrapperPropagationTest extends LibraryInstrumentationS
   def setup() {
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, "io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestStreamWrapperPropagationTest\$TestRequestHandler::handleRequest")
     TracingRequestStreamWrapper.WRAPPED_LAMBDA = WrappedLambda.fromConfiguration()
-    wrapper = new TracingRequestStreamWrapper()
+    wrapper = new TracingRequestStreamWrapper(testRunner().openTelemetrySdk)
   }
 
   def cleanup() {

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
@@ -46,7 +46,7 @@ class TracingRequestStreamWrapperTest extends LibraryInstrumentationSpecificatio
   def setup() {
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, "io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestStreamWrapperTest\$TestRequestHandler::handleRequest")
     TracingRequestStreamWrapper.WRAPPED_LAMBDA = WrappedLambda.fromConfiguration()
-    wrapper = new TracingRequestStreamWrapper()
+    wrapper = new TracingRequestStreamWrapper(testRunner().openTelemetrySdk)
   }
 
   def cleanup() {

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
@@ -27,7 +27,7 @@ class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
 
   def "handler string traced"() {
     given:
-    setLambda(TestRequestHandlerString.getName() + "::handleRequest", TracingRequestWrapper)
+    setLambda(TestRequestHandlerString.getName() + "::handleRequest", { new TracingRequestWrapper(it) })
 
     when:
     def result = wrapper.handleRequest("hello", context)
@@ -51,7 +51,7 @@ class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
 
   def "handler with exception"() {
     given:
-    setLambda(TestRequestHandlerString.getName() + "::handleRequest", TracingRequestWrapper)
+    setLambda(TestRequestHandlerString.getName() + "::handleRequest", { new TracingRequestWrapper(it) })
 
     when:
     def thrown

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import com.amazonaws.services.lambda.runtime.Context
+import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
@@ -23,15 +24,16 @@ class TracingRequestWrapperTestBase extends LibraryInstrumentationSpecification 
   Context context
 
   def setup() {
+    GlobalOpenTelemetry.resetForTest()
     context = Mock(Context)
     context.getFunctionName() >> "my_function"
     context.getAwsRequestId() >> "1-22-333"
     context.getInvokedFunctionArn() >> "arn:aws:lambda:us-east-1:123456789:function:test"
   }
 
-  def setLambda(handler, wrapperClass) {
+  def setLambda(handler, Closure<TracingRequestWrapperBase> wrapperConstructor) {
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, handler)
     TracingRequestWrapper.WRAPPED_LAMBDA = WrappedLambda.fromConfiguration()
-    wrapper = wrapperClass.getDeclaredConstructor().newInstance()
+    wrapper = wrapperConstructor.call(testRunner().openTelemetrySdk)
   }
 }

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
@@ -6,11 +6,10 @@
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import com.amazonaws.services.lambda.runtime.Context
-import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
-import spock.lang.Shared
+import spock.lang.Shared 
 
 class TracingRequestWrapperTestBase extends LibraryInstrumentationSpecification {
 
@@ -24,7 +23,6 @@ class TracingRequestWrapperTestBase extends LibraryInstrumentationSpecification 
   Context context
 
   def setup() {
-    GlobalOpenTelemetry.resetForTest()
     context = Mock(Context)
     context.getFunctionName() >> "my_function"
     context.getAwsRequestId() >> "1-22-333"

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
@@ -5,18 +5,17 @@
 
 package io.opentelemetry.instrumentation.test
 
-import io.opentelemetry.instrumentation.testing.InstrumentationTestRunner
-import io.opentelemetry.instrumentation.testing.LibraryTestRunner
 
+import io.opentelemetry.instrumentation.testing.LibraryTestRunner
 /**
  * A trait which initializes instrumentation library tests, including a test span exporter. All
  * library tests should implement this trait.
  */
 trait LibraryTestTrait {
   // library test runner has to be initialized statically so that GlobalOpenTelemetry is set as soon as possible
-  private static final InstrumentationTestRunner RUNNER = LibraryTestRunner.instance()
+  private static final LibraryTestRunner RUNNER = LibraryTestRunner.instance()
 
-  InstrumentationTestRunner testRunner() {
+  LibraryTestRunner testRunner() {
     RUNNER
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/LibraryTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/LibraryTestRunner.java
@@ -48,7 +48,7 @@ public final class LibraryTestRunner implements InstrumentationTestRunner {
             .buildAndRegisterGlobal();
   }
 
-  public static InstrumentationTestRunner instance() {
+  public static LibraryTestRunner instance() {
     return INSTANCE;
   }
 
@@ -79,6 +79,10 @@ public final class LibraryTestRunner implements InstrumentationTestRunner {
   public List<MetricData> getExportedMetrics() {
     // no metrics support yet
     return Collections.emptyList();
+  }
+
+  public OpenTelemetrySdk getOpenTelemetrySdk() {
+    return openTelemetry;
   }
 
   @Override


### PR DESCRIPTION
…f using global.

This change is needed to update to 0.17.0

I have changed the wrappers to use `autoconfigure` instead of "the global", I guess in general the global would be a noop without that anyways. But because our test infrastructure is not set up for handling library instrumentation which has its own autoconfigure, and we probably wouldn't update it for the one-and-only case where library instrumentation depends on the SDK, we'll need to add some smoke-tests eventually.