### PR TITLE
Fix spring-ws test post-merge

### DIFF
--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/test/groovy/test/boot/SpringWsTest.groovy
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/test/groovy/test/boot/SpringWsTest.groovy
@@ -88,7 +88,7 @@ class SpringWsTest extends AgentInstrumentationSpecification implements HttpServ
     and:
     assertTraces(1) {
       trace(0, 2) {
-        serverSpan(it, 0, getContextPath() + "/ws")
+        serverSpan(it, 0, getContextPath() + "/ws/*")
         handlerSpan(it, 1, methodName, span(0))
       }
     }
@@ -109,7 +109,7 @@ class SpringWsTest extends AgentInstrumentationSpecification implements HttpServ
     def expectedException = new Exception("hello exception")
     assertTraces(1) {
       trace(0, 2) {
-        serverSpan(it, 0, getContextPath() + "/ws", expectedException)
+        serverSpan(it, 0, getContextPath() + "/ws/*", expectedException)
         handlerSpan(it, 1, methodName, span(0), expectedException)
       }
     }


### PR DESCRIPTION
TBH, I'm a bit surprised to see a low-cardinality name have a longer name now, but I don't know much about servlet :)