### PR TITLE
Fix tests that verify experimental span attributes

### DIFF
--- a/instrumentation/couchbase/couchbase-2.6/javaagent/couchbase-2.6-javaagent.gradle
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/couchbase-2.6-javaagent.gradle
@@ -30,3 +30,8 @@ dependencies {
   latestDepTestLibrary group: 'org.springframework.data', name: 'spring-data-couchbase', version: '3.1+'
   latestDepTestLibrary group: 'com.couchbase.client', name: 'java-client', version: '2.+'
 }
+
+tasks.withType(Test) {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.couchbase.experimental-span-attributes=true"
+}

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/lettuce-4.0-javaagent.gradle
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/lettuce-4.0-javaagent.gradle
@@ -17,3 +17,8 @@ dependencies {
 
   latestDepTestLibrary group: 'biz.paluch.redis', name: 'lettuce', version: '4.+'
 }
+
+tasks.withType(Test) {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.lettuce.experimental-span-attributes=true"
+}

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/lettuce-5.0-javaagent.gradle
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/lettuce-5.0-javaagent.gradle
@@ -18,3 +18,8 @@ dependencies {
   testImplementation group: 'io.lettuce', name: 'lettuce-core', version: '5.0.0.RELEASE'
   testInstrumentation project(':instrumentation:reactor-3.1:javaagent')
 }
+
+tasks.withType(Test) {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.lettuce.experimental-span-attributes=true"
+}

--- a/instrumentation/spymemcached-2.12/javaagent/spymemcached-2.12-javaagent.gradle
+++ b/instrumentation/spymemcached-2.12/javaagent/spymemcached-2.12-javaagent.gradle
@@ -15,3 +15,8 @@ dependencies {
   testImplementation deps.guava
   testImplementation deps.testcontainers
 }
+
+tasks.withType(Test) {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.spymemcached.experimental-span-attributes=true"
+}


### PR DESCRIPTION
Some of the modules that add experimental span attributes didn't have the flag turned on for tests, which caused them to fail.