### PR TITLE
Better context passing for Netty 4.1

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/context/ContextPropagationDebug.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/context/ContextPropagationDebug.java
@@ -50,25 +50,30 @@ public final class ContextPropagationDebug {
       if (currentSpan != null) {
         log.error("It contains this span: {}", currentSpan);
       }
-      List<StackTraceElement[]> locations = ContextPropagationDebug.getLocations(current);
-      if (locations != null) {
-        StringBuilder sb = new StringBuilder();
-        Iterator<StackTraceElement[]> i = locations.iterator();
-        while (i.hasNext()) {
-          for (StackTraceElement ste : i.next()) {
-            sb.append("\n");
-            sb.append(ste);
-          }
-          if (i.hasNext()) {
-            sb.append("\nwhich was propagated from:");
-          }
-        }
-        log.error("a context leak was detected. it was propagated from:{}", sb);
-      }
+
+      debugContextPropagation(current);
 
       if (FAIL_ON_CONTEXT_LEAK) {
         throw new IllegalStateException("Context leak detected");
       }
+    }
+  }
+
+  public static void debugContextPropagation(Context context) {
+    List<StackTraceElement[]> locations = ContextPropagationDebug.getLocations(context);
+    if (locations != null) {
+      StringBuilder sb = new StringBuilder();
+      Iterator<StackTraceElement[]> i = locations.iterator();
+      while (i.hasNext()) {
+        for (StackTraceElement ste : i.next()) {
+          sb.append("\n");
+          sb.append(ste);
+        }
+        if (i.hasNext()) {
+          sb.append("\nwhich was propagated from:");
+        }
+      }
+      log.error("a context leak was detected. it was propagated from:{}", sb);
     }
   }
 

--- a/instrumentation/netty/netty-4.1/javaagent/netty-4.1-javaagent.gradle
+++ b/instrumentation/netty/netty-4.1/javaagent/netty-4.1-javaagent.gradle
@@ -30,7 +30,8 @@ dependencies {
   library group: 'io.netty', name: 'netty-codec-http', version: '4.1.0.Final'
   api project(':instrumentation:netty:netty-4.1:library')
 
-  testLibrary group: 'org.asynchttpclient', name: 'async-http-client', version: '2.1.0'
+  //Contains logging handler
+  testLibrary group: 'io.netty', name: 'netty-handler', version: '4.1.0.Final'
 
   latestDepTestLibrary group: 'io.netty', name: 'netty-codec-http', version: '(,5.0)'
 }

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/ChannelFutureInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/ChannelFutureInstrumentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
+
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.ClassLoaderMatcher.hasClassesNamed;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.netty.util.concurrent.GenericFutureListener;
+import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
+import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class ChannelFutureInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderOptimization() {
+    return hasClassesNamed("io.netty.channel.ChannelFuture");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return implementsInterface(named("io.netty.channel.ChannelFuture"));
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return singletonMap(
+        isMethod()
+            .and(named("addListener"))
+            .and(takesArgument(0, named("io.netty.util.concurrent.GenericFutureListener"))),
+        ChannelFutureInstrumentation.class.getName() + "$AddListenerAdvice");
+  }
+
+  public static class AddListenerAdvice {
+    @Advice.OnMethodEnter
+    public static void wrapListener(
+        @Advice.Argument(value = 0, readOnly = false) GenericFutureListener listener) {
+      listener = new WrappedFutureListener(Java8BytecodeBridge.currentContext(), listener);
+    }
+  }
+}

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/ChannelInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/ChannelInstrumentation.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
+
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.ClassLoaderMatcher.hasClassesNamed;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import io.netty.channel.Channel;
+import io.opentelemetry.instrumentation.netty.v4_1.AttributeKeys;
+import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
+import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * This instrumentation preserves the context that was active during call to any "write" operation
+ * on Netty Channel in that channel's attribute. This context is later used by our various tracing
+ * handlers to scope the work.
+ */
+public class ChannelInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderOptimization() {
+    return hasClassesNamed("io.netty.channel.Channel");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return implementsInterface(named("io.netty.channel.Channel"));
+  }
+
+  @Override
+  public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
+    return singletonMap(
+        isMethod().and(nameStartsWith("write")),
+        ChannelInstrumentation.class.getName() + "$AttachContextAdvice");
+  }
+
+  public static class AttachContextAdvice {
+    @Advice.OnMethodEnter
+    public static void attachContext(
+        @Advice.This Channel channel) {
+      channel.attr(AttributeKeys.WRITE_CONTEXT).compareAndSet(null, Java8BytecodeBridge.currentContext());
+    }
+  }
+}

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyInstrumentationModule.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyInstrumentationModule.java
@@ -30,6 +30,8 @@ public class NettyInstrumentationModule extends InstrumentationModule {
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
+        new ChannelInstrumentation(),
+        new ChannelFutureInstrumentation(),
         new ChannelFutureListenerInstrumentation(),
         new NettyChannelPipelineInstrumentation(),
         new AbstractChannelHandlerContextInstrumentation());

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/WrappedFutureListener.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/WrappedFutureListener.java
@@ -1,0 +1,23 @@
+package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+public class WrappedFutureListener implements GenericFutureListener {
+  private final Context context;
+  private final GenericFutureListener delegate;
+
+  public WrappedFutureListener(Context context, GenericFutureListener delegate) {
+    this.context = context;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void operationComplete(Future future) throws Exception {
+    try (Scope ignored = context.makeCurrent()) {
+      delegate.operationComplete(future);
+    }
+  }
+}

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/HttpClientRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/HttpClientRequestTracingHandler.java
@@ -24,7 +24,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
       return;
     }
 
