### PR TITLE
Add missing @Unroll to jax-rs 1 tests

### DIFF
--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -14,6 +14,7 @@ import javax.ws.rs.OPTIONS
 import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
+import spock.lang.Unroll
 
 class JaxRsAnnotations1InstrumentationTest extends AgentInstrumentationSpecification {
 
@@ -38,6 +39,7 @@ class JaxRsAnnotations1InstrumentationTest extends AgentInstrumentationSpecifica
     }
   }
 
+  @Unroll
   def "span named '#paramName' from annotations on class when is not root span"() {
     setup:
     runUnderServerTrace("test") {

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JerseyTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JerseyTest.groovy
@@ -10,6 +10,7 @@ import io.dropwizard.testing.junit.ResourceTestRule
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.junit.ClassRule
 import spock.lang.Shared
+import spock.lang.Unroll
 
 class JerseyTest extends AgentInstrumentationSpecification {
 
@@ -21,6 +22,7 @@ class JerseyTest extends AgentInstrumentationSpecification {
     .addResource(new Resource.Test3())
     .build()
 
+  @Unroll
   def "test #resource"() {
     when:
     // start a trace because the test doesn't go through any servlet or other instrumentation.


### PR DESCRIPTION
To avoid test failures like this one:

```
Execution failed for task ':instrumentation:jaxrs:jaxrs-1.0:javaagent:test'.
> Received a failure event for test with unknown id '23.11'. Registered test ids: '[:instrumentation:jaxrs:jaxrs-1.0:javaagent:test, 23.2, 23.1]'
```