### PR TITLE
Remove trivial uses of Guava from agent.

### DIFF
--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/TraceAnnotationsInstrumentationModule.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/TraceAnnotationsInstrumentationModule.java
@@ -17,12 +17,13 @@ import static net.bytebuddy.matcher.ElementMatchers.none;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.Sets;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.config.MethodsConfigurationParser;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,18 +50,17 @@ public class TraceAnnotationsInstrumentationModule extends InstrumentationModule
           + PACKAGE_CLASS_NAME_REGEX
           + "\\s*;?\\s*";
 
-  private static final String[] DEFAULT_ANNOTATIONS =
-      new String[] {
-        "com.appoptics.api.ext.LogMethod",
-        "com.newrelic.api.agent.Trace",
-        "com.signalfx.tracing.api.Trace",
-        "com.tracelytics.api.ext.LogMethod",
-        "datadog.trace.api.Trace",
-        "io.opentracing.contrib.dropwizard.Trace",
-        "kamon.annotation.Trace",
-        "kamon.annotation.api.Trace",
-        "org.springframework.cloud.sleuth.annotation.NewSpan"
-      };
+  private static final List<String> DEFAULT_ANNOTATIONS =
+      Arrays.asList(
+          "com.appoptics.api.ext.LogMethod",
+          "com.newrelic.api.agent.Trace",
+          "com.signalfx.tracing.api.Trace",
+          "com.tracelytics.api.ext.LogMethod",
+          "datadog.trace.api.Trace",
+          "io.opentracing.contrib.dropwizard.Trace",
+          "kamon.annotation.Trace",
+          "kamon.annotation.api.Trace",
+          "org.springframework.cloud.sleuth.annotation.NewSpan");
 
   private static final String TRACE_ANNOTATIONS_CONFIG =
       "otel.instrumentation.external-annotations.include";
@@ -128,7 +128,7 @@ public class TraceAnnotationsInstrumentationModule extends InstrumentationModule
     private static Set<String> configureAdditionalTraceAnnotations(Config config) {
       String configString = config.getProperty(TRACE_ANNOTATIONS_CONFIG);
       if (configString == null) {
-        return Collections.unmodifiableSet(Sets.newHashSet(DEFAULT_ANNOTATIONS));
+        return Collections.unmodifiableSet(new HashSet<>(DEFAULT_ANNOTATIONS));
       } else if (configString.isEmpty()) {
         return Collections.emptySet();
       } else if (!configString.matches(CONFIG_FORMAT)) {
@@ -137,7 +137,7 @@ public class TraceAnnotationsInstrumentationModule extends InstrumentationModule
             configString);
         return Collections.emptySet();
       } else {
-        Set<String> annotations = Sets.newHashSet();
+        Set<String> annotations = new HashSet<>();
         String[] annotationClasses = configString.split(";", -1);
         for (String annotationClass : annotationClasses) {
           if (!annotationClass.trim().isEmpty()) {

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientInstrumentationModule.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientInstrumentationModule.java
@@ -32,13 +32,6 @@ public class KubernetesClientInstrumentationModule extends InstrumentationModule
   }
 
   @Override
-  protected String[] additionalHelperClassNames() {
-    return new String[] {
-      "com.google.common.base.Strings",
-    };
-  }
-
-  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new ApiClientInstrumentation());
   }

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesRequestDigest.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesRequestDigest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.kubernetesclient;
 
-import com.google.common.base.Strings;
 import java.util.regex.Pattern;
 import okhttp3.Request;
 
@@ -59,11 +58,11 @@ class KubernetesRequestDigest {
   }
 
   private static boolean hasWatchParameter(Request request) {
-    return !Strings.isNullOrEmpty(request.url().queryParameter("watch"));
+    return !isNullOrEmpty(request.url().queryParameter("watch"));
   }
 
   private static boolean hasNamePathParameter(KubernetesResource resource) {
-    return !Strings.isNullOrEmpty(resource.getName());
+    return !isNullOrEmpty(resource.getName());
   }
 
   private final String urlPath;
@@ -95,14 +94,14 @@ class KubernetesRequestDigest {
     }
 
     String groupVersion;
