### PR TITLE
Concurrent http client tests with connection reuse

### DIFF
--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/ClientHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/ClientHandler.java
@@ -6,8 +6,8 @@
 import groovy.lang.Closure;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.util.ReferenceCountUtil;
 import java.util.concurrent.CompletableFuture;
 
 /*
@@ -15,27 +15,39 @@ Bridges from async Netty world to the sync world of our http client tests.
 When request initiated by a test gets a response, calls a given callback and completes given
 future with response's status code.
 */
-public class ClientHandler extends SimpleChannelInboundHandler<HttpObject> {
+public class ClientHandler extends SimpleChannelInboundHandler<HttpResponse> {
   private final Closure<Void> callback;
   private final CompletableFuture<Integer> responseCode;
+  private final String requestId;
 
   public ClientHandler(Closure<Void> callback, CompletableFuture<Integer> responseCode) {
+    this(callback, responseCode, null);
+  }
+
+  public ClientHandler(Closure<Void> callback, CompletableFuture<Integer> responseCode,
+      String requestId) {
     this.callback = callback;
     this.responseCode = responseCode;
+    this.requestId = requestId;
   }
 
   @Override
-  public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
-    if (msg instanceof HttpResponse) {
-      ctx.pipeline().remove(this);
-
-      if (callback != null) {
-        callback.call();
-      }
-
-      HttpResponse response = (HttpResponse) msg;
-      responseCode.complete(response.getStatus().code());
+  public void channelRead0(ChannelHandlerContext ctx, HttpResponse response) {
+    System.out.println("Waiting for response to " + requestId);
+    if (requestId != null && !requestId.equals(response.headers().get("test-request-id"))) {
+      ReferenceCountUtil.retain(response);
+      ctx.fireChannelRead(response);
+      return;
     }
+
+    System.out.println("Got response for " + requestId);
+
+    if (callback != null) {
+      callback.call();
+    }
+    responseCode.complete(response.getStatus().code());
+    ctx.pipeline().remove(this);
+
   }
 
   @Override

--- a/instrumentation/reactor-netty-1.0/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty-1.0/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
@@ -3,8 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static org.junit.Assume.assumeTrue
+
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import reactor.netty.http.client.HttpClient
 import reactor.netty.http.client.HttpClientResponse
 
@@ -45,4 +53,65 @@ class ReactorNettyHttpClientTest extends HttpClientTest implements AgentTestTrai
     }
     return resp.status().code()
   }
+
+  int doRequest(HttpClient connection, String method, URI uri, Map<String, String> headers = [:]) {
+    HttpClientResponse resp = connection
+      .followRedirect(true)
+      .headers({ h -> headers.each { k, v -> h.add(k, v) } })
+      ."${method.toLowerCase()}"()
+      .uri(uri.toString())
+      .response()
+      .block()
+    return resp.status().code()
+  }
+
+
+  def "high concurrency test over single connection"() {
+    setup:
+    assumeTrue(testCausality())
+    int count = 2
+    def method = 'GET'
+    def url = server.address.resolve("/success")
+    def latch = new CountDownLatch(1)
+    def pool = Executors.newFixedThreadPool(4)
+    HttpClient httpClient = connect()
+
+    when:
+    count.times { index ->
+      def job = {
+        latch.await()
+        runUnderTrace("Parent span " + index) {
+          Span.current().setAttribute("test.request.id", index)
+          doRequest(httpClient, method, url, ["test-request-id": index.toString()])
+        }
+      }
+      pool.submit(job)
+    }
+    latch.countDown()
+
+    then:
+    assertTraces(count) {
+      count.times { idx ->
+        trace(idx, 3) {
+          def rootSpan = it.span(0)
+          //Traces can be in arbitrary order, let us find out the request id of the current one
+          def requestId = Integer.parseInt(rootSpan.name.substring("Parent span ".length()))
+
+          basicSpan(it, 0, "Parent span " + requestId, null, null) {
+            it."test.request.id" requestId
+          }
+          clientSpan(it, 1, span(0), method, url)
+          serverSpan(it, 2, span(1)) {
+            it."test.request.id" requestId
+          }
+        }
+      }
+    }
+
+  }
+
+  private HttpClient connect(){
+    return HttpClient.newConnection().baseUrl(server.address.toString())
+  }
+
 }

--- a/instrumentation/vertx-web-3.0/src/test/groovy/client/VertxHttpClientTest.groovy
+++ b/instrumentation/vertx-web-3.0/src/test/groovy/client/VertxHttpClientTest.groovy
@@ -5,18 +5,26 @@
 
 package client
 
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static org.junit.Assume.assumeTrue
+
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
+import io.vertx.core.http.HttpClient
 import io.vertx.core.http.HttpClientOptions
 import io.vertx.core.http.HttpClientResponse
 import io.vertx.core.http.HttpMethod
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Timeout
 
-@Timeout(10)
 class VertxHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Shared
