### PR TITLE
Disable server ping for redisson tests

### DIFF
--- a/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonAsyncClientTest.groovy
+++ b/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonAsyncClientTest.groovy
@@ -16,6 +16,7 @@ import org.redisson.api.RList
 import org.redisson.api.RSet
 import org.redisson.api.RedissonClient
 import org.redisson.config.Config
+import org.redisson.config.SingleServerConfig
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
@@ -52,7 +53,10 @@ class RedissonAsyncClientTest extends AgentInstrumentationSpecification {
 
   def setup() {
     Config config = new Config()
-    config.useSingleServer().setAddress(address)
+    SingleServerConfig singleServerConfig = config.useSingleServer()
+    singleServerConfig.setAddress(address)
+    // disable connection ping if it exists
+    singleServerConfig.metaClass.getMetaMethod("setPingConnectionInterval", int)?.invoke(singleServerConfig, 0)
     redisson = Redisson.create(config)
     clearExportedData()
   }

--- a/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonClientTest.groovy
+++ b/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonClientTest.groovy
@@ -21,6 +21,7 @@ import org.redisson.api.RScoredSortedSet
 import org.redisson.api.RSet
 import org.redisson.api.RedissonClient
 import org.redisson.config.Config
+import org.redisson.config.SingleServerConfig
 import redis.embedded.RedisServer
 import spock.lang.Shared
 
@@ -57,7 +58,10 @@ class RedissonClientTest extends AgentInstrumentationSpecification {
 
   def setup() {
     Config config = new Config()
-    config.useSingleServer().setAddress(address)
+    SingleServerConfig singleServerConfig = config.useSingleServer()
+    singleServerConfig.setAddress(address)
+    // disable connection ping if it exists
+    singleServerConfig.metaClass.getMetaMethod("setPingConnectionInterval", int)?.invoke(singleServerConfig, 0)
     redisson = Redisson.create(config)
     clearExportedData()
   }


### PR DESCRIPTION
Later versions of redisson ping server with 30s interval. This creates extra spans which make tests flaky.