### PR TITLE
Exclude bad couchbase versions from muzzle

### DIFF
--- a/instrumentation/couchbase/couchbase-3.1/javaagent/couchbase-3.1-javaagent.gradle
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/couchbase-3.1-javaagent.gradle
@@ -5,6 +5,8 @@ muzzle {
     group = "com.couchbase.client"
     module = "java-client"
     versions = "[3.1,)"
+    // Version 2.7.5 and 2.7.8 were not released properly and muzzle cannot test against it causing failure.
+    skipVersions += ['2.7.5', '2.7.8']
     assertInverse = true
   }
 }


### PR DESCRIPTION
Copied from `couchbase-2.6-javaagent.gradle`