### PR TITLE
Apply new muzzle feature to mongo instrumentation

### DIFF
--- a/instrumentation/mongo/mongo-3.7/javaagent/mongo-3.7-javaagent.gradle
+++ b/instrumentation/mongo/mongo-3.7/javaagent/mongo-3.7-javaagent.gradle
@@ -14,7 +14,7 @@ muzzle {
     // the legacy API instrumented in mongo-3.1 continues to be shipped in 4.x, but doesn't conflict here
     // because they are triggered by different types: MongoClientSettings(new) vs MongoClientOptions(legacy)
     versions = "[3.7,)"
-    extraDependency "org.mongodb:bson:3.7.0"
+    extraDependency "org.mongodb:bson"
     assertInverse = true
   }
 }

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/mongo-async-3.3-javaagent.gradle
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/mongo-async-3.3-javaagent.gradle
@@ -5,7 +5,7 @@ muzzle {
     group = "org.mongodb"
     module = "mongodb-driver-async"
     versions = "[3.3,)"
-    extraDependency 'org.mongodb:mongo-java-driver:3.3.0'
+    extraDependency 'org.mongodb:mongo-java-driver'
     assertInverse = true
   }
 }


### PR DESCRIPTION
Didn't notice anywhere else that it applies, but applies nicely to mongo instrumentation.