### PR TITLE
Initialize Config for library instrumentations

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
@@ -21,11 +21,9 @@ import org.slf4j.LoggerFactory;
 public abstract class Config {
   private static final Logger log = LoggerFactory.getLogger(Config.class);
 
-  private static final Config DEFAULT = Config.create(Collections.emptyMap());
-
-  // INSTANCE can never be null - muzzle instantiates instrumenters when it generates
-  // getMuzzleReferenceMatcher() and the InstrumentationModule constructor uses Config
-  private static volatile Config INSTANCE = DEFAULT;
+  // lazy initialized, so that javaagent can set it, and library instrumentation can fall back and
+  // read system properties
+  private static volatile Config INSTANCE = null;
 
   /**
    * Sets the agent configuration singleton. This method is only supposed to be called once, from
@@ -33,7 +31,7 @@ public abstract class Config {
    * Config#get()} is used for the first time).
    */
   public static void internalInitializeConfig(Config config) {
-    if (INSTANCE != DEFAULT) {
+    if (INSTANCE != null) {
       log.warn("Config#INSTANCE was already set earlier");
       return;
     }
@@ -41,6 +39,12 @@ public abstract class Config {
   }
 
   public static Config get() {
+    if (INSTANCE == null) {
+      // this should only happen in library instrumentation
+      //
+      // no need to synchronize because worst case is creating INSTANCE more than once
+      INSTANCE = new ConfigBuilder().readEnvironmentVariables().readSystemProperties().build();
+    }
     return INSTANCE;
   }
 

--- a/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/HttpClientTracerTest.groovy
+++ b/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/HttpClientTracerTest.groovy
@@ -6,10 +6,10 @@
 package io.opentelemetry.instrumentation.api.tracer
 
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.context.propagation.TextMapSetter
 import io.opentelemetry.instrumentation.api.config.Config
 import io.opentelemetry.instrumentation.api.config.ConfigBuilder
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Shared
 
 class HttpClientTracerTest extends BaseTracerTest {
@@ -21,7 +21,7 @@ class HttpClientTracerTest extends BaseTracerTest {
   }
 
   def cleanupSpec() {
-    Config.INSTANCE = Config.DEFAULT
+    Config.INSTANCE = null
   }
 
   @Shared

--- a/instrumentation/external-annotations/javaagent-unittests/src/test/groovy/IncludeTest.groovy
+++ b/instrumentation/external-annotations/javaagent-unittests/src/test/groovy/IncludeTest.groovy
@@ -9,9 +9,11 @@ import io.opentelemetry.instrumentation.api.config.Config
 import io.opentelemetry.instrumentation.api.config.ConfigBuilder
 import io.opentelemetry.javaagent.instrumentation.extannotations.TraceAnnotationsInstrumentationModule
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class IncludeTest extends Specification {
 
+  @Unroll
   def "test configuration #value"() {
     setup:
     Config config
@@ -20,7 +22,7 @@ class IncludeTest extends Specification {
         "otel.instrumentation.external-annotations.include": value
       ]).build()
     } else {
-      config = null
+      config = Config.create([:])
     }
 
     expect:

--- a/instrumentation/external-annotations/javaagent-unittests/src/test/groovy/IncludeTest.groovy
+++ b/instrumentation/external-annotations/javaagent-unittests/src/test/groovy/IncludeTest.groovy
@@ -20,7 +20,7 @@ class IncludeTest extends Specification {
         "otel.instrumentation.external-annotations.include": value
       ]).build()
     } else {
-      config = Config.DEFAULT
+      config = null
     }
 
     expect:

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/InstrumentationModuleTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/InstrumentationModuleTest.groovy
@@ -77,7 +77,7 @@ class InstrumentationModuleTest extends Specification {
     target.applyCalled == enabled
 
     cleanup:
-    Config.INSTANCE = Config.DEFAULT
+    Config.INSTANCE = null
 
     where:
     enabled << [true, false]
@@ -96,7 +96,7 @@ class InstrumentationModuleTest extends Specification {
     target.applyCalled == enabled
 
     cleanup:
-    Config.INSTANCE = Config.DEFAULT
+    Config.INSTANCE = null
 
     where:
     value   | enabled
@@ -120,7 +120,7 @@ class InstrumentationModuleTest extends Specification {
     target.applyCalled == enabled
 
     cleanup:
-    Config.INSTANCE = Config.DEFAULT
+    Config.INSTANCE = null
 
     where:
     value             | enabled | name          | altName


### PR DESCRIPTION
Extracted from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2434

It turns out that this `Config` fix is needed in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2263