### PR TITLE
Use fetch-depth=0 for all non-release builds for consistent versioning.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11 for running checks
         uses: actions/setup-java@v1
@@ -32,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11 for running checks
         uses: actions/setup-java@v1
@@ -55,6 +59,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - id: setup-test-java
         name: Set up JDK ${{ matrix.java }} for running tests
         uses: actions/setup-java@v1

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11 for running checks
         uses: actions/setup-java@v1
@@ -36,6 +38,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - id: setup-test-java
         name: Set up JDK ${{ matrix.java }} for running tests
         uses: actions/setup-java@v1
@@ -62,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -83,9 +89,8 @@ jobs:
     needs: [ build, test, testLatestDep ]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Get all git tags
-        run: git fetch --prune --unshallow --tags
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11 for running checks
         uses: actions/setup-java@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11 for running checks
         uses: actions/setup-java@v1
@@ -36,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11 for running checks
         uses: actions/setup-java@v1
@@ -59,6 +63,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - id: setup-test-java
         name: Set up JDK ${{ matrix.java }} for running tests
         uses: actions/setup-java@v1
@@ -93,6 +99,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v1
@@ -114,6 +122,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
I noticed we only fetch tags on the `snapshot` step of the nightly build. I think within the same workflow we should always fetch tags to have consistent version numbers (not entirely sure how to reason out the build cache). And even between workflows it seems nice to be consistent.