### PR TITLE
Use atomic updaters instead of atomic fields to reduce allocations fo…

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/servlet/AppServerBridge.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/servlet/AppServerBridge.java
@@ -19,7 +19,7 @@ public class AppServerBridge {
       ContextKey.named("opentelemetry-servlet-app-server-bridge");
 
   private static final AtomicIntegerFieldUpdater<AppServerBridge>
-      servlerUpdatedServerSpanNameUpdater =
+      servletUpdatedServerSpanNameUpdater =
           AtomicIntegerFieldUpdater.newUpdater(
               AppServerBridge.class, "servletUpdatedServerSpanName");
 
@@ -69,7 +69,7 @@ public class AppServerBridge {
   public static boolean setUpdatedServerSpanName(Context ctx) {
     AppServerBridge appServerBridge = ctx.get(AppServerBridge.CONTEXT_KEY);
     if (appServerBridge != null) {
-      return servlerUpdatedServerSpanNameUpdater.compareAndSet(appServerBridge, FALSE, TRUE);
+      return servletUpdatedServerSpanNameUpdater.compareAndSet(appServerBridge, FALSE, TRUE);
     }
     return false;
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/servlet/AppServerBridge.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/servlet/AppServerBridge.java
@@ -7,7 +7,7 @@ package io.opentelemetry.instrumentation.api.servlet;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**
  * Helper container for Context attributes for transferring certain information between servlet
@@ -17,6 +17,14 @@ public class AppServerBridge {
 
   private static final ContextKey<AppServerBridge> CONTEXT_KEY =
       ContextKey.named("opentelemetry-servlet-app-server-bridge");
+
+  private static final AtomicIntegerFieldUpdater<AppServerBridge>
+      servlerUpdatedServerSpanNameUpdater =
+          AtomicIntegerFieldUpdater.newUpdater(
+              AppServerBridge.class, "servletUpdatedServerSpanName");
+
+  private static final int FALSE = 0;
+  private static final int TRUE = 1;
 
   /**
    * Attach AppServerBridge to context.
@@ -42,40 +50,28 @@ public class AppServerBridge {
     return ctx.with(AppServerBridge.CONTEXT_KEY, new AppServerBridge(shouldRecordException));
   }
 
-  private final AtomicBoolean servletUpdatedServerSpanName = new AtomicBoolean(false);
-  private final AtomicBoolean servletShouldRecordException;
+  private final boolean servletShouldRecordException;
+
+  private volatile int servletUpdatedServerSpanName = FALSE;
 
   private AppServerBridge(boolean shouldRecordException) {
-    servletShouldRecordException = new AtomicBoolean(shouldRecordException);
+    servletShouldRecordException = shouldRecordException;
   }
 
   /**
-   * Returns true, if servlet integration should update server span name. After server span name has
-   * been updated with <code>setServletUpdatedServerSpanName</code> this method will return <code>
-   * false</code>.
+   * Returns true, if servlet integration has not already updated the server span name. Subsequent
+   * invocations will return {@code false}. This is meant to be used in a compare-and-set fashion.
    *
    * @param ctx server context
-   * @return <code>true</code>, if the server span name should be updated by servlet integration, or
-   *     <code>false</code> otherwise.
+   * @return <code>true</code>, if the server span name had not already been updated by servlet
+   *     integration, or <code>false</code> otherwise.
    */
-  public static boolean shouldUpdateServerSpanName(Context ctx) {
+  public static boolean setUpdatedServerSpanName(Context ctx) {
     AppServerBridge appServerBridge = ctx.get(AppServerBridge.CONTEXT_KEY);
     if (appServerBridge != null) {
-      return !appServerBridge.servletUpdatedServerSpanName.get();
+      return servlerUpdatedServerSpanNameUpdater.compareAndSet(appServerBridge, FALSE, TRUE);
     }
     return false;
-  }
-
-  /**
-   * Indicate that the servlet integration has updated the name for the server span.
-   *
-   * @param ctx server context
-   */
-  public static void setServletUpdatedServerSpanName(Context ctx, boolean value) {
-    AppServerBridge appServerBridge = ctx.get(AppServerBridge.CONTEXT_KEY);
-    if (appServerBridge != null) {
-      appServerBridge.servletUpdatedServerSpanName.set(value);
-    }
   }
 
   /**
@@ -91,7 +87,7 @@ public class AppServerBridge {
   public static boolean shouldRecordException(Context ctx) {
     AppServerBridge appServerBridge = ctx.get(AppServerBridge.CONTEXT_KEY);
     if (appServerBridge != null) {
-      return appServerBridge.servletShouldRecordException.get();
+      return appServerBridge.servletShouldRecordException;
     }
     return true;
   }

--- a/instrumentation-core/servlet-2.2/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
+++ b/instrumentation-core/servlet-2.2/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
@@ -164,9 +164,8 @@ public abstract class ServletHttpServerTracer<RESPONSE>
    * reflected in the span name.
    */
   public Context runOnceUnderAppServer(Context context, HttpServletRequest request) {
-    if (AppServerBridge.shouldUpdateServerSpanName(context)) {
+    if (AppServerBridge.setUpdatedServerSpanName(context)) {
       updateSpanName(Span.fromContext(context), request);
-      AppServerBridge.setServletUpdatedServerSpanName(context, true);
       return addServletContextPath(context, request);
     }
     return context;


### PR DESCRIPTION
…r commonly created objects.

Randomly found this when looking though datadog changes and think it's easy to add here. It's a bit of extra code but otherwise is free memory (very commonly used pattern in Netty).