### PR TITLE
Rename Jdk8AsyncEndStrategy to Jdk8AsyncSpanEndStrategy

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/async/AsyncSpanEndStrategies.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/async/AsyncSpanEndStrategies.java
@@ -24,7 +24,7 @@ public class AsyncSpanEndStrategies {
   private final List<AsyncSpanEndStrategy> strategies = new CopyOnWriteArrayList<>();
 
   private AsyncSpanEndStrategies() {
-    strategies.add(Jdk8AsyncEndStrategy.INSTANCE);
+    strategies.add(Jdk8AsyncSpanEndStrategy.INSTANCE);
   }
 
   public void registerStrategy(AsyncSpanEndStrategy strategy) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/async/Jdk8AsyncSpanEndStrategy.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/async/Jdk8AsyncSpanEndStrategy.java
@@ -10,7 +10,7 @@ import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-enum Jdk8AsyncEndStrategy implements AsyncSpanEndStrategy {
+enum Jdk8AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
   INSTANCE;
 
   @Override

--- a/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/async/Jdk8AsyncSpanEndStrategyTest.groovy
+++ b/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/async/Jdk8AsyncSpanEndStrategyTest.groovy
@@ -12,12 +12,12 @@ import spock.lang.Specification
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 
-class Jdk8MethodStrategyTest extends Specification {
+class Jdk8AsyncSpanEndStrategyTest extends Specification {
   BaseTracer tracer
 
   Context context
 
-  def underTest = Jdk8AsyncEndStrategy.INSTANCE
+  def underTest = Jdk8AsyncSpanEndStrategy.INSTANCE
 
   void setup() {
     tracer = Mock()


### PR DESCRIPTION
Renames the class `Jdk8AsyncEndStrategy` and unit test class to match naming convention described in #2618.

/cc @trask 