### PR TITLE
Prevent duplicate telemetry when using both library and auto instrumentation

### DIFF
--- a/docs/contributing/muzzle.md
+++ b/docs/contributing/muzzle.md
@@ -21,13 +21,15 @@ The compile-time reference collection and code generation process is implemented
 plugin (called `MuzzleCodeGenerationPlugin`).
 
 For each instrumentation module the ByteBuddy plugin collects symbols referring to both internal and
-third party APIs used by the currently processed module's type instrumentations (`InstrumentationModule#typeInstrumentations()`).
-The reference collection process starts from advice classes (values of the map returned by the
-`TypeInstrumentation#transformers()`method) and traverses the class graph until it encounters
-a reference to a non-instrumentation class (determined by `InstrumentationClassPredicate`).
-Aside from references, the collection process also builds a graph of dependencies between internal
-instrumentation helper classes - this dependency graph is later used to construct a list of helper
-classes that will be injected to the application classloader (`InstrumentationModule#getMuzzleHelperClassNames()`).
+third party APIs used by the currently processed module's type
+instrumentations (`InstrumentationModule#typeInstrumentations()`). The reference collection process
+starts from advice classes (values of the map returned by the
+`TypeInstrumentation#transformers()` method) and traverses the class graph until it encounters a
+reference to a non-instrumentation class (determined by `InstrumentationClassPredicate` and
+the `InstrumentationModule#isLibraryInstrumentationClass(String)` predicate). Aside from references,
+the collection process also builds a graph of dependencies between internal instrumentation helper
+classes - this dependency graph is later used to construct a list of helper classes that will be
+injected to the application classloader (`InstrumentationModule#getMuzzleHelperClassNames()`).
 
 All collected references are then used to create a `ReferenceMatcher` instance. This matcher
 is stored in the instrumentation module class in the method `InstrumentationModule#getMuzzleReferenceMatcher()`

--- a/examples/distro/gradle/shadow.gradle
+++ b/examples/distro/gradle/shadow.gradle
@@ -4,8 +4,8 @@ ext.relocatePackages = { shadowJar ->
   // rewrite dependencies calling Logger.getLogger
   shadowJar.relocate 'java.util.logging.Logger', 'io.opentelemetry.javaagent.bootstrap.PatchLogger'
 
-  // rewrite library instrumentation dependencies
-  shadowJar.relocate "io.opentelemetry.instrumentation", "io.opentelemetry.javaagent.shaded.instrumentation"
+  // prevents conflict with library instrumentation, which uses its own instrumentation-api
+  shadowJar.relocate 'io.opentelemetry.instrumentation.api', 'io.opentelemetry.javaagent.shaded.instrumentation.api'
 
   // relocate OpenTelemetry API usage
   shadowJar.relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"

--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -79,15 +79,12 @@ shadowJar {
 
   archiveFileName = 'agent-testing.jar'
 
-  // rewrite library instrumentation dependencies
-  relocate "io.opentelemetry.instrumentation", "io.opentelemetry.javaagent.shaded.instrumentation"
-
   // Prevents conflict with other SLF4J instances. Important for premain.
   relocate 'org.slf4j', 'io.opentelemetry.javaagent.slf4j'
   // rewrite dependencies calling Logger.getLogger
   relocate 'java.util.logging.Logger', 'io.opentelemetry.javaagent.bootstrap.PatchLogger'
 
-  // prevents conflict with library instrumentation
+  // prevents conflict with library instrumentation, which uses its own instrumentation-api
   relocate 'io.opentelemetry.instrumentation.api', 'io.opentelemetry.javaagent.shaded.instrumentation.api'
 
   // relocate OpenTelemetry API usage

--- a/instrumentation/apache-dubbo/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/DubboInstrumentationModule.java
+++ b/instrumentation/apache-dubbo/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/DubboInstrumentationModule.java
@@ -33,6 +33,11 @@ public class DubboInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.apachedubbo.v2_7");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return Collections.singletonList(new DubboInstrumentation());
   }

--- a/instrumentation/armeria-1.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaInstrumentationModule.java
+++ b/instrumentation/armeria-1.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaInstrumentationModule.java
@@ -27,6 +27,11 @@ public class ArmeriaInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.armeria.v1_3");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
         new ArmeriaWebClientBuilderInstrumentation(), new ArmeriaServerBuilderInstrumentation());

