### PR TITLE
Run instrumentation that injects helper resources last.

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -246,7 +246,10 @@ public class AgentInstaller {
     return SafeServiceLoader.load(
             InstrumentationModule.class, AgentInstaller.class.getClassLoader())
         .stream()
-        .sorted(Comparator.comparingInt(InstrumentationModule::getOrder))
+        .sorted(
+            Comparator.comparingInt(InstrumentationModule::getOrder)
+                // Run instrumentation which injects helpers later since it initializes a weak map.
+                .thenComparing(module -> module.helperResourceNames().length))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
While working on #2601 I noticed that ever since adding HelperResources, there's a weak map in the bootstrap classloader. It brought me to think about #2612 - since weak map uses runnable, does it cause runnable to become uninstrumentable? This is just a strawman's PR, without knowing how to verify #2612 it doesn't make too muh sense.