### PR TITLE
Fix RestTemplateInterceptor so that it calls endExceptionally() on exception

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -31,6 +31,7 @@ ext {
     prometheus        : "0.9.0",
     assertj           : '3.19.0',
     awaitility        : '4.0.3',
+    mockito           : '3.6.0',
     // Caffeine 2.x to support Java 8+. 3.x is 11+.
     caffeine          : '2.9.0',
     testcontainers    : '1.15.2'
@@ -101,6 +102,10 @@ ext {
     coroutines                   : dependencies.create(group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: "${versions.coroutines}"),
     junitApi                     : "org.junit.jupiter:junit-jupiter-api:${versions.junit5}",
     assertj                      : "org.assertj:assertj-core:${versions.assertj}",
-    awaitility                   : "org.awaitility:awaitility:${versions.awaitility}"
+    awaitility                   : "org.awaitility:awaitility:${versions.awaitility}",
+    mockito                      : [
+      "org.mockito:mockito-core:${versions.mockito}",
+      "org.mockito:mockito-junit-jupiter:${versions.mockito}"
+    ]
   ]
 }

--- a/instrumentation-api/instrumentation-api.gradle
+++ b/instrumentation-api/instrumentation-api.gradle
@@ -30,7 +30,7 @@ dependencies {
   annotationProcessor deps.autoValue
 
   testImplementation project(':testing-common')
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation deps.mockito
   testImplementation deps.assertj
   testImplementation deps.awaitility
 }

--- a/instrumentation-core/servlet-2.2/servlet-2.2.gradle
+++ b/instrumentation-core/servlet-2.2/servlet-2.2.gradle
@@ -9,6 +9,6 @@ dependencies {
   compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.2'
 
   testImplementation group: 'javax.servlet', name: 'servlet-api', version: '2.2'
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation deps.mockito
   testImplementation deps.assertj
 }