@@ -28,17 +36,23 @@ class VertxHttpClientTest extends HttpClientTest implements AgentTestTrait {
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    return doRequest(httpClient, method, uri, headers, callback)
+  }
+
+  int doRequest(HttpClient client, String method, URI uri, Map<String, String> headers, Closure callback = null) {
     CompletableFuture<HttpClientResponse> future = new CompletableFuture<>()
-    def request = httpClient.request(HttpMethod.valueOf(method), uri.port, uri.host, "$uri")
+    def request = client.request(HttpMethod.valueOf(method), uri.port, uri.host, "$uri")
     headers.each { request.putHeader(it.key, it.value) }
     request.handler { response ->
       callback?.call()
       future.complete(response)
+      println headers.get("test-request-id") + " -- " + response.headers().get("test-request-id")
     }
     request.end()
 
     return future.get().statusCode()
   }
+
 
   @Override
   boolean testRedirects() {
@@ -54,4 +68,54 @@ class VertxHttpClientTest extends HttpClientTest implements AgentTestTrait {
     // FIXME: figure out how to configure timeouts.
     false
   }
+
+  private HttpClient connect(URI uri) {
+    HttpClientOptions clientOptions = new HttpClientOptions().setConnectTimeout(CONNECT_TIMEOUT_MS).setMaxPoolSize(1).setKeepAlive(true).setPipelining(true)
+    return vertx.createHttpClient(clientOptions)
+  }
+
+  def "high concurrency test over single connection"() {
+    setup:
+    assumeTrue(testCausality())
+    int count = 50
+    def method = 'GET'
+    def url = server.address.resolve("/success")
+    def latch = new CountDownLatch(1)
+    def pool = Executors.newFixedThreadPool(4)
+    HttpClient connection = connect(url)
+
+    when:
+    count.times { index ->
+      def job = {
+        latch.await()
+        runUnderTrace("Parent span " + index) {
+          Span.current().setAttribute("test.request.id", index)
+          doRequest(connection, method, url, ["test-request-id": index.toString()])
+        }
+      }
+      pool.submit(job)
+    }
+    latch.countDown()
+
+    then:
+    assertTraces(count) {
+      count.times { idx ->
+        trace(idx, 3) {
+          def rootSpan = it.span(0)
+          //Traces can be in arbitrary order, let us find out the request id of the current one
+          def requestId = Integer.parseInt(rootSpan.name.substring("Parent span ".length()))
+
+          basicSpan(it, 0, "Parent span " + requestId, null, null) {
+            it."test.request.id" requestId
+          }
+          clientSpan(it, 1, span(0), method, url)
+          serverSpan(it, 2, span(1)) {
+            it."test.request.id" requestId
+          }
+        }
+      }
+    }
+
+  }
+
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -43,7 +43,7 @@ abstract class HttpClientTest extends InstrumentationSpecification {
       prefix("success") {
         handleDistributedRequest()
         String msg = "Hello."
-        response.status(200).send(msg)
+        response.status(200).id(request.getHeader("test-request-id")).send(msg)
       }
       prefix("client-error") {
         handleDistributedRequest()
@@ -439,7 +439,7 @@ abstract class HttpClientTest extends InstrumentationSpecification {
       count.times { idx ->
         trace(idx, 3) {
           def rootSpan = it.span(0)
-          //Traces can be in arbitrary order, let us find out the request id if the current one
+          //Traces can be in arbitrary order, let us find out the request id of the current one
           def requestId = Integer.parseInt(rootSpan.name.substring("Parent span ".length()))
 
           basicSpan(it, 0, "Parent span " + requestId, null, null) {
@@ -452,7 +452,6 @@ abstract class HttpClientTest extends InstrumentationSpecification {
         }
       }
     }
-
   }
 
   // parent span must be cast otherwise it breaks debugging classloading (junit loads it early)

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/server/http/TestHttpServer.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/server/http/TestHttpServer.groovy
@@ -242,7 +242,7 @@ class TestHttpServer implements AutoCloseable {
       req.handled = true
     }
 
-    void handleDistributedRequest(Closure<Void> doInSpan = null) {
+    void handleDistributedRequest() {
       boolean isTestServer = true
       if (request.getHeader("is-test-server") != null) {
         isTestServer = Boolean.parseBoolean(request.getHeader("is-test-server"))
@@ -301,9 +301,15 @@ class TestHttpServer implements AutoCloseable {
 
     class ResponseApi {
       private int status = 200
+      private String id
 
       ResponseApi status(int status) {
         this.status = status
+        return this
+      }
+
+      ResponseApi id(String id) {
+        this.id = id
         return this
       }
 
@@ -311,6 +317,7 @@ class TestHttpServer implements AutoCloseable {
         assert !req.handled
         req.contentType = "text/plain;charset=utf-8"
         resp.status = status
+        resp.setHeader("test-request-id", id)
         req.handled = true
       }
 


### PR DESCRIPTION
This is a very early draft of tests of executing several concurrent http requests using the same "connection" with a given http library. It demonstrates our problems with Netty instrumentations and http request pipelining.