-    if (Strings.isNullOrEmpty(resourceMeta.getApiGroup())) { // core resource
+    if (isNullOrEmpty(resourceMeta.getApiGroup())) { // core resource
       groupVersion = "";
     } else { // regular resource
       groupVersion = resourceMeta.getApiGroup() + "/" + resourceMeta.getApiVersion();
     }
 
     String targetResourceName;
-    if (Strings.isNullOrEmpty(resourceMeta.getSubResource())) {
+    if (isNullOrEmpty(resourceMeta.getSubResource())) {
       targetResourceName = resourceMeta.getResource();
     } else { // subresource
       targetResourceName = resourceMeta.getResource() + "/" + resourceMeta.getSubResource();
@@ -115,5 +114,9 @@ class KubernetesRequestDigest {
         .append(' ')
         .append(targetResourceName)
         .toString();
+  }
+
+  private static boolean isNullOrEmpty(String s) {
+    return s == null || s.isEmpty();
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -33,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -491,18 +490,15 @@ public class AgentInstaller {
     @Override
     public Iterable<Iterable<Class<?>>> resolve(Instrumentation instrumentation) {
       // filter out our agent classes and injected helper classes
-      return iterableOf(
-          () ->
-              streamOf(delegate.resolve(instrumentation))
-                  .map(classes -> iterableOf(() -> streamOf(classes).filter(c -> !isIgnored(c)))));
+      return () -> streamOf(delegate.resolve(instrumentation)).map(this::filterClasses).iterator();
+    }
+
+    private Iterable<Class<?>> filterClasses(Iterable<Class<?>> classes) {
+      return () -> streamOf(classes).filter(c -> !isIgnored(c)).iterator();
     }
 
     private static <T> Stream<T> streamOf(Iterable<T> iterable) {
       return StreamSupport.stream(iterable.spliterator(), false);
-    }
-
-    private static <T> Iterable<T> iterableOf(Supplier<Stream<T>> stream) {
-      return () -> stream.get().iterator();
     }
 
     private static boolean isIgnored(Class<?> c) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -11,7 +11,6 @@ import static net.bytebuddy.matcher.ElementMatchers.any;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
-import com.google.common.collect.Iterables;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.internal.BootstrapPackagePrefixesHolder;
 import io.opentelemetry.javaagent.bootstrap.AgentClassLoader;
@@ -35,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
 import net.bytebuddy.description.type.TypeDefinition;
@@ -489,8 +489,16 @@ public class AgentInstaller {
     @Override
     public Iterable<Iterable<Class<?>>> resolve(Instrumentation instrumentation) {
       // filter out our agent classes and injected helper classes
-      return Iterables.transform(
-          delegate.resolve(instrumentation), i -> Iterables.filter(i, c -> !isIgnored(c)));
+      return () ->
+          StreamSupport.stream(delegate.resolve(instrumentation).spliterator(), false)
+              .map(
+                  classes ->
+                      (Iterable<Class<?>>)
+                          () ->
+                              StreamSupport.stream(classes.spliterator(), false)
+                                  .filter(c -> !isIgnored(c))
+                                  .iterator())
+              .iterator();
     }
 
     private static boolean isIgnored(Class<?> c) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -33,7 +33,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
@@ -489,16 +491,18 @@ public class AgentInstaller {
     @Override
     public Iterable<Iterable<Class<?>>> resolve(Instrumentation instrumentation) {
       // filter out our agent classes and injected helper classes
-      return () ->
-          StreamSupport.stream(delegate.resolve(instrumentation).spliterator(), false)
-              .map(
-                  classes ->
-                      (Iterable<Class<?>>)
-                          () ->
-                              StreamSupport.stream(classes.spliterator(), false)
-                                  .filter(c -> !isIgnored(c))
-                                  .iterator())
-              .iterator();
+      return iterableOf(
+          () ->
+              streamOf(delegate.resolve(instrumentation))
+                  .map(classes -> iterableOf(() -> streamOf(classes).filter(c -> !isIgnored(c)))));
+    }
+
+    private static <T> Stream<T> streamOf(Iterable<T> iterable) {
+      return StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    private static <T> Iterable<T> iterableOf(Supplier<Stream<T>> stream) {
+      return () -> stream.get().iterator();
     }
 
     private static boolean isIgnored(Class<?> c) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InstrumentationModule.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InstrumentationModule.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.tooling;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.failSafe;
 import static java.util.Arrays.asList;
 import static net.bytebuddy.matcher.ElementMatchers.any;
@@ -91,7 +90,9 @@ public abstract class InstrumentationModule {
    * @see #InstrumentationModule(String, String...)
    */
   public InstrumentationModule(List<String> instrumentationNames) {
-    checkArgument(instrumentationNames.size() > 0, "InstrumentationModules must be named");
+    if (instrumentationNames.isEmpty()) {
+      throw new IllegalArgumentException("InstrumentationModules must be named");
+    }
     this.instrumentationNames = new LinkedHashSet<>(instrumentationNames);
     enabled = Config.get().isInstrumentationEnabled(this.instrumentationNames, defaultEnabled());
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/WeakMapSuppliers.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/WeakMapSuppliers.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.tooling;
 
 import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.MapMaker;
 import io.opentelemetry.javaagent.instrumentation.api.WeakMap;
 import java.util.concurrent.TimeUnit;
@@ -35,7 +34,8 @@ class WeakMapSuppliers {
    */
   static class WeakConcurrent implements WeakMap.Implementation {
 
-    @VisibleForTesting static final long CLEAN_FREQUENCY_SECONDS = 1;
+    // Visible for testing
+    static final long CLEAN_FREQUENCY_SECONDS = 1;
 
     @Override
     public <K, V> WeakMap<K, V> get() {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -5,7 +5,8 @@
 
 package io.opentelemetry.javaagent.tooling.matcher;
 
-import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -314,21 +315,31 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
     return false;
   }
 
-  private static final Set<String> INSTRUMENTED_SPRING_BOOT_CLASSES =
-      Sets.newHashSet(
-          "org.springframework.boot.autoconfigure.BackgroundPreinitializer$",
-          "org.springframework.boot.autoconfigure.condition.OnClassCondition$",
-          "org.springframework.boot.web.embedded.netty.NettyWebServer$",
-          "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer$",
-          "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedWebappClassLoader",
-          "org.springframework.boot.context.embedded.EmbeddedWebApplicationContext",
-          "org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext",
-          // spring boot 2 classes
-          "org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext",
-          "org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext",
-          "org.springframework.boot.web.embedded.tomcat.TomcatWebServer$",
-          "org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLoader",
-          "org.springframework.boot.web.servlet.DelegatingFilterProxyRegistrationBean$");
+  private static final Set<String> INSTRUMENTED_SPRING_BOOT_CLASSES;
+
+  static {
+    Set<String> instrumented = new HashSet<>();
+    instrumented.add("org.springframework.boot.autoconfigure.BackgroundPreinitializer$");
+    instrumented.add("org.springframework.boot.autoconfigure.condition.OnClassCondition$");
+    instrumented.add("org.springframework.boot.web.embedded.netty.NettyWebServer$");
+    instrumented.add(
+        "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer$");
+    instrumented.add(
+        "org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedWebappClassLoader");
+    instrumented.add("org.springframework.boot.context.embedded.EmbeddedWebApplicationContext");
+    instrumented.add(
+        "org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext");
+    // spring boot 2 classes
+    instrumented.add(
+        "org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext");
+    instrumented.add(
+        "org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext");
+    instrumented.add("org.springframework.boot.web.embedded.tomcat.TomcatWebServer$");
+    instrumented.add(
+        "org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLoader");
+    instrumented.add("org.springframework.boot.web.servlet.DelegatingFilterProxyRegistrationBean$");
+    INSTRUMENTED_SPRING_BOOT_CLASSES = Collections.unmodifiableSet(instrumented);
+  }
 
   private static String outerClassName(final String name) {
     int separator = name.indexOf('$');

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.javaagent.tooling.muzzle.InstrumentationClassPred
 import static java.util.Collections.emptyList;
 import static net.bytebuddy.dynamic.loading.ClassLoadingStrategy.BOOTSTRAP_LOADER;
 
-import com.google.common.collect.Sets;
 import io.opentelemetry.javaagent.bootstrap.WeakCache;
 import io.opentelemetry.javaagent.tooling.AgentTooling;
 import io.opentelemetry.javaagent.tooling.Utils;
@@ -160,9 +159,8 @@ public final class ReferenceMatcher {
     Set<HelperReferenceWrapper.Method> plainMethods = new HashSet<>();
     collectMethodsFromTypeHierarchy(helperWrapper, abstractMethods, plainMethods);
 
-    Set<HelperReferenceWrapper.Method> unimplementedMethods =
-        Sets.difference(abstractMethods, plainMethods);
-    for (HelperReferenceWrapper.Method unimplementedMethod : unimplementedMethods) {
+    abstractMethods.removeAll(plainMethods);
+    for (HelperReferenceWrapper.Method unimplementedMethod : abstractMethods) {
       mismatches =
           lazyAdd(
               mismatches,


### PR DESCRIPTION
The only remaining usage in the agent is caching, and there is usage at compile time by muzzle of the graph library and some test usage. So we'll be able to replace the caching with caffeine for a bit smaller distribution size and probably better cache performance.