### PR TITLE
Document supported JVMs as a separate section

### DIFF
--- a/docs/supported-libraries.md
+++ b/docs/supported-libraries.md
@@ -1,5 +1,5 @@
 
-# Supported libraries, frameworks, and application servers
+# Supported libraries, frameworks, application servers, and JVMs
 
 We automatically instrument and support a huge number of libraries, frameworks,
 and application servers... right out of the box!
@@ -111,6 +111,15 @@ These are the supported application servers:
 | [Websphere Liberty Profile](https://www.ibm.com/cloud/websphere-liberty)                  | 20.0.0.12                   | OpenJDK 8, 11    | Ubuntu 18, Windows Server 2019 |
 | [WildFly](https://www.wildfly.org/)                                                       | 13.0.x                      | OpenJDK 8        | Ubuntu 18, Windows Server 2019 |
 | [WildFly](https://www.wildfly.org/)                                                       | 17.0.1, 21.0.0              | OpenJDK 8, 11    | Ubuntu 18, Windows Server 2019 |
+
+## JVMs and operating systems
+
+These are the supported JVM version and OS configurations which the javaagent is tested on:
+
+| JVM                                               | Versions  | OS                             |
+| ------------------------------------------------- | --------- | ------------------------------ |
+| [AdoptOpenJDK Hotspot](https://adoptopenjdk.net/) | 8, 11, 15 | Ubuntu 18, Windows Server 2019 |
+| [AdoptOpenJDK OpenJ9](https://adoptopenjdk.net/)  | 8, 11, 15 | Ubuntu 18, Windows Server 2019 |
 
 ## Disabled instrumentations
 


### PR DESCRIPTION
Since smoke tests are performed separately with HotSpot and OpenJ9 JVMs, having documentation contain the JVM list separately can be useful for quickly determining which JVM and OS configuration the agent is compatible with in general, not just specifically for a given framework.