### PR TITLE
Add AsyncSpanEndStrategy implementation for RxJava 2 instrumentation

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/async/AsyncSpanEndStrategies.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/async/AsyncSpanEndStrategies.java
@@ -32,6 +32,14 @@ public class AsyncSpanEndStrategies {
     strategies.add(strategy);
   }
 
+  public void unregisterStrategy(AsyncSpanEndStrategy strategy) {
+    strategies.remove(strategy);
+  }
+
+  public void unregisterStrategy(Class<? extends AsyncSpanEndStrategy> strategyClass) {
+    strategies.removeIf(strategy -> strategy.getClass() == strategyClass);
+  }
+
   @Nullable
   public AsyncSpanEndStrategy resolveStrategy(Class<?> returnType) {
     for (AsyncSpanEndStrategy strategy : strategies) {

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanAdvice.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanAdvice.java
@@ -45,7 +45,7 @@ public class WithSpanAdvice {
       @Advice.Origin Method method,
       @Advice.Local("otelContext") Context context,
       @Advice.Local("otelScope") Scope scope,
-      @Advice.Return(typing = Assigner.Typing.DYNAMIC) Object returnValue,
+      @Advice.Return(typing = Assigner.Typing.DYNAMIC, readOnly = false) Object returnValue,
       @Advice.Thrown Throwable throwable) {
     if (scope == null) {
       return;
@@ -55,7 +55,7 @@ public class WithSpanAdvice {
     if (throwable != null) {
       tracer().endExceptionally(context, throwable);
     } else {
-      tracer().end(context, method.getReturnType(), returnValue);
+      returnValue = tracer().end(context, method.getReturnType(), returnValue);
     }
   }
 }

--- a/instrumentation/rxjava-2.0/javaagent/rxjava-2.0-javaagent.gradle
+++ b/instrumentation/rxjava-2.0/javaagent/rxjava-2.0-javaagent.gradle
@@ -14,5 +14,6 @@ dependencies {
 
   implementation project(":instrumentation:rxjava-2.0:library")
 
+  testImplementation deps.opentelemetryExtAnnotations
   testImplementation project(':instrumentation:rxjava-2.0:testing')
 }

--- a/instrumentation/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
@@ -8,8 +8,20 @@ import io.opentelemetry.instrumentation.rxjava2.TracedWithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Maybe
+import io.reactivex.Observable
+import io.reactivex.Single
 import io.reactivex.observers.TestObserver
+import io.reactivex.processors.UnicastProcessor
 import io.reactivex.subjects.CompletableSubject
+import io.reactivex.subjects.MaybeSubject
+import io.reactivex.subjects.SingleSubject
+import io.reactivex.subjects.UnicastSubject
+import io.reactivex.subscribers.TestSubscriber
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 
 class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecification implements AgentTestTrait {
 
@@ -17,9 +29,9 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def observer = new TestObserver()
     def source = Completable.complete()
-    def result = new TracedWithSpan()
+    new TracedWithSpan()
       .completable(source)
-    result.subscribe(observer)
+      .subscribe(observer)
     observer.assertComplete()
 
     expect:
@@ -65,5 +77,780 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
         }
       }
     }
+  }
+
+  def "should capture span for already errored Completable"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def observer = new TestObserver()
+    def source = Completable.error(error)
+    new TracedWithSpan()
+      .completable(source)
+      .subscribe(observer)
+    observer.assertError(error)
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.completable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually errored Completable"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def source = CompletableSubject.create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .completable(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onError(error)
+    observer.assertError(error)
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.completable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already completed Maybe"() {
+    setup:
+    def observer = new TestObserver()
+    def source = Maybe.just("Value")
+    new TracedWithSpan()
+      .maybe(source)
+      .subscribe(observer)
+    observer.assertValue("Value")
+    observer.assertComplete()
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.maybe"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already empty Maybe"() {
+    setup:
+    def observer = new TestObserver()
+    def source = Maybe.<String>empty()
+    new TracedWithSpan()
+      .maybe(source)
+      .subscribe(observer)
+    observer.assertComplete()
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.maybe"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually completed Maybe"() {
+    setup:
+    def source = MaybeSubject.<String>create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .maybe(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onSuccess("Value")
+    observer.assertValue("Value")
+    observer.assertComplete()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.maybe"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already errored Maybe"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def observer = new TestObserver()
+    def source = Maybe.<String>error(error)
+    new TracedWithSpan()
+      .maybe(source)
+      .subscribe(observer)
+    observer.assertError(error)
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.maybe"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually errored Maybe"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def source = MaybeSubject.<String>create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .maybe(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onError(error)
+    observer.assertError(error)
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.maybe"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already completed Single"() {
+    setup:
+    def observer = new TestObserver()
+    def source = Single.just("Value")
+    new TracedWithSpan()
+      .single(source)
+      .subscribe(observer)
+    observer.assertValue("Value")
+    observer.assertComplete()
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.single"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually completed Single"() {
+    setup:
+    def source = SingleSubject.<String>create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .single(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onSuccess("Value")
+    observer.assertValue("Value")
+    observer.assertComplete()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.single"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already errored Single"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def observer = new TestObserver()
+    def source = Single.<String>error(error)
+    new TracedWithSpan()
+      .single(source)
+      .subscribe(observer)
+    observer.assertError(error)
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.single"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually errored Single"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def source = SingleSubject.<String>create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .single(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onError(error)
+    observer.assertError(error)
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.single"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already completed Observable"() {
+    setup:
+    def observer = new TestObserver()
+    def source = Observable.<String>just("Value")
+    new TracedWithSpan()
+      .observable(source)
+      .subscribe(observer)
+    observer.assertValue("Value")
+    observer.assertComplete()
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.observable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually completed Observable"() {
+    setup:
+    def source = UnicastSubject.<String>create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .observable(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onComplete()
+    observer.assertComplete()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.observable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already errored Observable"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def observer = new TestObserver()
+    def source = Observable.<String>error(error)
+    new TracedWithSpan()
+      .observable(source)
+      .subscribe(observer)
+    observer.assertError(error)
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.observable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually errored Observable"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def source = UnicastSubject.<String>create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .observable(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onError(error)
+    observer.assertError(error)
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.observable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already completed Flowable"() {
+    setup:
+    def observer = new TestSubscriber()
+    def source = Flowable.<String>just("Value")
+    new TracedWithSpan()
+      .flowable(source)
+      .subscribe(observer)
+    observer.assertValue("Value")
+    observer.assertComplete()
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.flowable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually completed Flowable"() {
+    setup:
+    def source = UnicastProcessor.<String>create()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .flowable(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onComplete()
+    observer.assertComplete()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.flowable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already errored Flowable"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def observer = new TestSubscriber()
+    def source = Flowable.<String>error(error)
+    new TracedWithSpan()
+      .flowable(source)
+      .subscribe(observer)
+    observer.assertError(error)
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.flowable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually errored Flowable"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def source = UnicastProcessor.<String>create()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .flowable(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onError(error)
+    observer.assertError(error)
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.flowable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already completed ParallelFlowable"() {
+    setup:
+    def observer = new TestSubscriber()
+    def source = Flowable.<String>just("Value")
+    new TracedWithSpan()
+      .parallelFlowable(source.parallel())
+      .sequential()
+      .subscribe(observer)
+    observer.assertValue("Value")
+    observer.assertComplete()
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.parallelFlowable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually completed ParallelFlowable"() {
+    setup:
+    def source = UnicastProcessor.<String>create()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .parallelFlowable(source.parallel())
+      .sequential()
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onComplete()
+    observer.assertComplete()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.parallelFlowable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for already errored ParallelFlowable"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def observer = new TestSubscriber()
+    def source = Flowable.<String>error(error)
+    new TracedWithSpan()
+      .parallelFlowable(source.parallel())
+      .sequential()
+      .subscribe(observer)
+    observer.assertError(error)
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.parallelFlowable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually errored ParallelFlowable"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def source = UnicastProcessor.<String>create()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .parallelFlowable(source.parallel())
+      .sequential()
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onError(error)
+    observer.assertError(error)
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.parallelFlowable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually completed Publisher"() {
+    setup:
+    def source = new CustomPublisher()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .publisher(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onComplete()
+    observer.assertComplete()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.publisher"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually errored Publisher"() {
+    setup:
+    def error = new IllegalArgumentException("Boom")
+    def source = new CustomPublisher()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .publisher(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onError(error)
+    observer.assertError(error)
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.publisher"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored true
+          errorEvent(IllegalArgumentException, "Boom")
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  static class CustomPublisher implements Publisher<String>, Subscription {
+    Subscriber<? super String> subscriber
+
+    @Override
+    void subscribe(Subscriber<? super String> subscriber) {
+      this.subscriber = subscriber
+      subscriber.onSubscribe(this)
+    }
+
+    void onComplete() {
+      this.subscriber.onComplete()
+    }
+
+    void onError(Throwable exception) {
+      this.subscriber.onError(exception)
+    }
+
+    @Override
+    void request(long l) { }
+
+    @Override
+    void cancel() { }
   }
 }

--- a/instrumentation/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
@@ -6,7 +6,6 @@
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.rxjava2.TracedWithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
@@ -23,7 +22,7 @@ import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
-class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecification implements AgentTestTrait {
+class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
 
   def "should capture span for already completed Completable"() {
     setup:

--- a/instrumentation/rxjava-2.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava-2.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.rxjava2.TracedWithSpan
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.instrumentation.test.AgentTestTrait
+import io.reactivex.Completable
+import io.reactivex.observers.TestObserver
+import io.reactivex.subjects.CompletableSubject
+
+class WithSpanInstrumentationTest extends AgentInstrumentationSpecification implements AgentTestTrait {
+
+  def "should capture span for already completed CompletionStage"() {
+    setup:
+    def observer = new TestObserver()
+    def result = new TracedWithSpan().completable(Completable.complete())
+    result.subscribe(observer)
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.completable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually completed Completable"() {
+    setup:
+    def source = CompletableSubject.create()
+    def observer = new TestObserver()
+    def result = new TracedWithSpan().completable(source)
+    result.subscribe(observer)
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onComplete()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.completable"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          errored false
+          attributes {
+          }
+        }
+      }
+    }
+  }
+}

--- a/instrumentation/rxjava-2.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rxjava2/TracedWithSpan.java
+++ b/instrumentation/rxjava-2.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rxjava2/TracedWithSpan.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rxjava2;
+
+import io.opentelemetry.extension.annotations.WithSpan;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import io.reactivex.parallel.ParallelFlowable;
+import org.reactivestreams.Publisher;
+
+public class TracedWithSpan {
+
+  @WithSpan
+  public Completable completable(Completable source) {
+    return source;
+  }
+
+  @WithSpan
+  public Maybe<String> maybe(Maybe<String> source) {
+    return source;
+  }
+
+  @WithSpan
+  public Single<String> single(Single<String> source) {
+    return source;
+  }
+
+  @WithSpan
+  public Observable<String> observable(Observable<String> source) {
+    return source;
+  }
+
+  @WithSpan
+  public Flowable<String> flowable(Flowable<String> source) {
+    return source;
+  }
+
+  @WithSpan
+  public ParallelFlowable<String> parallelFlowable(ParallelFlowable<String> source) {
+    return source;
+  }
+
+  @WithSpan
+  public Publisher<String> publisher(Publisher<String> source) {
+    return source;
+  }
+}

--- a/instrumentation/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategy.java
+++ b/instrumentation/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategy.java
@@ -48,9 +48,12 @@ public enum RxJava2AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
   }
 
   private Completable endWhenComplete(BaseTracer tracer, Context context, Completable completable) {
-    return completable
+
+    Completable withNotifications = completable
+        .doOnSubscribe(s -> System.out.println("Subscribed!"))
         .doOnComplete(() -> tracer.end(context))
         .doOnError(exception -> tracer.endExceptionally(context, exception));
+    return withNotifications;
   }
 
   private Maybe<?> endWhenMaybeComplete(BaseTracer tracer, Context context, Maybe<?> maybe) {

--- a/instrumentation/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategy.java
+++ b/instrumentation/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategy.java
@@ -73,6 +73,12 @@ public enum RxJava2AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
         .doOnError(exception -> tracer.endExceptionally(context, exception));
   }
 
+  /**
+   * The {@link ParallelFlowable} class makes multiple parallel subscriptions which results in the
+   * OnComplete and OnError signals being received multiple times, once for each subscriber. The
+   * use of {@link AtomicBoolean} is to ensure that the span is only ended once for the first
+   * signal.
+   */
   private ParallelFlowable<?> endWhenFirstComplete(
       BaseTracer tracer, Context context, ParallelFlowable<?> parallelFlowable) {
     AtomicBoolean done = new AtomicBoolean(false);

--- a/instrumentation/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategy.java
+++ b/instrumentation/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategy.java
@@ -75,9 +75,8 @@ public enum RxJava2AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
 
   /**
    * The {@link ParallelFlowable} class makes multiple parallel subscriptions which results in the
-   * OnComplete and OnError signals being received multiple times, once for each subscriber. The
-   * use of {@link AtomicBoolean} is to ensure that the span is only ended once for the first
-   * signal.
+   * OnComplete and OnError signals being received multiple times, once for each subscriber. The use
+   * of {@link AtomicBoolean} is to ensure that the span is only ended once for the first signal.
    */
   private ParallelFlowable<?> endWhenFirstComplete(
       BaseTracer tracer, Context context, ParallelFlowable<?> parallelFlowable) {

--- a/instrumentation/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategy.java
+++ b/instrumentation/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategy.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rxjava2;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
+import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategy;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import io.reactivex.parallel.ParallelFlowable;
+import org.reactivestreams.Publisher;
+
+public enum RxJava2AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
+  INSTANCE;
+
+  @Override
+  public boolean supports(Class<?> returnType) {
+    return returnType == Publisher.class
+        || returnType == Completable.class
+        || returnType == Maybe.class
+        || returnType == Single.class
+        || returnType == Observable.class
+        || returnType == Flowable.class
+        || returnType == ParallelFlowable.class;
+  }
+
+  @Override
+  public Object end(BaseTracer tracer, Context context, Object returnValue) {
+    if (returnValue instanceof Completable) {
+      return endWhenComplete(tracer, context, (Completable) returnValue);
+    } else if (returnValue instanceof Maybe) {
+      return endWhenMaybeComplete(tracer, context, (Maybe<?>) returnValue);
+    } else if (returnValue instanceof Single) {
+      return endWhenSingleComplete(tracer, context, (Single<?>) returnValue);
+    } else if (returnValue instanceof Observable) {
+      return endWhenObservableComplete(tracer, context, (Observable<?>) returnValue);
+    } else if (returnValue instanceof ParallelFlowable) {
+      return endWhenFirstComplete(tracer, context, (ParallelFlowable<?>) returnValue);
+    }
+    return endWhenPublisherComplete(tracer, context, (Publisher<?>) returnValue);
+  }
+
+  private Completable endWhenComplete(BaseTracer tracer, Context context, Completable completable) {
+    return completable
+        .doOnComplete(() -> tracer.end(context))
+        .doOnError(exception -> tracer.endExceptionally(context, exception));
+  }
+
+  private Maybe<?> endWhenMaybeComplete(BaseTracer tracer, Context context, Maybe<?> maybe) {
+    return maybe
+        .doOnComplete(() -> tracer.end(context))
+        .doOnSuccess(ignored -> tracer.end(context))
+        .doOnError(exception -> tracer.endExceptionally(context, exception));
+  }
+
+  private Single<?> endWhenSingleComplete(BaseTracer tracer, Context context, Single<?> single) {
+    return single
+        .doOnSuccess(ignored -> tracer.end(context))
+        .doOnError(exception -> tracer.endExceptionally(context, exception));
+  }
+
+  private Observable<?> endWhenObservableComplete(BaseTracer tracer, Context context, Observable<?> observable) {
+    return observable
+        .doOnComplete(() -> tracer.end(context))
+        .doOnError(exception -> tracer.endExceptionally(context, exception));
+  }
+
+  private ParallelFlowable<?> endWhenFirstComplete(BaseTracer tracer, Context context, ParallelFlowable<?> parallelFlowable) {
+    AtomicBoolean done = new AtomicBoolean(false);
+    return parallelFlowable
+        .doOnComplete(() -> {
+          if (done.compareAndSet(false, true)) {
+            tracer.end(context);
+          }
+        })
+        .doOnError(exception -> {
+          if (done.compareAndSet(false, true)) {
+            tracer.endExceptionally(context, exception);
+          }
+        });
+  }
+
+  private Flowable<?> endWhenPublisherComplete(BaseTracer tracer, Context context, Publisher<?> publisher) {
+
+    Flowable<?> flowable;
+    if (publisher instanceof Flowable) {
+      flowable = (Flowable<?>) publisher;
+    } else {
+      flowable = Flowable.fromPublisher(publisher);
+    }
+    return flowable
+        .doOnComplete(() -> tracer.end(context))
+        .doOnError(exception -> tracer.endExceptionally(context, exception));
+  }
+}

--- a/instrumentation/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/TracingAssembly.java
+++ b/instrumentation/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/TracingAssembly.java
@@ -24,6 +24,7 @@ package io.opentelemetry.instrumentation.rxjava2;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategies;
 import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
 import io.reactivex.Flowable;
@@ -107,6 +108,8 @@ public final class TracingAssembly {
 
     enableParallel();
 
+    enableWithSpanStrategy();
+
     enabled = true;
   }
 
@@ -126,6 +129,8 @@ public final class TracingAssembly {
     disableFlowable();
 
     disableParallel();
+
+    disableWithSpanStrategy();
 
     enabled = false;
   }
@@ -215,6 +220,10 @@ public final class TracingAssembly {
                     }));
   }
 
+  private static void enableWithSpanStrategy() {
+    AsyncSpanEndStrategies.getInstance().registerStrategy(RxJava2AsyncSpanEndStrategy.INSTANCE);
+  }
+
   private static void disableParallel() {
     RxJavaPlugins.setOnParallelAssembly(oldOnParallelAssembly);
     oldOnParallelAssembly = null;
@@ -245,6 +254,10 @@ public final class TracingAssembly {
     RxJavaPlugins.setOnMaybeSubscribe(
         (BiFunction<? super Maybe, MaybeObserver, ? extends MaybeObserver>) oldOnMaybeSubscribe);
     oldOnMaybeSubscribe = null;
+  }
+
+  private static void disableWithSpanStrategy() {
+    AsyncSpanEndStrategies.getInstance().unregisterStrategy(RxJava2AsyncSpanEndStrategy.INSTANCE);
   }
 
   private static <T> Function<? super T, ? extends T> compose(

--- a/instrumentation/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
+++ b/instrumentation/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
@@ -1,4 +1,7 @@
-
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer

--- a/instrumentation/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
+++ b/instrumentation/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
@@ -13,9 +13,11 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver
 import io.reactivex.parallel.ParallelFlowable
+import io.reactivex.processors.ReplayProcessor
 import io.reactivex.processors.UnicastProcessor
 import io.reactivex.subjects.CompletableSubject
 import io.reactivex.subjects.MaybeSubject
+import io.reactivex.subjects.ReplaySubject
 import io.reactivex.subjects.SingleSubject
 import io.reactivex.subjects.UnicastSubject
 import io.reactivex.subscribers.TestSubscriber
@@ -108,6 +110,32 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span once for multiple subscribers"() {
+      given:
+      def source = CompletableSubject.create()
+      def observer1 = new TestObserver()
+      def observer2 = new TestObserver()
+      def observer3 = new TestObserver()
+
+      when:
+      def result = (Completable) underTest.end(tracer, context, source)
+      result.subscribe(observer1)
+      result.subscribe(observer2)
+      result.subscribe(observer3)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onComplete()
+
+      then:
+      1 * tracer.end(context)
+      observer1.assertComplete()
+      observer2.assertComplete()
+      observer3.assertComplete()
     }
   }
 
@@ -217,6 +245,35 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
     }
+
+    def "ends span once for multiple subscribers"() {
+      given:
+      def source = MaybeSubject.create()
+      def observer1 = new TestObserver()
+      def observer2 = new TestObserver()
+      def observer3 = new TestObserver()
+
+      when:
+      def result = (Maybe<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer1)
+      result.subscribe(observer2)
+      result.subscribe(observer3)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onSuccess("Value")
+
+      then:
+      1 * tracer.end(context)
+      observer1.assertValue("Value")
+      observer1.assertComplete()
+      observer2.assertValue("Value")
+      observer2.assertComplete()
+      observer3.assertValue("Value")
+      observer3.assertComplete()
+    }
   }
 
   static class SingleTest extends RxJava2AsyncSpanEndStrategyTest {
@@ -291,6 +348,35 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span once for multiple subscribers"() {
+      given:
+      def source = SingleSubject.create()
+      def observer1 = new TestObserver()
+      def observer2 = new TestObserver()
+      def observer3 = new TestObserver()
+
+      when:
+      def result = (Single<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer1)
+      result.subscribe(observer2)
+      result.subscribe(observer3)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onSuccess("Value")
+
+      then:
+      1 * tracer.end(context)
+      observer1.assertValue("Value")
+      observer1.assertComplete()
+      observer2.assertValue("Value")
+      observer2.assertComplete()
+      observer3.assertValue("Value")
+      observer3.assertComplete()
     }
   }
 
@@ -367,6 +453,32 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
     }
+
+    def "ends span once for multiple subscribers"() {
+      given:
+      def source = ReplaySubject.create()
+      def observer1 = new TestObserver()
+      def observer2 = new TestObserver()
+      def observer3 = new TestObserver()
+
+      when:
+      def result = (Observable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer1)
+      result.subscribe(observer2)
+      result.subscribe(observer3)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onComplete()
+
+      then:
+      1 * tracer.end(context)
+      observer1.assertComplete()
+      observer2.assertComplete()
+      observer3.assertComplete()
+    }
   }
 
   static class FlowableTest extends RxJava2AsyncSpanEndStrategyTest {
@@ -441,6 +553,32 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span once for multiple subscribers"() {
+      given:
+      def source = ReplayProcessor.create()
+      def observer1 = new TestSubscriber()
+      def observer2 = new TestSubscriber()
+      def observer3 = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer1)
+      result.subscribe(observer2)
+      result.subscribe(observer3)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onComplete()
+
+      then:
+      1 * tracer.end(context)
+      observer1.assertComplete()
+      observer2.assertComplete()
+      observer3.assertComplete()
     }
   }
 

--- a/instrumentation/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
+++ b/instrumentation/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
@@ -1,0 +1,590 @@
+
+
+import io.opentelemetry.context.Context
+import io.opentelemetry.instrumentation.api.tracer.BaseTracer
+import io.opentelemetry.instrumentation.rxjava2.RxJava2AsyncSpanEndStrategy
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Maybe
+import io.reactivex.Observable
+import io.reactivex.Single
+import io.reactivex.observers.TestObserver
+import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.processors.UnicastProcessor
+import io.reactivex.subjects.CompletableSubject
+import io.reactivex.subjects.MaybeSubject
+import io.reactivex.subjects.SingleSubject
+import io.reactivex.subjects.UnicastSubject
+import io.reactivex.subscribers.TestSubscriber
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import spock.lang.Specification
+
+class RxJava2AsyncSpanEndStrategyTest extends Specification {
+  BaseTracer tracer
+
+  Context context
+
+  def underTest = RxJava2AsyncSpanEndStrategy.INSTANCE
+
+  void setup() {
+    tracer = Mock()
+    context = Mock()
+  }
+
+  static class CompletableTest extends RxJava2AsyncSpanEndStrategyTest {
+    def "is supported"() {
+      expect:
+      underTest.supports(Completable)
+    }
+
+    def "ends span on already completed"() {
+      given:
+      def observer = new TestObserver()
+
+      when:
+      def result = (Completable) underTest.end(tracer, context, Completable.complete())
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span on already errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Completable) underTest.end(tracer, context, Completable.error(exception))
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+
+    def "ends span when completed"() {
+      given:
+      def source = CompletableSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Completable) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onComplete()
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span when errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def source = CompletableSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Completable) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onError(exception)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+  }
+
+  static class MaybeTest extends RxJava2AsyncSpanEndStrategyTest {
+    def "is supported"() {
+      expect:
+      underTest.supports(Maybe)
+    }
+
+    def "ends span on already completed"() {
+      given:
+      def observer = new TestObserver()
+
+      when:
+      def result = (Maybe<?>) underTest.end(tracer, context, Maybe.just("Value"))
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span on already empty"() {
+      given:
+      def observer = new TestObserver()
+
+      when:
+      def result = (Maybe<?>) underTest.end(tracer, context, Maybe.empty())
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span on already errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Maybe<?>) underTest.end(tracer, context, Maybe.error(exception))
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+
+    def "ends span when completed"() {
+      given:
+      def source = MaybeSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Maybe<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onSuccess("Value")
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span when empty"() {
+      given:
+      def source = MaybeSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Maybe<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onComplete()
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span when errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def source = MaybeSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Maybe<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onError(exception)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+  }
+
+  static class SingleTest extends RxJava2AsyncSpanEndStrategyTest {
+    def "is supported"() {
+      expect:
+      underTest.supports(Single)
+    }
+
+    def "ends span on already completed"() {
+      given:
+      def observer = new TestObserver()
+
+      when:
+      def result = (Single<?>) underTest.end(tracer, context, Single.just("Value"))
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span on already errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Single<?>) underTest.end(tracer, context, Single.error(exception))
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+
+    def "ends span when completed"() {
+      given:
+      def source = SingleSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Single<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onSuccess("Value")
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span when errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def source = SingleSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Single<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onError(exception)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+  }
+
+  static class ObservableTest extends RxJava2AsyncSpanEndStrategyTest {
+    def "is supported"() {
+      expect:
+      underTest.supports(Observable)
+    }
+
+    def "ends span on already completed"() {
+      given:
+      def observer = new TestObserver()
+
+      when:
+      def result = (Observable<?>) underTest.end(tracer, context, Observable.just("Value"))
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span on already errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Observable<?>) underTest.end(tracer, context, Observable.error(exception))
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+
+    def "ends span when completed"() {
+      given:
+      def source = UnicastSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Observable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onComplete()
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span when errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def source = UnicastSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Observable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onError(exception)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+  }
+
+  static class FlowableTest extends RxJava2AsyncSpanEndStrategyTest {
+    def "is supported"() {
+      expect:
+      underTest.supports(Flowable)
+    }
+
+    def "ends span on already completed"() {
+      given:
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, Flowable.just("Value"))
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span on already errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, Flowable.error(exception))
+      result.subscribe(observer)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+
+    def "ends span when completed"() {
+      given:
+      def source = UnicastProcessor.create()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onComplete()
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span when errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def source = UnicastProcessor.create()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onError(exception)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+  }
+
+  static class ParallelFlowableTest extends RxJava2AsyncSpanEndStrategyTest {
+    def "is supported"() {
+      expect:
+      underTest.supports(ParallelFlowable)
+    }
+
+    def "ends span on already completed"() {
+      given:
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (ParallelFlowable<?>) underTest.end(tracer, context, Flowable.just("Value").parallel())
+      result.sequential().subscribe(observer)
+
+      then:
+      observer.assertComplete()
+      1 * tracer.end(context)
+    }
+
+    def "ends span on already errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (ParallelFlowable<?>) underTest.end(tracer, context, Flowable.error(exception).parallel())
+      result.sequential().subscribe(observer)
+
+      then:
+      observer.assertError(exception)
+      1 * tracer.endExceptionally(context, exception)
+    }
+
+    def "ends span when completed"() {
+      given:
+      def source = UnicastProcessor.create()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (ParallelFlowable<?>) underTest.end(tracer, context, source.parallel())
+      result.sequential().subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onComplete()
+
+      then:
+      observer.assertComplete()
+      1 * tracer.end(context)
+    }
+
+    def "ends span when errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def source = UnicastProcessor.create()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (ParallelFlowable<?>) underTest.end(tracer, context, source.parallel())
+      result.sequential().subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onError(exception)
+
+      then:
+      observer.assertError(exception)
+      1 * tracer.endExceptionally(context, exception)
+    }
+  }
+
+  static class PublisherTest extends RxJava2AsyncSpanEndStrategyTest {
+    def "is supported"() {
+      expect:
+      underTest.supports(Publisher)
+    }
+
+    def "ends span when completed"() {
+      given:
+      def source = new CustomPublisher()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onComplete()
+
+      then:
+      1 * tracer.end(context)
+      observer.assertComplete()
+    }
+
+    def "ends span when errored"() {
+      given:
+      def exception = new IllegalStateException()
+      def source = new CustomPublisher()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      source.onError(exception)
+
+      then:
+      1 * tracer.endExceptionally(context, exception)
+      observer.assertError(exception)
+    }
+  }
+
+  static class CustomPublisher implements Publisher<String>, Subscription {
+    Subscriber<? super String> subscriber
+
+    @Override
+    void subscribe(Subscriber<? super String> subscriber) {
+      this.subscriber = subscriber
+      subscriber.onSubscribe(this)
+    }
+
+    def onComplete() {
+      this.subscriber.onComplete()
+    }
+
+    def onError(Throwable exception) {
+      this.subscriber.onError(exception)
+    }
+
+    @Override
+    void request(long l) { }
+
+    @Override
+    void cancel() { }
+  }
+}

--- a/instrumentation/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
+++ b/instrumentation/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
@@ -12,7 +12,7 @@ import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver
-import io.reactivex.parallel.ParallelFlowable;
+import io.reactivex.parallel.ParallelFlowable
 import io.reactivex.processors.UnicastProcessor
 import io.reactivex.subjects.CompletableSubject
 import io.reactivex.subjects.MaybeSubject


### PR DESCRIPTION
Adds an implementation of `AsyncSpanEndStrategy` which supports RxJava 2 publishers returned from methods annotated with the `@WithSpan` annotation.