### PR TITLE
Add runtime.jvm.gc.collection.count metric

### DIFF
--- a/instrumentation/runtime-metrics/javaagent/src/test/groovy/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsTest.groovy
+++ b/instrumentation/runtime-metrics/javaagent/src/test/groovy/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsTest.groovy
@@ -17,6 +17,7 @@ class RuntimeMetricsTest extends AgentInstrumentationSpecification {
     then:
     conditions.eventually {
       assert getMetrics().any { it.name == "runtime.jvm.gc.collection" }
+      assert getMetrics().any { it.name == "runtime.jvm.gc.collection.count" }
       assert getMetrics().any { it.name == "runtime.jvm.memory.area" }
       assert getMetrics().any { it.name == "runtime.jvm.memory.pool" }
     }

--- a/instrumentation/runtime-metrics/javaagent/src/test/groovy/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsTest.groovy
+++ b/instrumentation/runtime-metrics/javaagent/src/test/groovy/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsTest.groovy
@@ -16,7 +16,7 @@ class RuntimeMetricsTest extends AgentInstrumentationSpecification {
 
     then:
     conditions.eventually {
-      assert getMetrics().any { it.name == "runtime.jvm.gc.collection" }
+      assert getMetrics().any { it.name == "runtime.jvm.gc.collection.time" }
       assert getMetrics().any { it.name == "runtime.jvm.gc.collection.count" }
       assert getMetrics().any { it.name == "runtime.jvm.memory.area" }
       assert getMetrics().any { it.name == "runtime.jvm.memory.pool" }

--- a/instrumentation/runtime-metrics/javaagent/src/test/groovy/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsTest.groovy
+++ b/instrumentation/runtime-metrics/javaagent/src/test/groovy/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsTest.groovy
@@ -16,8 +16,8 @@ class RuntimeMetricsTest extends AgentInstrumentationSpecification {
 
     then:
     conditions.eventually {
-      assert getMetrics().any { it.name == "runtime.jvm.gc.collection.time" }
-      assert getMetrics().any { it.name == "runtime.jvm.gc.collection.count" }
+      assert getMetrics().any { it.name == "runtime.jvm.gc.time" }
+      assert getMetrics().any { it.name == "runtime.jvm.gc.count" }
       assert getMetrics().any { it.name == "runtime.jvm.memory.area" }
       assert getMetrics().any { it.name == "runtime.jvm.memory.pool" }
     }

--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
@@ -25,8 +25,8 @@ import java.util.List;
  * <p>Example metrics being exported:
  *
  * <pre>
- *   runtime.jvm.gc.collection.time{gc="PS1"} 6.7
- *   runtime.jvm.gc.collection.count{gc="PS1"} 1
+ *   runtime.jvm.gc.time{gc="PS1"} 6.7
+ *   runtime.jvm.gc.count{gc="PS1"} 1
  * </pre>
  */
 public final class GarbageCollector {
@@ -41,7 +41,7 @@ public final class GarbageCollector {
       labelSets.add(Labels.of(GC_LABEL_KEY, gc.getName()));
     }
     meter
-        .longSumObserverBuilder("runtime.jvm.gc.collection.time")
+        .longSumObserverBuilder("runtime.jvm.gc.time")
         .setDescription("Time spent in a given JVM garbage collector in milliseconds.")
         .setUnit("ms")
         .setUpdater(
@@ -53,7 +53,7 @@ public final class GarbageCollector {
             })
         .build();
     meter
-        .longSumObserverBuilder("runtime.jvm.gc.collection.count")
+        .longSumObserverBuilder("runtime.jvm.gc.count")
         .setDescription(
             "The number of collections that have occurred for a given JVM garbage collector.")
         .setUnit("collections")

--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
@@ -25,7 +25,7 @@ import java.util.List;
  * <p>Example metrics being exported:
  *
  * <pre>
- *   runtime.jvm.gc.collection{gc="PS1"} 6.7
+ *   runtime.jvm.gc.collection.time{gc="PS1"} 6.7
  *   runtime.jvm.gc.collection.count{gc="PS1"} 1
  * </pre>
  */
@@ -41,7 +41,7 @@ public final class GarbageCollector {
       labelSets.add(Labels.of(GC_LABEL_KEY, gc.getName()));
     }
     meter
-        .longSumObserverBuilder("runtime.jvm.gc.collection")
+        .longSumObserverBuilder("runtime.jvm.gc.collection.time")
         .setDescription("Time spent in a given JVM garbage collector in milliseconds.")
         .setUnit("ms")
         .setUpdater(

--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
@@ -54,7 +54,8 @@ public final class GarbageCollector {
         .build();
     meter
         .longSumObserverBuilder("runtime.jvm.gc.collection.count")
-        .setDescription("The number of collections that have occurred for a given JVM garbage collector.")
+        .setDescription(
+            "The number of collections that have occurred for a given JVM garbage collector.")
         .setUnit("collections")
         .setUpdater(
             resultLongObserver -> {

--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
@@ -26,6 +26,7 @@ import java.util.List;
  *
  * <pre>
  *   runtime.jvm.gc.collection{gc="PS1"} 6.7
+ *   runtime.jvm.gc.collection.count{gc="PS1"} 1
  * </pre>
  */
 public final class GarbageCollector {
@@ -48,6 +49,18 @@ public final class GarbageCollector {
               for (int i = 0; i < garbageCollectors.size(); i++) {
                 resultLongObserver.observe(
                     garbageCollectors.get(i).getCollectionTime(), labelSets.get(i));
+              }
+            })
+        .build();
+    meter
+        .longSumObserverBuilder("runtime.jvm.gc.collection.count")
+        .setDescription("The number of collections that have occurred for a given JVM garbage collector.")
+        .setUnit("collections")
+        .setUpdater(
+            resultLongObserver -> {
+              for (int i = 0; i < garbageCollectors.size(); i++) {
+                resultLongObserver.observe(
+                    garbageCollectors.get(i).getCollectionCount(), labelSets.get(i));
               }
             })
         .build();

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -62,7 +62,7 @@ class SpringBootSmokeTest extends SmokeTest {
 
     then: "JVM metrics are exported"
     def metrics = new MetricsInspector(waitForMetrics())
-    metrics.hasMetricsNamed("runtime.jvm.gc.collection")
+    metrics.hasMetricsNamed("runtime.jvm.gc.collection.time")
     metrics.hasMetricsNamed("runtime.jvm.gc.collection.count")
     metrics.hasMetricsNamed("runtime.jvm.memory.area")
     metrics.hasMetricsNamed("runtime.jvm.memory.pool")

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -63,6 +63,7 @@ class SpringBootSmokeTest extends SmokeTest {
     then: "JVM metrics are exported"
     def metrics = new MetricsInspector(waitForMetrics())
     metrics.hasMetricsNamed("runtime.jvm.gc.collection")
+    metrics.hasMetricsNamed("runtime.jvm.gc.collection.count")
     metrics.hasMetricsNamed("runtime.jvm.memory.area")
     metrics.hasMetricsNamed("runtime.jvm.memory.pool")
 

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -62,8 +62,8 @@ class SpringBootSmokeTest extends SmokeTest {
 
     then: "JVM metrics are exported"
     def metrics = new MetricsInspector(waitForMetrics())
-    metrics.hasMetricsNamed("runtime.jvm.gc.collection.time")
-    metrics.hasMetricsNamed("runtime.jvm.gc.collection.count")
+    metrics.hasMetricsNamed("runtime.jvm.gc.time")
+    metrics.hasMetricsNamed("runtime.jvm.gc.count")
     metrics.hasMetricsNamed("runtime.jvm.memory.area")
     metrics.hasMetricsNamed("runtime.jvm.memory.pool")
 


### PR DESCRIPTION
The OTel agent already reports the collection time per GC. 

The collection count can be useful to compare the count and the duration to see if there are a lot of short GCs or few long GCs, for example.
Please let me know whether you think adding the collection count would also be interesting for OTel.

Background: I'm working for Elastic and we're trying to convert the OTel semantic convention attributes to the Elastic Common Schema so that users can use the OTel agent with the Elastic Stack and the Elastic APM UI. As a part of that effort, we also want to convert the metrics (see https://github.com/elastic/apm-server/issues/4919). We have a screen in our UI displays [JVM runtime metrics](https://www.elastic.co/guide/en/kibana/current/metrics.html). One of the charts uses not only the collection time but also the collection count per GC.