### PR TITLE
Add OpenJ9 image smoke test configurations

### DIFF
--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GlassFishSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GlassFishSmokeTest.groovy
@@ -11,11 +11,13 @@ import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.containers.wait.strategy.WaitStrategy
 
 @AppServer(version = "5.2020.6", jdk = "8")
-@AppServer(version = "5.2020.6-jdk11", jdk = "11")
+@AppServer(version = "5.2020.6", jdk = "8-openj9")
+@AppServer(version = "5.2020.6", jdk = "11")
+@AppServer(version = "5.2020.6", jdk = "11-openj9")
 class GlassFishSmokeTest extends AppServerTest {
 
   protected String getTargetImage(String jdk, String serverVersion) {
-    "ghcr.io/open-telemetry/java-test-containers:payara-${serverVersion}-jdk$jdk-20201215.422527843"
+    "ghcr.io/open-telemetry/java-test-containers:payara-${serverVersion}-jdk$jdk-20210223.592806654"
   }
 
   @Override

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
@@ -6,13 +6,17 @@
 package io.opentelemetry.smoketest
 
 @AppServer(version = "9.4.35", jdk = "8")
+@AppServer(version = "9.4.35", jdk = "8-openj9")
 @AppServer(version = "9.4.35", jdk = "11")
+@AppServer(version = "9.4.35", jdk = "11-openj9")
 @AppServer(version = "10.0.0", jdk = "11")
+@AppServer(version = "10.0.0", jdk = "11-openj9")
 @AppServer(version = "10.0.0", jdk = "15")
+@AppServer(version = "10.0.0", jdk = "15-openj9")
 class JettySmokeTest extends AppServerTest {
 
   protected String getTargetImage(String jdk, String serverVersion) {
-    "ghcr.io/open-telemetry/java-test-containers:jetty-${serverVersion}-jdk$jdk-20201215.422527843"
+    "ghcr.io/open-telemetry/java-test-containers:jetty-${serverVersion}-jdk$jdk-20210223.592806654"
   }
 
   def getJettySpanName() {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/LibertySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/LibertySmokeTest.groovy
@@ -10,13 +10,13 @@ import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.containers.wait.strategy.WaitStrategy
 
 @AppServer(version = "20.0.0.12", jdk = "8")
+@AppServer(version = "20.0.0.12", jdk = "8-openj9")
 @AppServer(version = "20.0.0.12", jdk = "11")
-@AppServer(version = "20.0.0.12", jdk = "8-jdk-openj9")
-@AppServer(version = "20.0.0.12", jdk = "11-jdk-openj9")
+@AppServer(version = "20.0.0.12", jdk = "11-openj9")
 class LibertySmokeTest extends AppServerTest {
 
   protected String getTargetImage(String jdk, String serverVersion) {
-    "ghcr.io/open-telemetry/java-test-containers:liberty-${serverVersion}-jdk$jdk-20201215.422527843"
+    "ghcr.io/open-telemetry/java-test-containers:liberty-${serverVersion}-jdk$jdk-20210223.592806654"
   }
 
   @Override

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TomcatSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TomcatSmokeTest.groovy
@@ -6,14 +6,19 @@
 package io.opentelemetry.smoketest
 
 @AppServer(version = "7.0.107", jdk = "8")
+@AppServer(version = "7.0.107", jdk = "8-openj9")
 @AppServer(version = "8.5.60", jdk = "8")
+@AppServer(version = "8.5.60", jdk = "8-openj9")
 @AppServer(version = "8.5.60", jdk = "11")
+@AppServer(version = "8.5.60", jdk = "11-openj9")
 @AppServer(version = "9.0.40", jdk = "8")
+@AppServer(version = "9.0.40", jdk = "8-openj9")
 @AppServer(version = "9.0.40", jdk = "11")
+@AppServer(version = "9.0.40", jdk = "11-openj9")
 class TomcatSmokeTest extends AppServerTest {
 
   protected String getTargetImage(String jdk, String serverVersion) {
-    "ghcr.io/open-telemetry/java-test-containers:tomcat-${serverVersion}-jdk$jdk-20201215.422527843"
+    "ghcr.io/open-telemetry/java-test-containers:tomcat-${serverVersion}-jdk$jdk-20210223.592806654"
   }
 
   @Override

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TomeeSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TomeeSmokeTest.groovy
@@ -10,12 +10,15 @@ import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.containers.wait.strategy.WaitStrategy
 
 @AppServer(version = "7.0.0", jdk = "8")
+@AppServer(version = "7.0.0", jdk = "8-openj9")
 @AppServer(version = "8.0.6", jdk = "8")
+@AppServer(version = "8.0.6", jdk = "8-openj9")
 @AppServer(version = "8.0.6", jdk = "11")
+@AppServer(version = "8.0.6", jdk = "11-openj9")
 class TomeeSmokeTest extends AppServerTest {
 
   protected String getTargetImage(String jdk, String serverVersion) {
-    "ghcr.io/open-telemetry/java-test-containers:tomee-${serverVersion}-jdk$jdk-20210202.531569197"
+    "ghcr.io/open-telemetry/java-test-containers:tomee-${serverVersion}-jdk$jdk-20210223.592806654"
   }
 
   @Override

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
@@ -10,12 +10,15 @@ import okhttp3.Request
 import spock.lang.Unroll
 
 @AppServer(version = "13.0.0.Final", jdk = "8")
+@AppServer(version = "13.0.0.Final", jdk = "8-openj9")
 @AppServer(version = "17.0.1.Final", jdk = "11")
+@AppServer(version = "17.0.1.Final", jdk = "11-openj9")
 @AppServer(version = "21.0.0.Final", jdk = "11")
+@AppServer(version = "21.0.0.Final", jdk = "11-openj9")
 class WildflySmokeTest extends AppServerTest {
 
   protected String getTargetImage(String jdk, String serverVersion) {
-    "ghcr.io/open-telemetry/java-test-containers:wildfly-${serverVersion}-jdk$jdk-20201215.422527843"
+    "ghcr.io/open-telemetry/java-test-containers:wildfly-${serverVersion}-jdk$jdk-20210223.592806654"
   }
 
   @Override


### PR DESCRIPTION
Adds the corresponding test cases for the OpenJ9 smoke test images added in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2377