### PR TITLE
Use direct caffeine executor.

### DIFF
--- a/instrumentation-api-caching/src/main/java/io/opentelemetry/instrumentation/api/caching/CacheBuilder.java
+++ b/instrumentation-api-caching/src/main/java/io/opentelemetry/instrumentation/api/caching/CacheBuilder.java
@@ -52,6 +52,8 @@ public final class CacheBuilder {
     }
     if (executor != null) {
       caffeine.executor(executor);
+    } else {
+      caffeine.executor(Runnable::run);
     }
     @SuppressWarnings("unchecked")
     com.github.benmanes.caffeine.cache.Cache<K, V> delegate =


### PR DESCRIPTION
I don't know what the actual problem is with the ForkJoinPool default executor but while I easily had crashes with it, after changing to direct execution, the crashes seem to have gone away. So just 70% sure this PR helps :P

We only have bounds, no async work, so direct execution of cleanup shouldn't really decrease performance much. (/cc @ben-manes JFYI since you had suggested this in the first place). In the future we could consider our `CommonTaskExecutor`, which presumably doesn't have the problem (not sure the essential difference vs ForkJoinPool would be though) if it seems like it would help.