### PR TITLE
Merge war resources

### DIFF
--- a/instrumentation/gwt-2.0/javaagent/gwt-2.0-javaagent.gradle
+++ b/instrumentation/gwt-2.0/javaagent/gwt-2.0-javaagent.gradle
@@ -45,6 +45,8 @@ dependencies {
   testImplementation group: 'org.eclipse.jetty', name: 'jetty-webapp', version: '9.4.35.v20201120'
 }
 
+def warDir = "$buildDir/testapp/war"
+
 task compileGwt(dependsOn: classes, type: JavaExec) {
   // versions before 2.9 require java8
   javaLauncher = javaToolchains.launcherFor {
@@ -52,7 +54,6 @@ task compileGwt(dependsOn: classes, type: JavaExec) {
   }
 
   def extraDir = "$buildDir/testapp/extra"
-  def warDir = "$buildDir/testapp/war"
 
   outputs.cacheIf { true }
 
@@ -79,7 +80,16 @@ task compileGwt(dependsOn: classes, type: JavaExec) {
   ]
 }
 
-test.dependsOn sourceSets.testapp.output, compileGwt
+task copyTestWebapp(type: Copy) {
+  dependsOn compileGwt
+  
+  from file("src/testapp/webapp")
+  from warDir
+
+  into file("$buildDir/testapp/web")
+}
+
+test.dependsOn sourceSets.testapp.output, copyTestWebapp
 
 test {
   // add test app classes to classpath

--- a/instrumentation/gwt-2.0/javaagent/src/test/groovy/GwtTest.groovy
+++ b/instrumentation/gwt-2.0/javaagent/src/test/groovy/GwtTest.groovy
@@ -34,7 +34,7 @@ class GwtTest extends AgentInstrumentationSpecification implements HttpServerTes
   Server startServer(int port) {
     WebAppContext webAppContext = new WebAppContext()
     webAppContext.setContextPath(getContextPath())
-    webAppContext.setBaseResource(Resource.newResource(new File("build/testapp/war")))
+    webAppContext.setBaseResource(Resource.newResource(new File("build/testapp/web")))
 
     def jettyServer = new Server(port)
     jettyServer.connectors.each {


### PR DESCRIPTION
Something about outputing to the same directory from two tasks seems to have caused CI to pass before without copying the WEB-INF in. This should be more robust.