### PR TITLE
Reset context class loader for new thread

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/SupportabilityMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/SupportabilityMetrics.java
@@ -64,6 +64,7 @@ class SupportabilityMetrics {
               runnable -> {
                 Thread result = new Thread(runnable, "supportability_metrics_reporter");
                 result.setDaemon(true);
+                result.setContextClassLoader(null);
                 return result;
               })
           .scheduleAtFixedRate(this::report, 5, 5, TimeUnit.SECONDS);


### PR DESCRIPTION
When running `JspInstrumentationBasicTests` at the end of the output there is
```
SEVERE: The web application [/jsptest-context] appears to have started a thread named [supportability_metrics_reporter] but has failed to stop it. This is very likely to create a memory leak.
```