--- a/instrumentation/aws-lambda-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambda/v1_0/AwsLambdaInstrumentationModule.java
+++ b/instrumentation/aws-lambda-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambda/v1_0/AwsLambdaInstrumentationModule.java
@@ -24,6 +24,11 @@ public class AwsLambdaInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.awslambda.v1_0");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new AwsLambdaRequestHandlerInstrumentation());
   }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/AwsSdkInstrumentationModule.java
@@ -24,6 +24,11 @@ public class AwsSdkInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.awssdk.v1_11");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
         new AwsClientInstrumentation(),

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInstrumentationModule.java
@@ -44,6 +44,11 @@ public class AwsSdkInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.awssdk.v2_2");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return Collections.singletonList(new AwsSdkInitializationInstrumentation());
   }

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/couchbase-3.1-javaagent.gradle
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/couchbase-3.1-javaagent.gradle
@@ -22,3 +22,8 @@ dependencies {
 
   testImplementation group: "org.testcontainers", name: "couchbase", version: versions.testcontainers
 }
+
+configurations {
+  // exclude lib from test classpath, otherwise the javaagent would be skipped
+  testImplementation.exclude group: 'com.couchbase.client', module: 'tracing-opentelemetry'
+}

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_1/CouchbaseInstrumentationModule.java
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_1/CouchbaseInstrumentationModule.java
@@ -21,16 +21,16 @@ public class CouchbaseInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
-  public boolean isHelperClass(String className) {
-    return className.startsWith("com.couchbase.client.tracing.opentelemetry");
-  }
-
-  @Override
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // New class introduced in 3.1, the minimum version we support.
     // NB: Couchbase does not provide any API guarantees on their core IO artifact so reconsider
     // instrumenting it instead of each individual JVM artifact if this becomes unmaintainable.
     return hasClassesNamed("com.couchbase.client.core.cnc.TracingIdentifiers");
+  }
+
+  @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("com.couchbase.client.tracing.opentelemetry");
   }
 
   @Override

--- a/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcInstrumentationModule.java
+++ b/instrumentation/grpc-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_5/GrpcInstrumentationModule.java
@@ -19,6 +19,11 @@ public class GrpcInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.grpc.v1_5");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
         new GrpcClientBuilderBuildInstrumentation(), new GrpcServerBuilderInstrumentation());

--- a/instrumentation/instrumentation.gradle
+++ b/instrumentation/instrumentation.gradle
@@ -61,11 +61,11 @@ shadowJar {
     exclude(project(':javaagent-api'))
   }
 
-  // rewrite library instrumentation dependencies
-  relocate "io.opentelemetry.instrumentation", "io.opentelemetry.javaagent.shaded.instrumentation"
-
   // rewrite dependencies calling Logger.getLogger
   relocate 'java.util.logging.Logger', 'io.opentelemetry.javaagent.bootstrap.PatchLogger'
+
+  // prevents conflict with library instrumentation, which uses its own instrumentation-api
+  relocate 'io.opentelemetry.instrumentation.api', 'io.opentelemetry.javaagent.shaded.instrumentation.api'
 
   // relocate OpenTelemetry API usage
   relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"

--- a/instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/axis2/Axis2InstrumentationModule.java
+++ b/instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/axis2/Axis2InstrumentationModule.java
@@ -27,6 +27,11 @@ public class Axis2InstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.axis2");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return Collections.singletonList(new InvocationListenerRegistryTypeInstrumentation());
   }

--- a/instrumentation/jaxws/jaxws-2.0-cxf-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cxf/CxfInstrumentationModule.java
+++ b/instrumentation/jaxws/jaxws-2.0-cxf-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cxf/CxfInstrumentationModule.java
@@ -18,6 +18,11 @@ public class CxfInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.cxf");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return Collections.singletonList(new EndpointImplTypeInstrumentation());
   }

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceInstrumentationModule.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceInstrumentationModule.java
@@ -37,6 +37,11 @@ public class LettuceInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.lettuce.v5_1");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new DefaultClientResourcesInstrumentation());
   }