-    Context parentContext = ctx.channel().attr(AttributeKeys.CONNECT_CONTEXT).getAndRemove();
+    Context parentContext = ctx.channel().attr(AttributeKeys.WRITE_CONTEXT).getAndRemove();
     if (parentContext == null) {
       parentContext = Context.current();
     }

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/ClientHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/ClientHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import groovy.lang.Closure;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+
+/*
+Bridges from async Netty world to the sync world of our http client tests.
+When request initiated by a test gets a response, calls a given callback and completes given
+future with response's status code.
+*/
+public class ClientHandler extends SimpleChannelInboundHandler<HttpObject> {
+  private final Closure<Void> callback;
+  private final CompletableFuture<Integer> responseCode;
+
+  public ClientHandler(Closure<Void> callback, CompletableFuture<Integer> responseCode) {
+    this.callback = callback;
+    this.responseCode = responseCode;
+  }
+
+  @Override
+  public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
+    if (msg instanceof HttpResponse) {
+      ctx.pipeline().remove(this);
+
+      if (callback != null) {
+        callback.call();
+      }
+
+      HttpResponse response = (HttpResponse) msg;
+      responseCode.complete(response.getStatus().code());
+    }
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    cause.printStackTrace();
+    ctx.close();
+  }
+}

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AttributeKeys.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AttributeKeys.java
@@ -12,6 +12,8 @@ public class AttributeKeys {
 
   public static final AttributeKey<Context> CONNECT_CONTEXT =
       AttributeKey.valueOf(AttributeKeys.class, "connect-context");
+  public static final AttributeKey<Context> WRITE_CONTEXT =
+      AttributeKey.valueOf(AttributeKeys.class, "passed-context");
 
   // this is the context that has the server span
   //

--- a/instrumentation/reactor-netty-0.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyInstrumentationModule.java
+++ b/instrumentation/reactor-netty-0.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyInstrumentationModule.java
@@ -101,7 +101,7 @@ public class ReactorNettyInstrumentationModule extends InstrumentationModule {
     @Override
     public void accept(HttpClientRequest r, Connection c) {
       Context context = r.currentContext().get(MapConnect.CONTEXT_ATTRIBUTE);
-      c.channel().attr(AttributeKeys.CONNECT_CONTEXT).set(context);
+      c.channel().attr(AttributeKeys.WRITE_CONTEXT).set(context);
     }
   }
 }

--- a/instrumentation/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyInstrumentationModule.java
+++ b/instrumentation/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyInstrumentationModule.java
@@ -100,7 +100,7 @@ public class ReactorNettyInstrumentationModule extends InstrumentationModule {
     @Override
     public void accept(HttpClientRequest r, Connection c) {
       Context context = r.currentContextView().get(MapConnect.CONTEXT_ATTRIBUTE);
-      c.channel().attr(AttributeKeys.CONNECT_CONTEXT).set(context);
+      c.channel().attr(AttributeKeys.WRITE_CONTEXT).set(context);
     }
   }
 }


### PR DESCRIPTION
Follows #2323 
Fixes #1312

This PR changes one important aspect of Netty 4.1 instrumentation. Before, we remembered the context that was active when Netty establishes a network connection. Now we remember the context that was active during write operation on the channel. This is the lowest level operation in Netty to trigger the actual request execution.

Now, integrations with specific http client libraries which are based on Netty have to ensure the context propagation from request initiation method in their high level API to the point where library's implementation calls Netty.

This PR also rewrites Netty41ClientTest to actually use Netty, and not higher level AsyncHttpClient.