### PR TITLE
Add shadowJar as input to test task.

### DIFF
--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -109,6 +109,8 @@ shadowJar {
 evaluationDependsOn(":testing:agent-for-testing")
 
 tasks.withType(Test).configureEach {
+  inputs.file(shadowJar.archiveFile)
+
   jvmArgs "-Dotel.javaagent.debug=true"
   jvmArgs "-javaagent:${project(":testing:agent-for-testing").tasks.shadowJar.archiveFile.get().asFile.absolutePath}"
   jvmArgs "-Dotel.javaagent.experimental.initializer.jar=${shadowJar.archiveFile.get().asFile.absolutePath}"


### PR DESCRIPTION
I thought all outputs are automatically used as inputs when using `dependsOn` but maybe not. That being said, I'm surprised we don't see even more missed tests as this seems to affect any change to the jar, not just `testInstrumentation` transitive ones. Or maybe we just missed the missed tests :)