### PR TITLE
Expose only minimal entrypoint for Armeria library instrumentation.

### DIFF
--- a/instrumentation/armeria-1.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaDecorators.java
+++ b/instrumentation/armeria-1.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaDecorators.java
@@ -7,17 +7,19 @@ package io.opentelemetry.javaagent.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.server.HttpService;
-import io.opentelemetry.instrumentation.armeria.v1_3.client.OpenTelemetryClient;
-import io.opentelemetry.instrumentation.armeria.v1_3.server.OpenTelemetryService;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.armeria.v1_3.ArmeriaTracing;
 import java.util.function.Function;
 
 // Holds singleton references to decorators to match against during suppression.
 // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/903
 public final class ArmeriaDecorators {
 
+  private static final ArmeriaTracing TRACING = ArmeriaTracing.create(GlobalOpenTelemetry.get());
+
   public static final Function<? super HttpClient, ? extends HttpClient> CLIENT_DECORATOR =
-      OpenTelemetryClient.newDecorator();
+      TRACING.newClientDecorator();
 
   public static final Function<? super HttpService, ? extends HttpService> SERVER_DECORATOR =
-      OpenTelemetryService.newDecorator();
+      TRACING.newServiceDecorator();
 }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTracer.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTracer.java
@@ -3,27 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.armeria.v1_3.client;
+package io.opentelemetry.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
-import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.instrumentation.api.tracer.HttpClientTracer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class ArmeriaClientTracer
+final class ArmeriaClientTracer
     extends HttpClientTracer<ClientRequestContext, ClientRequestContext, RequestLog> {
 
-  ArmeriaClientTracer() {}
-
-  ArmeriaClientTracer(Tracer tracer) {
-    super(tracer);
+  ArmeriaClientTracer(OpenTelemetry openTelemetry) {
+    super(openTelemetry);
   }
 
   @Override

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTracer.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTracer.java
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.armeria.v1_3.server;
+package io.opentelemetry.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.netty.util.AsciiString;
-import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.tracer.HttpServerTracer;
@@ -19,13 +19,11 @@ import java.net.SocketAddress;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class ArmeriaServerTracer
+final class ArmeriaServerTracer
     extends HttpServerTracer<HttpRequest, RequestLog, ServiceRequestContext, Void> {
 
-  ArmeriaServerTracer() {}
-
-  ArmeriaServerTracer(Tracer tracer) {
-    super(tracer);
+  ArmeriaServerTracer(OpenTelemetry openTelemetry) {
+    super(openTelemetry);
   }
 
   @Override

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTracing.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTracing.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.armeria.v1_3;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.server.HttpService;
+import io.opentelemetry.api.OpenTelemetry;
+import java.util.function.Function;
+
+/** Entrypoint for tracing Armeria services or clients. */
+public final class ArmeriaTracing {
+
+  /** Returns a new {@link ArmeriaTracing} configured with the given {@link OpenTelemetry}. */
+  public static ArmeriaTracing create(OpenTelemetry openTelemetry) {
+    return new ArmeriaTracing(openTelemetry);
+  }
+
+  private final ArmeriaClientTracer clientTracer;
+  private final ArmeriaServerTracer serverTracer;
+
+  private ArmeriaTracing(OpenTelemetry openTelemetry) {
+    clientTracer = new ArmeriaClientTracer(openTelemetry);
+    serverTracer = new ArmeriaServerTracer(openTelemetry);
+  }
+
+  /**
+   * Returns a new {@link HttpClient} decorator for use with methods like {@link
+   * com.linecorp.armeria.client.ClientBuilder#decorator(Function)}.
+   */
+  public Function<? super HttpClient, ? extends HttpClient> newClientDecorator() {
+    return client -> new OpenTelemetryClient(client, clientTracer);
+  }
+
+  /**
+   * Returns a new {@link HttpService} decorator for use with methods like {@link
+   * HttpService#decorate(Function)}.
+   */
+  public Function<? super HttpService, ? extends HttpService> newServiceDecorator() {
+    return service -> new OpenTelemetryService(service, serverTracer);
+  }
+}

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/OpenTelemetryClient.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/OpenTelemetryClient.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.armeria.v1_3.client;
+package io.opentelemetry.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
@@ -12,37 +12,17 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.tracer.utils.NetPeerUtils;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 /** Decorates an {@link HttpClient} to trace outbound {@link HttpResponse}s. */
-public class OpenTelemetryClient extends SimpleDecoratingHttpClient {
-
-  /** Creates a new tracing {@link HttpClient} decorator using the default {@link Tracer}. */
-  public static OpenTelemetryClient.Decorator newDecorator() {
-    return new Decorator(new ArmeriaClientTracer());
-  }
-
-  /** Creates a new tracing {@link HttpClient} decorator using the specified {@link Tracer}. */
-  public static OpenTelemetryClient.Decorator newDecorator(Tracer tracer) {
-    return new Decorator(new ArmeriaClientTracer(tracer));
-  }
-
-  /**
-   * Creates a new tracing {@link HttpClient} decorator using the specified {@link
-   * ArmeriaClientTracer}.
-   */
-  public static OpenTelemetryClient.Decorator newDecorator(ArmeriaClientTracer clientTracer) {
-    return new Decorator(clientTracer);
-  }
+final class OpenTelemetryClient extends SimpleDecoratingHttpClient {
 
   private final ArmeriaClientTracer clientTracer;
 
-  private OpenTelemetryClient(HttpClient delegate, ArmeriaClientTracer clientTracer) {
+  OpenTelemetryClient(HttpClient delegate, ArmeriaClientTracer clientTracer) {
     super(delegate);
     this.clientTracer = clientTracer;
   }
@@ -75,20 +55,6 @@ public class OpenTelemetryClient extends SimpleDecoratingHttpClient {
 
     try (Scope ignored = context.makeCurrent()) {
       return unwrap().execute(ctx, req);
-    }
-  }
-
-  private static class Decorator implements Function<HttpClient, OpenTelemetryClient> {
-
-    private final ArmeriaClientTracer clientTracer;
-
-    private Decorator(ArmeriaClientTracer clientTracer) {
-      this.clientTracer = clientTracer;
-    }
-
-    @Override
-    public OpenTelemetryClient apply(HttpClient httpClient) {
-      return new OpenTelemetryClient(httpClient, clientTracer);
     }
   }
 }

--- a/instrumentation/armeria-1.3/library/src/test/groovy/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientTest.groovy
+++ b/instrumentation/armeria-1.3/library/src/test/groovy/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientTest.groovy
@@ -6,12 +6,11 @@
 package io.opentelemetry.instrumentation.armeria.v1_3
 
 import com.linecorp.armeria.client.WebClientBuilder
-import io.opentelemetry.instrumentation.armeria.v1_3.client.OpenTelemetryClient
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
 
 class ArmeriaHttpClientTest extends AbstractArmeriaHttpClientTest implements LibraryTestTrait {
   @Override
   WebClientBuilder configureClient(WebClientBuilder clientBuilder) {
-    return clientBuilder.decorator(OpenTelemetryClient.newDecorator())
+    return clientBuilder.decorator(ArmeriaTracing.create(getOpenTelemetry()).newClientDecorator())
   }
 }

--- a/instrumentation/armeria-1.3/library/src/test/groovy/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerTest.groovy
+++ b/instrumentation/armeria-1.3/library/src/test/groovy/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerTest.groovy
@@ -6,12 +6,11 @@
 package io.opentelemetry.instrumentation.armeria.v1_3
 
 import com.linecorp.armeria.server.ServerBuilder
-import io.opentelemetry.instrumentation.armeria.v1_3.server.OpenTelemetryService
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
 
 class ArmeriaHttpServerTest extends AbstractArmeriaHttpServerTest implements LibraryTestTrait{
   @Override
   ServerBuilder configureServer(ServerBuilder sb) {
-    return sb.decorator(OpenTelemetryService.newDecorator())
+    return sb.decorator(ArmeriaTracing.create(getOpenTelemetry()).newServiceDecorator())
   }
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/LibraryTestTrait.groovy
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.test
 
-
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.instrumentation.testing.LibraryTestRunner
 /**
  * A trait which initializes instrumentation library tests, including a test span exporter. All
@@ -17,5 +17,9 @@ trait LibraryTestTrait {
 
   LibraryTestRunner testRunner() {
     RUNNER
+  }
+
+  OpenTelemetry getOpenTelemetry() {
+    RUNNER.openTelemetrySdk
   }
 }


### PR DESCRIPTION
Also switches to accepting `OpenTelemetry` as an argument.

I think this does make the library ready for a 1.0 release.