### PR TITLE
Add missing method to PatchLogger

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/PatchLogger.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/PatchLogger.java
@@ -332,6 +332,8 @@ public class PatchLogger {
     return new Handler[0];
   }
 
+  public void addHandler(Handler handler) {}
+
   public static PatchLogger getAnonymousLogger() {
     return getLogger("");
   }


### PR DESCRIPTION
This missing method doesn't cause any issues in our standard distro, but can be an issue in custom distros if they use 3rd party dependencies that call `java.util.logging.Logger.addHandler()`.