### PR TITLE
Remove --no-daemon from CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -154,7 +154,7 @@ jobs:
         with:
           java-version: 11
       - name: Run muzzle
-        run: ./gradlew ${{ matrix.module }}:muzzle --no-daemon
+        run: ./gradlew ${{ matrix.module }}:muzzle
 
   accept-pr:
     needs: [ build, test, smoke-test, muzzle ]


### PR DESCRIPTION
we've removed it elsewhere per gradle recommendation https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:disabling_the_daemon, don't recall if there was a specific reason for it here