### PR TITLE
Enable debug logging for docker java client

### DIFF
--- a/smoke-tests/src/test/resources/logback.xml
+++ b/smoke-tests/src/test/resources/logback.xml
@@ -17,6 +17,7 @@
   <logger name="org.testcontainers" level="debug"/>
   <logger name="org.testcontainers.shaded" level="warn"/>
   <logger name="org.testcontainers.containers.output.WaitingConsumer" level="warn"/>
+  <logger name="com.github.dockerjava" level="debug"/>
   <logger name="Collector" level="debug"/>
   <logger name="Backend" level="debug"/>
 


### PR DESCRIPTION
Maybe extra logging will show why windows smoke tests run slow.