### PR TITLE
Fix nightly build

### DIFF
--- a/instrumentation/apache-dubbo/apache-dubbo-2.7/javaagent/apache-dubbo-2.7-javaagent.gradle
+++ b/instrumentation/apache-dubbo/apache-dubbo-2.7/javaagent/apache-dubbo-2.7-javaagent.gradle
@@ -14,4 +14,6 @@ dependencies {
   library group: 'org.apache.dubbo', name: 'dubbo', version: '2.7.0'
 
   testImplementation project(':instrumentation:apache-dubbo:apache-dubbo-2.7:testing')
+
+  testLibrary group: 'org.apache.dubbo', name: 'dubbo-config-api', version: '2.7.0'
 }

--- a/instrumentation/apache-dubbo/apache-dubbo-2.7/library/apache-dubbo-2.7-library.gradle
+++ b/instrumentation/apache-dubbo/apache-dubbo-2.7/library/apache-dubbo-2.7-library.gradle
@@ -4,4 +4,6 @@ dependencies {
   library group: 'org.apache.dubbo', name: 'dubbo', version: '2.7.0'
 
   testImplementation project(':instrumentation:apache-dubbo:apache-dubbo-2.7:testing')
+
+  testLibrary group: 'org.apache.dubbo', name: 'dubbo-config-api', version: '2.7.0'
 }


### PR DESCRIPTION
Dubbo 2.7.9 introduced breaking change which requires version sync between `dubbo` and `dubbo-config-api` artifacts.