### PR TITLE
Small cleanups to executor tests

### DIFF
--- a/instrumentation/executors/javaagent/executors-javaagent.gradle
+++ b/instrumentation/executors/javaagent/executors-javaagent.gradle
@@ -8,4 +8,5 @@ muzzle {
 
 tasks.withType(Test) {
   jvmArgs "-Dotel.instrumentation.executors.include=ExecutorInstrumentationTest\$CustomThreadPoolExecutor"
+  jvmArgs "-Djava.awt.headless=true"
 }


### PR DESCRIPTION
- Wait for executor shutdown on all tests. The test can actually continue before the executed runnable finishes, closing scope. While the amount of time is tiny, we know that CI will exercise any sort of race that's possible. Basically no slowdown by waiting anyways.

- Fix test method names include pool state

- Fix AWT popup during test execution