### PR TITLE
precompile pattern and use char replacement.

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Utils.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Utils.java
@@ -30,6 +30,8 @@ public class Utils {
     }
   }
 
+  private static final String CLASS_SUFFIX = ".class";
+
   /** Return the classloader the core agent is running on. */
   public static ClassLoader getAgentClassLoader() {
     return AgentInstaller.class.getClassLoader();
@@ -46,10 +48,10 @@ public class Utils {
 
   /** com.foo.Bar to com/foo/Bar.class */
   public static String getResourceName(String className) {
-    if (className.endsWith(".class")) {
+    if (className.endsWith(CLASS_SUFFIX)) {
       return className;
     }
-    return className.replace('.', '/') + ".class";
+    return className.replace('.', '/') + CLASS_SUFFIX;
   }
 
   /** com/foo/Bar.class to com.foo.Bar */
@@ -63,9 +65,8 @@ public class Utils {
   }
 
   private static String stripDotClassSuffix(String resourceName) {
-    String suffix = ".class";
-    if (resourceName.endsWith(suffix)) {
-      return resourceName.substring(0, resourceName.length() - suffix.length());
+    if (resourceName.endsWith(CLASS_SUFFIX)) {
+      return resourceName.substring(0, resourceName.length() - CLASS_SUFFIX.length());
     }
     return resourceName;
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Utils.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/Utils.java
@@ -11,7 +11,6 @@ import io.opentelemetry.javaagent.bootstrap.AgentClassLoader;
 import io.opentelemetry.javaagent.bootstrap.AgentClassLoader.BootstrapClassLoaderProxy;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.regex.Pattern;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDefinition;
 
@@ -30,8 +29,6 @@ public class Utils {
       throw new IllegalStateException(e);
     }
   }
-
-  private static final Pattern CLASS_SUFFIX_PATTERN = Pattern.compile("\\.class$");
 
   /** Return the classloader the core agent is running on. */
   public static ClassLoader getAgentClassLoader() {
@@ -66,7 +63,11 @@ public class Utils {
   }
 
   private static String stripDotClassSuffix(String resourceName) {
-    return CLASS_SUFFIX_PATTERN.matcher(resourceName).replaceAll("");
+    String suffix = ".class";
+    if (resourceName.endsWith(suffix)) {
+      return resourceName.substring(0, resourceName.length() - suffix.length());
+    }
+    return resourceName;
   }
 
   /**

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/UtilsTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/UtilsTest.groovy
@@ -17,4 +17,26 @@ class UtilsTest extends Specification {
     stackTrace.contains('io.opentelemetry.javaagent.tooling.Utils')
     stackTrace.contains(System.getProperty("line.separator"))
   }
+
+  def "getClassName() removes suffix and slashes to dots"(){
+    setup:
+    def result = Utils.getClassName("com/example/Something.class")
+    expect:
+    result == "com.example.Something"
+  }
+
+  def "getInternalName() removes suffix and slashes to dots"(){
+    setup:
+    def result = Utils.getInternalName("com.example.Something.class")
+    expect:
+    result == "com/example/Something"
+  }
+
+  def "convertToInnerClassName()"(){
+    setup:
+    def result = Utils.convertToInnerClassName("com/example/MyOuter.MyInner")
+    expect:
+    result == 'com/example/MyOuter$MyInner'
+  }
+
 }

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/UtilsTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/UtilsTest.groovy
@@ -32,7 +32,7 @@ class UtilsTest extends Specification {
     result == "com/example/Something"
   }
 
-  def "convertToInnerClassName()"(){
+  def "convertToInnerClassName() makes dollar into dots"(){
     setup:
     def result = Utils.convertToInnerClassName("com/example/MyOuter.MyInner")
     expect:


### PR DESCRIPTION
I saw some allocations being done in a stack trace that pointed to the compiling of a regex inside of `Utils.getInternalName()`.  Upon closer inspection, it became clear that:

1. the pattern should probably be precompiled for efficiency
2. there was duplicate code to do this replacement
3. 🔥 I think there was a bug in the regex.  It had expected a literal `$` at the end of the resource name after the `.class`.  That didn't match the comments, nor does that make immediate sense to me, so I changed it.  I believe it was trying to match the end of string, in which case the `$` should not have been escaped.  Marking with a 🔥 because this is a change of behavior.
 
So this PR consolidates that duplication, fixes the bug, does a precompilation of the pattern, and backfills some missing unit tests.

It also changes a single character `replaceAll()` over to just a basic character replace in `convertToInnerClassName()`.