### PR TITLE
Increase smoke test timeout

### DIFF
--- a/smoke-tests/smoke-tests.gradle
+++ b/smoke-tests/smoke-tests.gradle
@@ -32,7 +32,7 @@ test {
   inputs.files(tasks.findByPath(':javaagent:shadowJar').outputs.files)
   maxParallelForks = 2
 
-  timeout.set(Duration.ofMinutes(30))
+  timeout.set(Duration.ofMinutes(60))
 
   //We enable/disable smoke tests based on the java version requests
   //In addition to that we disable them by default on local machines


### PR DESCRIPTION
Saw a failure due to the 30 min timeout. Checked and saw a couple of successful runs in the 20-25 min range, so makes sense to bump for now until we break it up into multiple jobs.