### PR TITLE
Fix shading of caching artifact.

### DIFF
--- a/instrumentation-api-caching/instrumentation-api-caching.gradle
+++ b/instrumentation-api-caching/instrumentation-api-caching.gradle
@@ -7,17 +7,24 @@ group = 'io.opentelemetry.instrumentation'
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
 
+configurations {
+  shadowInclude
+}
+
 dependencies {
-  implementation(deps.caffeine) {
+  compileOnly deps.caffeine
+  shadowInclude(deps.caffeine) {
     exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
     exclude group: 'org.checkerframework', module: 'checker-qual'
   }
 }
 
 shadowJar {
+  configurations = [project.configurations.shadowInclude]
+
   archiveClassifier.set("")
 
-  relocate "com.github.benmanes.caffeine", "io.opentelemetry.instrumentation.internal.shaded.caffeine"
+  relocate "com.github.benmanes.caffeine", "io.opentelemetry.instrumentation.api.internal.shaded.caffeine"
 
   minimize()
 }

--- a/javaagent-bootstrap/javaagent-bootstrap.gradle
+++ b/javaagent-bootstrap/javaagent-bootstrap.gradle
@@ -15,7 +15,7 @@ sourceSets {
 }
 jar {
   from(sourceSets.patch.output) {
-    include 'io/opentelemetry/instrumentation/internal/shaded/caffeine/cache/BoundedLocalCache$PerformCleanupTask.class'
+    include 'io/opentelemetry/instrumentation/api/internal/shaded/caffeine/cache/BoundedLocalCache$PerformCleanupTask.class'
   }
 }
 

--- a/javaagent-bootstrap/src/patch/java/io/opentelemetry/instrumentation/api/internal/shaded/caffeine/cache/BoundedLocalCache.java
+++ b/javaagent-bootstrap/src/patch/java/io/opentelemetry/instrumentation/api/internal/shaded/caffeine/cache/BoundedLocalCache.java
@@ -35,7 +35,7 @@
  * limitations under the License.
  */
 
-package io.opentelemetry.instrumentation.internal.shaded.caffeine.cache;
+package io.opentelemetry.instrumentation.api.internal.shaded.caffeine.cache;
 
 import java.lang.ref.WeakReference;
 


### PR DESCRIPTION
- Moves shaded package to `instrumentation.api` to match our relocation rules
- Uses special configuration for inclusion so `javaagent` doesn't transitively pick up caffeine itself too and add it unshaded

This seems to have gotten through the build before due to the other caching problem.

