### PR TITLE
Update java in windows fake backend image

### DIFF
--- a/smoke-tests/fake-backend/src/docker/backend/windows.dockerfile
+++ b/smoke-tests/fake-backend/src/docker/backend/windows.dockerfile
@@ -1,3 +1,3 @@
-FROM winamd64/openjdk:11.0.9.1-jdk-windowsservercore-1809
+FROM winamd64/openjdk:11.0.10-jdk-windowsservercore-1809
 COPY fake-backend.jar /fake-backend.jar
 CMD ["java", "-jar", "/fake-backend.jar"]


### PR DESCRIPTION
My hypothesis is that to make windows tests faster our test images should use the windows base images that are cached on github action runners https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#cached-docker-images. These cached images are occasionally update. Fake backend image is base on a java image that is ~3 months old replacing it with a newer image will hopefully help.
