### PR TITLE
Hide non-specd attributes behind experimental flag

### DIFF
--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseConfig.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.instrumentation.couchbase.v2_6;
 
 import io.opentelemetry.instrumentation.api.config.Config;

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseConfig.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseConfig.java
@@ -7,8 +7,11 @@ package io.opentelemetry.javaagent.instrumentation.couchbase.v2_6;
 
 import io.opentelemetry.instrumentation.api.config.Config;
 
-public class CouchbaseConfig {
+public final class CouchbaseConfig {
+
   public static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
       Config.get()
           .getBooleanProperty("otel.instrumentation.couchbase.experimental-span-attributes", false);
+
+  private CouchbaseConfig() {}
 }

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseConfig.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseConfig.java
@@ -1,0 +1,9 @@
+package io.opentelemetry.javaagent.instrumentation.couchbase.v2_6;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+
+public class CouchbaseConfig {
+  public static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
+      Config.get()
+          .getBooleanProperty("otel.instrumentation.couchbase.experimental-span-attributes", false);
+}

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseCoreInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseCoreInstrumentation.java
@@ -57,8 +57,9 @@ public class CouchbaseCoreInstrumentation implements TypeInstrumentation {
         if (span == null) {
           span = parentSpan;
           contextStore.put(request, span);
-
-          span.setAttribute("couchbase.operation_id", request.operationId());
+          if (CouchbaseConfig.CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+            span.setAttribute("couchbase.operation_id", request.operationId());
+          }
         }
       }
     }

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseNetworkInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseNetworkInstrumentation.java
@@ -79,7 +79,9 @@ public class CouchbaseNetworkInstrumentation implements TypeInstrumentation {
           }
         }
 
-        span.setAttribute("couchbase.local.address", localSocket);
+        if (CouchbaseConfig.CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+          span.setAttribute("couchbase.local.address", localSocket);
+        }
       }
     }
   }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
@@ -13,7 +13,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.instrumentation.api.ContextStore;
 import io.opentelemetry.javaagent.instrumentation.api.InstrumentationContext;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
