### PR TITLE
Fix muzzle failure

### DIFF
--- a/instrumentation/undertow-1.4/javaagent/undertow-1.4-javaagent.gradle
+++ b/instrumentation/undertow-1.4/javaagent/undertow-1.4-javaagent.gradle
@@ -5,6 +5,10 @@ muzzle {
     group = "io.undertow"
     module = 'undertow-core'
     versions = "[1.4.0.Final,)"
+    // TODO (trask) try to remove the skipVersions in the future
+    //  not sure what's wrong with this recent version, hopefully just publishing blip that
+    //  will work itself out
+    skipVersions += ['2.2.7.Final']
     assertInverse = true
   }
 }


### PR DESCRIPTION
May just be a blip mid-publishing new `2.2.7.Final` release, but it's holding up a couple of PRs due to CI failure.

Probably will fix itself at some point, `maven-metadata.xml` at
https://repo1.maven.org/maven2/io/undertow/undertow-core/
contains `2.2.7.Final`, but there's no `2.2.7.Final` published yet.

Still think worth merging this to unblock PRs. Or alternatively, we could override the check and merge PRs blocked on this anyways.