### PR TITLE
Add metrics collection to smoke-tests' fake-backend

### DIFF
--- a/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
+++ b/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
@@ -102,7 +102,7 @@ public class FakeBackendMain {
             .service(
                 "/get-metrics",
                 (ctx, req) -> {
-                  var requests = traceCollector.getRequests();
+                  var requests = metricsCollector.getRequests();
                   var buf = new ByteBufOutputStream(ctx.alloc().buffer());
                   OBJECT_MAPPER.writeValue((OutputStream) buf, requests);
                   return HttpResponse.of(

--- a/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
+++ b/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import io.netty.buffer.ByteBufOutputStream;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -43,6 +44,7 @@ public class FakeBackendMain {
     var marshaller =
         MessageMarshaller.builder()
             .register(ExportTraceServiceRequest.getDefaultInstance())
+            .register(ExportMetricsServiceRequest.getDefaultInstance())
             .build();
 
     var mapper = JsonMapper.builder();
@@ -57,27 +59,50 @@ public class FakeBackendMain {
             marshaller.writeValue(value, gen);
           }
         });
+    serializers.addSerializer(
+        new StdSerializer<>(ExportMetricsServiceRequest.class) {
+          @Override
+          public void serialize(
+              ExportMetricsServiceRequest value, JsonGenerator gen, SerializerProvider provider)
+              throws IOException {
+            marshaller.writeValue(value, gen);
+          }
+        });
     module.setSerializers(serializers);
     mapper.addModule(module);
     OBJECT_MAPPER = mapper.build();
   }
 
   public static void main(String[] args) {
-    var collector = new FakeCollectorService();
+    var traceCollector = new FakeTraceCollectorService();
+    var metricsCollector = new FakeMetricsCollectorService();
     var server =
         Server.builder()
             .http(8080)
-            .service(GrpcService.builder().addService(collector).build())
+            .service(GrpcService.builder()
+                .addService(traceCollector)
+                .addService(metricsCollector)
+                .build())
             .service(
-                "/clear-requests",
+                "/clear",
                 (ctx, req) -> {
-                  collector.clearRequests();
+                  traceCollector.clearRequests();
+                  metricsCollector.clearRequests();
                   return HttpResponse.of(HttpStatus.OK);
                 })
             .service(
-                "/get-requests",
+                "/get-traces",
                 (ctx, req) -> {
-                  var requests = collector.getRequests();
+                  var requests = traceCollector.getRequests();
+                  var buf = new ByteBufOutputStream(ctx.alloc().buffer());
+                  OBJECT_MAPPER.writeValue((OutputStream) buf, requests);
+                  return HttpResponse.of(
+                      HttpStatus.OK, MediaType.JSON, HttpData.wrap(buf.buffer()));
+                })
+            .service(
+                "/get-metrics",
+                (ctx, req) -> {
+                  var requests = traceCollector.getRequests();
                   var buf = new ByteBufOutputStream(ctx.alloc().buffer());
                   OBJECT_MAPPER.writeValue((OutputStream) buf, requests);
                   return HttpResponse.of(

--- a/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeMetricsCollectorService.java
+++ b/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeMetricsCollectorService.java
@@ -1,0 +1,33 @@
+package io.opentelemetry.smoketest.fakebackend;
+
+import com.google.common.collect.ImmutableList;
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+class FakeMetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase {
+
+  private final BlockingQueue<ExportMetricsServiceRequest> exportRequests =
+      new LinkedBlockingDeque<>();
+
+  List<ExportMetricsServiceRequest> getRequests() {
+    return ImmutableList.copyOf(exportRequests);
+  }
+
+  void clearRequests() {
+    exportRequests.clear();
+  }
+
+  @Override
+  public void export(
+      ExportMetricsServiceRequest request,
+      StreamObserver<ExportMetricsServiceResponse> responseObserver) {
+    exportRequests.add(request);
+    responseObserver.onNext(ExportMetricsServiceResponse.getDefaultInstance());
+    responseObserver.onCompleted();
+  }
+}

--- a/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeTraceCollectorService.java
+++ b/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeTraceCollectorService.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 
-class FakeCollectorService extends TraceServiceGrpc.TraceServiceImplBase {
+class FakeTraceCollectorService extends TraceServiceGrpc.TraceServiceImplBase {
 
   private final BlockingQueue<ExportTraceServiceRequest> exportRequests =
       new LinkedBlockingDeque<>();


### PR DESCRIPTION
In next PR I'll add some assertions to our smoke tests that verify that JVM runtime metrics are exported.