--- a/instrumentation/log4j/log4j-2.13.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v2_13_2/Log4j2InstrumentationModule.java
+++ b/instrumentation/log4j/log4j-2.13.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v2_13_2/Log4j2InstrumentationModule.java
@@ -38,6 +38,11 @@ public class Log4j2InstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.log4j.v2_13_2");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return Arrays.asList(new BugFixingInstrumentation(), new EmptyTypeInstrumentation());
   }

--- a/instrumentation/logback/logback-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/v1_0/LogbackInstrumentationModule.java
+++ b/instrumentation/logback/logback-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/v1_0/LogbackInstrumentationModule.java
@@ -27,6 +27,11 @@ public class LogbackInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.logback.v1_0");
+  }
+
+  @Override
   public Map<String, String> contextStore() {
     return singletonMap("ch.qos.logback.classic.spi.ILoggingEvent", Span.class.getName());
   }

--- a/instrumentation/okhttp/okhttp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttp3InstrumentationModule.java
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttp3InstrumentationModule.java
@@ -30,6 +30,11 @@ public class OkHttp3InstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.okhttp.v3_0");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new OkHttpClientInstrumentation());
   }

--- a/instrumentation/oshi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/OshiInstrumentationModule.java
+++ b/instrumentation/oshi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/OshiInstrumentationModule.java
@@ -32,6 +32,11 @@ public class OshiInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.oshi");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new SystemInfoInstrumentation());
   }

--- a/instrumentation/oshi/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/oshi/OshiTest.groovy
+++ b/instrumentation/oshi/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/oshi/OshiTest.groovy
@@ -21,13 +21,13 @@ class OshiTest extends AgentInstrumentationSpecification {
     expect:
     platform != null
     // TODO (trask) is this the instrumentation library name we want?
-    findMetric("io.opentelemetry.javaagent.shaded.instrumentation.oshi", "system.disk.io") != null
-    findMetric("io.opentelemetry.javaagent.shaded.instrumentation.oshi", "system.disk.operations") != null
-    findMetric("io.opentelemetry.javaagent.shaded.instrumentation.oshi", "system.memory.usage") != null
-    findMetric("io.opentelemetry.javaagent.shaded.instrumentation.oshi", "system.memory.utilization") != null
-    findMetric("io.opentelemetry.javaagent.shaded.instrumentation.oshi", "system.network.errors") != null
-    findMetric("io.opentelemetry.javaagent.shaded.instrumentation.oshi", "system.network.io") != null
-    findMetric("io.opentelemetry.javaagent.shaded.instrumentation.oshi", "system.network.packets") != null
+    findMetric("io.opentelemetry.instrumentation.oshi", "system.disk.io") != null
+    findMetric("io.opentelemetry.instrumentation.oshi", "system.disk.operations") != null
+    findMetric("io.opentelemetry.instrumentation.oshi", "system.memory.usage") != null
+    findMetric("io.opentelemetry.instrumentation.oshi", "system.memory.utilization") != null
+    findMetric("io.opentelemetry.instrumentation.oshi", "system.network.errors") != null
+    findMetric("io.opentelemetry.instrumentation.oshi", "system.network.io") != null
+    findMetric("io.opentelemetry.instrumentation.oshi", "system.network.packets") != null
   }
 
   def findMetric(instrumentationName, metricName) {

--- a/instrumentation/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/ReactorInstrumentationModule.java
+++ b/instrumentation/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/ReactorInstrumentationModule.java
@@ -27,6 +27,11 @@ public class ReactorInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.reactor");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new HooksInstrumentation());
   }

--- a/instrumentation/rocketmq-client-4.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmq/RocketMqInstrumentationModule.java
+++ b/instrumentation/rocketmq-client-4.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmq/RocketMqInstrumentationModule.java
@@ -19,6 +19,11 @@ public class RocketMqInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.rocketmq");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(new RocketMqProducerInstrumentation(), new RocketMqConsumerInstrumentation());
   }

--- a/instrumentation/rxjava-2.0/javaagent/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2InstrumentationModule.java
+++ b/instrumentation/rxjava-2.0/javaagent/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2InstrumentationModule.java
@@ -27,6 +27,11 @@ public class RxJava2InstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.rxjava2");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return Collections.singletonList(new PluginInstrumentation());
   }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/client/WebfluxClientInstrumentationModule.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/client/WebfluxClientInstrumentationModule.java