@@ -26,10 +25,6 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 public class JaxRsAsyncResponseInstrumentation implements TypeInstrumentation {
-
-  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
-      Config.get()
-          .getBooleanProperty("otel.instrumentation.jaxrs.experimental-span-attributes", false);
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {
@@ -100,7 +95,7 @@ public class JaxRsAsyncResponseInstrumentation implements TypeInstrumentation {
       Span span = contextStore.get(asyncResponse);
       if (span != null) {
         contextStore.put(asyncResponse, null);
-        if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+        if (JaxrsConfig.CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
           span.setAttribute("jaxrs.canceled", true);
         }
         tracer().end(span);

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
@@ -13,6 +13,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.instrumentation.api.ContextStore;
 import io.opentelemetry.javaagent.instrumentation.api.InstrumentationContext;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
@@ -25,6 +26,10 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 public class JaxRsAsyncResponseInstrumentation implements TypeInstrumentation {
+
+  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
+      Config.get()
+          .getBooleanProperty("otel.instrumentation.jaxrs.experimental-span-attributes", false);
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {
@@ -95,7 +100,9 @@ public class JaxRsAsyncResponseInstrumentation implements TypeInstrumentation {
       Span span = contextStore.get(asyncResponse);
       if (span != null) {
         contextStore.put(asyncResponse, null);
-        span.setAttribute("jaxrs.canceled", true);
+        if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+          span.setAttribute("jaxrs.canceled", true);
+        }
         tracer().end(span);
       }
     }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsConfig.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsConfig.java
@@ -1,0 +1,10 @@
+package io.opentelemetry.javaagent.instrumentation.jaxrs.v2_0;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+
+public class JaxrsConfig {
+
+  public static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
+      Config.get()
+          .getBooleanProperty("otel.instrumentation.jaxrs.experimental-span-attributes", false);
+}

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsConfig.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsConfig.java
@@ -7,9 +7,11 @@ package io.opentelemetry.javaagent.instrumentation.jaxrs.v2_0;
 
 import io.opentelemetry.instrumentation.api.config.Config;
 
-public class JaxrsConfig {
+public final class JaxrsConfig {
 
   public static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
       Config.get()
           .getBooleanProperty("otel.instrumentation.jaxrs.experimental-span-attributes", false);
+
+  private JaxrsConfig() {}
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsConfig.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.instrumentation.jaxrs.v2_0;
 
 import io.opentelemetry.instrumentation.api.config.Config;

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/javaagent/jaxrs-2.0-cxf-3.2-javaagent.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/javaagent/jaxrs-2.0-cxf-3.2-javaagent.gradle
@@ -25,3 +25,8 @@ dependencies {
   testLibrary group: 'org.apache.cxf', name: 'cxf-rt-transports-http-jetty', version: '3.2.0'
   testLibrary group: 'org.apache.cxf', name: 'cxf-rt-ws-policy', version: '3.2.0'
 }
+
+tasks.withType(Test) {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.jaxrs.experimental-span-attributes=true"
+}

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/jaxrs-2.0-jersey-2.0-javaagent.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/jaxrs-2.0-jersey-2.0-javaagent.gradle
@@ -30,3 +30,8 @@ dependencies {
 test {
   systemProperty 'testLatestDeps', testLatestDeps
 }
+
+tasks.withType(Test) {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.jaxrs.experimental-span-attributes=true"
+}

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/jaxrs-2.0-resteasy-3.0-javaagent.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/jaxrs-2.0-resteasy-3.0-javaagent.gradle
@@ -45,3 +45,8 @@ dependencies {
 test {
   systemProperty 'testLatestDeps', testLatestDeps
 }
+
+tasks.withType(Test) {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.jaxrs.experimental-span-attributes=true"
+}

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/jaxrs-2.0-resteasy-3.1-javaagent.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/jaxrs-2.0-resteasy-3.1-javaagent.gradle
@@ -49,3 +49,8 @@ if (findProperty('testLatestDeps')) {
     testImplementation.exclude group: 'org.jboss.resteasy', module: 'resteasy-jaxrs'
   }
 }
+
+tasks.withType(Test) {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.jaxrs.experimental-span-attributes=true"
+}

--- a/instrumentation/jsp-2.3/javaagent/jsp-2.3-javaagent.gradle
+++ b/instrumentation/jsp-2.3/javaagent/jsp-2.3-javaagent.gradle
@@ -40,4 +40,7 @@ tasks.withType(Test) {
   // JarScanFilter did not exist in the tomcat 7 api
   jvmArgs '-Dorg.apache.catalina.startup.ContextConfig.jarsToSkip=*'
   jvmArgs '-Dorg.apache.catalina.startup.TldConfig.jarsToSkip=*'
+
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.jsp.experimental-span-attributes=true"
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncBiFunction.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncBiFunction.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.LettuceDat
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.config.Config;
 import java.util.concurrent.CancellationException;
 import java.util.function.BiFunction;
 
@@ -24,6 +25,10 @@ import java.util.function.BiFunction;
 public class LettuceAsyncBiFunction<T, U extends Throwable, R>
     implements BiFunction<T, Throwable, R> {
 
+  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
+      Config.get()
+          .getBooleanProperty("otel.instrumentation.lettuce.experimental-span-attributes", false);
+
   private final Context context;
 
   public LettuceAsyncBiFunction(Context context) {
@@ -33,8 +38,10 @@ public class LettuceAsyncBiFunction<T, U extends Throwable, R>
   @Override
   public R apply(T t, Throwable throwable) {
     if (throwable instanceof CancellationException) {
-      Span span = Span.fromContext(context);
-      span.setAttribute("lettuce.command.cancelled", true);
+      if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+        Span span = Span.fromContext(context);
+        span.setAttribute("lettuce.command.cancelled", true);
+      }
       tracer().end(context);
     } else {
       tracer().endExceptionally(context, throwable);

--- a/instrumentation/rabbitmq-2.7/javaagent/rabbitmq-2.7-javaagent.gradle
+++ b/instrumentation/rabbitmq-2.7/javaagent/rabbitmq-2.7-javaagent.gradle
@@ -22,3 +22,8 @@ configurations.testRuntime {
     force group: 'com.rabbitmq', name: 'amqp-client', version: '2.7.0'
   }
 }
+
+tasks.withType(Test) {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.rabbitmq.experimental-span-attributes=true"
+}

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitTracer.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitTracer.java
@@ -19,6 +19,7 @@ import com.rabbitmq.client.GetResponse;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -26,6 +27,10 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class RabbitTracer extends BaseTracer {
+
+  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
+      Config.get()
+          .getBooleanProperty("otel.instrumentation.rabbitmq.experimental-span-attributes", false);
 
   private static final RabbitTracer TRACER = new RabbitTracer();
 
@@ -60,8 +65,9 @@ public class RabbitTracer extends BaseTracer {
       spanBuilder.setAttribute(
           SemanticAttributes.MESSAGING_DESTINATION,
           normalizeExchangeName(response.getEnvelope().getExchange()));
-      spanBuilder.setAttribute(
-          "messaging.rabbitmq.routing_key", response.getEnvelope().getRoutingKey());
+      if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+        spanBuilder.setAttribute("rabbitmq.routing_key", response.getEnvelope().getRoutingKey());
+      }
       spanBuilder.setAttribute(
           SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES,
           (long) response.getBody().length);
@@ -92,7 +98,7 @@ public class RabbitTracer extends BaseTracer {
       span.setAttribute(
           SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES, (long) body.length);
     }
-    if (properties.getTimestamp() != null) {
+    if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES && properties.getTimestamp() != null) {
       // this will be set if the sender sets the timestamp,
       // or if a plugin is installed on the rabbitmq broker
       long produceTime = properties.getTimestamp().getTime();
@@ -111,9 +117,11 @@ public class RabbitTracer extends BaseTracer {
             ? "<all>"
             : routingKey.startsWith("amq.gen-") ? "<generated>" : routingKey;
     span.updateName(exchangeName + " -> " + routing + " send");
-    span.setAttribute("rabbitmq.command", "basic.publish");
-    if (routingKey != null && !routingKey.isEmpty()) {
-      span.setAttribute("messaging.rabbitmq.routing_key", routingKey);
+    if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+      span.setAttribute("rabbitmq.command", "basic.publish");
+      if (routingKey != null && !routingKey.isEmpty()) {
+        span.setAttribute("rabbitmq.routing_key", routingKey);
+      }
     }
   }
 
@@ -122,8 +130,10 @@ public class RabbitTracer extends BaseTracer {
   }
 
   public void onGet(SpanBuilder span, String queue) {
-    span.setAttribute("rabbitmq.command", "basic.get");
-    span.setAttribute("rabbitmq.queue", queue);
+    if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+      span.setAttribute("rabbitmq.command", "basic.get");
+      span.setAttribute("rabbitmq.queue", queue);
+    }
   }
 
   public String spanNameOnDeliver(String queue) {
@@ -137,14 +147,18 @@ public class RabbitTracer extends BaseTracer {
   }
 
   public void onDeliver(Span span, Envelope envelope) {
-    span.setAttribute("rabbitmq.command", "basic.deliver");
+    if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+      span.setAttribute("rabbitmq.command", "basic.deliver");
+    }
 
     if (envelope != null) {
       String exchange = envelope.getExchange();
       span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION, normalizeExchangeName(exchange));
-      String routingKey = envelope.getRoutingKey();
-      if (routingKey != null && !routingKey.isEmpty()) {
-        span.setAttribute("messaging.rabbitmq.routing_key", routingKey);
+      if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+        String routingKey = envelope.getRoutingKey();
+        if (routingKey != null && !routingKey.isEmpty()) {
+          span.setAttribute("rabbitmq.routing_key", routingKey);
+        }
       }
     }
   }
@@ -159,7 +173,9 @@ public class RabbitTracer extends BaseTracer {
     if (!name.equals("basic.publish")) {
       span.updateName(name);
     }
-    span.setAttribute("rabbitmq.command", name);
+    if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+      span.setAttribute("rabbitmq.command", name);
+    }
   }
 
   @Override

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMQTest.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMQTest.groovy
@@ -364,7 +364,7 @@ class RabbitMQTest extends AgentInstrumentationSpecification {
         "${SemanticAttributes.MESSAGING_DESTINATION.key}" exchange
         "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "queue"
         //TODO add to SemanticAttributes
-        "messaging.rabbitmq.routing_key" { it == null || it == routingKey || it.startsWith("amq.gen-") }
+        "rabbitmq.routing_key" { it == null || it == routingKey || it.startsWith("amq.gen-") }
         if (operation != null && operation != "send") {
           "${SemanticAttributes.MESSAGING_OPERATION.key}" operation
         }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3HttpServerTracer.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3HttpServerTracer.java
@@ -8,11 +8,16 @@ package io.opentelemetry.javaagent.instrumentation.servlet.v3_0;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.servlet.ServletHttpServerTracer;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class Servlet3HttpServerTracer extends ServletHttpServerTracer<HttpServletResponse> {
+
+  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
+      Config.get()
+          .getBooleanProperty("otel.instrumentation.servlet.experimental-span-attributes", false);
 
   private static final Servlet3HttpServerTracer TRACER = new Servlet3HttpServerTracer();
 
@@ -43,7 +48,9 @@ public class Servlet3HttpServerTracer extends ServletHttpServerTracer<HttpServle
   public void onTimeout(Context context, long timeout) {
     Span span = Span.fromContext(context);
     span.setStatus(StatusCode.ERROR);
-    span.setAttribute("servlet.timeout", timeout);
+    if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+      span.setAttribute("servlet.timeout", timeout);
+    }
     span.end();
   }
 

--- a/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioTracer.java
+++ b/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioTracer.java
@@ -12,6 +12,7 @@ import com.twilio.rest.api.v2010.account.Call;
 import com.twilio.rest.api.v2010.account.Message;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
@@ -19,6 +20,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TwilioTracer extends BaseTracer {
+
+  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
+      Config.get()
+          .getBooleanProperty("otel.instrumentation.twilio.experimental-span-attributes", false);
 
   private static final Logger log = LoggerFactory.getLogger(TwilioTracer.class);
 
@@ -67,36 +72,38 @@ public class TwilioTracer extends BaseTracer {
       return;
     }
 
-    // Provide helpful metadata for some of the more common response types
-    span.setAttribute("twilio.type", result.getClass().getCanonicalName());
+    if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
+      // Provide helpful metadata for some of the more common response types
+      span.setAttribute("twilio.type", result.getClass().getCanonicalName());
 
-    // Instrument the most popular resource types directly
-    if (result instanceof Message) {
-      Message message = (Message) result;
-      span.setAttribute("twilio.account", message.getAccountSid());
-      span.setAttribute("twilio.sid", message.getSid());
-      Message.Status status = message.getStatus();
-      if (status != null) {
-        span.setAttribute("twilio.status", status.toString());
+      // Instrument the most popular resource types directly
+      if (result instanceof Message) {
+        Message message = (Message) result;
+        span.setAttribute("twilio.account", message.getAccountSid());
+        span.setAttribute("twilio.sid", message.getSid());
+        Message.Status status = message.getStatus();
+        if (status != null) {
+          span.setAttribute("twilio.status", status.toString());
+        }
+      } else if (result instanceof Call) {
+        Call call = (Call) result;
+        span.setAttribute("twilio.account", call.getAccountSid());
+        span.setAttribute("twilio.sid", call.getSid());
+        span.setAttribute("twilio.parentSid", call.getParentCallSid());
+        Call.Status status = call.getStatus();
+        if (status != null) {
+          span.setAttribute("twilio.status", status.toString());
+        }
+      } else {
+        // Use reflection to gather insight from other types; note that Twilio requests take close
+        // to
+        // 1 second, so the added hit from reflection here is relatively minimal in the grand scheme
+        // of things
+        setTagIfPresent(span, result, "twilio.sid", "getSid");
+        setTagIfPresent(span, result, "twilio.account", "getAccountSid");
+        setTagIfPresent(span, result, "twilio.status", "getStatus");
       }
-    } else if (result instanceof Call) {
-      Call call = (Call) result;
-      span.setAttribute("twilio.account", call.getAccountSid());
-      span.setAttribute("twilio.sid", call.getSid());
-      span.setAttribute("twilio.parentSid", call.getParentCallSid());
-      Call.Status status = call.getStatus();
-      if (status != null) {
-        span.setAttribute("twilio.status", status.toString());
-      }
-    } else {
-      // Use reflection to gather insight from other types; note that Twilio requests take close to
-      // 1 second, so the added hit from reflection here is relatively minimal in the grand scheme
-      // of things
-      setTagIfPresent(span, result, "twilio.sid", "getSid");
-      setTagIfPresent(span, result, "twilio.account", "getAccountSid");
-      setTagIfPresent(span, result, "twilio.status", "getStatus");
     }
-
     super.end(span);
   }
 

--- a/instrumentation/twilio-6.6/javaagent/twilio-6.6-javaagent.gradle
+++ b/instrumentation/twilio-6.6/javaagent/twilio-6.6-javaagent.gradle
@@ -17,3 +17,8 @@ dependencies {
 
   latestDepTestLibrary group: 'com.twilio.sdk', name: 'twilio', version: '7.+'
 }
+
+tasks.withType(Test) {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.twilio.experimental-span-attributes=true"
+}


### PR DESCRIPTION
Even though instrumentation attributes are not being declared stable with 1.0, I still think #1874 is a good thing.

Still todo for #1874 after this PR (will doc on the issue)
* elasticsearch
* apache-camel
* (will leave up to @anuraaga if we apply to aws-sdk, I'm assuming not)