--- a/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
+++ b/instrumentation/aws-lambda-1.0/library/aws-lambda-1.0-library.gradle
@@ -45,6 +45,6 @@ dependencies {
   testImplementation deps.guava
 
   testImplementation project(':instrumentation:aws-lambda-1.0:testing')
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation deps.mockito
   testImplementation deps.assertj
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/aws-sdk-2.2-library.gradle
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/aws-sdk-2.2-library.gradle
@@ -9,7 +9,7 @@ dependencies {
   testImplementation project(':instrumentation:aws-sdk:aws-sdk-2.2:testing')
 
   testImplementation deps.assertj
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation deps.mockito
 }
 
 test {

--- a/instrumentation/kafka-clients-0.11/javaagent/kafka-clients-0.11-javaagent.gradle
+++ b/instrumentation/kafka-clients-0.11/javaagent/kafka-clients-0.11-javaagent.gradle
@@ -16,7 +16,7 @@ dependencies {
   testLibrary group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '1.3.3.RELEASE'
   testImplementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.3'
   testLibrary group: 'org.assertj', name: 'assertj-core', version: '2.9.+'
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation deps.mockito
 
   // Include latest version of kafka itself along with latest version of client libs.
   // This seems to help with jar compatibility hell.

--- a/instrumentation/kafka-streams-0.11/javaagent/kafka-streams-0.11-javaagent.gradle
+++ b/instrumentation/kafka-streams-0.11/javaagent/kafka-streams-0.11-javaagent.gradle
@@ -19,7 +19,7 @@ dependencies {
   testLibrary group: 'org.springframework.kafka', name: 'spring-kafka-test', version: '1.3.3.RELEASE'
   testImplementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.3'
   testLibrary group: 'org.assertj', name: 'assertj-core', version: '2.9.+'
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation deps.mockito
 
 
   // Include latest version of kafka itself along with latest version of client libs.

--- a/instrumentation/runtime-metrics/library/runtime-metrics-library.gradle
+++ b/instrumentation/runtime-metrics/library/runtime-metrics-library.gradle
@@ -5,5 +5,5 @@ dependencies {
 
   testImplementation deps.opentelemetrySdkMetrics
   testImplementation project(':testing-common')
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation deps.mockito
 }

--- a/instrumentation/spring/spring-web-3.1/library/README.md
+++ b/instrumentation/spring/spring-web-3.1/library/README.md
@@ -10,7 +10,7 @@ Replace `SPRING_VERSION` with the version of spring you're using.
 `Minimum version: 3.1`
 
 Replace `OPENTELEMETRY_VERSION` with the latest stable [release](https://mvnrepository.com/artifact/io.opentelemetry).
-`Minimum version: 0.8.0`
+`Minimum version: 0.17.0`
 
 For Maven add to your `pom.xml`:
 ```xml
@@ -60,8 +60,8 @@ interface. An example is shown below:
 
 ```java
 
-import io.opentelemetry.instrumentation.spring.httpclients.RestTemplateInterceptor
-import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.instrumentation.spring.httpclients.RestTemplateInterceptor;
+import io.opentelemetry.api.OpenTelemetry;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -73,10 +73,10 @@ import org.springframework.web.client.RestTemplate;
 public class RestTemplateConfig {
 
    @Bean
-   public RestTemplate restTemplate(Tracer tracer) {
+   public RestTemplate restTemplate(OpenTelemetry openTelemetry) {
 
       RestTemplate restTemplate = new RestTemplate();
-      RestTemplateInterceptor restTemplateInterceptor = new RestTemplateInterceptor(tracer);
+      RestTemplateInterceptor restTemplateInterceptor = new RestTemplateInterceptor(openTelemetry);
       restTemplate.getInterceptors().add(restTemplateInterceptor);
 
       return restTemplate;

--- a/instrumentation/spring/spring-web-3.1/library/spring-web-3.1-library.gradle
+++ b/instrumentation/spring/spring-web-3.1/library/spring-web-3.1-library.gradle
@@ -2,4 +2,11 @@ apply from: "$rootDir/gradle/instrumentation-library.gradle"
 
 dependencies {
   compileOnly "org.springframework:spring-web:3.1.0.RELEASE"
+
+  testImplementation "org.springframework:spring-web:3.1.0.RELEASE"
+
+  testImplementation project(':testing-common')
+  testImplementation deps.assertj
+  testImplementation deps.mockito
+  testImplementation deps.opentelemetrySdkTesting
 }

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/httpclients/RestTemplateInterceptor.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/httpclients/RestTemplateInterceptor.java
@@ -36,7 +36,9 @@ public final class RestTemplateInterceptor implements ClientHttpRequestIntercept
       ClientHttpResponse response = execution.execute(request, body);
       tracer.end(context, response);
       return response;
+    } catch (Throwable t) {
+      tracer.endExceptionally(context, t);
+      throw t;
     }
-    // TODO: endExceptionally?
   }
 }

--- a/instrumentation/spring/spring-web-3.1/library/src/test/groovy/RestTemplateInstrumentationTest.groovy
+++ b/instrumentation/spring/spring-web-3.1/library/src/test/groovy/RestTemplateInstrumentationTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import io.opentelemetry.instrumentation.spring.httpclients.RestTemplateInterceptor
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import io.opentelemetry.instrumentation.test.base.HttpClientTest
+import org.springframework.http.HttpMethod
+import org.springframework.web.client.ResourceAccessException
+import org.springframework.web.client.RestTemplate
+import spock.lang.Shared
+
+class RestTemplateInstrumentationTest extends HttpClientTest implements LibraryTestTrait {
+  @Shared
+  RestTemplate restTemplate
+
+  def setupSpec() {
+    if (restTemplate == null) {
+      restTemplate = new RestTemplate()
+      restTemplate.getInterceptors().add(new RestTemplateInterceptor(getOpenTelemetry()))
+    }
+  }
+
+  @Override
+  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {
+    try {
+      return restTemplate.execute(uri, HttpMethod.valueOf(method), { request ->
+        headers.forEach(request.getHeaders().&add)
+      }, { response ->
+        callback?.call()
+        response.statusCode.value()
+      })
+    } catch (ResourceAccessException exception) {
+      throw exception.getCause()
+    }
+  }
+
+  @Override
+  boolean testCircularRedirects() {
+    false
+  }
+
+  @Override
+  boolean testRemoteConnection() {
+    false
+  }
+}

--- a/instrumentation/spring/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/httpclients/RestTemplateInterceptorTest.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/httpclients/RestTemplateInterceptorTest.java
@@ -6,32 +6,18 @@
 package io.opentelemetry.instrumentation.spring.httpclients;
 
 import static io.opentelemetry.instrumentation.testing.util.TraceUtils.withClientSpan;
-import static io.opentelemetry.instrumentation.testing.util.TraceUtils.withSpan;
 import static io.opentelemetry.sdk.testing.assertj.TracesAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
-import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.data.StatusData;
-import java.io.IOException;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpRequest;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpRequestExecution;
-import org.springframework.http.client.ClientHttpResponse;
 
 @ExtendWith(MockitoExtension.class)
 class RestTemplateInterceptorTest {
@@ -40,9 +26,7 @@ class RestTemplateInterceptorTest {
       LibraryInstrumentationExtension.create();
 
   @Mock HttpRequest httpRequestMock;
-  @Mock HttpHeaders httpHeadersMock;
   @Mock ClientHttpRequestExecution requestExecutionMock;
-  @Mock ClientHttpResponse httpResponseMock;
   byte[] requestBody = new byte[0];
 
   @Test
@@ -66,77 +50,5 @@ class RestTemplateInterceptorTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasKind(SpanKind.CLIENT)));
-  }
-
-  @Test
-  void shouldStartAndEndSpan() throws Exception {
-    // given
-    RestTemplateInterceptor interceptor =
-        new RestTemplateInterceptor(instrumentation.getOpenTelemetry());
-
-    given(httpRequestMock.getMethod()).willReturn(HttpMethod.GET);
-    given(httpRequestMock.getHeaders()).willReturn(httpHeadersMock);
-
-    given(requestExecutionMock.execute(httpRequestMock, requestBody)).willReturn(httpResponseMock);
-
-    given(httpResponseMock.getStatusCode()).willReturn(HttpStatus.OK);
-
-    // when
-    ClientHttpResponse actual =
-        withSpan(
-            "parent",
-            () -> interceptor.intercept(httpRequestMock, requestBody, requestExecutionMock));
-
-    // then
-    assertSame(httpResponseMock, actual);
-
-    then(httpHeadersMock).should().set(eq("traceparent"), anyString());
-
-    List<List<SpanData>> traces = instrumentation.waitForTraces(1);
-    assertThat(traces)
-        .hasTracesSatisfyingExactly(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    parentSpan -> parentSpan.hasName("parent").hasKind(SpanKind.INTERNAL),
-                    span -> span.hasName("HTTP GET").hasKind(SpanKind.CLIENT)));
-  }
-
-  @Test
-  void shouldStartAndEndSpanWithException() throws Exception {
-    // given
-    RestTemplateInterceptor interceptor =
-        new RestTemplateInterceptor(instrumentation.getOpenTelemetry());
-
-    given(httpRequestMock.getMethod()).willReturn(HttpMethod.GET);
-    given(httpRequestMock.getHeaders()).willReturn(httpHeadersMock);
-
-    Exception thrown = new IOException("boom");
-    given(requestExecutionMock.execute(httpRequestMock, requestBody)).willThrow(thrown);
-
-    // when
-    IOException actual =
-        assertThrows(
-            IOException.class,
-            () ->
-                withSpan(
-                    "parent",
-                    () ->
-                        interceptor.intercept(httpRequestMock, requestBody, requestExecutionMock)));
-
-    // then
-    assertSame(thrown, actual);
-
-    then(httpHeadersMock).should().set(eq("traceparent"), anyString());
-
-    List<List<SpanData>> traces = instrumentation.waitForTraces(1);
-    assertThat(traces)
-        .hasTracesSatisfyingExactly(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    parentSpan -> parentSpan.hasName("parent").hasKind(SpanKind.INTERNAL),
-                    span ->
-                        span.hasName("HTTP GET")
-                            .hasKind(SpanKind.CLIENT)
-                            .hasStatus(StatusData.error())));
   }
 }

--- a/instrumentation/spring/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/httpclients/RestTemplateInterceptorTest.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/httpclients/RestTemplateInterceptorTest.java
@@ -1,0 +1,137 @@
+package io.opentelemetry.instrumentation.spring.httpclients;
+
+import static io.opentelemetry.instrumentation.testing.util.TraceUtils.withClientSpan;
+import static io.opentelemetry.instrumentation.testing.util.TraceUtils.withSpan;
+import static io.opentelemetry.sdk.testing.assertj.TracesAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+
+@ExtendWith(MockitoExtension.class)
+class RestTemplateInterceptorTest {
+  @RegisterExtension
+  static final LibraryInstrumentationExtension instrumentation =
+      LibraryInstrumentationExtension.create();
+
+  @Mock HttpRequest httpRequestMock;
+  @Mock HttpHeaders httpHeadersMock;
+  @Mock ClientHttpRequestExecution requestExecutionMock;
+  @Mock ClientHttpResponse httpResponseMock;
+  byte[] requestBody = new byte[0];
+
+  @Test
+  void shouldSkipWhenContextHasClientSpan() throws Exception {
+    // given
+    RestTemplateInterceptor interceptor =
+        new RestTemplateInterceptor(instrumentation.getOpenTelemetry());
+
+    // when
+    withClientSpan(
+        "parent",
+        () -> {
+          interceptor.intercept(httpRequestMock, requestBody, requestExecutionMock);
+        });
+
+    // then
+    then(requestExecutionMock).should().execute(httpRequestMock, requestBody);
+
+    assertThat(instrumentation.waitForTraces(1))
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.CLIENT)));
+  }
+
+  @Test
+  void shouldStartAndEndSpan() throws Exception {
+    // given
+    RestTemplateInterceptor interceptor =
+        new RestTemplateInterceptor(instrumentation.getOpenTelemetry());
+
+    given(httpRequestMock.getMethod()).willReturn(HttpMethod.GET);
+    given(httpRequestMock.getHeaders()).willReturn(httpHeadersMock);
+
+    given(requestExecutionMock.execute(httpRequestMock, requestBody)).willReturn(httpResponseMock);
+
+    given(httpResponseMock.getStatusCode()).willReturn(HttpStatus.OK);
+
+    // when
+    ClientHttpResponse actual =
+        withSpan(
+            "parent",
+            () -> interceptor.intercept(httpRequestMock, requestBody, requestExecutionMock));
+
+    // then
+    assertSame(httpResponseMock, actual);
+
+    then(httpHeadersMock).should().set(eq("traceparent"), anyString());
+
+    List<List<SpanData>> traces = instrumentation.waitForTraces(1);
+    assertThat(traces)
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    parentSpan -> parentSpan.hasName("parent").hasKind(SpanKind.INTERNAL),
+                    span -> span.hasName("HTTP GET").hasKind(SpanKind.CLIENT)));
+  }
+
+  @Test
+  void shouldStartAndEndSpanWithException() throws Exception {
+    // given
+    RestTemplateInterceptor interceptor =
+        new RestTemplateInterceptor(instrumentation.getOpenTelemetry());
+
+    given(httpRequestMock.getMethod()).willReturn(HttpMethod.GET);
+    given(httpRequestMock.getHeaders()).willReturn(httpHeadersMock);
+
+    Exception thrown = new IOException("boom");
+    given(requestExecutionMock.execute(httpRequestMock, requestBody)).willThrow(thrown);
+
+    // when
+    IOException actual =
+        assertThrows(
+            IOException.class,
+            () ->
+                withSpan(
+                    "parent",
+                    () ->
+                        interceptor.intercept(httpRequestMock, requestBody, requestExecutionMock)));
+
+    // then
+    assertSame(thrown, actual);
+
+    then(httpHeadersMock).should().set(eq("traceparent"), anyString());
+
+    List<List<SpanData>> traces = instrumentation.waitForTraces(1);
+    assertThat(traces)
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    parentSpan -> parentSpan.hasName("parent").hasKind(SpanKind.INTERNAL),
+                    span ->
+                        span.hasName("HTTP GET")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasStatus(StatusData.error())));
+  }
+}

