### PR TITLE
Flag off enableStrictContext for now.

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -224,9 +224,9 @@ tasks.withType(Test).configureEach {
 
   // There's no real harm in setting this for all tests even if any happen to not be using context
   // propagation.
-  jvmArgs "-Dio.opentelemetry.context.enableStrictContext=true"
+  jvmArgs "-Dio.opentelemetry.context.enableStrictContext=${rootProject.findProperty('enableStrictContext') ?: false}"
   // TODO(anuraaga): Have agent map unshaded to shaded.
-  jvmArgs "-Dio.opentelemetry.javaagent.shaded.io.opentelemetry.context.enableStrictContext=true"
+  jvmArgs "-Dio.opentelemetry.javaagent.shaded.io.opentelemetry.context.enableStrictContext=${rootProject.findProperty('enableStrictContext') ?: false}"
 }
 
 tasks.withType(AbstractArchiveTask) {


### PR DESCRIPTION
While I want to solve context issues, which this flag does help with, it's too flaky to enable for all the builds right now. I'll probably need to set up a separate job for this just to investigate the propagation under the stress of CI which brings them up.