@@ -30,6 +30,11 @@ public class WebfluxClientInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.spring.webflux.client");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new WebClientBuilderInstrumentation());
   }

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcInstrumentationModule.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcInstrumentationModule.java
@@ -19,6 +19,11 @@ public class SpringWebMvcInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isLibraryInstrumentationClass(String className) {
+    return className.startsWith("io.opentelemetry.instrumentation.spring.webmvc");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
         new WebApplicationContextInstrumentation(),

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InstrumentationModule.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/InstrumentationModule.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.javaagent.tooling;
 
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.callWhenTrue;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.failSafe;
+import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.ClassLoaderMatcher.hasAnyClassesNamed;
 import static java.util.Arrays.asList;
 import static net.bytebuddy.matcher.ElementMatchers.any;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.annotation.AnnotationSource;
 import net.bytebuddy.description.method.MethodDescription;
@@ -130,7 +133,8 @@ public abstract class InstrumentationModule {
       return parentAgentBuilder;
     }
 
-    ElementMatcher.Junction<ClassLoader> moduleClassLoaderMatcher = classLoaderMatcher();
+    ElementMatcher.Junction<ClassLoader> moduleClassLoaderMatcher =
+        createModuleClassLoaderMatcher(helperClassNames);
     MuzzleMatcher muzzleMatcher = new MuzzleMatcher();
     HelperInjector helperInjector =
         new HelperInjector(mainInstrumentationName(), helperClassNames, helperResourceNames);
@@ -173,6 +177,40 @@ public abstract class InstrumentationModule {
     helperClassNames.addAll(asList(additionalHelperClassNames()));
     helperClassNames.addAll(asList(getMuzzleHelperClassNames()));
     return helperClassNames;
+  }
+
+  /**
+   * Returns the matcher produced by {@link #classLoaderMatcher()} with an additional condition
+   * added: no library instrumentation classes defined by this module can be present in the
+   * application classloader. This disables the javaagent instrumentation if the library
+   * instrumentation is already used by the application.
+   */
+  private ElementMatcher.Junction<ClassLoader> createModuleClassLoaderMatcher(
+      List<String> helperClassNames) {
+    // TODO: optimization: refactor matcher caching, only the matcher returned by this method should
+    // cache results, the intermediary ones don't need to cache anything
+    // right now every matcher returned from ClassLoaderMatcher caches separately
+    // this will also make those "Skipping ..." logs appear less
+
+    List<String> libraryHelperClasses =
+        helperClassNames.stream()
+            .filter(this::isLibraryInstrumentationClass)
+            .collect(Collectors.toList());
+
+    if (libraryHelperClasses.isEmpty()) {
+      return classLoaderMatcher();
+    }
+
+    ElementMatcher.Junction<ClassLoader> libraryMatcher =
+        callWhenTrue(
+            hasAnyClassesNamed(libraryHelperClasses), this::logLibraryInstrumentationDetected);
+    return classLoaderMatcher().and(not(libraryMatcher));
+  }
+
+  private void logLibraryInstrumentationDetected() {
+    log.debug(
+        "Skipping instrumentation {} because library instrumentation was detected on classpath",
+        mainInstrumentationName());
   }
 
   private AgentBuilder.Identified.Extendable applyInstrumentationTransformers(
@@ -258,23 +296,8 @@ public abstract class InstrumentationModule {
    * Java helper function here.
    */
   @SuppressWarnings("unused")
-  protected final Predicate<String> additionalLibraryInstrumentationPackage() {
-    return this::isHelperClass;
-  }
-
-  /**
-   * Instrumentation modules can override this method to specify additional packages (or classes)
-   * that should be treated as "library instrumentation" packages. Classes from those packages will
-   * be treated by muzzle as instrumentation helper classes: they will be scanned for references and
-   * automatically injected into the application classloader if they're used in any type
-   * instrumentation. The classes for which this predicate returns {@code true} will be treated as
-   * helper classes, in addition to the default ones defined in {@link
-   * InstrumentationClassPredicate}.
-   *
-   * @param className The name of the class that may or may not be a helper class.
-   */
-  public boolean isHelperClass(String className) {
-    return false;
+  protected final Predicate<String> isLibraryInstrumentationClassPredicate() {
+    return this::isLibraryInstrumentationClass;
   }
 
   /**
@@ -304,9 +327,9 @@ public abstract class InstrumentationModule {
 
   /**
    * Instrumentation modules can override this method to provide additional helper classes that are
-   * not located in instrumentation packages described in {@link InstrumentationClassPredicate} (and
-   * not automatically detected by muzzle). These additional classes will be injected into the
-   * application classloader first.
+   * not located in instrumentation packages described in {@link InstrumentationClassPredicate} and
+   * {@link #isLibraryInstrumentationClass(String)} (and not automatically detected by muzzle).
+   * These additional classes will be injected into the application classloader first.
    */
   protected String[] additionalHelperClassNames() {
     return EMPTY;
@@ -340,6 +363,26 @@ public abstract class InstrumentationModule {
    */
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return any();
+  }
+
+  /**
+   * Instrumentation modules that use existing library instrumentation should override this method
+   * to specify additional packages (or classes) that should be treated as "library instrumentation"
+   * packages/classes.
+   *
+   * <p>Classes marked as library instrumentation classes will be treated by muzzle as
+   * instrumentation helper classes: they will be scanned for references and automatically injected
+   * into the application classloader if they're used in any type instrumentation.
+   *
+   * <p>In addition to that, the javaagent will prevent the instrumentations from this module from
+   * being applied when it detects that the application classloader already contains one of the
+   * library classes. This behavior prevents interference between library and javaagent
+   * instrumentation (for example, duplicate telemetry).
+   *
+   * @param className The name of the class that may or may not be a library instrumentation class.
+   */
+  public boolean isLibraryInstrumentationClass(String className) {
+    return false;
   }
 
   /** Returns a list of all individual type instrumentation in this module. */

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/AgentElementMatchers.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/AgentElementMatchers.java
@@ -92,4 +92,10 @@ public class AgentElementMatchers {
       }
     }
   }
+
+  /** Execute {@code callback} action whenever decorated {@code matcher} returns true. */
+  public static <T> ElementMatcher.Junction<T> callWhenTrue(
+      ElementMatcher<? super T> matcher, Runnable callback) {
+    return new CallWhenTrueDecorator<>(matcher, callback);
+  }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/CallWhenTrueDecorator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/CallWhenTrueDecorator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.bytebuddy.matcher;
+
+import net.bytebuddy.matcher.ElementMatcher;
+
+final class CallWhenTrueDecorator<T> extends ElementMatcher.Junction.AbstractBase<T> {
+  private final ElementMatcher<? super T> delegate;
+  private final Runnable callback;
+
+  CallWhenTrueDecorator(ElementMatcher<? super T> delegate, Runnable callback) {
+    this.delegate = delegate;
+    this.callback = callback;
+  }
+
+  @Override
+  public boolean matches(T target) {
+    if (delegate.matches(target)) {
+      callback.run();
+      return true;
+    }
+    return false;
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/InstrumentationClassPredicate.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/InstrumentationClassPredicate.java
@@ -14,8 +14,9 @@ public final class InstrumentationClassPredicate {
   private static final String JAVAAGENT_API_PACKAGE =
       "io.opentelemetry.javaagent.instrumentation.api.";
 
-  // library instrumentation packages (both shaded in the agent)
+  // library instrumentation packages
   private static final String LIBRARY_INSTRUMENTATION_PACKAGE = "io.opentelemetry.instrumentation.";
+  // note that instrumentation-api is shaded in the agent
   private static final String INSTRUMENTATION_API_PACKAGE = "io.opentelemetry.instrumentation.api.";
 
   private final Predicate<String> additionalLibraryInstrumentationPredicate;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/collector/MuzzleCodeGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/collector/MuzzleCodeGenerator.java
@@ -147,7 +147,8 @@ class MuzzleCodeGenerator implements AsmVisitorWrapper {
               .flatMap(typeInstrumentation -> typeInstrumentation.transformers().values().stream())
               .collect(Collectors.toSet());
 
-      ReferenceCollector collector = new ReferenceCollector(instrumentationModule::isHelperClass);
+      ReferenceCollector collector =
+          new ReferenceCollector(instrumentationModule::isLibraryInstrumentationClass);
       for (String adviceClass : adviceClassNames) {
         collector.collectReferencesFromAdvice(adviceClass);
       }
@@ -206,7 +207,7 @@ class MuzzleCodeGenerator implements AsmVisitorWrapper {
        *                                                        new Reference[]{
        *                                                          // reference builders
        *                                                        },
-       *                                                        this.additionalLibraryInstrumentationPackage());
+       *                                                        this.isLibraryInstrumentationClassPredicate());
        *   }
        *   return this.muzzleReferenceMatcher;
        * }
@@ -472,7 +473,7 @@ class MuzzleCodeGenerator implements AsmVisitorWrapper {
         mv.visitMethodInsn(
             Opcodes.INVOKEVIRTUAL,
             instrumentationClassName,
-            "additionalLibraryInstrumentationPackage",
+            "isLibraryInstrumentationClassPredicate",
             "()Ljava/util/function/Predicate;",
             false);
 

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/CallWhenTrueDecoratorTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/CallWhenTrueDecoratorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.bytebuddy.matcher;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import net.bytebuddy.matcher.ElementMatcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CallWhenTrueDecoratorTest {
+  @Mock ElementMatcher<String> delegateMatcher;
+  @Mock Runnable callback;
+
+  @Test
+  void shouldExecuteCallbackWhenMatcherReturnsTrue() {
+    // given
+    ElementMatcher<String> matcher = new CallWhenTrueDecorator<>(delegateMatcher, callback);
+
+    given(delegateMatcher.matches("true")).willReturn(true);
+
+    // when
+    boolean result = matcher.matches("true");
+
+    // then
+    assertTrue(result);
+    then(callback).should().run();
+  }
+
+  @Test
+  void shouldNotExecuteCallbackWhenMatcherReturnsFalse() {
+    // given
+    ElementMatcher<String> matcher = new CallWhenTrueDecorator<>(delegateMatcher, callback);
+
+    // when
+    boolean result = matcher.matches("not really true");
+
+    // then
+    assertFalse(result);
+    then(callback).should(never()).run();
+  }
+}

--- a/javaagent/javaagent.gradle
+++ b/javaagent/javaagent.gradle
@@ -87,7 +87,7 @@ tasks.withType(ShadowJar).configureEach {
   // rewrite dependencies calling Logger.getLogger
   relocate 'java.util.logging.Logger', 'io.opentelemetry.javaagent.bootstrap.PatchLogger'
 
-  // prevents conflict with library instrumentation
+  // prevents conflict with library instrumentation, which uses its own instrumentation-api
   relocate 'io.opentelemetry.instrumentation.api', 'io.opentelemetry.javaagent.shaded.instrumentation.api'
 
   // relocate OpenTelemetry API

--- a/testing/agent-exporter/agent-exporter.gradle
+++ b/testing/agent-exporter/agent-exporter.gradle
@@ -43,11 +43,11 @@ shadowJar {
   // Prevents conflict with other SLF4J instances. Important for premain.
   relocate 'org.slf4j', 'io.opentelemetry.javaagent.slf4j'
 
-  // rewrite library instrumentation dependencies
-  relocate "io.opentelemetry.instrumentation", "io.opentelemetry.javaagent.shaded.instrumentation"
-
   // rewrite dependencies calling Logger.getLogger
   relocate 'java.util.logging.Logger', 'io.opentelemetry.javaagent.bootstrap.PatchLogger'
+
+  // prevents conflict with library instrumentation, which uses its own instrumentation-api
+  relocate 'io.opentelemetry.instrumentation.api', 'io.opentelemetry.javaagent.shaded.instrumentation.api'
 
   // relocate OpenTelemetry API usage
   relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"

--- a/testing/agent-for-testing/agent-for-testing.gradle
+++ b/testing/agent-for-testing/agent-for-testing.gradle
@@ -59,7 +59,7 @@ shadowJar {
   // rewrite dependencies calling Logger.getLogger
   relocate 'java.util.logging.Logger', 'io.opentelemetry.javaagent.bootstrap.PatchLogger'
 
-  // prevents conflict with library instrumentation
+  // prevents conflict with library instrumentation, which uses its own instrumentation-api
   relocate 'io.opentelemetry.instrumentation.api', 'io.opentelemetry.javaagent.shaded.instrumentation.api'
 
   // relocate OpenTelemetry API


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/903

I've removed the library instrumentation shading (`io.opentelemetry.instrumentation.*`); instrumentation-api is still shaded though (`io.opentelemetry.instrumentation.api.*`).
Since now the agent will disable the javaagent instrumentation when it encounters a library class I think that this offers a similar level of safety as shading everything.