### PR TITLE
Remove unnecessary libs from javaagent test classpath

### DIFF
--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -130,9 +130,13 @@ tasks.withType(Test).configureEach {
     if (file("$buildDir/resources/main").equals(it) || file("$buildDir/classes/java/main").equals(it)) {
       return false
     }
-    // If agent depends on library instrumentation, it will be packaged into the testing jar so we
-    // need to make sure to exclude from the test classpath.
-    if (it.absolutePath.startsWith(file("${projectDir.parent}/library/build/libs").absolutePath)) {
+    // If agent depends on some shared instrumentation module that is not a testing module, it will
+    // be packaged into the testing jar so we need to make sure to exclude from the test classpath.
+    String libPath = it.absolutePath
+    String instrumentationPath = file("${rootDir}/instrumentation/").absolutePath
+    if (libPath.startsWith(instrumentationPath) &&
+      libPath.endsWith(".jar") &&
+      !libPath.substring(instrumentationPath.size()).contains("testing")) {
       return false
     }
     return true

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 
-import io.opentelemetry.instrumentation.api.config.Config
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -26,8 +26,6 @@ import server.TestController
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [SpringWebFluxTestApplication, ForceNettyAutoConfiguration])
 class SpringWebfluxTest extends AgentInstrumentationSpecification {
-  static Config previousConfig
-
   @TestConfiguration
   static class ForceNettyAutoConfiguration {
     @Bean

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 


### PR DESCRIPTION
All `javaagent` & `library` modules are now filtered out: for instance, `hibernate-3.3:javaagent` tests no longer have `hibernate-common:javaagent` on classpath (previously they had).

Honestly this is kind of hacky, but I don't know gradle enough to solve that "properly" - maybe it is possible to filter out all `implementation` libraries from the classpath?