### PR TITLE
Fix suppressed NPE in netty instrumentation

### DIFF
--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
@@ -14,6 +14,7 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpRequestDecoder;
@@ -100,7 +101,13 @@ public class NettyChannelPipelineInstrumentation implements TypeInstrumentation 
 
       String name = handlerName;
       if (name == null) {
-        name = pipeline.context(handler).name();
+        ChannelHandlerContext context = pipeline.context(handler);
+        if (context == null) {
+          // probably a ChannelInitializer that was used and removed
+          // see the comment above in @Advice.OnMethodEnter
+          return;
+        }
+        name = context.name();
       }
 
       try {


### PR DESCRIPTION
This cleans up the NPE that is logged at debug level in `reactor-netty-0.9` and `reactor-netty-1.0` tests