--- a/instrumentation/spring/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/httpclients/RestTemplateInterceptorTest.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/httpclients/RestTemplateInterceptorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.spring.httpclients;
 
 import static io.opentelemetry.instrumentation.testing.util.TraceUtils.withClientSpan;

--- a/javaagent-api/javaagent-api.gradle
+++ b/javaagent-api/javaagent-api.gradle
@@ -13,6 +13,6 @@ dependencies {
   implementation project(':instrumentation-api')
 
   testImplementation project(':testing-common')
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation deps.mockito
   testImplementation deps.assertj
 }

--- a/javaagent-bootstrap/javaagent-bootstrap.gradle
+++ b/javaagent-bootstrap/javaagent-bootstrap.gradle
@@ -40,6 +40,6 @@ dependencies {
   implementation project(':instrumentation-api')
 
   testImplementation project(':testing-common')
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation deps.mockito
   testImplementation deps.assertj
 }

--- a/javaagent-tooling/javaagent-tooling.gradle
+++ b/javaagent-tooling/javaagent-tooling.gradle
@@ -62,7 +62,7 @@ dependencies {
 
   testImplementation project(':testing-common')
   testImplementation deps.assertj
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'
+  testImplementation deps.mockito
 
   instrumentationMuzzle sourceSets.main.output
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/utils/TraceUtils.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/utils/TraceUtils.groovy
@@ -16,10 +16,10 @@ import io.opentelemetry.instrumentation.test.asserts.AttributesAssert
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.server.ServerTraceUtils
 import io.opentelemetry.sdk.trace.data.SpanData
-
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutionException
 
+// TODO: convert all usages of this class to the Java TraceUtils one
 class TraceUtils {
 
   private static final Tracer tracer = GlobalOpenTelemetry.getTracer("test")

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ThrowingRunnable.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ThrowingRunnable.java
@@ -1,0 +1,11 @@
+package io.opentelemetry.instrumentation.testing.util;
+
+/**
+ * A utility interface representing a {@link Runnable} that may throw.
+ *
+ * @param <E> Thrown exception type.
+ */
+@FunctionalInterface
+public interface ThrowingRunnable<E extends Throwable> {
+  void run() throws E;
+}

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ThrowingRunnable.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ThrowingRunnable.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.testing.util;
 
 /**

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ThrowingSupplier.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ThrowingSupplier.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.testing.util;
 
 import java.util.function.Supplier;

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ThrowingSupplier.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ThrowingSupplier.java
@@ -1,0 +1,13 @@
+package io.opentelemetry.instrumentation.testing.util;
+
+import java.util.function.Supplier;
+
+/**
+ * A utility interface representing a {@link Supplier} that may throw.
+ *
+ * @param <E> Thrown exception type.
+ */
+@FunctionalInterface
+public interface ThrowingSupplier<T, E extends Throwable> {
+  T get() throws E;
+}

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TraceUtils.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TraceUtils.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.testing.util;
 
 import io.opentelemetry.api.trace.Span;

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TraceUtils.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TraceUtils.java
@@ -1,0 +1,101 @@
+package io.opentelemetry.instrumentation.testing.util;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
+
+/** Utility class for creating spans in tests. */
+public final class TraceUtils {
+
+  private static final TestTracer TRACER = new TestTracer();
+
+  public static <E extends Exception> void withSpan(String spanName, ThrowingRunnable<E> callback)
+      throws E {
+    withSpan(
+        spanName,
+        () -> {
+          callback.run();
+          return null;
+        });
+  }
+
+  public static <T, E extends Throwable> T withSpan(
+      String spanName, ThrowingSupplier<T, E> callback) throws E {
+    Context context = TRACER.startSpan(spanName);
+    try (Scope ignored = context.makeCurrent()) {
+      T result = callback.get();
+      TRACER.end(context);
+      return result;
+    } catch (Throwable t) {
+      TRACER.endExceptionally(context, t);
+      throw t;
+    }
+  }
+
+  public static <E extends Throwable> void withClientSpan(
+      String spanName, ThrowingRunnable<E> callback) throws E {
+    withClientSpan(
+        spanName,
+        () -> {
+          callback.run();
+          return null;
+        });
+  }
+
+  public static <T, E extends Throwable> T withClientSpan(
+      String spanName, ThrowingSupplier<T, E> callback) throws E {
+    Context context = TRACER.startClientSpan(spanName);
+    try (Scope ignored = context.makeCurrent()) {
+      T result = callback.get();
+      TRACER.end(context);
+      return result;
+    } catch (Throwable t) {
+      TRACER.endExceptionally(context, t);
+      throw t;
+    }
+  }
+
+  public static <E extends Throwable> void withServerSpan(
+      String spanName, ThrowingRunnable<E> callback) throws E {
+    withServerSpan(
+        spanName,
+        () -> {
+          callback.run();
+          return null;
+        });
+  }
+
+  public static <T, E extends Throwable> T withServerSpan(
+      String spanName, ThrowingSupplier<T, E> callback) throws E {
+    Context context = TRACER.startServerSpan(spanName);
+    try (Scope ignored = context.makeCurrent()) {
+      T result = callback.get();
+      TRACER.end(context);
+      return result;
+    } catch (Throwable t) {
+      TRACER.endExceptionally(context, t);
+      throw t;
+    }
+  }
+
+  private static final class TestTracer extends BaseTracer {
+    @Override
+    protected String getInstrumentationName() {
+      return "test";
+    }
+
+    Context startClientSpan(String name) {
+      Span span = spanBuilder(name, SpanKind.CLIENT).startSpan();
+      return withClientSpan(Context.current(), span);
+    }
+
+    Context startServerSpan(String name) {
+      Span span = spanBuilder(name, SpanKind.SERVER).startSpan();
+      return withServerSpan(Context.current(), span);
+    }
+  }
+
+  private TraceUtils() {}
+}

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TraceUtils.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TraceUtils.java
@@ -92,13 +92,15 @@ public final class TraceUtils {
     }
 
     Context startClientSpan(String name) {
-      Span span = spanBuilder(name, SpanKind.CLIENT).startSpan();
-      return withClientSpan(Context.current(), span);
+      Context parentContext = Context.current();
+      Span span = spanBuilder(parentContext, name, SpanKind.CLIENT).startSpan();
+      return withClientSpan(parentContext, span);
     }
 
     Context startServerSpan(String name) {
-      Span span = spanBuilder(name, SpanKind.SERVER).startSpan();
-      return withServerSpan(Context.current(), span);
+      Context parentContext = Context.current();
+      Span span = spanBuilder(parentContext, name, SpanKind.SERVER).startSpan();
+      return withServerSpan(parentContext, span);
     }
   }
 

--- a/testing-common/testing-common.gradle
+++ b/testing-common/testing-common.gradle
@@ -25,6 +25,7 @@ dependencies {
   implementation deps.slf4j
   implementation deps.testLogging
   implementation deps.opentelemetryExtAnnotations
+  implementation project(':instrumentation-api')
 
   api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.0'
   api group: 'com.squareup.okhttp3', name: 'logging-interceptor', version: '4.9.0'
@@ -37,7 +38,6 @@ dependencies {
 
   testImplementation deps.assertj
 
-  testImplementation project(':instrumentation-api')
   testImplementation project(':javaagent-api')
   testImplementation project(':javaagent-tooling')
   testImplementation project(':instrumentation:external-annotations:javaagent')


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2479

I've added a few testing changes in this PR because I wouldn't be able to unit-test my change otherwise:
* implemented a new `TraceUtils` class in testing-common; contrary to the old one it uses `BaseTracer` to create spans, so we can now test span suppression;
* added mockito to dependencies.gradle