### PR TITLE
Use instance field for wrapped lambda instead of static.

### DIFF
--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapper.java
@@ -21,7 +21,7 @@ public class TracingRequestApiGatewayWrapper
   }
 
   // Visible for testing
-  TracingRequestApiGatewayWrapper(OpenTelemetrySdk openTelemetrySdk) {
-    super(openTelemetrySdk);
+  TracingRequestApiGatewayWrapper(OpenTelemetrySdk openTelemetrySdk, WrappedLambda wrappedLambda) {
+    super(openTelemetrySdk, wrappedLambda);
   }
 }

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapper.java
@@ -21,29 +21,28 @@ import java.io.OutputStream;
  */
 public class TracingRequestStreamWrapper extends TracingRequestStreamHandler {
 
-  // visible for testing
-  static WrappedLambda WRAPPED_LAMBDA = WrappedLambda.fromConfiguration();
+  private final WrappedLambda wrappedLambda;
 
   public TracingRequestStreamWrapper() {
-    this(OpenTelemetrySdkAutoConfiguration.initialize());
+    this(OpenTelemetrySdkAutoConfiguration.initialize(), WrappedLambda.fromConfiguration());
   }
 
   // Visible for testing
-  TracingRequestStreamWrapper(OpenTelemetrySdk openTelemetrySdk) {
+  TracingRequestStreamWrapper(OpenTelemetrySdk openTelemetrySdk, WrappedLambda wrappedLambda) {
     super(openTelemetrySdk, WrapperConfiguration.flushTimeout());
+    this.wrappedLambda = wrappedLambda;
   }
 
   @Override
   protected void doHandleRequest(InputStream inputStream, OutputStream output, Context context)
       throws IOException {
 
-    if (!(WRAPPED_LAMBDA.getTargetObject() instanceof RequestStreamHandler)) {
+    if (!(wrappedLambda.getTargetObject() instanceof RequestStreamHandler)) {
       throw new RuntimeException(
-          WRAPPED_LAMBDA.getTargetClass().getName()
-              + " is not an instance of RequestStreamHandler");
+          wrappedLambda.getTargetClass().getName() + " is not an instance of RequestStreamHandler");
     }
 
-    ((RequestStreamHandler) WRAPPED_LAMBDA.getTargetObject())
+    ((RequestStreamHandler) wrappedLambda.getTargetObject())
         .handleRequest(inputStream, output, context);
   }
 }

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapper.java
@@ -17,7 +17,7 @@ public class TracingRequestWrapper extends TracingRequestWrapperBase<Object, Obj
   }
 
   // Visible for testing
-  TracingRequestWrapper(OpenTelemetrySdk openTelemetrySdk) {
-    super(openTelemetrySdk);
+  TracingRequestWrapper(OpenTelemetrySdk openTelemetrySdk, WrappedLambda wrappedLambda) {
+    super(openTelemetrySdk, wrappedLambda);
   }
 }

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapperTest.groovy
@@ -38,7 +38,7 @@ class TracingRequestApiGatewayWrapperTest extends TracingRequestWrapperTestBase 
 
   def "handler traced with trace propagation"() {
     given:
-    setLambda(TestApiGatewayHandler.getName() + "::handleRequest", { new TracingRequestApiGatewayWrapper(it) })
+    setLambda(TestApiGatewayHandler.getName() + "::handleRequest", TracingRequestApiGatewayWrapper.metaClass.&invokeConstructor)
 
     def headers = ImmutableMap.builder()
       .putAll(propagationHeaders())
@@ -83,7 +83,7 @@ class TracingRequestApiGatewayWrapperTest extends TracingRequestWrapperTestBase 
 
   def "test empty request & response"() {
     given:
-    setLambda(TestApiGatewayHandler.getName() + "::handleRequest", { new TracingRequestApiGatewayWrapper(it) })
+    setLambda(TestApiGatewayHandler.getName() + "::handleRequest", TracingRequestApiGatewayWrapper.metaClass.&invokeConstructor)
 
     def input = new APIGatewayProxyRequestEvent()
       .withBody("empty")

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
@@ -49,8 +49,7 @@ class TracingRequestStreamWrapperPropagationTest extends LibraryInstrumentationS
 
   def setup() {
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, "io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestStreamWrapperPropagationTest\$TestRequestHandler::handleRequest")
-    TracingRequestStreamWrapper.WRAPPED_LAMBDA = WrappedLambda.fromConfiguration()
-    wrapper = new TracingRequestStreamWrapper(testRunner().openTelemetrySdk)
+    wrapper = new TracingRequestStreamWrapper(testRunner().openTelemetrySdk, WrappedLambda.fromConfiguration())
   }
 
   def cleanup() {

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
@@ -45,8 +45,7 @@ class TracingRequestStreamWrapperTest extends LibraryInstrumentationSpecificatio
 
   def setup() {
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, "io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestStreamWrapperTest\$TestRequestHandler::handleRequest")
-    TracingRequestStreamWrapper.WRAPPED_LAMBDA = WrappedLambda.fromConfiguration()
-    wrapper = new TracingRequestStreamWrapper(testRunner().openTelemetrySdk)
+    wrapper = new TracingRequestStreamWrapper(testRunner().openTelemetrySdk, WrappedLambda.fromConfiguration())
   }
 
   def cleanup() {

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
@@ -27,7 +27,7 @@ class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
 
   def "handler string traced"() {
     given:
-    setLambda(TestRequestHandlerString.getName() + "::handleRequest", { new TracingRequestWrapper(it) })
+    setLambda(TestRequestHandlerString.getName() + "::handleRequest", TracingRequestWrapper.metaClass.&invokeConstructor)
 
     when:
     def result = wrapper.handleRequest("hello", context)
@@ -51,7 +51,7 @@ class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
 
   def "handler with exception"() {
     given:
-    setLambda(TestRequestHandlerString.getName() + "::handleRequest", { new TracingRequestWrapper(it) })
+    setLambda(TestRequestHandlerString.getName() + "::handleRequest", TracingRequestWrapper.metaClass.&invokeConstructor)
 
     when:
     def thrown

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
@@ -31,7 +31,6 @@ class TracingRequestWrapperTestBase extends LibraryInstrumentationSpecification 
 
   def setLambda(handler, Closure<TracingRequestWrapperBase> wrapperConstructor) {
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, handler)
-    TracingRequestWrapper.WRAPPED_LAMBDA = WrappedLambda.fromConfiguration()
-    wrapper = wrapperConstructor.call(testRunner().openTelemetrySdk)
+    wrapper = wrapperConstructor.call(testRunner().openTelemetrySdk, WrappedLambda.fromConfiguration())
   }
 }


### PR DESCRIPTION
Otherwise wrapped lambda is initialized on wrapper's classload, before wrapper + opentelemetry SDK load, which is surprising.