### PR TITLE
Refactor DatabaseClientTracer (in preparation for low-cardinality span names)

### DIFF
--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraDatabaseClientTracer.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraDatabaseClientTracer.java
@@ -9,15 +9,18 @@ import com.datastax.driver.core.ExecutionInfo;
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.Session;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
+import io.opentelemetry.javaagent.instrumentation.api.db.SqlStatementInfo;
 import io.opentelemetry.javaagent.instrumentation.api.db.SqlStatementSanitizer;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DbSystemValues;
 import java.net.InetSocketAddress;
 
-public class CassandraDatabaseClientTracer extends DatabaseClientTracer<Session, String> {
+public class CassandraDatabaseClientTracer
+    extends DatabaseClientTracer<Session, String, SqlStatementInfo> {
   private static final CassandraDatabaseClientTracer TRACER = new CassandraDatabaseClientTracer();
 
   public static CassandraDatabaseClientTracer tracer() {
@@ -30,8 +33,23 @@ public class CassandraDatabaseClientTracer extends DatabaseClientTracer<Session,
   }
 
   @Override
-  protected String normalizeQuery(String query) {
-    return SqlStatementSanitizer.sanitize(query).getFullStatement();
+  protected SqlStatementInfo sanitizeStatement(String statement) {
+    return SqlStatementSanitizer.sanitize(statement);
+  }
+
+  // TODO: use the <operation> <db.name>.<table> naming scheme
+  protected String spanName(
+      Session connection, String statement, SqlStatementInfo sanitizedStatement) {
+    String fullStatement = sanitizedStatement.getFullStatement();
+    if (fullStatement != null) {
+      return fullStatement;
+    }
+
+    String result = null;
+    if (connection != null) {
+      result = dbName(connection);
+    }
+    return result == null ? DB_QUERY : result;
   }
 
   @Override
@@ -40,19 +58,25 @@ public class CassandraDatabaseClientTracer extends DatabaseClientTracer<Session,
   }
 
   @Override
+  protected void onConnection(SpanBuilder span, Session session) {
+    span.setAttribute(SemanticAttributes.DB_CASSANDRA_KEYSPACE, session.getLoggedKeyspace());
+    super.onConnection(span, session);
+  }
+
+  @Override
   protected String dbName(Session session) {
     return session.getLoggedKeyspace();
   }
 
   @Override
-  protected Span onConnection(Span span, Session session) {
-    span.setAttribute(SemanticAttributes.DB_CASSANDRA_KEYSPACE, session.getLoggedKeyspace());
-    return super.onConnection(span, session);
+  protected InetSocketAddress peerAddress(Session session) {
+    return null;
   }
 
   @Override
-  protected InetSocketAddress peerAddress(Session session) {
-    return null;
+  protected String dbStatement(
+      Session connection, String statement, SqlStatementInfo sanitizedStatement) {
+    return sanitizedStatement.getFullStatement();
   }
 
   public void end(Context context, ExecutionInfo executionInfo) {

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseClientTracer.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseClientTracer.java
@@ -10,7 +10,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DbSystemValu
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 
-public class CouchbaseClientTracer extends DatabaseClientTracer<Void, Method> {
+public class CouchbaseClientTracer extends DatabaseClientTracer<Void, Method, Void> {
   private static final CouchbaseClientTracer TRACER = new CouchbaseClientTracer();
 
   public static CouchbaseClientTracer tracer() {
@@ -18,11 +18,16 @@ public class CouchbaseClientTracer extends DatabaseClientTracer<Void, Method> {
   }
 
   @Override
-  protected String normalizeQuery(Method method) {
+  protected String spanName(Void connection, Method method, Void sanitizedStatement) {
     Class<?> declaringClass = method.getDeclaringClass();
     String className =
         declaringClass.getSimpleName().replace("CouchbaseAsync", "").replace("DefaultAsync", "");
     return className + "." + method.getName();
+  }
+
+  @Override
+  protected Void sanitizeStatement(Method method) {
+    return null;
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestClientTracer.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestClientTracer.java
@@ -13,7 +13,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
 import org.elasticsearch.client.Response;
 
-public class ElasticsearchRestClientTracer extends DatabaseClientTracer<Void, String> {
+public class ElasticsearchRestClientTracer extends DatabaseClientTracer<Void, String, String> {
   private static final ElasticsearchRestClientTracer TRACER = new ElasticsearchRestClientTracer();
 
   public static ElasticsearchRestClientTracer tracer() {
@@ -29,13 +29,8 @@ public class ElasticsearchRestClientTracer extends DatabaseClientTracer<Void, St
   }
 
   @Override
-  protected void onStatement(Span span, String statement) {
-    span.setAttribute(SemanticAttributes.DB_OPERATION, statement);
-  }
-
-  @Override
-  protected String normalizeQuery(String query) {
-    return query;
+  protected String sanitizeStatement(String operation) {
+    return operation;
   }
 
   @Override
@@ -46,6 +41,11 @@ public class ElasticsearchRestClientTracer extends DatabaseClientTracer<Void, St
   @Override
   protected InetSocketAddress peerAddress(Void connection) {
     return null;
+  }
+
+  @Override
+  protected String dbOperation(Void connection, String operation, String ignored) {
+    return operation;
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportClientTracer.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportClientTracer.java
@@ -8,12 +8,11 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
 import org.elasticsearch.action.Action;
 
 public class ElasticsearchTransportClientTracer
-    extends DatabaseClientTracer<Void, Action<?, ?, ?>> {
+    extends DatabaseClientTracer<Void, Action<?, ?, ?>, String> {
   private static final ElasticsearchTransportClientTracer TRACER =
       new ElasticsearchTransportClientTracer();
 
@@ -21,15 +20,15 @@ public class ElasticsearchTransportClientTracer
     return TRACER;
   }
 
-  public void onRequest(Context context, Class action, Class request) {
+  public void onRequest(Context context, Class<?> action, Class<?> request) {
     Span span = Span.fromContext(context);
     span.setAttribute("elasticsearch.action", action.getSimpleName());
     span.setAttribute("elasticsearch.request", request.getSimpleName());
   }
 
   @Override
-  protected String normalizeQuery(Action<?, ?, ?> query) {
-    return query.getClass().getSimpleName();
+  protected String sanitizeStatement(Action<?, ?, ?> action) {
+    return action.getClass().getSimpleName();
   }
 
   @Override
@@ -43,8 +42,8 @@ public class ElasticsearchTransportClientTracer
   }
 
   @Override
-  protected void onStatement(Span span, String statement) {
-    span.setAttribute(SemanticAttributes.DB_OPERATION, statement);
+  protected String dbOperation(Void connection, Action<?, ?, ?> action, String operation) {
+    return operation;
   }
 
   @Override

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeTracer.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeTracer.java
@@ -8,13 +8,15 @@ package io.opentelemetry.javaagent.instrumentation.geode;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
+import io.opentelemetry.javaagent.instrumentation.api.db.SqlStatementInfo;
 import io.opentelemetry.javaagent.instrumentation.api.db.SqlStatementSanitizer;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
 import org.apache.geode.cache.Region;
 
-public class GeodeTracer extends DatabaseClientTracer<Region<?, ?>, String> {
+public class GeodeTracer extends DatabaseClientTracer<Region<?, ?>, String, SqlStatementInfo> {
   private static final GeodeTracer TRACER = new GeodeTracer();
 
   public static GeodeTracer tracer() {
@@ -22,33 +24,30 @@ public class GeodeTracer extends DatabaseClientTracer<Region<?, ?>, String> {
   }
 
   public Span startSpan(String operation, Region<?, ?> connection, String query) {
-    String normalizedQuery = normalizeQuery(query);
+    SqlStatementInfo sanitizedStatement = sanitizeStatement(query);
 
-    Span span =
+    SpanBuilder span =
         tracer
             .spanBuilder(operation)
             .setSpanKind(CLIENT)
             .setAttribute(SemanticAttributes.DB_SYSTEM, dbSystem(connection))
-            .setAttribute(SemanticAttributes.DB_OPERATION, operation)
-            .startSpan();
+            .setAttribute(SemanticAttributes.DB_OPERATION, operation);
 
     onConnection(span, connection);
     setNetSemanticConvention(span, connection);
-    onStatement(span, normalizedQuery);
+    onStatement(span, connection, query, sanitizedStatement);
 
-    return span;
+    return span.startSpan();
   }
 
   @Override
-  protected String normalizeQuery(String query) {
-    return SqlStatementSanitizer.sanitize(query).getFullStatement();
+  protected SqlStatementInfo sanitizeStatement(String statement) {
+    return SqlStatementSanitizer.sanitize(statement);
   }
 
   @Override
   protected String dbSystem(Region<?, ?> region) {
-    // TODO(anuraaga): Replace with semantic attribute
-    // https://github.com/open-telemetry/opentelemetry-specification/pull/1321
-    return "geode";
+    return SemanticAttributes.DbSystemValues.GEODE;
   }
 
   @Override
@@ -59,6 +58,12 @@ public class GeodeTracer extends DatabaseClientTracer<Region<?, ?>, String> {
   @Override
   protected InetSocketAddress peerAddress(Region<?, ?> region) {
     return null;
+  }
+
+  @Override
+  protected String dbStatement(
+      Region<?, ?> connection, String statement, SqlStatementInfo sanitizedStatement) {
+    return sanitizedStatement.getFullStatement();
   }
 
   @Override

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -14,7 +14,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
-import io.opentelemetry.javaagent.instrumentation.api.db.SqlStatementSanitizer;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.sql.PreparedStatement;
 import java.util.Map;
@@ -49,7 +48,7 @@ public class ConnectionInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void addDbInfo(
         @Advice.Argument(0) String sql, @Advice.Return PreparedStatement statement) {
-      JdbcMaps.preparedStatements.put(statement, SqlStatementSanitizer.sanitize(sql));
+      JdbcMaps.preparedStatements.put(statement, sql);
     }
   }
 }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcMaps.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcMaps.java
@@ -8,7 +8,6 @@ package io.opentelemetry.javaagent.instrumentation.jdbc;
 import static io.opentelemetry.javaagent.instrumentation.api.WeakMap.Provider.newWeakMap;
 
 import io.opentelemetry.javaagent.instrumentation.api.WeakMap;
-import io.opentelemetry.javaagent.instrumentation.api.db.SqlStatementInfo;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 
@@ -19,6 +18,5 @@ import java.sql.PreparedStatement;
  */
 public class JdbcMaps {
   public static final WeakMap<Connection, DbInfo> connectionInfo = newWeakMap();
-  public static final WeakMap<PreparedStatement, SqlStatementInfo> preparedStatements =
-      newWeakMap();
+  public static final WeakMap<PreparedStatement, String> preparedStatements = newWeakMap();
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisClientTracer.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisClientTracer.java
@@ -15,7 +15,7 @@ import java.util.List;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol.Command;
 
-public class JedisClientTracer extends DatabaseClientTracer<Connection, CommandWithArgs> {
+public class JedisClientTracer extends DatabaseClientTracer<Connection, CommandWithArgs, String> {
   private static final JedisClientTracer TRACER = new JedisClientTracer();
 
   public static JedisClientTracer tracer() {
@@ -23,13 +23,14 @@ public class JedisClientTracer extends DatabaseClientTracer<Connection, CommandW
   }
 
   @Override
-  protected String spanName(Connection connection, CommandWithArgs query, String normalizedQuery) {
-    return query.getStringCommand();
+  protected String sanitizeStatement(CommandWithArgs command) {
+    return RedisCommandSanitizer.sanitize(command.getStringCommand(), command.getArgs());
   }
 
   @Override
-  protected String normalizeQuery(CommandWithArgs command) {
-    return RedisCommandSanitizer.sanitize(command.getStringCommand(), command.getArgs());
+  protected String spanName(
+      Connection connection, CommandWithArgs command, String sanitizedStatement) {
+    return command.getStringCommand();
   }
 
   @Override
@@ -45,6 +46,12 @@ public class JedisClientTracer extends DatabaseClientTracer<Connection, CommandW
   @Override
   protected InetSocketAddress peerAddress(Connection connection) {
     return new InetSocketAddress(connection.getHost(), connection.getPort());
+  }
+
+  @Override
+  protected String dbStatement(
+      Connection connection, CommandWithArgs command, String sanitizedStatement) {
+    return sanitizedStatement;
   }
 
   @Override

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAbstractDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAbstractDatabaseClientTracer.java
@@ -6,14 +6,28 @@
 package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
 
 import com.lambdaworks.redis.RedisURI;
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DbSystemValues;
 import java.net.InetSocketAddress;
 
-public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
-    extends DatabaseClientTracer<RedisURI, QUERY> {
+public abstract class LettuceAbstractDatabaseClientTracer<STATEMENT>
+    extends DatabaseClientTracer<RedisURI, STATEMENT, String> {
+
+  @Override
+  protected String spanName(RedisURI connection, STATEMENT statement, String operation) {
+    return operation;
+  }
+
+  @Override
+  public void onConnection(SpanBuilder span, RedisURI connection) {
+    if (connection != null && connection.getDatabase() != 0) {
+      span.setAttribute(
+          SemanticAttributes.DB_REDIS_DATABASE_INDEX, (long) connection.getDatabase());
+    }
+    super.onConnection(span, connection);
+  }
 
   @Override
   protected String dbSystem(RedisURI connection) {
@@ -26,11 +40,8 @@ public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
   }
 
   @Override
-  public Span onConnection(Span span, RedisURI connection) {
-    if (connection != null && connection.getDatabase() != 0) {
-      span.setAttribute(SemanticAttributes.DB_REDIS_DATABASE_INDEX, connection.getDatabase());
-    }
-    return super.onConnection(span, connection);
+  protected String dbStatement(RedisURI connection, STATEMENT statement, String operation) {
+    return operation;
   }
 
   @Override

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectionDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectionDatabaseClientTracer.java
@@ -16,7 +16,7 @@ public class LettuceConnectionDatabaseClientTracer
   }
 
   @Override
-  protected String normalizeQuery(String command) {
+  protected String sanitizeStatement(String command) {
     return command;
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceDatabaseClientTracer.java
@@ -17,7 +17,7 @@ public class LettuceDatabaseClientTracer
   }
 
   @Override
-  protected String normalizeQuery(RedisCommand<?, ?, ?> command) {
+  protected String sanitizeStatement(RedisCommand<?, ?, ?> command) {
     return command.getType().name();
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAbstractDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAbstractDatabaseClientTracer.java
@@ -6,14 +6,14 @@
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
 import io.lettuce.core.RedisURI;
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DbSystemValues;
 import java.net.InetSocketAddress;
 
-public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
-    extends DatabaseClientTracer<RedisURI, QUERY> {
+public abstract class LettuceAbstractDatabaseClientTracer<STATEMENT>
+    extends DatabaseClientTracer<RedisURI, STATEMENT, String> {
   @Override
   protected String getInstrumentationName() {
     return "io.opentelemetry.javaagent.lettuce";
@@ -30,10 +30,17 @@ public abstract class LettuceAbstractDatabaseClientTracer<QUERY>
   }
 
   @Override
-  public Span onConnection(Span span, RedisURI connection) {
+  public void onConnection(SpanBuilder span, RedisURI connection) {
     if (connection != null && connection.getDatabase() != 0) {
-      span.setAttribute(SemanticAttributes.DB_REDIS_DATABASE_INDEX, connection.getDatabase());
+      span.setAttribute(
+          SemanticAttributes.DB_REDIS_DATABASE_INDEX, (long) connection.getDatabase());
     }
-    return super.onConnection(span, connection);
+    super.onConnection(span, connection);
+  }
+
+  @Override
+  protected String dbStatement(
+      RedisURI connection, STATEMENT statement, String sanitizedStatement) {
+    return sanitizedStatement;
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncBiFunction.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncBiFunction.java
@@ -37,10 +37,11 @@ public class LettuceAsyncBiFunction<T, U extends Throwable, R>
 
   @Override
   public R apply(T t, Throwable throwable) {
-    if (throwable instanceof CancellationException) {
+    if (throwable == null) {
+      tracer().end(context);
+    } else if (throwable instanceof CancellationException) {
       if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
-        Span span = Span.fromContext(context);
-        span.setAttribute("lettuce.command.cancelled", true);
+        Span.fromContext(context).setAttribute("lettuce.command.cancelled", true);
       }
       tracer().end(context);
     } else {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectionDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectionDatabaseClientTracer.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
+import io.lettuce.core.RedisURI;
+
 public class LettuceConnectionDatabaseClientTracer
     extends LettuceAbstractDatabaseClientTracer<String> {
   private static final LettuceConnectionDatabaseClientTracer TRACER =
@@ -15,7 +17,12 @@ public class LettuceConnectionDatabaseClientTracer
   }
 
   @Override
-  protected String normalizeQuery(String query) {
-    return query;
+  protected String sanitizeStatement(String command) {
+    return command;
+  }
+
+  @Override
+  protected String spanName(RedisURI connection, String command, String ignored) {
+    return command;
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceDatabaseClientTracer.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceDatabaseClientTracer.java
@@ -21,18 +21,18 @@ public class LettuceDatabaseClientTracer
   }
 
   @Override
-  protected String spanName(
-      RedisURI connection, RedisCommand<?, ?, ?> query, String normalizedQuery) {
-    return LettuceInstrumentationUtil.getCommandName(query);
-  }
-
-  @Override
-  protected String normalizeQuery(RedisCommand<?, ?, ?> redisCommand) {
+  protected String sanitizeStatement(RedisCommand<?, ?, ?> redisCommand) {
     String command = LettuceInstrumentationUtil.getCommandName(redisCommand);
     List<String> args =
         redisCommand.getArgs() == null
             ? Collections.emptyList()
             : LettuceArgSplitter.splitArgs(redisCommand.getArgs().toCommandString());
     return RedisCommandSanitizer.sanitize(command, args);
+  }
+
+  @Override
+  protected String spanName(
+      RedisURI connection, RedisCommand<?, ?, ?> command, String sanitizedStatement) {
+    return LettuceInstrumentationUtil.getCommandName(command);
   }
 }

--- a/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
+++ b/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import com.mongodb.event.CommandStartedEvent
 
 import static java.util.Arrays.asList
 
+import com.mongodb.event.CommandStartedEvent
 import io.opentelemetry.javaagent.instrumentation.mongo.MongoClientTracer
 import org.bson.BsonArray
 import org.bson.BsonDocument
@@ -15,21 +15,21 @@ import org.bson.BsonString
 import spock.lang.Specification
 
 class MongoClientTracerTest extends Specification {
-  def 'should normalize queries to json'() {
+  def 'should sanitize statements to json'() {
     setup:
     def tracer = new MongoClientTracer()
 
     expect:
-    normalizeQueryAcrossVersions(tracer,
+    sanitizeStatementAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonInt32(1))) ==
       '{"cmd": "?"}'
 
-    normalizeQueryAcrossVersions(tracer,
+    sanitizeStatementAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonInt32(1))
         .append("sub", new BsonDocument("a", new BsonInt32(1)))) ==
       '{"cmd": "?", "sub": {"a": "?"}}'
 
-    normalizeQueryAcrossVersions(tracer,
+    sanitizeStatementAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonInt32(1))
         .append("sub", new BsonArray(asList(new BsonInt32(1))))) ==
       '{"cmd": "?", "sub": ["?"]}'
@@ -40,7 +40,7 @@ class MongoClientTracerTest extends Specification {
     def tracer = new MongoClientTracer()
 
     expect:
-    normalizeQueryAcrossVersions(tracer,
+    sanitizeStatementAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonString("c"))
         .append("f", new BsonString("c"))
         .append("sub", new BsonString("c"))) ==
@@ -51,7 +51,7 @@ class MongoClientTracerTest extends Specification {
     setup:
     def tracer = new MongoClientTracer(20)
 
-    def normalized = normalizeQueryAcrossVersions(tracer,
+    def normalized = sanitizeStatementAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonString("c"))
         .append("f1", new BsonString("c1"))
         .append("f2", new BsonString("c2")))
@@ -64,7 +64,7 @@ class MongoClientTracerTest extends Specification {
     setup:
     def tracer = new MongoClientTracer(27)
 
-    def normalized = normalizeQueryAcrossVersions(tracer,
+    def normalized = sanitizeStatementAcrossVersions(tracer,
       new BsonDocument("cmd", new BsonString("c"))
         .append("f1", new BsonArray(Arrays.asList(new BsonString("c1"), new BsonString("c2"))))
         .append("f2", new BsonString("c3")))
@@ -89,11 +89,11 @@ class MongoClientTracerTest extends Specification {
     command = "listDatabases"
   }
 
-  def normalizeQueryAcrossVersions(MongoClientTracer tracer, BsonDocument query) {
-    return normalizeAcrossVersions(tracer.normalizeQuery(query))
+  def sanitizeStatementAcrossVersions(MongoClientTracer tracer, BsonDocument query) {
+    return sanitizeAcrossVersions(tracer.sanitizeStatement(query))
   }
 
-  def normalizeAcrossVersions(String json) {
+  def sanitizeAcrossVersions(String json) {
     json = json.replaceAll('\\{ ', '{')
     json = json.replaceAll(' }', '}')
     json = json.replaceAll(' :', ':')

--- a/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
+++ b/instrumentation/mongo/mongo-common/javaagent/src/test/groovy/MongoClientTracerTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static java.util.Arrays.asList
 
 import com.mongodb.event.CommandStartedEvent

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaClientTracer.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaClientTracer.java
@@ -11,7 +11,7 @@ import java.net.InetSocketAddress;
 import redis.RedisCommand;
 
 public class RediscalaClientTracer
-    extends DatabaseClientTracer<RedisCommand<?, ?>, RedisCommand<?, ?>> {
+    extends DatabaseClientTracer<RedisCommand<?, ?>, RedisCommand<?, ?>, String> {
 
   private static final RediscalaClientTracer TRACER = new RediscalaClientTracer();
 
@@ -20,18 +20,30 @@ public class RediscalaClientTracer
   }
 
   @Override
-  protected String normalizeQuery(RedisCommand redisCommand) {
+  protected String sanitizeStatement(RedisCommand<?, ?> redisCommand) {
     return spanNameForClass(redisCommand.getClass());
   }
 
   @Override
-  protected String dbSystem(RedisCommand redisCommand) {
+  protected String spanName(
+      RedisCommand<?, ?> connection, RedisCommand<?, ?> statement, String operation) {
+    return operation;
+  }
+
+  @Override
+  protected String dbSystem(RedisCommand<?, ?> redisCommand) {
     return DbSystemValues.REDIS;
   }
 
   @Override
-  protected InetSocketAddress peerAddress(RedisCommand redisCommand) {
+  protected InetSocketAddress peerAddress(RedisCommand<?, ?> redisCommand) {
     return null;
+  }
+
+  @Override
+  protected String dbStatement(
+      RedisCommand<?, ?> connection, RedisCommand<?, ?> command, String operation) {
+    return operation;
   }
 
   @Override

--- a/instrumentation/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonClientTracer.java
+++ b/instrumentation/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonClientTracer.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.redisson;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
@@ -13,11 +16,13 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DbSystemValu
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.redisson.client.RedisConnection;
 import org.redisson.client.protocol.CommandData;
 import org.redisson.client.protocol.CommandsData;
 
-public class RedissonClientTracer extends DatabaseClientTracer<RedisConnection, Object> {
+public class RedissonClientTracer
+    extends DatabaseClientTracer<RedisConnection, Object, List<String>> {
   private static final String UNKNOWN_COMMAND = "Redis Command";
 
   private static final RedissonClientTracer TRACER = new RedissonClientTracer();
@@ -27,22 +32,24 @@ public class RedissonClientTracer extends DatabaseClientTracer<RedisConnection, 
   }
 
   @Override
-  protected String spanName(RedisConnection connection, Object query, String normalizedQuery) {
-    if (query instanceof CommandsData) {
-      List<CommandData<?, ?>> commands = ((CommandsData) query).getCommands();
-      StringBuilder commandStrings = new StringBuilder();
-      for (CommandData<?, ?> commandData : commands) {
-        commandStrings.append(commandData.getCommand().getName()).append(";");
-      }
-      if (commandStrings.length() > 0) {
-        commandStrings.deleteCharAt(commandStrings.length() - 1);
-      }
-      return commandStrings.toString();
-    } else if (query instanceof CommandData) {
-      return ((CommandData<?, ?>) query).getCommand().getName();
+  protected String spanName(
+      RedisConnection connection, Object ignored, List<String> sanitizedStatements) {
+    switch (sanitizedStatements.size()) {
+      case 0:
+        return UNKNOWN_COMMAND;
+        // optimize for the most common case
+      case 1:
+        return getCommandName(sanitizedStatements.get(0));
+      default:
+        return sanitizedStatements.stream()
+            .map(this::getCommandName)
+            .collect(Collectors.joining(";"));
     }
+  }
 
-    return UNKNOWN_COMMAND;
+  private String getCommandName(String statement) {
+    int spacePos = statement.indexOf(' ');
+    return spacePos == -1 ? statement : statement.substring(0, spacePos);
   }
 
   @Override
@@ -51,22 +58,15 @@ public class RedissonClientTracer extends DatabaseClientTracer<RedisConnection, 
   }
 
   @Override
-  protected String normalizeQuery(Object command) {
+  protected List<String> sanitizeStatement(Object command) {
     // get command
     if (command instanceof CommandsData) {
       List<CommandData<?, ?>> commands = ((CommandsData) command).getCommands();
-      StringBuilder commandStrings = new StringBuilder();
-      for (CommandData<?, ?> commandData : commands) {
-        commandStrings.append(normalizeSingleCommand(commandData)).append(";");
-      }
-      if (commandStrings.length() > 0) {
-        commandStrings.deleteCharAt(commandStrings.length() - 1);
-      }
-      return commandStrings.toString();
+      return commands.stream().map(this::normalizeSingleCommand).collect(Collectors.toList());
     } else if (command instanceof CommandData) {
-      return normalizeSingleCommand((CommandData<?, ?>) command);
+      return singletonList(normalizeSingleCommand((CommandData<?, ?>) command));
     }
-    return UNKNOWN_COMMAND;
+    return emptyList();
   }
 
   private String normalizeSingleCommand(CommandData<?, ?> command) {
@@ -109,5 +109,19 @@ public class RedissonClientTracer extends DatabaseClientTracer<RedisConnection, 
     Channel channel = connection.getChannel();
     InetSocketAddress remoteAddress = (InetSocketAddress) channel.remoteAddress();
     return remoteAddress.getHostString() + ":" + remoteAddress.getPort();
+  }
+
+  @Override
+  protected String dbStatement(
+      RedisConnection connection, Object ignored, List<String> sanitizedStatements) {
+    switch (sanitizedStatements.size()) {
+      case 0:
+        return UNKNOWN_COMMAND;
+        // optimize for the most common case
+      case 1:
+        return sanitizedStatements.get(0);
+      default:
+        return String.join(";", sanitizedStatements);
+    }
   }
 }

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/CompletionListener.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/CompletionListener.java
@@ -64,7 +64,11 @@ public abstract class CompletionListener<T> {
   }
 
   protected void closeSyncSpan(Throwable thrown) {
-    tracer().endExceptionally(context, thrown);
+    if (thrown == null) {
+      tracer().end(context);
+    } else {
+      tracer().endExceptionally(context, thrown);
+    }
   }
 
   protected abstract void processResult(Span span, T future)

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/MemcacheClientTracer.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/MemcacheClientTracer.java
@@ -5,17 +5,31 @@
 
 package io.opentelemetry.javaagent.instrumentation.spymemcached;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.api.tracer.DatabaseClientTracer;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
 import net.spy.memcached.MemcachedConnection;
 
-public class MemcacheClientTracer extends DatabaseClientTracer<MemcachedConnection, String> {
+public class MemcacheClientTracer
+    extends DatabaseClientTracer<MemcachedConnection, String, String> {
   private static final MemcacheClientTracer TRACER = new MemcacheClientTracer();
 
   public static MemcacheClientTracer tracer() {
     return TRACER;
+  }
+
+  @Override
+  protected String sanitizeStatement(String methodName) {
+    char[] chars =
+        methodName
+            .replaceFirst("^async", "")
+            // 'CAS' name is special, we have to lowercase whole name
+            .replaceFirst("^CAS", "cas")
+            .toCharArray();
+
+    // Lowercase first letter
+    chars[0] = Character.toLowerCase(chars[0]);
+
+    return new String(chars);
   }
 
   @Override
@@ -29,23 +43,9 @@ public class MemcacheClientTracer extends DatabaseClientTracer<MemcachedConnecti
   }
 
   @Override
-  protected void onStatement(Span span, String statement) {
-    span.setAttribute(SemanticAttributes.DB_OPERATION, statement);
-  }
-
-  @Override
-  protected String normalizeQuery(String query) {
-    char[] chars =
-        query
-            .replaceFirst("^async", "")
-            // 'CAS' name is special, we have to lowercase whole name
-            .replaceFirst("^CAS", "cas")
-            .toCharArray();
-
-    // Lowercase first letter
-    chars[0] = Character.toLowerCase(chars[0]);
-
-    return new String(chars);
+  protected String dbOperation(
+      MemcachedConnection connection, String methodName, String operation) {
+    return operation;
   }
 
   @Override


### PR DESCRIPTION
First step of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2128

This is purely a refactoring, traces emitted by database instrumentation haven't changed - that will be the subject of the next PRs, where I'll correct span names (and set additional attributes, like `db.operation`, where applicable) in all DB instrumentations. 