### PR TITLE
AWS SDK - SNS to SQS tracing propagation test

### DIFF
--- a/benchmark-e2e/benchmark-e2e.gradle
+++ b/benchmark-e2e/benchmark-e2e.gradle
@@ -5,7 +5,7 @@ description = 'e2e benchmark'
 dependencies {
   implementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
   implementation 'org.slf4j:slf4j-simple:1.6.1'
-  implementation 'org.testcontainers:testcontainers:1.15.1'
+  implementation 'org.testcontainers:testcontainers:1.15.2'
 }
 
 test {

--- a/examples/distro/smoke-tests/build.gradle
+++ b/examples/distro/smoke-tests/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  testImplementation("org.testcontainers:testcontainers:1.15.1")
+  testImplementation("org.testcontainers:testcontainers:1.15.2")
   testImplementation("com.fasterxml.jackson.core:jackson-databind:2.11.2")
   testImplementation("com.google.protobuf:protobuf-java-util:3.12.4")
   testImplementation("com.squareup.okhttp3:okhttp:3.12.12")

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -29,7 +29,8 @@ ext {
     autoValue         : "1.7.4",
     systemLambda      : "1.1.0",
     prometheus        : "0.9.0",
-    assertj           : '3.19.0'
+    assertj           : '3.19.0',
+    testcontainers    : '1.15.2'
   ]
 
   deps = [
@@ -84,7 +85,7 @@ ext {
     ],
     groovy                       : "org.codehaus.groovy:groovy-all:${versions.groovy}",
     systemLambda                 : "com.github.stefanbirkner:system-lambda:${versions.systemLambda}",
-    testcontainers               : "org.testcontainers:testcontainers:1.15.2",
+    testcontainers               : "org.testcontainers:testcontainers:${versions.testcontainers}",
     testLogging                  : [
       dependencies.create(group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback),
       dependencies.create(group: 'org.slf4j', name: 'log4j-over-slf4j', version: versions.slf4j),

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -84,7 +84,7 @@ ext {
     ],
     groovy                       : "org.codehaus.groovy:groovy-all:${versions.groovy}",
     systemLambda                 : "com.github.stefanbirkner:system-lambda:${versions.systemLambda}",
-    testcontainers               : "org.testcontainers:testcontainers:1.15.1",
+    testcontainers               : "org.testcontainers:testcontainers:1.15.2",
     testLogging                  : [
       dependencies.create(group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback),
       dependencies.create(group: 'org.slf4j', name: 'log4j-over-slf4j', version: versions.slf4j),

--- a/instrumentation/apache-camel-2.20/javaagent/apache-camel-2.20-javaagent.gradle
+++ b/instrumentation/apache-camel-2.20/javaagent/apache-camel-2.20-javaagent.gradle
@@ -41,7 +41,7 @@ dependencies {
    *    Temporarily using emq instead of localstack till the latter supports AWS trace propagation
    *
    *    testImplementation deps.testcontainers
-   *    testImplementation "org.testcontainers:localstack:1.15.1"
+   *    testImplementation "org.testcontainers:localstack:${versions.testcontainers}
    **/
 
   latestDepTestLibrary group: 'org.apache.camel', name: 'camel-core', version: '2.+'

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/SqsCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/SqsCamelTest.groovy
@@ -105,7 +105,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "SendMessageRequest"
+            "aws.operation" "SendMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -124,7 +124,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -156,7 +156,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -177,7 +177,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "DeleteMessageRequest"
+            "aws.operation" "DeleteMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -198,7 +198,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -219,7 +219,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -240,7 +240,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -275,7 +275,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "SendMessageRequest"
+            "aws.operation" "SendMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -294,7 +294,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -326,7 +326,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -347,7 +347,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "DeleteMessageRequest"
+            "aws.operation" "DeleteMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -368,7 +368,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -389,7 +389,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -410,7 +410,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -449,7 +449,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "CreateQueueRequest"
+            "aws.operation" "CreateQueue"
             "aws.queue.name" "sqsCamelSeparateQueueTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -488,7 +488,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "SendMessageRequest"
+            "aws.operation" "SendMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelSeparateQueueTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -507,7 +507,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelSeparateQueueTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"
@@ -533,7 +533,7 @@ class SqsCamelTest extends AgentInstrumentationSpecification {
           attributes {
             "aws.agent" "java-aws-sdk"
             "aws.endpoint" "http://localhost:$sqsPort"
-            "aws.operation" "ReceiveMessageRequest"
+            "aws.operation" "ReceiveMessage"
             "aws.queue.url" "http://localhost:$sqsPort/queue/sqsCamelSeparateQueueTest"
             "aws.service" "AmazonSQS"
             "http.flavor" "1.1"

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/aws-sdk-1.11-javaagent.gradle
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/aws-sdk-1.11-javaagent.gradle
@@ -73,7 +73,7 @@ dependencies {
 
   // needed for SNS
   testImplementation deps.testcontainers
-  testImplementation "org.testcontainers:localstack:1.15.2"
+  testImplementation "org.testcontainers:localstack:${versions.testcontainers}"
 
   test_before_1_11_106Implementation(group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.0')
   test_before_1_11_106Implementation(group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '1.11.0')

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/aws-sdk-1.11-javaagent.gradle
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/aws-sdk-1.11-javaagent.gradle
@@ -44,6 +44,7 @@ configurations {
     resolutionStrategy.force 'com.amazonaws:aws-java-sdk-ec2:1.11.0'
     resolutionStrategy.force 'com.amazonaws:aws-java-sdk-kinesis:1.11.0'
     resolutionStrategy.force 'com.amazonaws:aws-java-sdk-sqs:1.11.0'
+    resolutionStrategy.force 'com.amazonaws:aws-java-sdk-sns:1.11.0'
     resolutionStrategy.force 'com.amazonaws:aws-java-sdk-dynamodb:1.11.0'
   }
 }
@@ -58,6 +59,7 @@ dependencies {
   testLibrary group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.106'
   testLibrary group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version: '1.11.106'
   testLibrary group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: '1.11.106'
+  testLibrary group: 'com.amazonaws', name: 'aws-java-sdk-sns', version: '1.11.106'
 
   testSqsImplementation group: 'com.amazonaws', name: 'aws-java-sdk-sqs', version: '1.11.106'
   // needed for SQS - using emq directly as localstack references emq v0.15.7 ie WITHOUT AWS trace header propagation
@@ -69,11 +71,16 @@ dependencies {
   // needed for kinesis:
   testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: versions.jackson
 
+  // needed for SNS
+  testImplementation deps.testcontainers
+  testImplementation "org.testcontainers:localstack:1.15.2"
+
   test_before_1_11_106Implementation(group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.0')
   test_before_1_11_106Implementation(group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '1.11.0')
   test_before_1_11_106Implementation(group: 'com.amazonaws', name: 'aws-java-sdk-ec2', version: '1.11.0')
   test_before_1_11_106Implementation(group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version: '1.11.0')
   test_before_1_11_106Implementation(group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: '1.11.0')
+  test_before_1_11_106Implementation(group: 'com.amazonaws', name: 'aws-java-sdk-sns', version: '1.11.0')
 }
 
 test {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SnsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SnsTracingTest.groovy
@@ -1,0 +1,299 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+
+import com.amazonaws.services.sns.AmazonSNSAsyncClient
+import com.amazonaws.services.sns.model.CreateTopicResult
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient
+import com.amazonaws.services.sqs.model.CreateQueueResult
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.Ignore
+import spock.lang.Shared
+
+class SnsTracingTest extends AgentInstrumentationSpecification {
+
+  @Shared
+  int sqsPort
+  @Shared
+  LocalStackContainer localstack
+  @Shared
+  AmazonSQSAsyncClient sqsClient
+
+  @Shared
+  int snsPort
+  @Shared
+  LocalStackContainer sns
+  @Shared
+  AmazonSNSAsyncClient snsClient
+
+  def setupSpec() {
+
+    localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
+      .withServices(LocalStackContainer.Service.SQS, LocalStackContainer.Service.SNS)
+      .withEnv("DEBUG", "1")
+      .withEnv("SQS_PROVIDER", "elasticmq")
+    localstack.start()
+
+    sqsPort = localstack.getMappedPort(4566)
+
+    sqsClient = AmazonSQSAsyncClient.asyncBuilder()
+      .withEndpointConfiguration(localstack.getEndpointConfiguration(LocalStackContainer.Service.SQS))
+      .withCredentials(localstack.getDefaultCredentialsProvider())
+      .build()
+
+    snsPort = localstack.getMappedPort(4566)
+    snsClient = AmazonSNSAsyncClient.asyncBuilder()
+      .withEndpointConfiguration(localstack.getEndpointConfiguration(LocalStackContainer.Service.SNS))
+      .withCredentials(localstack.getDefaultCredentialsProvider())
+      .build()
+
+    localstack.followOutput(new Slf4jLogConsumer(LoggerFactory.getLogger("test")))
+  }
+
+  def cleanupSpec() {
+    if (localstack != null) {
+      localstack.stop()
+    }
+    if (sns != null) {
+      sns.stop()
+    }
+  }
+
+  def createQueue(String queueName) {
+    CreateQueueResult cqr = sqsClient.createQueue(queueName)
+    sqsClient.setQueueAttributes(cqr.getQueueUrl(), Collections.singletonMap("Policy", policy(queueName)))
+    return cqr.getQueueUrl()
+  }
+
+  def getQueueArn(String queueUrl) {
+    return sqsClient.getQueueAttributes(
+      new GetQueueAttributesRequest(queueUrl)
+        .withAttributeNames("QueueArn")).getAttributes()
+      .get("QueueArn")
+  }
+
+  def createAndSubscribeTopic(String topicName, String queueArn) {
+    CreateTopicResult ctr = snsClient.createTopic(topicName)
+    snsClient.subscribe(ctr.getTopicArn(), "sqs", queueArn)
+    return ctr.getTopicArn()
+  }
+
+  @Ignore("Requires https://github.com/localstack/localstack/issues/3669 to work with localstack")
+  def "simple SNS producer - SQS consumer services"() {
+    setup:
+    String queueName = "snsToSqsTestQueue"
+    String topicName = "snsToSqsTestTopic"
+
+    String queueUrl = createQueue(queueName)
+    String queueArn = getQueueArn(queueUrl)
+    String topicArn = createAndSubscribeTopic(topicName, queueArn)
+
+    when:
+    snsClient.publish(topicArn, "Hello There")
+    Thread.sleep(1000)
+    ReceiveMessageRequest rmr = new ReceiveMessageRequest(queueUrl).withMessageAttributeNames("test")
+    sqsClient.receiveMessage(rmr)
+    Thread.sleep(1000)
+
+    then:
+    assertTraces(7) {
+      trace(0, 1) {
+
+        span(0) {
+          name "SQS.CreateQueue"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" String
+            "aws.operation" "CreateQueueRequest"
+            "aws.queue.name" queueName
+            "aws.service" "AmazonSQS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" String
+            "net.peer.name" String
+            "net.transport" "IP.TCP"
+            "net.peer.port" {it == null || Number}
+          }
+        }
+      }
+      trace(1, 1) {
+
+        span(0) {
+          name "SQS.SetQueueAttributes"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" String
+            "aws.operation" "SetQueueAttributesRequest"
+            "aws.queue.url" queueUrl
+            "aws.service" "AmazonSQS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" String
+            "net.peer.name" String
+            "net.transport" "IP.TCP"
+            "net.peer.port" {it == null || Number}
+          }
+        }
+      }
+      trace(2, 1) {
+
+        span(0) {
+          name "SQS.GetQueueAttributes"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" String
+            "aws.operation" "GetQueueAttributesRequest"
+            "aws.queue.url" queueUrl
+            "aws.service" "AmazonSQS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" String
+            "net.peer.name" String
+            "net.transport" "IP.TCP"
+            "net.peer.port" {it == null || Number}
+          }
+        }
+      }
+      trace(3, 1) {
+
+        span(0) {
+          name "SNS.CreateTopic"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" String
+            "aws.operation" "CreateTopicRequest"
+            "aws.service" "AmazonSNS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" String
+            "net.peer.name" String
+            "net.transport" "IP.TCP"
+            "net.peer.port" {it == null || Number}
+          }
+        }
+      }
+      trace(4, 1) {
+
+        span(0) {
+          name "SNS.Subscribe"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" String
+            "aws.operation" "SubscribeRequest"
+            "aws.service" "AmazonSNS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" String
+            "net.peer.name" String
+            "net.transport" "IP.TCP"
+            "net.peer.port" {it == null || Number}
+          }
+        }
+      }
+      trace(5, 2) {
+        span(0) {
+          name "SNS.Publish"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" String
+            "aws.operation" "PublishRequest"
+            "aws.service" "AmazonSNS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" String
+            "net.peer.name" String
+            "net.transport" "IP.TCP"
+            "net.peer.port" {it == null || Number}
+          }
+        }
+        span(1) {
+          name "SQS.ReceiveMessage"
+          kind CONSUMER
+          childOf span(0)
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" String
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.queue.url" queueUrl
+            "aws.service" "AmazonSQS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" String
+            "http.user_agent" String
+            "net.peer.name" String
+            "net.transport" "IP.TCP"
+            "net.peer.port" {it == null || Number}
+          }
+        }
+      }
+      /**
+       * This span represents HTTP "sending of receive message" operation. It's always single, while there can be multiple CONSUMER spans (one per consumed message).
+       * This one could be suppressed (by IF in TracingRequestHandler#beforeRequest but then HTTP instrumentation span would appear
+       */
+      trace(6, 1) {
+        span(0) {
+          name "SQS.ReceiveMessage"
+          kind CLIENT
+          hasNoParent()
+          attributes {
+            "aws.agent" "java-aws-sdk"
+            "aws.endpoint" String
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.queue.url" queueUrl
+            "aws.service" "AmazonSQS"
+            "http.flavor" "1.1"
+            "http.method" "POST"
+            "http.status_code" 200
+            "http.url" String
+            "net.peer.name" String
+            "net.transport" "IP.TCP"
+            "net.peer.port" {it == null || Number}
+          }
+        }
+      }
+    }
+  }
+
+  def policy(String queueName) {
+    return String.format(SQS_POLICY, queueName)
+  }
+
+  private static final String SQS_POLICY = "{" +
+    "  \"Statement\": [" +
+    "    {" +
+    "      \"Effect\": \"Allow\"," +
+    "      \"Principal\": \"*\"," +
+    "      \"Action\": \"sqs:SendMessage\"," +
+    "      \"Resource\": \"arn:aws:sqs:us-east-1:906383545488:%s\"" +
+    "    }]" +
+    "}"
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/resources/logback-test.xml
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/resources/logback-test.xml
@@ -9,10 +9,12 @@
     </layout>
   </appender>
 
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="console"/>
   </root>
 
-  <logger name="org.elasticmq" level="debug" />
-
+  <logger name="org.elasticmq" level="INFO" />
+  <logger name="test" level="WARN"/>
+  <logger name="org.testcontainers" level="WARN" />
+  <logger name="com.amazonaws" level="DEBUG" />
 </configuration>


### PR DESCRIPTION
- adds test ensuring proper SNS to SQS trace context propagation for AWS SDK v1
- test is ignored as localstack needs to implement X-Ray feature for SNS (PR filed)