### PR TITLE
Use ClassValue instead of WeakMap to cache span name

### DIFF
--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotationsTracer.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotationsTracer.java
@@ -5,15 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrs.v1_0;
 
-import static io.opentelemetry.javaagent.instrumentation.api.WeakMap.Provider.newWeakMap;
-
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.servlet.ServletContextPath;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.instrumentation.api.tracer.ServerSpan;
-import io.opentelemetry.javaagent.instrumentation.api.WeakMap;
 import io.opentelemetry.javaagent.tooling.ClassHierarchyIterable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -30,7 +27,12 @@ public class JaxRsAnnotationsTracer extends BaseTracer {
     return TRACER;
   }
 
-  private final WeakMap<Class<?>, Map<Method, String>> spanNames = newWeakMap();
+  private final ClassValue<Map<Method, String>> spanNames = new ClassValue<Map<Method, String>>() {
+    @Override
+    protected Map<Method, String> computeValue(Class<?> type) {
+      return new ConcurrentHashMap<>();
+    }
+  };
 
   public Context startSpan(Class<?> target, Method method) {
     String pathBasedSpanName = getPathSpanName(target, method);
@@ -63,14 +65,6 @@ public class JaxRsAnnotationsTracer extends BaseTracer {
    */
   private String getPathSpanName(Class<?> target, Method method) {
     Map<Method, String> classMap = spanNames.get(target);
-
-    if (classMap == null) {
-      spanNames.putIfAbsent(target, new ConcurrentHashMap<>());
-      classMap = spanNames.get(target);
-      // classMap should not be null at this point because we have a
-      // strong reference to target and don't manually clear the map.
-    }
-
     String spanName = classMap.get(method);
     if (spanName == null) {
       String httpMethod = null;

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotationsTracer.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotationsTracer.java
@@ -27,12 +27,13 @@ public class JaxRsAnnotationsTracer extends BaseTracer {
     return TRACER;
   }
 
-  private final ClassValue<Map<Method, String>> spanNames = new ClassValue<Map<Method, String>>() {
-    @Override
-    protected Map<Method, String> computeValue(Class<?> type) {
-      return new ConcurrentHashMap<>();
-    }
-  };
+  private final ClassValue<Map<Method, String>> spanNames =
+      new ClassValue<Map<Method, String>>() {
+        @Override
+        protected Map<Method, String> computeValue(Class<?> type) {
+          return new ConcurrentHashMap<>();
+        }
+      };
 
   public Context startSpan(Class<?> target, Method method) {
     String pathBasedSpanName = getPathSpanName(target, method);

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAnnotationsTracer.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAnnotationsTracer.java
@@ -30,12 +30,13 @@ public class JaxRsAnnotationsTracer extends BaseTracer {
     return TRACER;
   }
 
-  private final ClassValue<Map<Method, String>> spanNames = new ClassValue<Map<Method, String>>() {
-    @Override
-    protected Map<Method, String> computeValue(Class<?> type) {
-      return new ConcurrentHashMap<>();
-    }
-  };
+  private final ClassValue<Map<Method, String>> spanNames =
+      new ClassValue<Map<Method, String>>() {
+        @Override
+        protected Map<Method, String> computeValue(Class<?> type) {
+          return new ConcurrentHashMap<>();
+        }
+      };
 
   public Context startSpan(Class<?> target, Method method) {
     return startSpan(Context.current(), target, method);

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAnnotationsTracer.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAnnotationsTracer.java
@@ -5,14 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrs.v2_0;
 
-import static io.opentelemetry.javaagent.instrumentation.api.WeakMap.Provider.newWeakMap;
-
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.servlet.ServletContextPath;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.instrumentation.api.tracer.ServerSpan;
-import io.opentelemetry.javaagent.instrumentation.api.WeakMap;
 import io.opentelemetry.javaagent.tooling.ClassHierarchyIterable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -33,7 +30,12 @@ public class JaxRsAnnotationsTracer extends BaseTracer {
     return TRACER;
   }
 
-  private final WeakMap<Class<?>, Map<Method, String>> spanNames = newWeakMap();
+  private final ClassValue<Map<Method, String>> spanNames = new ClassValue<Map<Method, String>>() {
+    @Override
+    protected Map<Method, String> computeValue(Class<?> type) {
+      return new ConcurrentHashMap<>();
+    }
+  };
 
   public Context startSpan(Class<?> target, Method method) {
     return startSpan(Context.current(), target, method);
@@ -74,14 +76,6 @@ public class JaxRsAnnotationsTracer extends BaseTracer {
    */
   private String getPathSpanName(Class<?> target, Method method) {
     Map<Method, String> classMap = spanNames.get(target);
-
-    if (classMap == null) {
-      spanNames.putIfAbsent(target, new ConcurrentHashMap<>());
-      classMap = spanNames.get(target);
-      // classMap should not be null at this point because we have a
-      // strong reference to target and don't manually clear the map.
-    }
-
     String spanName = classMap.get(method);
     if (spanName == null) {
       String httpMethod = null;


### PR DESCRIPTION
As values stored in `WeakMap` may reference the key used (key is class, value may contain method of the same class which has a reference to class) it does not serve intended purpose.