### PR TITLE
Make BaseTracer fields private

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
@@ -49,8 +49,8 @@ public abstract class BaseTracer {
   private static final SupportabilityMetrics supportability =
       new SupportabilityMetrics(Config.get()).start();
 
-  protected final Tracer tracer;
-  protected final ContextPropagators propagators;
+  private final Tracer tracer;
+  private final ContextPropagators propagators;
 
   public BaseTracer() {
     this(GlobalOpenTelemetry.get());
@@ -153,12 +153,13 @@ public abstract class BaseTracer {
    * name {@code spanName} and kind {@code kind}.
    */
   public Context startSpan(Context parentContext, String spanName, SpanKind kind) {
-    Span span = spanBuilder(spanName, kind).setParent(parentContext).startSpan();
+    Span span = spanBuilder(parentContext, spanName, kind).startSpan();
     return parentContext.with(span);
   }
 
-  protected SpanBuilder spanBuilder(String spanName, SpanKind kind) {
-    return tracer.spanBuilder(spanName).setSpanKind(kind);
+  /** Returns a {@link SpanBuilder} to create and start a new {@link Span}. */
+  protected final SpanBuilder spanBuilder(Context parentContext, String spanName, SpanKind kind) {
+    return tracer.spanBuilder(spanName).setSpanKind(kind).setParent(parentContext);
   }
 
   /**
@@ -217,7 +218,7 @@ public abstract class BaseTracer {
     if (clazz.getPackage() != null) {
       String pkgName = clazz.getPackage().getName();
       if (!pkgName.isEmpty()) {
-        className = clazz.getName().replace(pkgName, "").substring(1);
+        className = className.substring(pkgName.length() + 1);
       }
     }
     return className;

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/DatabaseClientTracer.java
@@ -40,10 +40,7 @@ public abstract class DatabaseClientTracer<CONNECTION, STATEMENT, SANITIZEDSTATE
     SANITIZEDSTATEMENT sanitizedStatement = sanitizeStatement(statement);
 
     SpanBuilder span =
-        tracer
-            .spanBuilder(spanName(connection, statement, sanitizedStatement))
-            .setParent(parentContext)
-            .setSpanKind(CLIENT)
+        spanBuilder(parentContext, spanName(connection, statement, sanitizedStatement), CLIENT)
             .setAttribute(SemanticAttributes.DB_SYSTEM, dbSystem(connection));
 
     if (connection != null) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
@@ -139,7 +139,7 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
 
   private Span internalStartSpan(
       SpanKind kind, Context parentContext, REQUEST request, String name, long startTimeNanos) {
-    SpanBuilder spanBuilder = tracer.spanBuilder(name).setSpanKind(kind).setParent(parentContext);
+    SpanBuilder spanBuilder = spanBuilder(parentContext, name, kind);
     if (startTimeNanos > 0) {
       spanBuilder.setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS);
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
@@ -82,7 +82,7 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
     // whether to call end() or not on the Span in the returned Context
 
     Context parentContext = extract(request, getGetter());
-    SpanBuilder builder = tracer.spanBuilder(spanName).setSpanKind(SERVER).setParent(parentContext);
+    SpanBuilder builder = spanBuilder(parentContext, spanName, SERVER);
 
     if (startTimestamp >= 0) {
       builder.setStartTimestamp(startTimestamp, TimeUnit.NANOSECONDS);

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelTracer.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelTracer.java
@@ -24,7 +24,6 @@
 package io.opentelemetry.javaagent.instrumentation.apachecamel;
 
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
@@ -41,10 +40,6 @@ class CamelTracer extends BaseTracer {
   @Override
   protected String getInstrumentationName() {
     return "io.opentelemetry.javaagent.apache-camel-2.20";
-  }
-
-  public SpanBuilder spanBuilder(String name) {
-    return tracer.spanBuilder(name);
   }
 
   public Scope startClientScope(Span span) {

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientTracer.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientTracer.java
@@ -33,12 +33,7 @@ public class ApacheHttpAsyncClientTracer
   }
 
   public Context startSpan(Context parentContext) {
-    Span span =
-        tracer
-            .spanBuilder(DEFAULT_SPAN_NAME)
-            .setSpanKind(CLIENT)
-            .setParent(parentContext)
-            .startSpan();
+    Span span = spanBuilder(parentContext, DEFAULT_SPAN_NAME, CLIENT).startSpan();
     return withClientSpan(parentContext, span);
   }
 

--- a/instrumentation/aws-lambda-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambda/v1_0/AwsLambdaRequestHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambda/v1_0/AwsLambdaRequestHandlerInstrumentation.java
@@ -63,7 +63,7 @@ public class AwsLambdaRequestHandlerInstrumentation implements TypeInstrumentati
       functionContext = functionTracer().startSpan(context, SpanKind.SERVER, arg);
       functionScope = functionContext.makeCurrent();
       if (arg instanceof SQSEvent) {
-        messageContext = messageTracer().startSpan((SQSEvent) arg);
+        messageContext = messageTracer().startSpan(functionContext, (SQSEvent) arg);
         messageScope = messageContext.makeCurrent();
       }
     }

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaTracer.java
@@ -118,11 +118,10 @@ public class AwsLambdaTracer extends BaseTracer {
       Context awsContext, SpanKind kind, Object input, Map<String, String> headers) {
     io.opentelemetry.context.Context parentContext = ParentContextExtractor.extract(headers, this);
 
-    SpanBuilder spanBuilder = tracer.spanBuilder(spanName(awsContext, input));
+    SpanBuilder spanBuilder = spanBuilder(parentContext, spanName(awsContext, input), kind);
     setAttributes(spanBuilder, awsContext, input);
-    Span span = spanBuilder.setParent(parentContext).setSpanKind(kind).startSpan();
 
-    return withServerSpan(parentContext, span);
+    return withServerSpan(parentContext, spanBuilder.startSpan());
   }
 
   public void onOutput(io.opentelemetry.context.Context context, Object output) {

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsEventHandler.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsEventHandler.java
@@ -45,7 +45,8 @@ public abstract class TracingSqsEventHandler extends TracingRequestHandler<SQSEv
 
   @Override
   public Void doHandleRequest(SQSEvent event, Context context) {
-    io.opentelemetry.context.Context otelContext = tracer.startSpan(event);
+    io.opentelemetry.context.Context parentContext = io.opentelemetry.context.Context.current();
+    io.opentelemetry.context.Context otelContext = tracer.startSpan(parentContext, event);
     Throwable error = null;
     try (Scope ignored = otelContext.makeCurrent()) {
       handleEvent(event, context);

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsMessageHandler.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsMessageHandler.java
@@ -43,8 +43,9 @@ public abstract class TracingSqsMessageHandler extends TracingSqsEventHandler {
 
   @Override
   protected final void handleEvent(SQSEvent event, Context context) {
+    io.opentelemetry.context.Context parentContext = io.opentelemetry.context.Context.current();
     for (SQSMessage message : event.getRecords()) {
-      io.opentelemetry.context.Context otelContext = getTracer().startSpan(message);
+      io.opentelemetry.context.Context otelContext = getTracer().startSpan(parentContext, message);
       Throwable error = null;
       try (Scope ignored = otelContext.makeCurrent()) {
         handleMessage(message, context);

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpClientTracer.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpClientTracer.java
@@ -29,8 +29,7 @@ final class AwsSdkHttpClientTracer
 
   public Context startSpan(Context parentContext, ExecutionAttributes attributes) {
     String spanName = spanName(attributes);
-    Span span =
-        tracer.spanBuilder(spanName).setSpanKind(CLIENT).setParent(parentContext).startSpan();
+    Span span = spanBuilder(parentContext, spanName, CLIENT).startSpan();
     return withClientSpan(parentContext, span);
   }
 

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeTracer.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeTracer.java
@@ -24,12 +24,11 @@ public class GeodeTracer extends DatabaseClientTracer<Region<?, ?>, String, SqlS
   }
 
   public Context startSpan(String operation, Region<?, ?> connection, String query) {
+    Context parentContext = Context.current();
     SqlStatementInfo sanitizedStatement = sanitizeStatement(query);
 
     SpanBuilder span =
-        tracer
-            .spanBuilder(operation)
-            .setSpanKind(CLIENT)
+        spanBuilder(parentContext, operation, CLIENT)
             .setAttribute(SemanticAttributes.DB_SYSTEM, dbSystem(connection))
             .setAttribute(SemanticAttributes.DB_OPERATION, operation);
 
@@ -37,7 +36,7 @@ public class GeodeTracer extends DatabaseClientTracer<Region<?, ?>, String, SqlS
     setNetSemanticConvention(span, connection);
     onStatement(span, connection, query, sanitizedStatement);
 
-    return Context.current().with(span.startSpan());
+    return parentContext.with(span.startSpan());
   }
 
   @Override

--- a/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/GrpcClientTracer.java
+++ b/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/GrpcClientTracer.java
@@ -26,11 +26,13 @@ final class GrpcClientTracer extends RpcClientTracer {
   }
 
   public Context startSpan(String name) {
+    Context parentContext = Context.current();
     Span span =
-        spanBuilder(name, CLIENT)
+        spanBuilder(parentContext, name, CLIENT)
             .setAttribute(SemanticAttributes.RPC_SYSTEM, getRpcSystem())
             .startSpan();
-    return Context.current().with(span);
+    // TODO: withClientSpan()
+    return parentContext.with(span);
   }
 
   public void end(Context context, Status status) {

--- a/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/GrpcServerTracer.java
+++ b/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/GrpcServerTracer.java
@@ -24,10 +24,11 @@ final class GrpcServerTracer extends RpcServerTracer<Metadata> {
   }
 
   public Context startSpan(String name, Metadata headers) {
-    SpanBuilder spanBuilder =
-        tracer.spanBuilder(name).setSpanKind(SERVER).setParent(extract(headers, getGetter()));
+    Context parentContext = extract(headers, getGetter());
+    SpanBuilder spanBuilder = spanBuilder(parentContext, name, SERVER);
     spanBuilder.setAttribute(SemanticAttributes.RPC_SYSTEM, "grpc");
-    return Context.current().with(spanBuilder.startSpan());
+    // TODO: withServerSpan()
+    return parentContext.with(spanBuilder.startSpan());
   }
 
   public void setStatus(Context context, Status status) {

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAnnotationsTracer.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxRsAnnotationsTracer.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrs.v2_0;
 
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.servlet.ServletContextPath;
@@ -46,7 +48,7 @@ public class JaxRsAnnotationsTracer extends BaseTracer {
     // We create span and immediately update its name
     // We do that in order to reuse logic inside updateSpanNames method, which is used externally as
     // well.
-    Span span = tracer.spanBuilder("jax-rs.request").setParent(parentContext).startSpan();
+    Span span = spanBuilder(parentContext, "jax-rs.request", INTERNAL).startSpan();
     updateSpanNames(
         parentContext, span, ServerSpan.fromContextOrNull(parentContext), target, method);
     return parentContext.with(span);
@@ -59,7 +61,7 @@ public class JaxRsAnnotationsTracer extends BaseTracer {
       updateSpanName(span, pathBasedSpanName);
     } else {
       updateSpanName(serverSpan, pathBasedSpanName);
-      updateSpanName(span, tracer().spanNameForMethod(target, method));
+      updateSpanName(span, spanNameForMethod(target, method));
     }
   }
 

--- a/instrumentation/jaxws/jaxws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/common/JaxWsTracer.java
+++ b/instrumentation/jaxws/jaxws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/common/JaxWsTracer.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxws.common;
 
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
@@ -34,12 +36,11 @@ public class JaxWsTracer extends BaseTracer {
       serverSpan.updateName(spanName);
     }
 
-    return parentContext.with(
-        tracer
-            .spanBuilder(spanName)
-            .setParent(parentContext)
+    Span span =
+        spanBuilder(parentContext, spanName, INTERNAL)
             .setAttribute(SemanticAttributes.CODE_NAMESPACE, method.getDeclaringClass().getName())
             .setAttribute(SemanticAttributes.CODE_FUNCTION, method.getName())
-            .startSpan());
+            .startSpan();
+    return parentContext.with(span);
   }
 }

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsTracer.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsTracer.java
@@ -41,13 +41,6 @@ public class JmsTracer extends BaseTracer {
 
   public Context startConsumerSpan(
       MessageDestination destination, String operation, Message message, long startTime) {
-    SpanBuilder spanBuilder =
-        tracer
-            .spanBuilder(spanName(destination, operation))
-            .setSpanKind(CONSUMER)
-            .setStartTimestamp(startTime, TimeUnit.MILLISECONDS)
-            .setAttribute(SemanticAttributes.MESSAGING_OPERATION, operation);
-
     Context parentContext = Context.root();
     if (message != null && "process".equals(operation)) {
       // TODO use BaseTracer.extract() which has context leak detection
@@ -57,16 +50,21 @@ public class JmsTracer extends BaseTracer {
               .getTextMapPropagator()
               .extract(Context.root(), message, GETTER);
     }
-    spanBuilder.setParent(parentContext);
+
+    SpanBuilder spanBuilder =
+        spanBuilder(parentContext, spanName(destination, operation), CONSUMER)
+            .setStartTimestamp(startTime, TimeUnit.MILLISECONDS)
+            .setAttribute(SemanticAttributes.MESSAGING_OPERATION, operation);
 
     afterStart(spanBuilder, destination, message);
     return parentContext.with(spanBuilder.startSpan());
   }
 
   public Context startProducerSpan(MessageDestination destination, Message message) {
-    SpanBuilder span = tracer.spanBuilder(spanName(destination, "send")).setSpanKind(PRODUCER);
+    Context parentContext = Context.current();
+    SpanBuilder span = spanBuilder(parentContext, spanName(destination, "send"), PRODUCER);
     afterStart(span, destination, message);
-    return Context.current().with(span.startSpan());
+    return parentContext.with(span.startSpan());
   }
 
   public Scope startProducerScope(Context context, Message message) {

--- a/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaConsumerTracer.java
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaConsumerTracer.java
@@ -28,10 +28,7 @@ public class KafkaConsumerTracer extends BaseTracer {
 
     Context parentContext = extractParent(record);
     Span span =
-        tracer
-            .spanBuilder(spanNameOnConsume(record))
-            .setSpanKind(CONSUMER)
-            .setParent(parentContext)
+        spanBuilder(parentContext, spanNameOnConsume(record), CONSUMER)
             .setStartTimestamp(now, TimeUnit.MILLISECONDS)
             .setAttribute(SemanticAttributes.MESSAGING_SYSTEM, "kafka")
             .setAttribute(SemanticAttributes.MESSAGING_DESTINATION, record.topic())

--- a/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerTracer.java
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerTracer.java
@@ -23,7 +23,7 @@ public class KafkaProducerTracer extends BaseTracer {
   }
 
   public Context startProducerSpan(Context parentContext, ProducerRecord<?, ?> record) {
-    SpanBuilder span = spanBuilder(spanNameOnProduce(record), PRODUCER).setParent(parentContext);
+    SpanBuilder span = spanBuilder(parentContext, spanNameOnProduce(record), PRODUCER);
     onProduce(span, record);
     return parentContext.with(span.startSpan());
   }

--- a/instrumentation/kafka-streams-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsTracer.java
+++ b/instrumentation/kafka-streams-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/KafkaStreamsTracer.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkastreams;
 
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.javaagent.instrumentation.kafkastreams.TextMapExtractAdapter.GETTER;
 
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
@@ -29,10 +29,7 @@ public class KafkaStreamsTracer extends BaseTracer {
   public Context startSpan(StampedRecord record) {
     Context parentContext = extract(record.value.headers(), GETTER);
     Span span =
-        tracer
-            .spanBuilder(spanNameForConsume(record))
-            .setSpanKind(SpanKind.CONSUMER)
-            .setParent(parentContext)
+        spanBuilder(parentContext, spanNameForConsume(record), CONSUMER)
             .setAttribute(SemanticAttributes.MESSAGING_SYSTEM, "kafka")
             .setAttribute(SemanticAttributes.MESSAGING_DESTINATION, record.topic())
             .setAttribute(SemanticAttributes.MESSAGING_DESTINATION_KIND, "topic")

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientTracer.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientTracer.java
@@ -32,12 +32,7 @@ public class NettyHttpClientTracer
   }
 
   public Context startSpan(Context parentContext, ChannelHandlerContext ctx, HttpRequest request) {
-    Span span =
-        tracer
-            .spanBuilder(spanNameForRequest(request))
-            .setSpanKind(CLIENT)
-            .setParent(parentContext)
-            .startSpan();
+    Span span = spanBuilder(parentContext, spanNameForRequest(request), CLIENT).startSpan();
     onRequest(span, request);
     NetPeerUtils.INSTANCE.setNetPeer(span, (InetSocketAddress) ctx.getChannel().getRemoteAddress());
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/NettyHttpClientTracer.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/NettyHttpClientTracer.java
@@ -32,12 +32,7 @@ public class NettyHttpClientTracer
   }
 
   public Context startSpan(Context parentContext, ChannelHandlerContext ctx, HttpRequest request) {
-    Span span =
-        tracer
-            .spanBuilder(spanNameForRequest(request))
-            .setSpanKind(CLIENT)
-            .setParent(parentContext)
-            .startSpan();
+    Span span = spanBuilder(parentContext, spanNameForRequest(request), CLIENT).startSpan();
     onRequest(span, request);
     NetPeerUtils.INSTANCE.setNetPeer(span, (InetSocketAddress) ctx.channel().remoteAddress());
 

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/NettyHttpClientTracer.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/NettyHttpClientTracer.java
@@ -32,12 +32,7 @@ public class NettyHttpClientTracer
   }
 
   public Context startSpan(Context parentContext, ChannelHandlerContext ctx, HttpRequest request) {
-    Span span =
-        tracer
-            .spanBuilder(spanNameForRequest(request))
-            .setSpanKind(CLIENT)
-            .setParent(parentContext)
-            .startSpan();
+    Span span = spanBuilder(parentContext, spanNameForRequest(request), CLIENT).startSpan();
     onRequest(span, request);
     NetPeerUtils.INSTANCE.setNetPeer(span, (InetSocketAddress) ctx.channel().remoteAddress());
 

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanTracer.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanTracer.java
@@ -24,18 +24,18 @@ public class WithSpanTracer extends BaseTracer {
   private static final Logger log = LoggerFactory.getLogger(WithSpanTracer.class);
 
   public Context startSpan(
-      Context context, WithSpan applicationAnnotation, Method method, SpanKind kind) {
+      Context parentContext, WithSpan applicationAnnotation, Method method, SpanKind kind) {
     Span span =
-        spanBuilder(spanNameForMethodWithAnnotation(applicationAnnotation, method), kind)
-            .setParent(context)
+        spanBuilder(
+                parentContext, spanNameForMethodWithAnnotation(applicationAnnotation, method), kind)
             .startSpan();
     if (kind == SpanKind.SERVER) {
-      return withServerSpan(context, span);
+      return withServerSpan(parentContext, span);
     }
     if (kind == SpanKind.CLIENT) {
-      return withClientSpan(context, span);
+      return withClientSpan(parentContext, span);
     }
-    return context.with(span);
+    return parentContext.with(span);
   }
 
   /**

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientTracer.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientTracer.java
@@ -21,17 +21,18 @@ public class RmiClientTracer extends RpcClientTracer {
   }
 
   public Context startSpan(Method method) {
+    Context parentContext = Context.current();
     String serviceName = method.getDeclaringClass().getName();
     String methodName = method.getName();
 
     Span span =
-        spanBuilder(serviceName + "/" + methodName, CLIENT)
+        spanBuilder(parentContext, serviceName + "/" + methodName, CLIENT)
             .setAttribute(SemanticAttributes.RPC_SYSTEM, getRpcSystem())
             .setAttribute(SemanticAttributes.RPC_SERVICE, serviceName)
             .setAttribute(SemanticAttributes.RPC_METHOD, methodName)
             .startSpan();
 
-    return Context.current().with(span);
+    return parentContext.with(span);
   }
 
   @Override

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerTracer.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerTracer.java
@@ -26,10 +26,7 @@ public class RmiServerTracer extends RpcServerTracer {
     String methodName = method.getName();
 
     SpanBuilder spanBuilder =
-        tracer
-            .spanBuilder(serviceName + "/" + methodName)
-            .setSpanKind(SERVER)
-            .setParent(parentContext)
+        spanBuilder(parentContext, serviceName + "/" + methodName, SERVER)
             .setAttribute(SemanticAttributes.RPC_SYSTEM, "java_rmi")
             .setAttribute(SemanticAttributes.RPC_SERVICE, serviceName)
             .setAttribute(SemanticAttributes.RPC_METHOD, methodName);

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/job/JobExecutionTracer.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/job/JobExecutionTracer.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.batch.job;
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
-
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import org.springframework.batch.core.JobExecution;
@@ -20,7 +18,7 @@ public class JobExecutionTracer extends BaseTracer {
 
   public Context startSpan(JobExecution jobExecution) {
     String jobName = jobExecution.getJobInstance().getJobName();
-    return startSpan("BatchJob " + jobName, INTERNAL);
+    return startSpan("BatchJob " + jobName);
   }
 
   @Override

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/step/StepExecutionTracer.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/step/StepExecutionTracer.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.batch.step;
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
-
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import org.springframework.batch.core.StepExecution;
@@ -21,7 +19,7 @@ public class StepExecutionTracer extends BaseTracer {
   public Context startSpan(StepExecution stepExecution) {
     String jobName = stepExecution.getJobExecution().getJobInstance().getJobName();
     String stepName = stepExecution.getStepName();
-    return startSpan("BatchJob " + jobName + "." + stepName, INTERNAL);
+    return startSpan("BatchJob " + jobName + "." + stepName);
   }
 
   @Override

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/WithSpanAspectTracer.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/WithSpanAspectTracer.java
@@ -24,9 +24,7 @@ class WithSpanAspectTracer extends BaseTracer {
 
   Context startSpan(Context parentContext, WithSpan annotation, Method method) {
     Span span =
-        spanBuilder(spanName(annotation, method), annotation.kind())
-            .setParent(parentContext)
-            .startSpan();
+        spanBuilder(parentContext, spanName(annotation, method), annotation.kind()).startSpan();
     switch (annotation.kind()) {
       case SERVER:
         return withServerSpan(parentContext, span);

--- a/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxHttpClientTracer.java
+++ b/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxHttpClientTracer.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.spring.webflux.client;
 import static io.opentelemetry.instrumentation.spring.webflux.client.HttpHeadersInjectAdapter.SETTER;
 
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.instrumentation.api.config.Config;
@@ -83,10 +82,6 @@ public class SpringWebfluxHttpClientTracer
   @Override
   protected String getInstrumentationName() {
     return "io.opentelemetry.javaagent.spring-webflux-5.0";
-  }
-
-  public Tracer getTracer() {
-    return tracer;
   }
 
   // rawStatusCode() method was introduced in webflux 5.1

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcTracer.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcTracer.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.springwebmvc;
 
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
-import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.servlet.ServletContextPath;
@@ -36,13 +37,14 @@ public class SpringWebMvcTracer extends BaseTracer {
   }
 
   public Context startHandlerSpan(Context parentContext, Object handler) {
-    return startSpan(parentContext, spanNameOnHandle(handler), SpanKind.INTERNAL);
+    return startSpan(parentContext, spanNameOnHandle(handler), INTERNAL);
   }
 
   public Context startSpan(ModelAndView mv) {
-    SpanBuilder span = tracer.spanBuilder(spanNameOnRender(mv));
+    Context parentContext = Context.current();
+    SpanBuilder span = spanBuilder(parentContext, spanNameOnRender(mv), INTERNAL);
     onRender(span, mv);
-    return Context.current().with(span.startSpan());
+    return parentContext.with(span.startSpan());
   }
 
   public void onRequest(Context context, Span span, HttpServletRequest request) {

--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/SpringWsTracer.java
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/SpringWsTracer.java
@@ -21,12 +21,13 @@ public class SpringWsTracer extends BaseTracer {
   }
 
   public Context startSpan(Method method) {
+    Context parentContext = Context.current();
     Span span =
-        spanBuilder(spanNameForMethod(method), SpanKind.INTERNAL)
+        spanBuilder(parentContext, spanNameForMethod(method), SpanKind.INTERNAL)
             .setAttribute(SemanticAttributes.CODE_NAMESPACE, method.getDeclaringClass().getName())
             .setAttribute(SemanticAttributes.CODE_FUNCTION, method.getName())
             .startSpan();
-    return Context.current().with(span);
+    return parentContext.with(span);
   }
 
   @Override

--- a/instrumentation/struts-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/struts2/Struts2Tracer.java
+++ b/instrumentation/struts-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/struts2/Struts2Tracer.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.struts2;
 
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+
 import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.ActionProxy;
 import io.opentelemetry.api.trace.Span;
@@ -31,7 +33,7 @@ public class Struts2Tracer extends BaseTracer {
     String method = actionInvocation.getProxy().getMethod();
     String spanName = spanNameForMethod(actionClass, method);
 
-    SpanBuilder strutsSpan = tracer.spanBuilder(spanName).setParent(parentContext);
+    SpanBuilder strutsSpan = spanBuilder(parentContext, spanName, INTERNAL);
 
     strutsSpan.setAttribute(SemanticAttributes.CODE_NAMESPACE, actionClass.getName());
     if (method != null) {

--- a/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioTracer.java
+++ b/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioTracer.java
@@ -38,12 +38,8 @@ public class TwilioTracer extends BaseTracer {
   }
 
   public Context startSpan(Context parentContext, Object serviceExecutor, String methodName) {
-    Span span =
-        tracer
-            .spanBuilder(spanNameOnServiceExecution(serviceExecutor, methodName))
-            .setSpanKind(CLIENT)
-            .setParent(parentContext)
-            .startSpan();
+    String spanName = spanNameOnServiceExecution(serviceExecutor, methodName);
+    Span span = spanBuilder(parentContext, spanName, CLIENT).startSpan();
     return withClientSpan(parentContext, span);
   }
 


### PR DESCRIPTION
By making `tracer` private we're forcing all tracer implementation to use the `spanBuilder()` utility method and pass the parent context manually.

Closes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1265
Closes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1360