### PR TITLE
Remove duplicate status verification

### DIFF
--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -84,7 +84,7 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<HttpRequest> impl
           hasNoParent()
           name "HTTP request"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent(NullPointerException, e.getMessage())
         }
       }

--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import akka.actor.ActorSystem
 import akka.http.javadsl.Http

--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 

--- a/instrumentation/apache-dubbo/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.groovy
+++ b/instrumentation/apache-dubbo/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.groovy
@@ -5,6 +5,11 @@
 
 package io.opentelemetry.instrumentation.apachedubbo.v2_7
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.impl.HelloServiceImpl
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
@@ -21,11 +26,6 @@ import org.apache.dubbo.config.utils.ReferenceConfigCache
 import org.apache.dubbo.rpc.service.GenericService
 import spock.lang.Shared
 import spock.lang.Unroll
-
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 @Unroll
 abstract class AbstractDubboTest extends InstrumentationSpecification {
@@ -93,7 +93,7 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
           name "org.apache.dubbo.rpc.service.GenericService/\$invoke"
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "dubbo"
             "${SemanticAttributes.RPC_SERVICE.key}" "org.apache.dubbo.rpc.service.GenericService"
@@ -106,7 +106,7 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
           name "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService/hello"
           kind SERVER
           childOf span(1)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "dubbo"
             "${SemanticAttributes.RPC_SERVICE.key}" "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"
@@ -162,7 +162,7 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
           name "org.apache.dubbo.rpc.service.GenericService/\$invokeAsync"
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "dubbo"
             "${SemanticAttributes.RPC_SERVICE.key}" "org.apache.dubbo.rpc.service.GenericService"
@@ -175,7 +175,7 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
           name "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService/hello"
           kind SERVER
           childOf span(1)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "dubbo"
             "${SemanticAttributes.RPC_SERVICE.key}" "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"

--- a/instrumentation/apache-dubbo/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.groovy
+++ b/instrumentation/apache-dubbo/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.groovy
@@ -93,7 +93,6 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
           name "org.apache.dubbo.rpc.service.GenericService/\$invoke"
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "dubbo"
             "${SemanticAttributes.RPC_SERVICE.key}" "org.apache.dubbo.rpc.service.GenericService"
@@ -106,7 +105,6 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
           name "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService/hello"
           kind SERVER
           childOf span(1)
-          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "dubbo"
             "${SemanticAttributes.RPC_SERVICE.key}" "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"
@@ -162,7 +160,6 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
           name "org.apache.dubbo.rpc.service.GenericService/\$invokeAsync"
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "dubbo"
             "${SemanticAttributes.RPC_SERVICE.key}" "org.apache.dubbo.rpc.service.GenericService"
@@ -175,7 +172,6 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
           name "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService/hello"
           kind SERVER
           childOf span(1)
-          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "dubbo"
             "${SemanticAttributes.RPC_SERVICE.key}" "io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService"

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -65,7 +65,7 @@ class ApacheHttpAsyncClientTest extends HttpClientTest<HttpUriRequest> implement
   }
 
   @Override
-  Integer statusOnRedirectError() {
+  Integer responseCodeOnRedirectError() {
     return 302
   }
 

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
@@ -120,7 +120,7 @@ class TracingRequestStreamWrapperPropagationTest extends LibraryInstrumentationS
           traceId("4fd0b6131f19f39af59518d127b0cafe")
           name("my_function")
           kind SERVER
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "bad argument")
           attributes {
             "${SemanticAttributes.FAAS_EXECUTION.key}" "1-22-333"

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
@@ -102,7 +102,7 @@ class TracingRequestStreamWrapperTest extends LibraryInstrumentationSpecificatio
         span(0) {
           name("my_function")
           kind SERVER
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "bad argument")
           attributes {
             "$ResourceAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
@@ -68,7 +68,7 @@ class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
         span(0) {
           name("my_function")
           kind SERVER
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "bad argument")
           attributes {
             "$ResourceAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler

--- a/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaRequestHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaRequestHandlerTest.groovy
@@ -67,7 +67,7 @@ abstract class AbstractAwsLambdaRequestHandlerTest extends InstrumentationSpecif
         span(0) {
           name("my_function")
           kind SERVER
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "bad argument")
           attributes {
             "${SemanticAttributes.FAAS_EXECUTION.key}" "1-22-333"

--- a/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaRequestHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaRequestHandlerTest.groovy
@@ -6,12 +6,13 @@
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.github.stefanbirkner.systemlambda.SystemLambda
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 abstract class AbstractAwsLambdaRequestHandlerTest extends InstrumentationSpecification {
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/Aws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/Aws1ClientTest.groovy
@@ -90,7 +90,7 @@ class Aws1ClientTest extends AbstractAws1ClientTest implements AgentTestTrait {
         span(0) {
           name "S3.HeadBucket"
           kind SpanKind.CLIENT
-          errored true
+          status ERROR
           errorEvent RuntimeException, "bad handler"
           hasNoParent()
           attributes {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/Aws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/Aws1ClientTest.groovy
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.awssdk.v1_11
 
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+
 import com.amazonaws.AmazonWebServiceClient
 import com.amazonaws.Request
 import com.amazonaws.auth.BasicAWSCredentials

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.httpServer

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -101,7 +101,7 @@ class Aws0ClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind CLIENT
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -160,7 +160,7 @@ class Aws0ClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent AmazonClientException, ~/Unable to execute HTTP request/
           hasNoParent()
           attributes {
@@ -208,7 +208,7 @@ class Aws0ClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "S3.GetObject"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent RuntimeException, "bad handler"
           hasNoParent()
           attributes {
@@ -254,7 +254,7 @@ class Aws0ClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "S3.GetObject"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent AmazonClientException, ~/Unable to execute HTTP request/
           hasNoParent()
           attributes {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -102,7 +102,6 @@ class Aws0ClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind CLIENT
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.httpServer
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awssdk.v1_11
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.httpServer
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
@@ -95,7 +95,6 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind operation == "SendMessage" ? PRODUCER : CLIENT
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
@@ -94,7 +94,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind operation == "SendMessage" ? PRODUCER : CLIENT
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -119,19 +119,19 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
     server.lastRequest.headers.get("traceparent") == null
 
     where:
-    service      | operation           | method | path                  | clientBuilder                                                             | call                                                                            | additionalAttributes              | body
-    "S3"         | "CreateBucket"      | "PUT"  | "/testbucket/"        | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true)         | { c  -> c.createBucket("testbucket") }                                          | ["aws.bucket.name": "testbucket"] | ""
-    "S3"         | "GetObject"         | "GET"  | "/someBucket/someKey" | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true)         | { c -> c.getObject("someBucket", "someKey") }                                   | ["aws.bucket.name": "someBucket"] | ""
-    "DynamoDBv2" | "CreateTable"       | "POST" | "/"                   | AmazonDynamoDBClientBuilder.standard()                                    | { c -> c.createTable(new CreateTableRequest("sometable", null)) }               | ["aws.table.name": "sometable"]   | ""
-    "Kinesis"    | "DeleteStream"      | "POST" | "/"                   | AmazonKinesisClientBuilder.standard()                                     | { c -> c.deleteStream(new DeleteStreamRequest().withStreamName("somestream")) } | ["aws.stream.name": "somestream"] | ""
-    "EC2"        | "AllocateAddress"   | "POST" | "/"                   | AmazonEC2ClientBuilder.standard()                                         | { c -> c.allocateAddress() }                                                    | [:]                               | """
+    service      | operation           | method | path                  | clientBuilder                                                     | call                                                                            | additionalAttributes              | body
+    "S3"         | "CreateBucket"      | "PUT"  | "/testbucket/"        | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true) | { c -> c.createBucket("testbucket") }                                           | ["aws.bucket.name": "testbucket"] | ""
+    "S3"         | "GetObject"         | "GET"  | "/someBucket/someKey" | AmazonS3ClientBuilder.standard().withPathStyleAccessEnabled(true) | { c -> c.getObject("someBucket", "someKey") }                                   | ["aws.bucket.name": "someBucket"] | ""
+    "DynamoDBv2" | "CreateTable"       | "POST" | "/"                   | AmazonDynamoDBClientBuilder.standard()                            | { c -> c.createTable(new CreateTableRequest("sometable", null)) }               | ["aws.table.name": "sometable"]   | ""
+    "Kinesis"    | "DeleteStream"      | "POST" | "/"                   | AmazonKinesisClientBuilder.standard()                             | { c -> c.deleteStream(new DeleteStreamRequest().withStreamName("somestream")) } | ["aws.stream.name": "somestream"] | ""
+    "EC2"        | "AllocateAddress"   | "POST" | "/"                   | AmazonEC2ClientBuilder.standard()                                 | { c -> c.allocateAddress() }                                                    | [:]                               | """
         <AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
            <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
            <publicIp>192.0.2.1</publicIp>
            <domain>standard</domain>
         </AllocateAddressResponse>
       """
-    "RDS"        | "DeleteOptionGroup" | "POST" | "/"                   | AmazonRDSClientBuilder.standard()                                         | { c -> c.deleteOptionGroup(new DeleteOptionGroupRequest()) }                    | [:]                               | """
+    "RDS"        | "DeleteOptionGroup" | "POST" | "/"                   | AmazonRDSClientBuilder.standard()                                 | { c -> c.deleteOptionGroup(new DeleteOptionGroupRequest()) }                    | [:]                               | """
         <DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
           <ResponseMetadata>
             <RequestId>0ac9cda2-bbf4-11d3-f92b-31fa5e8dbc99</RequestId>
@@ -160,7 +160,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent SdkClientException, ~/Unable to execute HTTP request/
           hasNoParent()
           attributes {
@@ -183,8 +183,8 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
     }
 
     where:
-    service | operation   | method | url                  | call                                                    | additionalAttributes              | body | clientBuilder
-    "S3"    | "GetObject" | "GET"  | "someBucket/someKey" | { c -> c.getObject("someBucket", "someKey") }           | ["aws.bucket.name": "someBucket"] | ""   | AmazonS3ClientBuilder.standard()
+    service | operation   | method | url                  | call                                          | additionalAttributes              | body | clientBuilder
+    "S3"    | "GetObject" | "GET"  | "someBucket/someKey" | { c -> c.getObject("someBucket", "someKey") } | ["aws.bucket.name": "someBucket"] | ""   | AmazonS3ClientBuilder.standard()
   }
 
   // TODO(anuraaga): Add events for retries.
@@ -215,7 +215,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
         span(0) {
           name "S3.GetObject"
           kind CLIENT
-          errored true
+          status ERROR
           try {
             errorEvent AmazonClientException, ~/Unable to execute HTTP request/
           } catch (AssertionError e) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -153,7 +153,7 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "DynamoDb.CreateTable"
           kind CLIENT
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -189,7 +189,7 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "DynamoDb.Query"
           kind CLIENT
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -224,7 +224,7 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind CLIENT
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -337,7 +337,7 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind CLIENT
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -426,7 +426,7 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind CLIENT
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -526,7 +526,7 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "S3.GetObject"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent SdkClientException, "Unable to execute HTTP request: Read timed out"
           hasNoParent()
           attributes {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -154,7 +154,6 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "DynamoDb.CreateTable"
           kind CLIENT
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -190,7 +189,6 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "DynamoDb.Query"
           kind CLIENT
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -225,7 +223,6 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind CLIENT
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -338,7 +335,6 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind CLIENT
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -427,7 +423,6 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
         span(0) {
           name "$service.$operation"
           kind CLIENT
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awssdk.v2_2
 
 import static com.google.common.collect.ImmutableMap.of
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.httpServer
 
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -16,7 +16,7 @@ class CouchbaseSpanUtil {
     trace.span(index) {
       name spanName
       kind CLIENT
-      errored false
+      status UNSET
       if (parentSpan == null) {
         hasNoParent()
       } else {
@@ -41,7 +41,7 @@ class CouchbaseSpanUtil {
         // that do have operation ids
         "couchbase.operation_id" { it == null || String }
 
-        "${SemanticAttributes.DB_STATEMENT.key}" (statement ?: spanName)
+        "${SemanticAttributes.DB_STATEMENT.key}"(statement ?: spanName)
       }
     }
   }

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -16,7 +16,6 @@ class CouchbaseSpanUtil {
     trace.span(index) {
       name spanName
       kind CLIENT
-      status UNSET
       if (parentSpan == null) {
         hasNoParent()
       } else {

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/util/AbstractCouchbaseTest.groovy
@@ -107,7 +107,7 @@ abstract class AbstractCouchbaseTest extends AgentInstrumentationSpecification {
     trace.span(index) {
       name spanName
       kind CLIENT
-      errored false
+      status UNSET
       if (parentSpan == null) {
         hasNoParent()
       } else {
@@ -118,7 +118,7 @@ abstract class AbstractCouchbaseTest extends AgentInstrumentationSpecification {
         if (bucketName != null) {
           "${SemanticAttributes.DB_NAME.key}" bucketName
         }
-        "${SemanticAttributes.DB_STATEMENT.key}" (statement ?: spanName)
+        "${SemanticAttributes.DB_STATEMENT.key}"(statement ?: spanName)
       }
     }
   }

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/util/AbstractCouchbaseTest.groovy
@@ -107,7 +107,6 @@ abstract class AbstractCouchbaseTest extends AgentInstrumentationSpecification {
     trace.span(index) {
       name spanName
       kind CLIENT
-      status UNSET
       if (parentSpan == null) {
         hasNoParent()
       } else {

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -101,7 +101,7 @@ class Elasticsearch5NodeClientTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "GetAction"
-          errored true
+          status ERROR
           errorEvent IndexNotFoundException, "no such index"
           kind CLIENT
           attributes {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -69,10 +69,10 @@ class Elasticsearch5NodeClientTest extends AgentInstrumentationSpecification {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest())
 
-    def status = result.get().status
+    def clusterHealthStatus = result.get().status
 
     expect:
-    status.name() == "GREEN"
+    clusterHealthStatus.name() == "GREEN"
 
     assertTraces(1) {
       trace(0, 1) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -85,10 +85,10 @@ class Elasticsearch5TransportClientTest extends AgentInstrumentationSpecificatio
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest())
 
-    def status = result.get().status
+    def clusterHealthStatus = result.get().status
 
     expect:
-    status.name() == "GREEN"
+    clusterHealthStatus.name() == "GREEN"
 
     assertTraces(1) {
       trace(0, 1) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -121,7 +121,7 @@ class Elasticsearch5TransportClientTest extends AgentInstrumentationSpecificatio
         span(0) {
           name "GetAction"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent RemoteTransportException, String
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -72,10 +72,10 @@ class Elasticsearch53NodeClientTest extends AgentInstrumentationSpecification {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest())
 
-    def status = result.get().status
+    def clusterHealthStatus = result.get().status
 
     expect:
-    status.name() == "GREEN"
+    clusterHealthStatus.name() == "GREEN"
 
     assertTraces(1) {
       trace(0, 1) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -105,7 +105,7 @@ class Elasticsearch53NodeClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GetAction"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent IndexNotFoundException, "no such index"
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -90,10 +90,10 @@ class Elasticsearch53TransportClientTest extends AgentInstrumentationSpecificati
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest())
 
-    def status = result.get().status
+    def clusterHealthStatus = result.get().status
 
     expect:
-    status.name() == "GREEN"
+    clusterHealthStatus.name() == "GREEN"
 
     assertTraces(1) {
       trace(0, 1) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -126,7 +126,7 @@ class Elasticsearch53TransportClientTest extends AgentInstrumentationSpecificati
         span(0) {
           name "GetAction"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent RemoteTransportException, String
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -89,7 +89,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
         span(1) {
           name "SearchAction"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -89,7 +89,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
         span(1) {
           name "SearchAction"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -93,7 +93,7 @@ class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecificatio
         span(0) {
           name "RefreshAction"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent IndexNotFoundException, "no such index"
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -6,6 +6,7 @@
 package springdata
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -67,10 +67,10 @@ class Elasticsearch6NodeClientTest extends AgentInstrumentationSpecification {
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest()).get()
 
-    def status = result.status
+    def clusterHealthStatus = result.status
 
     expect:
-    status.name() == "GREEN"
+    clusterHealthStatus.name() == "GREEN"
 
     assertTraces(1) {
       trace(0, 1) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -100,7 +100,7 @@ class Elasticsearch6NodeClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GetAction"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent IndexNotFoundException, ~/no such index( \[invalid-index\])?/
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -83,10 +83,10 @@ class Elasticsearch6TransportClientTest extends AgentInstrumentationSpecificatio
     setup:
     def result = client.admin().cluster().health(new ClusterHealthRequest())
 
-    def status = result.get().status
+    def clusterHealthStatus = result.get().status
 
     expect:
-    status.name() == "GREEN"
+    clusterHealthStatus.name() == "GREEN"
 
     assertTraces(1) {
       trace(0, 1) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -119,7 +119,7 @@ class Elasticsearch6TransportClientTest extends AgentInstrumentationSpecificatio
         span(0) {
           name "GetAction"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent RemoteTransportException, String
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/TraceAnnotationsTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.test.annotation.SayTracedHello
 import io.opentracing.contrib.dropwizard.Trace

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/TraceAnnotationsTest.groovy
@@ -23,7 +23,6 @@ class TraceAnnotationsTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SayTracedHello.sayHello"
           hasNoParent()
-          status UNSET
           attributes {
             "myattr" "test"
           }
@@ -43,7 +42,6 @@ class TraceAnnotationsTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SayTracedHello.sayHelloSayHa"
           hasNoParent()
-          status UNSET
           attributes {
             "myattr" "test2"
           }
@@ -51,7 +49,6 @@ class TraceAnnotationsTest extends AgentInstrumentationSpecification {
         span(1) {
           name "SayTracedHello.sayHello"
           childOf span(0)
-          status UNSET
           attributes {
             "myattr" "test"
           }
@@ -59,7 +56,6 @@ class TraceAnnotationsTest extends AgentInstrumentationSpecification {
         span(2) {
           name "SayTracedHello.sayHello"
           childOf span(0)
-          status UNSET
           attributes {
             "myattr" "test"
           }

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/TraceAnnotationsTest.groovy
@@ -21,7 +21,7 @@ class TraceAnnotationsTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SayTracedHello.sayHello"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
             "myattr" "test"
           }
@@ -41,7 +41,7 @@ class TraceAnnotationsTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SayTracedHello.sayHelloSayHa"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
             "myattr" "test2"
           }
@@ -49,7 +49,7 @@ class TraceAnnotationsTest extends AgentInstrumentationSpecification {
         span(1) {
           name "SayTracedHello.sayHello"
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "myattr" "test"
           }
@@ -57,7 +57,7 @@ class TraceAnnotationsTest extends AgentInstrumentationSpecification {
         span(2) {
           name "SayTracedHello.sayHello"
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "myattr" "test"
           }
@@ -80,7 +80,7 @@ class TraceAnnotationsTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "SayTracedHello.sayError"
-          errored true
+          status ERROR
           errorEvent(error.class)
         }
       }

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/TraceProvidersTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/TraceProvidersTest.groovy
@@ -21,7 +21,6 @@ class TraceProvidersTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SayTracedHello.${provider.toLowerCase()}"
           hasNoParent()
-          status UNSET
           attributes {
             "providerAttr" provider
           }

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/TraceProvidersTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/TraceProvidersTest.groovy
@@ -21,7 +21,7 @@ class TraceProvidersTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SayTracedHello.${provider.toLowerCase()}"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
             "providerAttr" provider
           }

--- a/instrumentation/finatra-2.9/javaagent/src/latestDepTest/groovy/FinatraServerLatestTest.groovy
+++ b/instrumentation/finatra-2.9/javaagent/src/latestDepTest/groovy/FinatraServerLatestTest.groovy
@@ -90,7 +90,7 @@ class FinatraServerLatestTest extends HttpServerTest<HttpServer> implements Agen
       childOf(parent as SpanData)
       // Finatra doesn't propagate the stack trace or exception to the instrumentation
       // so the normal errorAttributes() method can't be used
-      errored false
+      status UNSET
       attributes {
       }
     }

--- a/instrumentation/finatra-2.9/javaagent/src/latestDepTest/groovy/FinatraServerLatestTest.groovy
+++ b/instrumentation/finatra-2.9/javaagent/src/latestDepTest/groovy/FinatraServerLatestTest.groovy
@@ -90,7 +90,6 @@ class FinatraServerLatestTest extends HttpServerTest<HttpServer> implements Agen
       childOf(parent as SpanData)
       // Finatra doesn't propagate the stack trace or exception to the instrumentation
       // so the normal errorAttributes() method can't be used
-      status UNSET
       attributes {
       }
     }

--- a/instrumentation/finatra-2.9/javaagent/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/javaagent/src/test/groovy/FinatraServerTest.groovy
@@ -76,7 +76,6 @@ class FinatraServerTest extends HttpServerTest<HttpServer> implements AgentTestT
       childOf(parent as SpanData)
       // Finatra doesn't propagate the stack trace or exception to the instrumentation
       // so the normal errorAttributes() method can't be used
-      status UNSET
       attributes {
       }
     }

--- a/instrumentation/finatra-2.9/javaagent/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/javaagent/src/test/groovy/FinatraServerTest.groovy
@@ -76,7 +76,7 @@ class FinatraServerTest extends HttpServerTest<HttpServer> implements AgentTestT
       childOf(parent as SpanData)
       // Finatra doesn't propagate the stack trace or exception to the instrumentation
       // so the normal errorAttributes() method can't be used
-      errored false
+      status UNSET
       attributes {
       }
     }

--- a/instrumentation/geode-1.4/javaagent/src/test/groovy/PutGetTest.groovy
+++ b/instrumentation/geode-1.4/javaagent/src/test/groovy/PutGetTest.groovy
@@ -112,12 +112,12 @@ class PutGetTest extends AgentInstrumentationSpecification {
         span(0) {
           name "someTrace"
           kind INTERNAL
-          errored false
+          status UNSET
         }
         span(1) {
           name "clear"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "geode"
             "$SemanticAttributes.DB_NAME.key" "test-region"
@@ -127,7 +127,7 @@ class PutGetTest extends AgentInstrumentationSpecification {
         span(2) {
           name "put"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "geode"
             "$SemanticAttributes.DB_NAME.key" "test-region"
@@ -137,7 +137,7 @@ class PutGetTest extends AgentInstrumentationSpecification {
         span(3) {
           name verb
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "geode"
             "$SemanticAttributes.DB_NAME.key" "test-region"
@@ -171,7 +171,7 @@ class PutGetTest extends AgentInstrumentationSpecification {
         span(0) {
           name "query"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "geode"
             "$SemanticAttributes.DB_NAME.key" "test-region"

--- a/instrumentation/geode-1.4/javaagent/src/test/groovy/PutGetTest.groovy
+++ b/instrumentation/geode-1.4/javaagent/src/test/groovy/PutGetTest.groovy
@@ -112,12 +112,10 @@ class PutGetTest extends AgentInstrumentationSpecification {
         span(0) {
           name "someTrace"
           kind INTERNAL
-          status UNSET
         }
         span(1) {
           name "clear"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "geode"
             "$SemanticAttributes.DB_NAME.key" "test-region"
@@ -127,7 +125,6 @@ class PutGetTest extends AgentInstrumentationSpecification {
         span(2) {
           name "put"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "geode"
             "$SemanticAttributes.DB_NAME.key" "test-region"
@@ -137,7 +134,6 @@ class PutGetTest extends AgentInstrumentationSpecification {
         span(3) {
           name verb
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "geode"
             "$SemanticAttributes.DB_NAME.key" "test-region"
@@ -171,7 +167,6 @@ class PutGetTest extends AgentInstrumentationSpecification {
         span(0) {
           name "query"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "geode"
             "$SemanticAttributes.DB_NAME.key" "test-region"

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -72,7 +72,7 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest<HttpRequest> 
       trace(0, 2) {
         span(0) {
           kind CLIENT
-          errored true
+          status ERROR
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -65,10 +65,10 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest<HttpRequest> 
     def uri = server.address.resolve("/error")
 
     when:
-    def status = doRequest(method, uri)
+    def responseCode = doRequest(method, uri)
 
     then:
-    status == 500
+    responseCode == 500
     assertTraces(1) {
       trace(0, 2) {
         span(0) {

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpRequest

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 

--- a/instrumentation/grails-3.0/javaagent/src/test/groovy/test/GrailsTest.groovy
+++ b/instrumentation/grails-3.0/javaagent/src/test/groovy/test/GrailsTest.groovy
@@ -117,7 +117,6 @@ class GrailsTest extends HttpServerTest<ConfigurableApplicationContext> implemen
     trace.span(index + 1) {
       name errorSpanName
       kind INTERNAL
-      status UNSET
       attributes {
       }
     }
@@ -125,7 +124,6 @@ class GrailsTest extends HttpServerTest<ConfigurableApplicationContext> implemen
       trace.span(index + 2) {
         name ~/\.sendError$/
         kind INTERNAL
-        status UNSET
         attributes {
         }
       }
@@ -137,7 +135,6 @@ class GrailsTest extends HttpServerTest<ConfigurableApplicationContext> implemen
     trace.span(index) {
       name endpoint == REDIRECT ? ~/\.sendRedirect$/ : ~/\.sendError$/
       kind INTERNAL
-      status UNSET
       attributes {
       }
     }

--- a/instrumentation/grails-3.0/javaagent/src/test/groovy/test/GrailsTest.groovy
+++ b/instrumentation/grails-3.0/javaagent/src/test/groovy/test/GrailsTest.groovy
@@ -16,6 +16,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
 import groovy.transform.CompileStatic
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -153,8 +154,8 @@ class GrailsTest extends HttpServerTest<ConfigurableApplicationContext> implemen
         name "TestController.${endpoint.name().toLowerCase()}"
       }
       kind INTERNAL
-      errored endpoint == EXCEPTION
       if (endpoint == EXCEPTION) {
+        status StatusCode.ERROR
         errorEvent(Exception, EXCEPTION.body)
       }
       childOf((SpanData) parent)

--- a/instrumentation/grails-3.0/javaagent/src/test/groovy/test/GrailsTest.groovy
+++ b/instrumentation/grails-3.0/javaagent/src/test/groovy/test/GrailsTest.groovy
@@ -36,7 +36,8 @@ class GrailsTest extends HttpServerTest<ConfigurableApplicationContext> implemen
       try {
         ServerProperties.getDeclaredMethod("getServlet")
         contextPathKey = "server.servlet.contextPath"
-      } catch (NoSuchMethodException ignore) {}
+      } catch (NoSuchMethodException ignore) {
+      }
       Map<String, Object> properties = new HashMap<>()
       properties.put("server.port", port)
       properties.put(contextPathKey, contextPath)
@@ -116,7 +117,7 @@ class GrailsTest extends HttpServerTest<ConfigurableApplicationContext> implemen
     trace.span(index + 1) {
       name errorSpanName
       kind INTERNAL
-      errored false
+      status UNSET
       attributes {
       }
     }
@@ -124,7 +125,7 @@ class GrailsTest extends HttpServerTest<ConfigurableApplicationContext> implemen
       trace.span(index + 2) {
         name ~/\.sendError$/
         kind INTERNAL
-        errored false
+        status UNSET
         attributes {
         }
       }
@@ -136,7 +137,7 @@ class GrailsTest extends HttpServerTest<ConfigurableApplicationContext> implemen
     trace.span(index) {
       name endpoint == REDIRECT ? ~/\.sendRedirect$/ : ~/\.sendError$/
       kind INTERNAL
-      errored false
+      status UNSET
       attributes {
       }
     }

--- a/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcStreamingTest.groovy
+++ b/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcStreamingTest.groovy
@@ -108,7 +108,6 @@ abstract class AbstractGrpcStreamingTest extends InstrumentationSpecification {
           name "example.Greeter/Conversation"
           kind CLIENT
           hasNoParent()
-          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "grpc"
             "${SemanticAttributes.RPC_SERVICE.key}" "example.Greeter"
@@ -129,7 +128,6 @@ abstract class AbstractGrpcStreamingTest extends InstrumentationSpecification {
           name "example.Greeter/Conversation"
           kind SERVER
           childOf span(0)
-          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "grpc"
             "${SemanticAttributes.RPC_SERVICE.key}" "example.Greeter"

--- a/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcStreamingTest.groovy
+++ b/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcStreamingTest.groovy
@@ -16,9 +16,9 @@ import io.grpc.ManagedChannelBuilder
 import io.grpc.Server
 import io.grpc.ServerBuilder
 import io.grpc.stub.StreamObserver
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -108,7 +108,7 @@ abstract class AbstractGrpcStreamingTest extends InstrumentationSpecification {
           name "example.Greeter/Conversation"
           kind CLIENT
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "grpc"
             "${SemanticAttributes.RPC_SERVICE.key}" "example.Greeter"
@@ -129,7 +129,7 @@ abstract class AbstractGrpcStreamingTest extends InstrumentationSpecification {
           name "example.Greeter/Conversation"
           kind SERVER
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "grpc"
             "${SemanticAttributes.RPC_SERVICE.key}" "example.Greeter"

--- a/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcTest.groovy
+++ b/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcTest.groovy
@@ -31,10 +31,9 @@ import io.grpc.ServerInterceptor
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import io.grpc.stub.StreamObserver
-import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -169,7 +168,6 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           kind CLIENT
           hasNoParent()
           errored true
-          status(StatusCode.ERROR)
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "grpc"
             "${SemanticAttributes.RPC_SERVICE.key}" "example.Greeter"
@@ -181,7 +179,6 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           kind SERVER
           childOf span(0)
           errored true
-          status(StatusCode.ERROR)
           event(0) {
             eventName "message"
             attributes {
@@ -269,7 +266,6 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           kind SERVER
           childOf span(0)
           errored true
-          status(StatusCode.ERROR)
           event(0) {
             eventName "message"
             attributes {

--- a/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcTest.groovy
+++ b/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcTest.groovy
@@ -85,7 +85,7 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           event(0) {
             eventName "message"
             attributes {
@@ -103,7 +103,7 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind SERVER
           childOf span(1)
-          errored false
+          status UNSET
           event(0) {
             eventName "message"
             attributes {
@@ -167,7 +167,7 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind CLIENT
           hasNoParent()
-          errored true
+          status ERROR
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "grpc"
             "${SemanticAttributes.RPC_SERVICE.key}" "example.Greeter"
@@ -178,7 +178,7 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind SERVER
           childOf span(0)
-          errored true
+          status ERROR
           event(0) {
             eventName "message"
             attributes {
@@ -252,7 +252,7 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind CLIENT
           hasNoParent()
-          errored true
+          status ERROR
           // NB: Exceptions thrown on the server don't appear to be propagated to the client, at
           // least for the version we test against.
           attributes {
@@ -265,7 +265,7 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind SERVER
           childOf span(0)
-          errored true
+          status ERROR
           event(0) {
             eventName "message"
             attributes {
@@ -409,7 +409,7 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           event(0) {
             eventName "message"
             attributes {
@@ -427,7 +427,7 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind SERVER
           childOf span(1)
-          errored false
+          status UNSET
           event(0) {
             eventName "message"
             attributes {

--- a/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcTest.groovy
+++ b/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcTest.groovy
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.grpc.v1_5
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 

--- a/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcTest.groovy
+++ b/instrumentation/grpc-1.5/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_5/AbstractGrpcTest.groovy
@@ -86,7 +86,6 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind CLIENT
           childOf span(0)
-          status UNSET
           event(0) {
             eventName "message"
             attributes {
@@ -104,7 +103,6 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind SERVER
           childOf span(1)
-          status UNSET
           event(0) {
             eventName "message"
             attributes {
@@ -410,7 +408,6 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind CLIENT
           childOf span(0)
-          status UNSET
           event(0) {
             eventName "message"
             attributes {
@@ -428,7 +425,6 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
           name "example.Greeter/SayHello"
           kind SERVER
           childOf span(1)
-          status UNSET
           event(0) {
             eventName "message"
             attributes {

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/SessionTest.groovy
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -286,7 +288,7 @@ class SessionTest extends AbstractHibernateTest {
           name "Session.replicate"
           kind INTERNAL
           childOf span(0)
-          errored(true)
+          status ERROR
           errorEvent(MappingException, "Unknown entity: java.lang.Long")
         }
         span(2) {

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/SessionTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/SessionTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/SessionTest.groovy
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -225,7 +227,7 @@ class SessionTest extends AbstractHibernateTest {
           name "Session.replicate"
           kind INTERNAL
           childOf span(0)
-          errored(true)
+          status ERROR
           errorEvent(MappingException, "Unknown entity: java.lang.Long")
         }
         span(2) {

--- a/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/groovy/ProcedureCallTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/groovy/ProcedureCallTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR

--- a/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/groovy/ProcedureCallTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/javaagent/src/test/groovy/ProcedureCallTest.groovy
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -151,7 +153,7 @@ class ProcedureCallTest extends AgentInstrumentationSpecification {
           name "ProcedureCall.getOutputs TEST_PROC"
           kind INTERNAL
           childOf span(0)
-          errored(true)
+          status ERROR
           errorEvent(SQLGrammarException, "could not prepare statement")
         }
         span(2) {

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
@@ -32,7 +32,7 @@ class HttpUrlConnectionResponseCodeOnlyTest extends HttpClientTest<HttpURLConnec
   }
 
   @Override
-  Integer statusOnRedirectError() {
+  Integer responseCodeOnRedirectError() {
     return 302
   }
 

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -99,7 +99,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
         span(0) {
           name "someTrace"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -107,7 +107,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("GET")
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
@@ -122,7 +122,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name "test-http-server"
           kind SERVER
           childOf span(1)
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -130,7 +130,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("GET")
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
@@ -145,7 +145,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name "test-http-server"
           kind SERVER
           childOf span(3)
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -190,7 +190,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
         span(0) {
           name "someTrace"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -198,7 +198,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("GET")
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
@@ -213,7 +213,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("GET")
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
@@ -249,7 +249,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
         span(0) {
           name "someTrace"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -257,7 +257,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("GET")
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
             "${SemanticAttributes.NET_PEER_PORT.key}" server.address.port
@@ -308,7 +308,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
         span(0) {
           name "someTrace"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -316,7 +316,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("POST")
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
@@ -331,7 +331,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name "test-http-server"
           kind SERVER
           childOf span(1)
-          errored false
+          status UNSET
           attributes {
           }
         }

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -51,7 +51,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
   }
 
   @Override
-  Integer statusOnRedirectError() {
+  Integer responseCodeOnRedirectError() {
     return 302
   }
 

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -99,7 +99,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
         span(0) {
           name "someTrace"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -107,7 +106,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("GET")
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
@@ -122,7 +120,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name "test-http-server"
           kind SERVER
           childOf span(1)
-          status UNSET
           attributes {
           }
         }
@@ -130,7 +127,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("GET")
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
@@ -145,7 +141,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name "test-http-server"
           kind SERVER
           childOf span(3)
-          status UNSET
           attributes {
           }
         }
@@ -190,7 +185,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
         span(0) {
           name "someTrace"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -198,7 +192,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("GET")
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
@@ -213,7 +206,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("GET")
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
@@ -249,7 +241,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
         span(0) {
           name "someTrace"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -257,7 +248,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("GET")
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
             "${SemanticAttributes.NET_PEER_PORT.key}" server.address.port
@@ -308,7 +298,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
         span(0) {
           name "someTrace"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -316,7 +305,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name expectedOperationName("POST")
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
@@ -331,7 +319,6 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
           name "test-http-server"
           kind SERVER
           childOf span(1)
-          status UNSET
           attributes {
           }
         }

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
@@ -39,7 +39,7 @@ class HttpUrlConnectionUseCachesFalseTest extends HttpClientTest<HttpURLConnecti
   }
 
   @Override
-  Integer statusOnRedirectError() {
+  Integer responseCodeOnRedirectError() {
     return 302
   }
 

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/SpringRestTemplateTest.groovy
@@ -59,7 +59,7 @@ class SpringRestTemplateTest extends HttpClientTest<HttpEntity<String>> implemen
   }
 
   @Override
-  Integer statusOnRedirectError() {
+  Integer responseCodeOnRedirectError() {
     return 302
   }
 }

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/UrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/UrlConnectionTest.groovy
@@ -13,53 +13,53 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 class UrlConnectionTest extends AgentInstrumentationSpecification {
 
-  def "trace request with connection failure #scheme"() {
-    when:
-    runUnderTrace("someTrace") {
-      URLConnection connection = url.openConnection()
-      connection.setConnectTimeout(10000)
-      connection.setReadTimeout(10000)
-      assert Span.current() != null
-      connection.inputStream
+    def "trace request with connection failure #scheme"() {
+        when:
+        runUnderTrace("someTrace") {
+            URLConnection connection = url.openConnection()
+            connection.setConnectTimeout(10000)
+            connection.setReadTimeout(10000)
+            assert Span.current() != null
+            connection.inputStream
+        }
+
+        then:
+        thrown ConnectException
+
+        expect:
+        assertTraces(1) {
+            trace(0, 2) {
+                span(0) {
+                    name "someTrace"
+                    hasNoParent()
+                    status ERROR
+                    errorEvent ConnectException, String
+                }
+                span(1) {
+                    name expectedOperationName("GET")
+                    kind CLIENT
+                    childOf span(0)
+                    status ERROR
+                    errorEvent ConnectException, String
+                    attributes {
+                        "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
+                        "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
+                        "${SemanticAttributes.NET_PEER_PORT.key}" UNUSABLE_PORT
+                        "${SemanticAttributes.HTTP_URL.key}" "$url"
+                        "${SemanticAttributes.HTTP_METHOD.key}" "GET"
+                        "${SemanticAttributes.HTTP_FLAVOR.key}" "1.1"
+                    }
+                }
+            }
+        }
+
+        where:
+        scheme << ["http", "https"]
+
+        url = new URI("$scheme://localhost:$UNUSABLE_PORT").toURL()
     }
 
-    then:
-    thrown ConnectException
-
-    expect:
-    assertTraces(1) {
-      trace(0, 2) {
-        span(0) {
-          name "someTrace"
-          hasNoParent()
-          errored true
-          errorEvent ConnectException, String
-        }
-        span(1) {
-          name expectedOperationName("GET")
-          kind CLIENT
-          childOf span(0)
-          errored true
-          errorEvent ConnectException, String
-          attributes {
-            "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
-            "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
-            "${SemanticAttributes.NET_PEER_PORT.key}" UNUSABLE_PORT
-            "${SemanticAttributes.HTTP_URL.key}" "$url"
-            "${SemanticAttributes.HTTP_METHOD.key}" "GET"
-            "${SemanticAttributes.HTTP_FLAVOR.key}" "1.1"
-          }
-        }
-      }
+    String expectedOperationName(String method) {
+        return method != null ? "HTTP $method" : "HTTP request"
     }
-
-    where:
-    scheme << ["http", "https"]
-
-    url = new URI("$scheme://localhost:$UNUSABLE_PORT").toURL()
-  }
-
-  String expectedOperationName(String method) {
-    return method != null ? "HTTP $method" : "HTTP request"
-  }
 }

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/UrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/UrlConnectionTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
@@ -13,53 +14,53 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 class UrlConnectionTest extends AgentInstrumentationSpecification {
 
-    def "trace request with connection failure #scheme"() {
-        when:
-        runUnderTrace("someTrace") {
-            URLConnection connection = url.openConnection()
-            connection.setConnectTimeout(10000)
-            connection.setReadTimeout(10000)
-            assert Span.current() != null
-            connection.inputStream
-        }
-
-        then:
-        thrown ConnectException
-
-        expect:
-        assertTraces(1) {
-            trace(0, 2) {
-                span(0) {
-                    name "someTrace"
-                    hasNoParent()
-                    status ERROR
-                    errorEvent ConnectException, String
-                }
-                span(1) {
-                    name expectedOperationName("GET")
-                    kind CLIENT
-                    childOf span(0)
-                    status ERROR
-                    errorEvent ConnectException, String
-                    attributes {
-                        "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
-                        "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
-                        "${SemanticAttributes.NET_PEER_PORT.key}" UNUSABLE_PORT
-                        "${SemanticAttributes.HTTP_URL.key}" "$url"
-                        "${SemanticAttributes.HTTP_METHOD.key}" "GET"
-                        "${SemanticAttributes.HTTP_FLAVOR.key}" "1.1"
-                    }
-                }
-            }
-        }
-
-        where:
-        scheme << ["http", "https"]
-
-        url = new URI("$scheme://localhost:$UNUSABLE_PORT").toURL()
+  def "trace request with connection failure #scheme"() {
+    when:
+    runUnderTrace("someTrace") {
+      URLConnection connection = url.openConnection()
+      connection.setConnectTimeout(10000)
+      connection.setReadTimeout(10000)
+      assert Span.current() != null
+      connection.inputStream
     }
 
-    String expectedOperationName(String method) {
-        return method != null ? "HTTP $method" : "HTTP request"
+    then:
+    thrown ConnectException
+
+    expect:
+    assertTraces(1) {
+      trace(0, 2) {
+        span(0) {
+          name "someTrace"
+          hasNoParent()
+          status ERROR
+          errorEvent ConnectException, String
+        }
+        span(1) {
+          name expectedOperationName("GET")
+          kind CLIENT
+          childOf span(0)
+          status ERROR
+          errorEvent ConnectException, String
+          attributes {
+            "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
+            "${SemanticAttributes.NET_PEER_NAME.key}" "localhost"
+            "${SemanticAttributes.NET_PEER_PORT.key}" UNUSABLE_PORT
+            "${SemanticAttributes.HTTP_URL.key}" "$url"
+            "${SemanticAttributes.HTTP_METHOD.key}" "GET"
+            "${SemanticAttributes.HTTP_FLAVOR.key}" "1.1"
+          }
+        }
+      }
     }
+
+    where:
+    scheme << ["http", "https"]
+
+    url = new URI("$scheme://localhost:$UNUSABLE_PORT").toURL()
+  }
+
+  String expectedOperationName(String method) {
+    return method != null ? "HTTP $method" : "HTTP request"
+  }
 }

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
@@ -63,14 +63,12 @@ class HystrixObservableChainTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
         span(1) {
           name "ExampleGroup.HystrixObservableChainTest\$1.execute"
           childOf span(0)
-          status UNSET
           attributes {
             "hystrix.command" "HystrixObservableChainTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -80,14 +78,12 @@ class HystrixObservableChainTest extends AgentInstrumentationSpecification {
         span(2) {
           name "tracedMethod"
           childOf span(1)
-          status UNSET
           attributes {
           }
         }
         span(3) {
           name "OtherGroup.HystrixObservableChainTest\$2.execute"
           childOf span(1)
-          status UNSET
           attributes {
             "hystrix.command" "HystrixObservableChainTest\$2"
             "hystrix.group" "OtherGroup"
@@ -97,7 +93,6 @@ class HystrixObservableChainTest extends AgentInstrumentationSpecification {
         span(4) {
           name "anotherTracedMethod"
           childOf span(3)
-          status UNSET
           attributes {
           }
         }

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
@@ -63,14 +63,14 @@ class HystrixObservableChainTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "ExampleGroup.HystrixObservableChainTest\$1.execute"
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "hystrix.command" "HystrixObservableChainTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -80,14 +80,14 @@ class HystrixObservableChainTest extends AgentInstrumentationSpecification {
         span(2) {
           name "tracedMethod"
           childOf span(1)
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(3) {
           name "OtherGroup.HystrixObservableChainTest\$2.execute"
           childOf span(1)
-          errored false
+          status UNSET
           attributes {
             "hystrix.command" "HystrixObservableChainTest\$2"
             "hystrix.group" "OtherGroup"
@@ -97,7 +97,7 @@ class HystrixObservableChainTest extends AgentInstrumentationSpecification {
         span(4) {
           name "anotherTracedMethod"
           childOf span(3)
-          errored false
+          status UNSET
           attributes {
           }
         }

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
@@ -54,14 +54,14 @@ class HystrixObservableTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "ExampleGroup.HystrixObservableTest\$1.execute"
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "hystrix.command" "HystrixObservableTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -71,7 +71,7 @@ class HystrixObservableTest extends AgentInstrumentationSpecification {
         span(2) {
           name "tracedMethod"
           childOf span(1)
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -148,14 +148,14 @@ class HystrixObservableTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "ExampleGroup.HystrixObservableTest\$2.execute"
           childOf span(0)
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException)
           attributes {
             "hystrix.command" "HystrixObservableTest\$2"
@@ -166,7 +166,7 @@ class HystrixObservableTest extends AgentInstrumentationSpecification {
         span(2) {
           name "ExampleGroup.HystrixObservableTest\$2.fallback"
           childOf span(1)
-          errored false
+          status UNSET
           attributes {
             "hystrix.command" "HystrixObservableTest\$2"
             "hystrix.group" "ExampleGroup"
@@ -245,13 +245,13 @@ class HystrixObservableTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(HystrixRuntimeException, "HystrixObservableTest\$3 failed and no fallback available.")
         }
         span(1) {
           name "FailingGroup.HystrixObservableTest\$3.execute"
           childOf span(0)
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException)
           attributes {
             "hystrix.command" "HystrixObservableTest\$3"
@@ -262,7 +262,7 @@ class HystrixObservableTest extends AgentInstrumentationSpecification {
         span(2) {
           name "FailingGroup.HystrixObservableTest\$3.fallback"
           childOf span(1)
-          errored true
+          status ERROR
           errorEvent(UnsupportedOperationException, "No fallback available.")
           attributes {
             "hystrix.command" "HystrixObservableTest\$3"

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
@@ -55,14 +55,12 @@ class HystrixObservableTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
         span(1) {
           name "ExampleGroup.HystrixObservableTest\$1.execute"
           childOf span(0)
-          status UNSET
           attributes {
             "hystrix.command" "HystrixObservableTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -72,7 +70,6 @@ class HystrixObservableTest extends AgentInstrumentationSpecification {
         span(2) {
           name "tracedMethod"
           childOf span(1)
-          status UNSET
           attributes {
           }
         }
@@ -149,7 +146,6 @@ class HystrixObservableTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -167,7 +163,6 @@ class HystrixObservableTest extends AgentInstrumentationSpecification {
         span(2) {
           name "ExampleGroup.HystrixObservableTest\$2.fallback"
           childOf span(1)
-          status UNSET
           attributes {
             "hystrix.command" "HystrixObservableTest\$2"
             "hystrix.group" "ExampleGroup"

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
@@ -39,14 +39,12 @@ class HystrixTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
         span(1) {
           name "ExampleGroup.HystrixTest\$1.execute"
           childOf span(0)
-          status UNSET
           attributes {
             "hystrix.command" "HystrixTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -56,7 +54,6 @@ class HystrixTest extends AgentInstrumentationSpecification {
         span(2) {
           name "tracedMethod"
           childOf span(1)
-          status UNSET
           attributes {
           }
         }
@@ -101,7 +98,6 @@ class HystrixTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -119,7 +115,6 @@ class HystrixTest extends AgentInstrumentationSpecification {
         span(2) {
           name "ExampleGroup.HystrixTest\$2.fallback"
           childOf span(1)
-          status UNSET
           attributes {
             "hystrix.command" "HystrixTest\$2"
             "hystrix.group" "ExampleGroup"

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
@@ -38,14 +38,14 @@ class HystrixTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "ExampleGroup.HystrixTest\$1.execute"
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "hystrix.command" "HystrixTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -55,7 +55,7 @@ class HystrixTest extends AgentInstrumentationSpecification {
         span(2) {
           name "tracedMethod"
           childOf span(1)
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -100,14 +100,14 @@ class HystrixTest extends AgentInstrumentationSpecification {
         span(0) {
           name "parent"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "ExampleGroup.HystrixTest\$2.execute"
           childOf span(0)
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException)
           attributes {
             "hystrix.command" "HystrixTest\$2"
@@ -118,7 +118,7 @@ class HystrixTest extends AgentInstrumentationSpecification {
         span(2) {
           name "ExampleGroup.HystrixTest\$2.fallback"
           childOf span(1)
-          errored false
+          status UNSET
           attributes {
             "hystrix.command" "HystrixTest\$2"
             "hystrix.group" "ExampleGroup"

--- a/instrumentation/java-httpclient/javaagent/src/test/groovy/JdkHttpClientTest.groovy
+++ b/instrumentation/java-httpclient/javaagent/src/test/groovy/JdkHttpClientTest.groovy
@@ -81,7 +81,7 @@ class JdkHttpClientTest extends HttpClientTest<HttpRequest> implements AgentTest
           hasNoParent()
           name expectedOperationName(method)
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" uri.host

--- a/instrumentation/java-httpclient/javaagent/src/test/groovy/JdkHttpClientTest.groovy
+++ b/instrumentation/java-httpclient/javaagent/src/test/groovy/JdkHttpClientTest.groovy
@@ -81,7 +81,6 @@ class JdkHttpClientTest extends HttpClientTest<HttpRequest> implements AgentTest
           hasNoParent()
           name expectedOperationName(method)
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" uri.host

--- a/instrumentation/java-httpclient/javaagent/src/test/groovy/JdkHttpClientTest.groovy
+++ b/instrumentation/java-httpclient/javaagent/src/test/groovy/JdkHttpClientTest.groovy
@@ -71,10 +71,10 @@ class JdkHttpClientTest extends HttpClientTest<HttpRequest> implements AgentTest
     def uri = new URI("https://www.google.com/")
 
     when:
-    def status = doRequest(method, uri)
+    def responseCode = doRequest(method, uri)
 
     then:
-    status == 200
+    responseCode == 200
     assertTraces(1) {
       trace(0, 1 + extraClientSpans()) {
         span(0) {
@@ -90,7 +90,7 @@ class JdkHttpClientTest extends HttpClientTest<HttpRequest> implements AgentTest
             "${SemanticAttributes.HTTP_URL.key}" { it == "${uri}" || it == "${removeFragment(uri)}" }
             "${SemanticAttributes.HTTP_METHOD.key}" method
             "${SemanticAttributes.HTTP_FLAVOR.key}" "2.0"
-            "${SemanticAttributes.HTTP_STATUS_CODE.key}" status
+            "${SemanticAttributes.HTTP_STATUS_CODE.key}" responseCode
           }
         }
       }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
@@ -83,7 +83,7 @@ abstract class JaxRsClientTest extends HttpClientTest<Invocation.Builder> implem
           hasNoParent()
           name expectedOperationName(method)
           kind CLIENT
-          errored true
+          status ERROR
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_NAME.key}" uri.host

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsFilterTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.api.trace.StatusCode.ERROR

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsFilterTest.groovy
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
@@ -74,11 +76,8 @@ abstract class JaxRsFilterTest extends AgentInstrumentationSpecification {
         span(0) {
           name parentSpanName != null ? parentSpanName : "test.span"
           kind SERVER
-          if (runsOnServer()) {
-            errored abortNormal
-          } else {
-            attributes {
-            }
+          if (runsOnServer() && abortNormal) {
+            status ERROR
           }
         }
         span(1) {

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.api.trace.StatusCode.ERROR

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
@@ -173,7 +175,9 @@ abstract class JaxRsHttpServerTest<S> extends HttpServerTest<S> implements Agent
     trace.span(index) {
       name path
       kind SERVER
-      errored isError
+      if (isError) {
+        status ERROR
+      }
       if (parentID != null) {
         traceId traceID
         parentSpanId parentID
@@ -216,8 +220,8 @@ abstract class JaxRsHttpServerTest<S> extends HttpServerTest<S> implements Agent
     trace.span(index) {
       name "JaxRsTestResource.${methodName}"
       kind INTERNAL
-      errored isError
       if (isError) {
+        status ERROR
         errorEvent(Exception, exceptionMessage)
       }
       childOf((SpanData) parent)

--- a/instrumentation/jaxws/jaxws-2.0-testing/src/main/groovy/AbstractJaxWsTest.groovy
+++ b/instrumentation/jaxws/jaxws-2.0-testing/src/main/groovy/AbstractJaxWsTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.api.trace.StatusCode.ERROR

--- a/instrumentation/jaxws/jaxws-2.0-testing/src/main/groovy/AbstractJaxWsTest.groovy
+++ b/instrumentation/jaxws/jaxws-2.0-testing/src/main/groovy/AbstractJaxWsTest.groovy
@@ -3,14 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.api.trace.SpanKind
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import io.opentelemetry.test.hello_web_service.HelloRequest
 import io.opentelemetry.test.hello_web_service.Hello2Request
+import io.opentelemetry.test.hello_web_service.HelloRequest
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.util.resource.Resource
 import org.eclipse.jetty.webapp.WebAppContext
@@ -156,8 +160,10 @@ abstract class AbstractJaxWsTest extends AgentInstrumentationSpecification imple
     trace.span(index) {
       hasNoParent()
       name operation
-      kind SpanKind.SERVER
-      errored exception != null
+      kind SERVER
+      if (exception != null) {
+        status ERROR
+      }
     }
   }
 
@@ -169,9 +175,9 @@ abstract class AbstractJaxWsTest extends AgentInstrumentationSpecification imple
         childOf((SpanData) parentSpan)
       }
       name "HelloService/" + operation
-      kind SpanKind.INTERNAL
-      errored exception != null
+      kind INTERNAL
       if (exception) {
+        status ERROR
         errorEvent(exception.class, exception.message)
       }
     }
@@ -185,9 +191,9 @@ abstract class AbstractJaxWsTest extends AgentInstrumentationSpecification imple
         childOf((SpanData) parentSpan)
       }
       name "HelloServiceImpl." + methodName
-      kind SpanKind.INTERNAL
-      errored exception != null
+      kind INTERNAL
       if (exception) {
+        status ERROR
         errorEvent(exception.class, exception.message)
       }
       attributes {

--- a/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
+++ b/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
@@ -180,7 +180,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -238,7 +238,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -288,7 +288,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -338,7 +338,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbName.toLowerCase()
@@ -388,7 +388,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name dbNameLower
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -439,7 +439,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name dbNameLower
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbName.toLowerCase()
@@ -501,7 +501,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -604,7 +604,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name "DB Query"
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "testdb"
             "$SemanticAttributes.DB_STATEMENT.key" "testing ?"
@@ -643,7 +643,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "testdb"
             "$SemanticAttributes.DB_NAME.key" databaseName
@@ -702,7 +702,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           span(0) {
             name "SELECT ${dbNameLower}.INFORMATION_SCHEMA.SYSTEM_USERS"
             kind CLIENT
-            errored false
+            status UNSET
             attributes {
               "$SemanticAttributes.DB_SYSTEM.key" "hsqldb"
               "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -748,7 +748,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name "SELECT table"
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "testdb"
             "$SemanticAttributes.DB_CONNECTION_STRING.key" "testdb://localhost"

--- a/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
+++ b/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
@@ -180,7 +180,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -238,7 +237,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -288,7 +286,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -338,7 +335,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbName.toLowerCase()
@@ -388,7 +384,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name dbNameLower
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -439,7 +434,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name dbNameLower
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbName.toLowerCase()
@@ -501,7 +495,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" system
             "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -604,7 +597,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name "DB Query"
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "testdb"
             "$SemanticAttributes.DB_STATEMENT.key" "testing ?"
@@ -643,7 +635,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name spanName
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "testdb"
             "$SemanticAttributes.DB_NAME.key" databaseName
@@ -702,7 +693,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           span(0) {
             name "SELECT ${dbNameLower}.INFORMATION_SCHEMA.SYSTEM_USERS"
             kind CLIENT
-            status UNSET
             attributes {
               "$SemanticAttributes.DB_SYSTEM.key" "hsqldb"
               "$SemanticAttributes.DB_NAME.key" dbNameLower
@@ -748,7 +738,6 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           name "SELECT table"
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "testdb"
             "$SemanticAttributes.DB_CONNECTION_STRING.key" "testdb://localhost"

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
@@ -239,7 +239,6 @@ class Jms2Test extends AgentInstrumentationSpecification {
     trace.span(index) {
       name destinationName + " send"
       kind PRODUCER
-      status UNSET
       hasNoParent()
       attributes {
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
@@ -264,7 +263,6 @@ class Jms2Test extends AgentInstrumentationSpecification {
       } else {
         hasNoParent()
       }
-      status UNSET
       attributes {
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
         "${SemanticAttributes.MESSAGING_DESTINATION.key}" destinationName

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
@@ -239,7 +239,7 @@ class Jms2Test extends AgentInstrumentationSpecification {
     trace.span(index) {
       name destinationName + " send"
       kind PRODUCER
-      errored false
+      status UNSET
       hasNoParent()
       attributes {
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
@@ -264,7 +264,7 @@ class Jms2Test extends AgentInstrumentationSpecification {
       } else {
         hasNoParent()
       }
-      errored false
+      status UNSET
       attributes {
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
         "${SemanticAttributes.MESSAGING_DESTINATION.key}" destinationName

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
@@ -199,7 +199,7 @@ class Jms1Test extends AgentInstrumentationSpecification {
           hasNoParent()
           name destinationName + " receive"
           kind CONSUMER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
             "${SemanticAttributes.MESSAGING_DESTINATION.key}" destinationName
@@ -271,7 +271,7 @@ class Jms1Test extends AgentInstrumentationSpecification {
     trace.span(index) {
       name destinationName + " send"
       kind PRODUCER
-      errored false
+      status UNSET
       hasNoParent()
       attributes {
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
@@ -296,7 +296,7 @@ class Jms1Test extends AgentInstrumentationSpecification {
       } else {
         hasNoParent()
       }
-      errored false
+      status UNSET
       attributes {
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
         "${SemanticAttributes.MESSAGING_DESTINATION.key}" destinationName

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
@@ -199,7 +199,6 @@ class Jms1Test extends AgentInstrumentationSpecification {
           hasNoParent()
           name destinationName + " receive"
           kind CONSUMER
-          status UNSET
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
             "${SemanticAttributes.MESSAGING_DESTINATION.key}" destinationName
@@ -271,7 +270,6 @@ class Jms1Test extends AgentInstrumentationSpecification {
     trace.span(index) {
       name destinationName + " send"
       kind PRODUCER
-      status UNSET
       hasNoParent()
       attributes {
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
@@ -296,7 +294,6 @@ class Jms1Test extends AgentInstrumentationSpecification {
       } else {
         hasNoParent()
       }
-      status UNSET
       attributes {
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "jms"
         "${SemanticAttributes.MESSAGING_DESTINATION.key}" destinationName

--- a/instrumentation/jsf/jsf-testing-common/src/main/groovy/BaseJsfTest.groovy
+++ b/instrumentation/jsf/jsf-testing-common/src/main/groovy/BaseJsfTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicServerSpan
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
@@ -126,7 +128,7 @@ abstract class BaseJsfTest extends AgentInstrumentationSpecification implements 
     // set up form parameter for post
     RequestBody formBody = new FormBody.Builder()
       .add("app-form", "app-form")
-      // value used for name is returned in app-form:output-message element
+    // value used for name is returned in app-form:output-message element
       .add("app-form:name", "test")
       .add("app-form:submit", "Say hello")
       .add("app-form_SUBMIT", "1") // MyFaces
@@ -186,7 +188,7 @@ abstract class BaseJsfTest extends AgentInstrumentationSpecification implements 
     // set up form parameter for post
     RequestBody formBody = new FormBody.Builder()
       .add("app-form", "app-form")
-      // setting name parameter to "exception" triggers throwing exception in GreetingForm
+    // setting name parameter to "exception" triggers throwing exception in GreetingForm
       .add("app-form:name", "exception")
       .add("app-form:submit", "Say hello")
       .add("app-form_SUBMIT", "1") // MyFaces
@@ -219,8 +221,8 @@ abstract class BaseJsfTest extends AgentInstrumentationSpecification implements 
     trace.span(index) {
       name spanName
       kind INTERNAL
-      errored expectedException != null
       if (expectedException != null) {
+        status ERROR
         errorEvent(expectedException.getClass(), expectedException.getMessage())
       }
       childOf((SpanData) parent)

--- a/instrumentation/jsf/jsf-testing-common/src/main/groovy/BaseJsfTest.groovy
+++ b/instrumentation/jsf/jsf-testing-common/src/main/groovy/BaseJsfTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicServerSpan

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
@@ -88,7 +88,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/$jspFileName"
           kind SERVER
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -103,7 +102,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /$jspFileName"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -112,7 +110,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /$jspFileName"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -147,7 +144,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/getQuery.jsp"
           kind SERVER
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -162,7 +158,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /getQuery.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.getQuery_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -171,7 +166,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /getQuery.jsp"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -203,7 +197,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/post.jsp"
           kind SERVER
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -218,7 +211,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /post.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.post_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -227,7 +219,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /post.jsp"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -283,7 +274,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /$jspFileName"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -338,7 +328,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/includes/includeHtml.jsp"
           kind SERVER
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -353,7 +342,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /includes/includeHtml.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.includes.includeHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -362,7 +350,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /includes/includeHtml.jsp"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -370,7 +357,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.include"
-          status UNSET
         }
       }
     }
@@ -395,7 +381,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/includes/includeMulti.jsp"
           kind SERVER
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -410,7 +395,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /includes/includeMulti.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -419,7 +403,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /includes/includeMulti.jsp"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -427,12 +410,10 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.include"
-          status UNSET
         }
         span(4) {
           childOf span(3)
           name "Compile /common/javaLoopH2.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -441,7 +422,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(5) {
           childOf span(3)
           name "Render /common/javaLoopH2.jsp"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -449,12 +429,10 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(6) {
           childOf span(2)
           name "ApplicationDispatcher.include"
-          status UNSET
         }
         span(7) {
           childOf span(6)
           name "Compile /common/javaLoopH2.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -463,7 +441,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(8) {
           childOf span(6)
           name "Render /common/javaLoopH2.jsp"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -543,7 +520,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/*"
           kind SERVER
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
@@ -87,7 +87,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/$jspFileName"
           kind SERVER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -102,7 +102,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /$jspFileName"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -111,7 +111,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /$jspFileName"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -146,7 +146,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/getQuery.jsp"
           kind SERVER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -161,7 +161,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /getQuery.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.getQuery_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -170,7 +170,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /getQuery.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -202,7 +202,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/post.jsp"
           kind SERVER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -217,7 +217,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /post.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.post_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -226,7 +226,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /post.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -255,7 +255,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/$jspFileName"
           kind SERVER
-          errored true
+          status ERROR
           event(0) {
             eventName(SemanticAttributes.EXCEPTION_EVENT_NAME)
             attributes {
@@ -282,7 +282,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /$jspFileName"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -291,7 +291,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /$jspFileName"
-          errored true
+          status ERROR
           event(0) {
             eventName(SemanticAttributes.EXCEPTION_EVENT_NAME)
             attributes {
@@ -337,7 +337,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/includes/includeHtml.jsp"
           kind SERVER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -352,7 +352,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /includes/includeHtml.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.includes.includeHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -361,7 +361,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /includes/includeHtml.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -369,7 +369,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.include"
-          errored false
+          status UNSET
         }
       }
     }
@@ -394,7 +394,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/includes/includeMulti.jsp"
           kind SERVER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -409,7 +409,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /includes/includeMulti.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -418,7 +418,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /includes/includeMulti.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -426,12 +426,12 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.include"
-          errored false
+          status UNSET
         }
         span(4) {
           childOf span(3)
           name "Compile /common/javaLoopH2.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -440,7 +440,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(5) {
           childOf span(3)
           name "Render /common/javaLoopH2.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -448,12 +448,12 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(6) {
           childOf span(2)
           name "ApplicationDispatcher.include"
-          errored false
+          status UNSET
         }
         span(7) {
           childOf span(6)
           name "Compile /common/javaLoopH2.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -462,7 +462,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(8) {
           childOf span(6)
           name "Render /common/javaLoopH2.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -490,7 +490,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/$jspFileName"
           kind SERVER
-          errored true
+          status ERROR
           errorEvent(JasperException, String)
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -506,7 +506,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /$jspFileName"
-          errored true
+          status ERROR
           errorEvent(JasperException, String)
           attributes {
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
@@ -542,7 +542,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/*"
           kind SERVER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
@@ -86,7 +86,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/$forwardFromFileName"
           kind SERVER
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -101,7 +100,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /$forwardFromFileName"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -110,7 +108,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /$forwardFromFileName"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -118,12 +115,10 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.forward"
-          status UNSET
         }
         span(4) {
           childOf span(3)
           name "Compile /$forwardDestFileName"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.$jspForwardDestClassPrefix$jspForwardDestClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -132,7 +127,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(5) {
           childOf span(3)
           name "Render /$forwardDestFileName"
-          status UNSET
           attributes {
             "jsp.forwardOrigin" "/$forwardFromFileName"
             "jsp.requestURL" baseUrl + "/$forwardDestFileName"
@@ -166,7 +160,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/forwards/forwardToHtml.jsp"
           kind SERVER
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -181,7 +174,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /forwards/forwardToHtml.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -190,7 +182,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /forwards/forwardToHtml.jsp"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -198,7 +189,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.forward"
-          status UNSET
         }
       }
     }
@@ -223,7 +213,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
           kind SERVER
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -238,7 +227,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /forwards/forwardToIncludeMulti.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -247,7 +235,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /forwards/forwardToIncludeMulti.jsp"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -255,12 +242,10 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.forward"
-          status UNSET
         }
         span(4) {
           childOf span(3)
           name "Compile /includes/includeMulti.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -269,7 +254,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(5) {
           childOf span(3)
           name "Render /includes/includeMulti.jsp"
-          status UNSET
           attributes {
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
@@ -278,12 +262,10 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(6) {
           childOf span(5)
           name "ApplicationDispatcher.include"
-          status UNSET
         }
         span(7) {
           childOf span(6)
           name "Compile /common/javaLoopH2.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -292,7 +274,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(8) {
           childOf span(6)
           name "Render /common/javaLoopH2.jsp"
-          status UNSET
           attributes {
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
@@ -301,12 +282,10 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(9) {
           childOf span(5)
           name "ApplicationDispatcher.include"
-          status UNSET
         }
         span(10) {
           childOf span(9)
           name "Compile /common/javaLoopH2.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -315,7 +294,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(11) {
           childOf span(9)
           name "Render /common/javaLoopH2.jsp"
-          status UNSET
           attributes {
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
@@ -344,7 +322,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/forwards/forwardToJspForward.jsp"
           kind SERVER
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -359,7 +336,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /forwards/forwardToJspForward.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -368,7 +344,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /forwards/forwardToJspForward.jsp"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -376,12 +351,10 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.forward"
-          status UNSET
         }
         span(4) {
           childOf span(3)
           name "Compile /forwards/forwardToSimpleJava.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -390,7 +363,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(5) {
           childOf span(3)
           name "Render /forwards/forwardToSimpleJava.jsp"
-          status UNSET
           attributes {
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
             "jsp.requestURL" baseUrl + "/forwards/forwardToSimpleJava.jsp"
@@ -399,12 +371,10 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(6) {
           childOf span(5)
           name "ApplicationDispatcher.forward"
-          status UNSET
         }
         span(7) {
           childOf span(6)
           name "Compile /common/loop.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.common.loop_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -413,7 +383,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(8) {
           childOf span(6)
           name "Render /common/loop.jsp"
-          status UNSET
           attributes {
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
             "jsp.requestURL" baseUrl + "/common/loop.jsp"
@@ -458,7 +427,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /forwards/forwardToCompileError.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -527,7 +495,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /forwards/forwardToNonExistent.jsp"
-          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToNonExistent_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -536,7 +503,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /forwards/forwardToNonExistent.jsp"
-          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
@@ -85,7 +85,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/$forwardFromFileName"
           kind SERVER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -100,7 +100,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /$forwardFromFileName"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -109,7 +109,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /$forwardFromFileName"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -117,12 +117,12 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.forward"
-          errored false
+          status UNSET
         }
         span(4) {
           childOf span(3)
           name "Compile /$forwardDestFileName"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.$jspForwardDestClassPrefix$jspForwardDestClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -131,7 +131,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(5) {
           childOf span(3)
           name "Render /$forwardDestFileName"
-          errored false
+          status UNSET
           attributes {
             "jsp.forwardOrigin" "/$forwardFromFileName"
             "jsp.requestURL" baseUrl + "/$forwardDestFileName"
@@ -165,7 +165,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/forwards/forwardToHtml.jsp"
           kind SERVER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -180,7 +180,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /forwards/forwardToHtml.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -189,7 +189,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /forwards/forwardToHtml.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -197,7 +197,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.forward"
-          errored false
+          status UNSET
         }
       }
     }
@@ -222,7 +222,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
           kind SERVER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -237,7 +237,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /forwards/forwardToIncludeMulti.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -246,7 +246,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /forwards/forwardToIncludeMulti.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -254,12 +254,12 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.forward"
-          errored false
+          status UNSET
         }
         span(4) {
           childOf span(3)
           name "Compile /includes/includeMulti.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -268,7 +268,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(5) {
           childOf span(3)
           name "Render /includes/includeMulti.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
@@ -277,12 +277,12 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(6) {
           childOf span(5)
           name "ApplicationDispatcher.include"
-          errored false
+          status UNSET
         }
         span(7) {
           childOf span(6)
           name "Compile /common/javaLoopH2.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -291,7 +291,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(8) {
           childOf span(6)
           name "Render /common/javaLoopH2.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
@@ -300,12 +300,12 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(9) {
           childOf span(5)
           name "ApplicationDispatcher.include"
-          errored false
+          status UNSET
         }
         span(10) {
           childOf span(9)
           name "Compile /common/javaLoopH2.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -314,7 +314,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(11) {
           childOf span(9)
           name "Render /common/javaLoopH2.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
@@ -343,7 +343,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/forwards/forwardToJspForward.jsp"
           kind SERVER
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -358,7 +358,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /forwards/forwardToJspForward.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -367,7 +367,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /forwards/forwardToJspForward.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }
@@ -375,12 +375,12 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.forward"
-          errored false
+          status UNSET
         }
         span(4) {
           childOf span(3)
           name "Compile /forwards/forwardToSimpleJava.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -389,7 +389,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(5) {
           childOf span(3)
           name "Render /forwards/forwardToSimpleJava.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
             "jsp.requestURL" baseUrl + "/forwards/forwardToSimpleJava.jsp"
@@ -398,12 +398,12 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(6) {
           childOf span(5)
           name "ApplicationDispatcher.forward"
-          errored false
+          status UNSET
         }
         span(7) {
           childOf span(6)
           name "Compile /common/loop.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.common.loop_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -412,7 +412,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(8) {
           childOf span(6)
           name "Render /common/loop.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
             "jsp.requestURL" baseUrl + "/common/loop.jsp"
@@ -441,7 +441,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/forwards/forwardToCompileError.jsp"
           kind SERVER
-          errored true
+          status ERROR
           errorEvent(JasperException, String)
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -457,7 +457,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /forwards/forwardToCompileError.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -466,7 +466,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /forwards/forwardToCompileError.jsp"
-          errored true
+          status ERROR
           errorEvent(JasperException, String)
           attributes {
             "jsp.requestURL" reqUrl
@@ -475,13 +475,13 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(3) {
           childOf span(2)
           name "ApplicationDispatcher.forward"
-          errored true
+          status ERROR
           errorEvent(JasperException, String)
         }
         span(4) {
           childOf span(3)
           name "Compile /compileError.jsp"
-          errored true
+          status ERROR
           errorEvent(JasperException, String)
           attributes {
             "jsp.classFQCN" "org.apache.jsp.compileError_jsp"
@@ -511,7 +511,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           hasNoParent()
           name "/$jspWebappContext/forwards/forwardToNonExistent.jsp"
           kind SERVER
-          errored true
+          status ERROR
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -526,7 +526,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(1) {
           childOf span(0)
           name "Compile /forwards/forwardToNonExistent.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToNonExistent_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -535,7 +535,7 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
         span(2) {
           childOf span(0)
           name "Render /forwards/forwardToNonExistent.jsp"
-          errored false
+          status UNSET
           attributes {
             "jsp.requestURL" reqUrl
           }

--- a/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
@@ -37,7 +37,6 @@ class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
         span(0) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -62,7 +61,6 @@ class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
         span(0) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -75,7 +73,6 @@ class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
         span(0) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"

--- a/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
@@ -37,7 +37,7 @@ class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
         span(0) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -62,7 +62,7 @@ class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
         span(0) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -75,7 +75,7 @@ class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
         span(0) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"

--- a/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
@@ -88,7 +88,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(1) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -99,7 +99,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(2) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          errored false
+          status UNSET
           childOf span(1)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -178,7 +178,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(1) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -189,7 +189,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(2) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          errored false
+          status UNSET
           childOf span(1)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -261,7 +261,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(0) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -274,7 +274,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(1) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -336,7 +336,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(0) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -348,7 +348,7 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(1) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"

--- a/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
+++ b/instrumentation/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
@@ -88,7 +88,6 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(1) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -99,7 +98,6 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(2) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          status UNSET
           childOf span(1)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -178,7 +176,6 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(1) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -189,7 +186,6 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(2) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          status UNSET
           childOf span(1)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -261,7 +257,6 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(0) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -274,7 +269,6 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(1) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -336,7 +330,6 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(0) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -348,7 +341,6 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
         span(1) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"

--- a/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
@@ -130,7 +130,6 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
         span(0) {
           name STREAM_PENDING + " send"
           kind PRODUCER
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -142,7 +141,6 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
         span(1) {
           name STREAM_PENDING + " process"
           kind CONSUMER
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -159,7 +157,6 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
         span(2) {
           name STREAM_PENDING + " process"
           kind CONSUMER
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -175,7 +172,6 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
         span(3) {
           name STREAM_PROCESSED + " send"
           kind PRODUCER
-          status UNSET
           childOf span(2)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -187,7 +183,6 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
         span(4) {
           name STREAM_PROCESSED + " process"
           kind CONSUMER
-          status UNSET
           childOf span(3)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"

--- a/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
@@ -130,7 +130,7 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
         span(0) {
           name STREAM_PENDING + " send"
           kind PRODUCER
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -142,7 +142,7 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
         span(1) {
           name STREAM_PENDING + " process"
           kind CONSUMER
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -159,7 +159,7 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
         span(2) {
           name STREAM_PENDING + " process"
           kind CONSUMER
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -175,7 +175,7 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
         span(3) {
           name STREAM_PROCESSED + " send"
           kind PRODUCER
-          errored false
+          status UNSET
           childOf span(2)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
@@ -187,7 +187,7 @@ class KafkaStreamsTest extends AgentInstrumentationSpecification {
         span(4) {
           name STREAM_PROCESSED + " process"
           kind CONSUMER
-          errored false
+          status UNSET
           childOf span(3)
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/test/groovy/KubernetesClientTest.groovy
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/test/groovy/KubernetesClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.distributedRequestSpan

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/test/groovy/KubernetesClientTest.groovy
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/test/groovy/KubernetesClientTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.distributedRequestSpan
 import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.httpServer
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
@@ -172,8 +174,8 @@ class KubernetesClientTest extends AgentInstrumentationSpecification {
       name spanName
       kind CLIENT
       childOf trace.span(0)
-      errored hasFailed
       if (hasFailed) {
+        status ERROR
         errorEvent exception.class, exception.message
       }
       attributes {

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -116,7 +116,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key}" HOST
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -149,7 +149,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent RedisConnectionException, String
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key}" HOST
@@ -175,7 +175,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "SET"
@@ -208,7 +208,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "GET"
@@ -255,7 +255,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "GET"
@@ -288,7 +288,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "RANDOMKEY"
@@ -340,7 +340,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HMSET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "HMSET"
@@ -351,7 +351,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HGETALL"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "HGETALL"
@@ -392,7 +392,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEL"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent(IllegalStateException, "TestException")
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
@@ -428,7 +428,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SADD"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "SADD"
@@ -449,7 +449,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEBUG"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "DEBUG"
@@ -470,7 +470,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SHUTDOWN"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "SHUTDOWN"

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -117,7 +117,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key}" HOST
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -176,7 +175,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "SET"
@@ -209,7 +207,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "GET"
@@ -256,7 +253,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "GET"
@@ -289,7 +285,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "RANDOMKEY"
@@ -341,7 +336,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HMSET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "HMSET"
@@ -352,7 +346,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HGETALL"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "HGETALL"
@@ -429,7 +422,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SADD"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "SADD"
@@ -450,7 +442,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEBUG"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "DEBUG"
@@ -471,7 +462,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SHUTDOWN"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "SHUTDOWN"

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -98,7 +98,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key}" HOST
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -129,7 +129,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent RedisConnectionException, String
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key}" HOST
@@ -154,7 +154,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "SET"
@@ -175,7 +175,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "GET"
@@ -196,7 +196,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "GET"
@@ -217,7 +217,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "RANDOMKEY"
@@ -238,7 +238,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "LPUSH"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "LPUSH"
@@ -259,7 +259,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HMSET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "HMSET"
@@ -280,7 +280,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HGETALL"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "HGETALL"
@@ -300,7 +300,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEBUG"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "DEBUG"
@@ -320,7 +320,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SHUTDOWN"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "SHUTDOWN"

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -99,7 +99,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_NAME.key}" HOST
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -155,7 +154,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "SET"
@@ -176,7 +174,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "GET"
@@ -197,7 +194,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "GET"
@@ -218,7 +214,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "RANDOMKEY"
@@ -239,7 +234,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "LPUSH"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "LPUSH"
@@ -260,7 +254,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HMSET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "HMSET"
@@ -281,7 +274,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HGETALL"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "HGETALL"
@@ -301,7 +293,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEBUG"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "DEBUG"
@@ -321,7 +312,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SHUTDOWN"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_STATEMENT.key}" "SHUTDOWN"

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -120,7 +120,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.NET_PEER_NAME.key" PEER_NAME
             "$SemanticAttributes.NET_PEER_IP.key" PEER_IP
@@ -154,7 +154,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent AbstractChannel.AnnotatedConnectException, String
           attributes {
             "$SemanticAttributes.NET_PEER_NAME.key" PEER_NAME
@@ -180,7 +180,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SET TESTSETKEY ?"
@@ -213,7 +213,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET TESTKEY"
@@ -260,7 +260,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET NON_EXISTENT_KEY"
@@ -293,7 +293,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "RANDOMKEY"
@@ -344,7 +344,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HMSET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "HMSET TESTHM firstname ? lastname ? age ?"
@@ -355,7 +355,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HGETALL"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "HGETALL TESTHM"
@@ -396,7 +396,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEL"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent(IllegalStateException, "TestException")
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -432,7 +432,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SADD"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SADD SKEY ? ?"
@@ -453,7 +453,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEBUG"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "DEBUG SEGFAULT"
@@ -474,7 +474,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SHUTDOWN"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SHUTDOWN NOSAVE"

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -121,7 +121,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.NET_PEER_NAME.key" PEER_NAME
             "$SemanticAttributes.NET_PEER_IP.key" PEER_IP
@@ -181,7 +180,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SET TESTSETKEY ?"
@@ -214,7 +212,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET TESTKEY"
@@ -261,7 +258,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET NON_EXISTENT_KEY"
@@ -294,7 +290,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "RANDOMKEY"
@@ -345,7 +340,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HMSET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "HMSET TESTHM firstname ? lastname ? age ?"
@@ -356,7 +350,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HGETALL"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "HGETALL TESTHM"
@@ -433,7 +426,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SADD"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SADD SKEY ? ?"
@@ -454,7 +446,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEBUG"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "DEBUG SEGFAULT"
@@ -475,7 +466,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SHUTDOWN"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SHUTDOWN NOSAVE"

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.ConnectionFuture

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -96,7 +96,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SET TESTSETKEY ?"
@@ -120,7 +119,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET TESTKEY"
@@ -152,7 +150,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET NON_EXISTENT_KEY"
@@ -182,7 +179,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "RANDOMKEY"
@@ -202,7 +198,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "COMMAND"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "COMMAND"
@@ -223,7 +218,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "COMMAND"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "COMMAND"
@@ -254,7 +248,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEBUG"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "DEBUG SEGFAULT"
@@ -274,7 +267,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SHUTDOWN"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SHUTDOWN NOSAVE"
@@ -297,14 +289,12 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -314,7 +304,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(2) {
           name "GET"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -338,14 +327,12 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -355,7 +342,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(2) {
           name "GET"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -380,14 +366,12 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -397,7 +381,6 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(2) {
           name "GET"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -96,7 +96,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SET TESTSETKEY ?"
@@ -120,7 +120,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET TESTKEY"
@@ -152,7 +152,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET NON_EXISTENT_KEY"
@@ -182,7 +182,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "RANDOMKEY"
@@ -202,7 +202,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "COMMAND"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "COMMAND"
@@ -223,7 +223,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "COMMAND"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "COMMAND"
@@ -254,7 +254,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEBUG"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "DEBUG SEGFAULT"
@@ -274,7 +274,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SHUTDOWN"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SHUTDOWN NOSAVE"
@@ -297,14 +297,14 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -314,7 +314,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(2) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -338,14 +338,14 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -355,7 +355,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(2) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -380,14 +380,14 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
@@ -397,7 +397,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
         span(2) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -100,7 +100,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.NET_PEER_NAME.key" PEER_NAME
             "$SemanticAttributes.NET_PEER_IP.key" PEER_IP
@@ -131,7 +131,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent AbstractChannel.AnnotatedConnectException, String
           attributes {
             "$SemanticAttributes.NET_PEER_NAME.key" PEER_NAME
@@ -156,7 +156,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SET TESTSETKEY ?"
@@ -177,7 +177,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET TESTKEY"
@@ -198,7 +198,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET NON_EXISTENT_KEY"
@@ -219,7 +219,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "RANDOMKEY"
@@ -240,7 +240,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "LPUSH"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "LPUSH TESTLIST ?"
@@ -261,7 +261,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HMSET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "HMSET user firstname ? lastname ? age ?"
@@ -282,7 +282,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HGETALL"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "HGETALL TESTHM"
@@ -302,7 +302,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEBUG"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "DEBUG SEGFAULT"
@@ -322,7 +322,7 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SHUTDOWN"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SHUTDOWN NOSAVE"

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -101,7 +101,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CONNECT"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.NET_PEER_NAME.key" PEER_NAME
             "$SemanticAttributes.NET_PEER_IP.key" PEER_IP
@@ -157,7 +156,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SET TESTSETKEY ?"
@@ -178,7 +176,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET TESTKEY"
@@ -199,7 +196,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "GET NON_EXISTENT_KEY"
@@ -220,7 +216,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "RANDOMKEY"
@@ -241,7 +236,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "LPUSH"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "LPUSH TESTLIST ?"
@@ -262,7 +256,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HMSET"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "HMSET user firstname ? lastname ? age ?"
@@ -283,7 +276,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "HGETALL"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "HGETALL TESTHM"
@@ -303,7 +295,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "DEBUG"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "DEBUG SEGFAULT"
@@ -323,7 +314,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
         span(0) {
           name "SHUTDOWN"
           kind CLIENT
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "redis"
             "$SemanticAttributes.DB_STATEMENT.key" "SHUTDOWN NOSAVE"

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
@@ -36,14 +36,14 @@ class LettuceReactiveClientTest extends AbstractLettuceReactiveClientTest implem
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind SpanKind.CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -63,7 +63,7 @@ class LettuceReactiveClientTest extends AbstractLettuceReactiveClientTest implem
         span(2) {
           name "GET"
           kind SpanKind.CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
@@ -36,14 +36,12 @@ class LettuceReactiveClientTest extends AbstractLettuceReactiveClientTest implem
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind SpanKind.CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -63,7 +61,6 @@ class LettuceReactiveClientTest extends AbstractLettuceReactiveClientTest implem
         span(2) {
           name "GET"
           kind SpanKind.CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.groovy
@@ -148,7 +148,6 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "SET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -191,7 +190,6 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -248,7 +246,6 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -291,7 +288,6 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -352,7 +348,6 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "HMSET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -373,7 +368,6 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "HGETALL"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.groovy
@@ -148,7 +148,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -191,7 +191,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -248,7 +248,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -291,7 +291,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -352,7 +352,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "HMSET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -373,7 +373,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
         span(0) {
           name "HGETALL"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.groovy
@@ -97,7 +97,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(0) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -131,7 +131,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -173,7 +173,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -213,7 +213,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -243,7 +243,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(0) {
           name "COMMAND"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -285,14 +285,14 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -312,7 +312,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(2) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -346,14 +346,14 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -373,7 +373,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(2) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.groovy
@@ -97,7 +97,6 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(0) {
           name "SET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -131,7 +130,6 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -173,7 +171,6 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -213,7 +210,6 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -243,7 +239,6 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(0) {
           name "COMMAND"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -285,14 +280,12 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -312,7 +305,6 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(2) {
           name "GET"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -346,14 +338,12 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
       trace(0, 3) {
         span(0) {
           name "test-parent"
-          status UNSET
           attributes {
           }
         }
         span(1) {
           name "SET"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
@@ -373,7 +363,6 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
         span(2) {
           name "GET"
           kind CLIENT
-          status UNSET
           childOf span(0)
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.groovy
@@ -71,7 +71,7 @@ abstract class AbstractLettuceSyncClientAuthTest extends InstrumentationSpecific
         span(0) {
           name "AUTH"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.groovy
@@ -71,7 +71,6 @@ abstract class AbstractLettuceSyncClientAuthTest extends InstrumentationSpecific
         span(0) {
           name "AUTH"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.groovy
@@ -133,7 +133,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -167,7 +167,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "SET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -199,7 +199,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -230,7 +230,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "GET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -261,7 +261,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -292,7 +292,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "LPUSH"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -323,7 +323,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "HMSET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -354,7 +354,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "HGETALL"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -390,7 +390,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "EVAL"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -425,7 +425,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "MSET"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -456,7 +456,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
           name "DEBUG"
           kind CLIENT
           // Disconnect not an actual error even though an exception is recorded.
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -492,7 +492,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
           kind CLIENT
           if (Boolean.getBoolean("testLatestDeps")) {
             // Seems to only be treated as an error with Lettuce 6+
-            errored true
+            status ERROR
           }
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.groovy
@@ -134,7 +134,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "SET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -168,7 +167,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "SET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -200,7 +198,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -231,7 +228,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "GET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -262,7 +258,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "RANDOMKEY"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -293,7 +288,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "LPUSH"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -324,7 +318,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "HMSET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -355,7 +348,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "HGETALL"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -391,7 +383,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "EVAL"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -426,7 +417,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         span(0) {
           name "MSET"
           kind CLIENT
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -457,7 +447,6 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
           name "DEBUG"
           kind CLIENT
           // Disconnect not an actual error even though an exception is recorded.
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_TRANSPORT.key}" "IP.TCP"
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.groovy
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static java.nio.charset.StandardCharsets.UTF_8
 
 import io.lettuce.core.RedisClient

--- a/instrumentation/netty/netty-3.8/javaagent/src/latestDepTest/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/latestDepTest/groovy/Netty38ClientTest.groovy
@@ -108,7 +108,7 @@ class Netty38ClientTest extends HttpClientTest<Request> implements AgentTestTrai
           name "CONNECT"
           kind CLIENT
           childOf span(0)
-          errored true
+          status ERROR
           Class errorClass = ConnectException
           try {
             errorClass = Class.forName('io.netty.channel.AbstractChannel$AnnotatedConnectException')

--- a/instrumentation/netty/netty-3.8/javaagent/src/latestDepTest/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/latestDepTest/groovy/Netty38ClientTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
@@ -105,7 +105,7 @@ class Netty38ClientTest extends HttpClientTest<Request> implements AgentTestTrai
           name "CONNECT"
           kind CLIENT
           childOf span(0)
-          errored true
+          status ERROR
           Class errorClass = ConnectException
           try {
             errorClass = Class.forName('io.netty.channel.AbstractChannel$AnnotatedConnectException')

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ClientTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ClientTest.groovy
@@ -118,7 +118,7 @@ class Netty40ClientTest extends HttpClientTest<DefaultFullHttpRequest> implement
           name "CONNECT"
           kind CLIENT
           childOf span(0)
-          errored true
+          status ERROR
           Class errorClass = ConnectException
           try {
             errorClass = Class.forName('io.netty.channel.AbstractChannel$AnnotatedConnectException')

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ClientTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ClientTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
@@ -185,7 +185,7 @@ class Netty41ClientTest extends HttpClientTest<DefaultFullHttpRequest> implement
             name "CONNECT"
             kind CLIENT
             childOf span(0)
-            errored true
+            status ERROR
             errorEvent(thrownException.class, ~/Connection refused:( no further information:)? localhost\/\[?[0-9.:]+\]?:$UNUSABLE_PORT/)
           }
         }
@@ -285,7 +285,7 @@ class Netty41ClientTest extends HttpClientTest<DefaultFullHttpRequest> implement
         span(1) {
           childOf span(0)
           name "tracedMethod"
-          errored false
+          status UNSET
           attributes {
           }
         }

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
@@ -274,12 +274,12 @@ class Netty41ClientTest extends HttpClientTest<DefaultFullHttpRequest> implement
     def annotatedClass = new TracedClass()
 
     when:
-    def status = runUnderTrace("parent") {
+    def responseCode = runUnderTrace("parent") {
       annotatedClass.tracedMethod(method)
     }
 
     then:
-    status == 200
+    responseCode == 200
     assertTraces(1) {
       trace(0, 4) {
         basicSpan(it, 0, "parent")

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
@@ -286,7 +286,6 @@ class Netty41ClientTest extends HttpClientTest<DefaultFullHttpRequest> implement
         span(1) {
           childOf span(0)
           name "tracedMethod"
-          status UNSET
           attributes {
           }
         }

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -40,7 +40,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.otel"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -58,7 +57,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
         span(0) {
           name "manualName"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -77,7 +75,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.oneOfAKind"
           kind PRODUCER
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -96,14 +93,12 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.server"
           kind SERVER
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
         span(1) {
           name "TracedWithSpan.otel"
           childOf span(0)
-          status UNSET
           attributes {
           }
         }
@@ -122,7 +117,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.nestedServers"
           kind SERVER
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -141,7 +135,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.nestedClients"
           kind CLIENT
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -170,7 +163,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completionStage"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -195,7 +187,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completionStage"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -262,7 +253,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completionStage"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -282,7 +272,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completableFuture"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -307,7 +296,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completableFuture"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -374,7 +362,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completableFuture"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -419,7 +406,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "GeneratedJava6TestClass.run"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -427,7 +413,6 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "intercept"
           kind SpanKind.INTERNAL
           childOf(span(0))
-          status UNSET
           attributes {
           }
         }

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.extension.annotations.WithSpan

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 
-import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.extension.annotations.WithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.TraceUtils
@@ -38,7 +39,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.otel"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -161,7 +162,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completionStage"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -185,7 +186,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completionStage"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -205,7 +206,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completionStage"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -231,7 +232,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completionStage"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -251,7 +252,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completionStage"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -270,7 +271,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completableFuture"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -294,7 +295,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completableFuture"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -314,7 +315,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completableFuture"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -340,7 +341,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completableFuture"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -360,7 +361,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completableFuture"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -404,14 +405,14 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "GeneratedJava6TestClass.run"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
         }
         span(1) {
           name "intercept"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           childOf(span(0))
           attributes {
           }

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import io.opentelemetry.extension.annotations.WithSpan
-import io.opentelemetry.instrumentation.test.utils.TraceUtils
-import java.lang.reflect.Modifier
-import java.util.concurrent.CompletableFuture
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.extension.annotations.WithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.instrumentation.test.utils.TraceUtils
 import io.opentelemetry.test.annotation.TracedWithSpan
+import java.lang.reflect.Modifier
+import java.util.concurrent.CompletableFuture
 import net.bytebuddy.ByteBuddy
 import net.bytebuddy.ClassFileVersion
 import net.bytebuddy.asm.MemberAttributeExtension
@@ -40,7 +40,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.otel"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -58,7 +58,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
         span(0) {
           name "manualName"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -77,7 +77,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.oneOfAKind"
           kind PRODUCER
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -96,14 +96,14 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.server"
           kind SERVER
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
         span(1) {
           name "TracedWithSpan.otel"
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -122,7 +122,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.nestedServers"
           kind SERVER
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -141,7 +141,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.nestedClients"
           kind CLIENT
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -170,7 +170,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completionStage"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -195,7 +195,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completionStage"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -216,7 +216,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completionStage"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -242,7 +242,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completionStage"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -262,7 +262,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completionStage"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -282,7 +282,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completableFuture"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -307,7 +307,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completableFuture"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -328,7 +328,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completableFuture"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -354,7 +354,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completableFuture"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -374,7 +374,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "TracedWithSpan.completableFuture"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -397,11 +397,11 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       .name("GeneratedJava6TestClass")
       .implement(Runnable)
       .defineMethod("run", void.class, Modifier.PUBLIC).intercept(MethodDelegation.to(new Object() {
-        @RuntimeType
-        void intercept(@This Object o) {
-          TraceUtils.runUnderTrace("intercept", {})
-        }
-      }))
+      @RuntimeType
+      void intercept(@This Object o) {
+        TraceUtils.runUnderTrace("intercept", {})
+      }
+    }))
       .visit(new MemberAttributeExtension.ForMethod()
         .annotateMethod(AnnotationDescription.Builder.ofType(WithSpan).build())
         .on(ElementMatchers.named("run")))
@@ -419,7 +419,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "GeneratedJava6TestClass.run"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -427,7 +427,7 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
           name "intercept"
           kind SpanKind.INTERNAL
           childOf(span(0))
-          errored false
+          status UNSET
           attributes {
           }
         }

--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/TracerTest.groovy
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/TracerTest.groovy
@@ -34,7 +34,7 @@ class TracerTest extends AgentInstrumentationSpecification {
           name "test"
           kind PRODUCER
           hasNoParent()
-          errored true
+          status ERROR
           attributes {
             "string" "1"
             "long" 2

--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/TracerTest.groovy
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/TracerTest.groovy
@@ -34,7 +34,7 @@ class TracerTest extends AgentInstrumentationSpecification {
           name "test"
           kind PRODUCER
           hasNoParent()
-          status ERROR
+          errored true
           attributes {
             "string" "1"
             "long" 2

--- a/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -70,8 +71,8 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
     trace.span(index) {
       name "play.request"
       kind INTERNAL
-      errored endpoint == EXCEPTION
       if (endpoint == EXCEPTION) {
+        status StatusCode.ERROR
         errorEvent(Exception, EXCEPTION.body)
       }
       childOf((SpanData) parent)
@@ -82,5 +83,4 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
   String expectedServerSpanName(ServerEndpoint endpoint) {
     return "HTTP GET"
   }
-
 }

--- a/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -72,9 +73,9 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
     trace.span(index) {
       name "play.request"
       kind INTERNAL
-      errored endpoint == EXCEPTION
       childOf((SpanData) parent)
       if (endpoint == EXCEPTION) {
+        status StatusCode.ERROR
         errorEvent(Exception, EXCEPTION.body)
       }
     }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMQTest.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMQTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMQTest.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMQTest.groovy
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import com.rabbitmq.client.AMQP
@@ -350,8 +352,8 @@ class RabbitMQTest extends AgentInstrumentationSpecification {
         hasLink((SpanData) linkSpan)
       }
 
-      errored exception != null
       if (exception) {
+        status ERROR
         errorEvent(exception.class, errorMsg)
       }
 

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/RatpackOtherTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/RatpackOtherTest.groovy
@@ -73,7 +73,6 @@ class RatpackOtherTest extends AgentInstrumentationSpecification {
           name "/$route"
           kind SERVER
           hasNoParent()
-          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -89,7 +88,6 @@ class RatpackOtherTest extends AgentInstrumentationSpecification {
           name "/$route"
           kind INTERNAL
           childOf span(0)
-          status UNSET
           attributes {
           }
         }

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/RatpackOtherTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/RatpackOtherTest.groovy
@@ -73,7 +73,7 @@ class RatpackOtherTest extends AgentInstrumentationSpecification {
           name "/$route"
           kind SERVER
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -89,7 +89,7 @@ class RatpackOtherTest extends AgentInstrumentationSpecification {
           name "/$route"
           kind INTERNAL
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
           }
         }

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -13,6 +13,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -112,9 +113,9 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> implements Agent
     trace.span(index) {
       name endpoint.status == 404 ? "/" : endpoint == PATH_PARAM ? "/path/:id/param" : endpoint.path
       kind INTERNAL
-      errored endpoint == EXCEPTION
       childOf((SpanData) parent)
       if (endpoint == EXCEPTION) {
+        status StatusCode.ERROR
         errorEvent(Exception, EXCEPTION.body)
       }
     }

--- a/instrumentation/reactor-3.1/testing/src/main/groovy/io/opentelemetry/instrumentation/reactor/AbstractReactorCoreTest.groovy
+++ b/instrumentation/reactor-3.1/testing/src/main/groovy/io/opentelemetry/instrumentation/reactor/AbstractReactorCoreTest.groovy
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.reactor
 
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 

--- a/instrumentation/reactor-3.1/testing/src/main/groovy/io/opentelemetry/instrumentation/reactor/AbstractReactorCoreTest.groovy
+++ b/instrumentation/reactor-3.1/testing/src/main/groovy/io/opentelemetry/instrumentation/reactor/AbstractReactorCoreTest.groovy
@@ -97,7 +97,7 @@ abstract class AbstractReactorCoreTest extends InstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "trace-parent"
-          errored true
+          status ERROR
           errorEvent(RuntimeException, EXCEPTION_MESSAGE)
           hasNoParent()
         }
@@ -128,7 +128,7 @@ abstract class AbstractReactorCoreTest extends InstrumentationSpecification {
       trace(0, workSpans + 2) {
         span(0) {
           name "trace-parent"
-          errored true
+          status ERROR
           errorEvent(RuntimeException, EXCEPTION_MESSAGE)
           hasNoParent()
         }

--- a/instrumentation/rmi/javaagent/src/test/groovy/RmiTest.groovy
+++ b/instrumentation/rmi/javaagent/src/test/groovy/RmiTest.groovy
@@ -5,6 +5,7 @@
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 

--- a/instrumentation/rmi/javaagent/src/test/groovy/RmiTest.groovy
+++ b/instrumentation/rmi/javaagent/src/test/groovy/RmiTest.groovy
@@ -107,7 +107,7 @@ class RmiTest extends AgentInstrumentationSpecification {
           name "rmi.app.Greeter/exceptional"
           kind CLIENT
           childOf span(0)
-          errored true
+          status ERROR
           errorEvent(RuntimeException, String)
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "java_rmi"
@@ -119,7 +119,7 @@ class RmiTest extends AgentInstrumentationSpecification {
         span(2) {
           name "rmi.app.Server/exceptional"
           kind SERVER
-          errored true
+          status ERROR
           errorEvent(RuntimeException, String)
           attributes {
             "${SemanticAttributes.RPC_SYSTEM.key}" "java_rmi"

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
@@ -42,7 +42,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -72,7 +71,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -155,7 +153,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -179,7 +176,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -210,7 +206,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -293,7 +288,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -324,7 +318,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -407,7 +400,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -443,7 +435,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -532,7 +523,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -568,7 +558,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -658,7 +647,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -695,7 +683,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -791,7 +778,6 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.publisher"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
@@ -40,7 +40,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -70,7 +70,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -95,7 +95,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -127,7 +127,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -153,7 +153,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -164,7 +164,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for already empty Maybe"() {
     setup:
     def observer = new TestObserver()
-    def source = Maybe.<String>empty()
+    def source = Maybe.<String> empty()
     new TracedWithSpan()
       .maybe(source)
       .subscribe(observer)
@@ -177,7 +177,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -187,7 +187,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed Maybe"() {
     setup:
-    def source = MaybeSubject.<String>create()
+    def source = MaybeSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .maybe(source)
@@ -208,7 +208,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -220,7 +220,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def error = new IllegalArgumentException("Boom")
     def observer = new TestObserver()
-    def source = Maybe.<String>error(error)
+    def source = Maybe.<String> error(error)
     new TracedWithSpan()
       .maybe(source)
       .subscribe(observer)
@@ -233,7 +233,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -245,7 +245,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored Maybe"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = MaybeSubject.<String>create()
+    def source = MaybeSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .maybe(source)
@@ -265,7 +265,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -291,7 +291,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -301,7 +301,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed Single"() {
     setup:
-    def source = SingleSubject.<String>create()
+    def source = SingleSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .single(source)
@@ -322,7 +322,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -334,7 +334,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def error = new IllegalArgumentException("Boom")
     def observer = new TestObserver()
-    def source = Single.<String>error(error)
+    def source = Single.<String> error(error)
     new TracedWithSpan()
       .single(source)
       .subscribe(observer)
@@ -347,7 +347,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -359,7 +359,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored Single"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = SingleSubject.<String>create()
+    def source = SingleSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .single(source)
@@ -379,7 +379,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -391,7 +391,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for already completed Observable"() {
     setup:
     def observer = new TestObserver()
-    def source = Observable.<String>just("Value")
+    def source = Observable.<String> just("Value")
     new TracedWithSpan()
       .observable(source)
       .subscribe(observer)
@@ -405,7 +405,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -415,7 +415,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed Observable"() {
     setup:
-    def source = UnicastSubject.<String>create()
+    def source = UnicastSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .observable(source)
@@ -441,7 +441,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -453,7 +453,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def error = new IllegalArgumentException("Boom")
     def observer = new TestObserver()
-    def source = Observable.<String>error(error)
+    def source = Observable.<String> error(error)
     new TracedWithSpan()
       .observable(source)
       .subscribe(observer)
@@ -466,7 +466,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -478,7 +478,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored Observable"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = UnicastSubject.<String>create()
+    def source = UnicastSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .observable(source)
@@ -504,7 +504,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -516,7 +516,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for already completed Flowable"() {
     setup:
     def observer = new TestSubscriber()
-    def source = Flowable.<String>just("Value")
+    def source = Flowable.<String> just("Value")
     new TracedWithSpan()
       .flowable(source)
       .subscribe(observer)
@@ -530,7 +530,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -540,7 +540,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed Flowable"() {
     setup:
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def observer = new TestSubscriber()
     new TracedWithSpan()
       .flowable(source)
@@ -566,7 +566,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -578,7 +578,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def error = new IllegalArgumentException("Boom")
     def observer = new TestSubscriber()
-    def source = Flowable.<String>error(error)
+    def source = Flowable.<String> error(error)
     new TracedWithSpan()
       .flowable(source)
       .subscribe(observer)
@@ -591,7 +591,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -603,7 +603,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored Flowable"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def observer = new TestSubscriber()
     new TracedWithSpan()
       .flowable(source)
@@ -629,7 +629,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -641,7 +641,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for already completed ParallelFlowable"() {
     setup:
     def observer = new TestSubscriber()
-    def source = Flowable.<String>just("Value")
+    def source = Flowable.<String> just("Value")
     new TracedWithSpan()
       .parallelFlowable(source.parallel())
       .sequential()
@@ -656,7 +656,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -666,7 +666,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed ParallelFlowable"() {
     setup:
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def observer = new TestSubscriber()
     new TracedWithSpan()
       .parallelFlowable(source.parallel())
@@ -693,7 +693,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -705,7 +705,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def error = new IllegalArgumentException("Boom")
     def observer = new TestSubscriber()
-    def source = Flowable.<String>error(error)
+    def source = Flowable.<String> error(error)
     new TracedWithSpan()
       .parallelFlowable(source.parallel())
       .sequential()
@@ -719,7 +719,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -731,7 +731,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored ParallelFlowable"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def observer = new TestSubscriber()
     new TracedWithSpan()
       .parallelFlowable(source.parallel())
@@ -758,7 +758,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -789,7 +789,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.publisher"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -820,7 +820,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.publisher"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -847,9 +847,9 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
 
     @Override
-    void request(long l) { }
+    void request(long l) {}
 
     @Override
-    void cancel() { }
+    void cancel() {}
   }
 }

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.rxjava2.TracedWithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 
-import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.rxjava2.TracedWithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.reactivex.Completable
@@ -40,7 +41,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -69,7 +70,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -93,7 +94,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -125,7 +126,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -151,7 +152,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.maybe"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -174,7 +175,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.maybe"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -204,7 +205,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.maybe"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -228,7 +229,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.maybe"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -260,7 +261,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.maybe"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -286,7 +287,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.single"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -316,7 +317,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.single"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -340,7 +341,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.single"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -372,7 +373,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.single"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -398,7 +399,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.observable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -433,7 +434,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.observable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -457,7 +458,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.observable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -495,7 +496,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.observable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -521,7 +522,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.flowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -556,7 +557,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.flowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -580,7 +581,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.flowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -618,7 +619,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.flowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -645,7 +646,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.parallelFlowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -681,7 +682,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.parallelFlowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -706,7 +707,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.parallelFlowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -745,7 +746,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.parallelFlowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -776,7 +777,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.publisher"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -806,7 +807,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.publisher"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 
-import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.rxjava3.TracedWithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.reactivex.rxjava3.core.Completable
@@ -40,7 +41,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -68,7 +69,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -92,7 +93,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -123,7 +124,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.completable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -149,7 +150,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.maybe"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -172,7 +173,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.maybe"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -201,7 +202,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.maybe"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -225,7 +226,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.maybe"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -256,7 +257,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.maybe"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -282,7 +283,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.single"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -311,7 +312,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.single"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -335,7 +336,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.single"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -366,7 +367,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.single"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -392,7 +393,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.observable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -426,7 +427,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.observable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -450,7 +451,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.observable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -487,7 +488,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.observable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -513,7 +514,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.flowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -547,7 +548,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.flowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -571,7 +572,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.flowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -608,7 +609,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.flowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -635,7 +636,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.parallelFlowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -670,7 +671,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.parallelFlowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -695,7 +696,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.parallelFlowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -733,7 +734,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.parallelFlowable"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
@@ -763,7 +764,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.publisher"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           attributes {
           }
@@ -792,7 +793,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
       trace(0, 1) {
         span(0) {
           name "TracedWithSpan.publisher"
-          kind SpanKind.INTERNAL
+          kind INTERNAL
           hasNoParent()
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.rxjava3.TracedWithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
@@ -42,7 +42,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -71,7 +70,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -153,7 +151,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -177,7 +174,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -207,7 +203,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -289,7 +284,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -319,7 +313,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -401,7 +394,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -436,7 +428,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -524,7 +515,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -559,7 +549,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -648,7 +637,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -684,7 +672,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -778,7 +765,6 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.publisher"
           kind SpanKind.INTERNAL
           hasNoParent()
-          status UNSET
           attributes {
           }
         }

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
@@ -40,7 +40,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -69,7 +69,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -94,7 +94,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -125,7 +125,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.completable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -151,7 +151,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -162,7 +162,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for already empty Maybe"() {
     setup:
     def observer = new TestObserver()
-    def source = Maybe.<String>empty()
+    def source = Maybe.<String> empty()
     new TracedWithSpan()
       .maybe(source)
       .subscribe(observer)
@@ -175,7 +175,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -185,7 +185,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed Maybe"() {
     setup:
-    def source = MaybeSubject.<String>create()
+    def source = MaybeSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .maybe(source)
@@ -205,7 +205,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -217,7 +217,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def error = new IllegalArgumentException("Boom")
     def observer = new TestObserver()
-    def source = Maybe.<String>error(error)
+    def source = Maybe.<String> error(error)
     new TracedWithSpan()
       .maybe(source)
       .subscribe(observer)
@@ -230,7 +230,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -242,7 +242,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored Maybe"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = MaybeSubject.<String>create()
+    def source = MaybeSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .maybe(source)
@@ -261,7 +261,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.maybe"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -287,7 +287,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -297,7 +297,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed Single"() {
     setup:
-    def source = SingleSubject.<String>create()
+    def source = SingleSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .single(source)
@@ -317,7 +317,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -329,7 +329,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def error = new IllegalArgumentException("Boom")
     def observer = new TestObserver()
-    def source = Single.<String>error(error)
+    def source = Single.<String> error(error)
     new TracedWithSpan()
       .single(source)
       .subscribe(observer)
@@ -342,7 +342,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -354,7 +354,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored Single"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = SingleSubject.<String>create()
+    def source = SingleSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .single(source)
@@ -373,7 +373,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.single"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -385,7 +385,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for already completed Observable"() {
     setup:
     def observer = new TestObserver()
-    def source = Observable.<String>just("Value")
+    def source = Observable.<String> just("Value")
     new TracedWithSpan()
       .observable(source)
       .subscribe(observer)
@@ -399,7 +399,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -409,7 +409,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed Observable"() {
     setup:
-    def source = UnicastSubject.<String>create()
+    def source = UnicastSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .observable(source)
@@ -434,7 +434,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -446,7 +446,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def error = new IllegalArgumentException("Boom")
     def observer = new TestObserver()
-    def source = Observable.<String>error(error)
+    def source = Observable.<String> error(error)
     new TracedWithSpan()
       .observable(source)
       .subscribe(observer)
@@ -459,7 +459,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -471,7 +471,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored Observable"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = UnicastSubject.<String>create()
+    def source = UnicastSubject.<String> create()
     def observer = new TestObserver()
     new TracedWithSpan()
       .observable(source)
@@ -496,7 +496,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.observable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -508,7 +508,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for already completed Flowable"() {
     setup:
     def observer = new TestSubscriber()
-    def source = Flowable.<String>just("Value")
+    def source = Flowable.<String> just("Value")
     new TracedWithSpan()
       .flowable(source)
       .subscribe(observer)
@@ -522,7 +522,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -532,7 +532,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed Flowable"() {
     setup:
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def observer = new TestSubscriber()
     new TracedWithSpan()
       .flowable(source)
@@ -557,7 +557,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -569,7 +569,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def error = new IllegalArgumentException("Boom")
     def observer = new TestSubscriber()
-    def source = Flowable.<String>error(error)
+    def source = Flowable.<String> error(error)
     new TracedWithSpan()
       .flowable(source)
       .subscribe(observer)
@@ -582,7 +582,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -594,7 +594,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored Flowable"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def observer = new TestSubscriber()
     new TracedWithSpan()
       .flowable(source)
@@ -619,7 +619,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.flowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -631,7 +631,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for already completed ParallelFlowable"() {
     setup:
     def observer = new TestSubscriber()
-    def source = Flowable.<String>just("Value")
+    def source = Flowable.<String> just("Value")
     new TracedWithSpan()
       .parallelFlowable(source.parallel())
       .sequential()
@@ -646,7 +646,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -656,7 +656,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed ParallelFlowable"() {
     setup:
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def observer = new TestSubscriber()
     new TracedWithSpan()
       .parallelFlowable(source.parallel())
@@ -682,7 +682,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -694,7 +694,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     setup:
     def error = new IllegalArgumentException("Boom")
     def observer = new TestSubscriber()
-    def source = Flowable.<String>error(error)
+    def source = Flowable.<String> error(error)
     new TracedWithSpan()
       .parallelFlowable(source.parallel())
       .sequential()
@@ -708,7 +708,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -720,7 +720,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored ParallelFlowable"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def observer = new TestSubscriber()
     new TracedWithSpan()
       .parallelFlowable(source.parallel())
@@ -746,7 +746,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.parallelFlowable"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -776,7 +776,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.publisher"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -806,7 +806,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           name "TracedWithSpan.publisher"
           kind SpanKind.INTERNAL
           hasNoParent()
-          errored true
+          status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
           }
@@ -833,9 +833,9 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
 
     @Override
-    void request(long l) { }
+    void request(long l) {}
 
     @Override
-    void cancel() { }
+    void cancel() {}
   }
 }

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 

--- a/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
@@ -26,7 +26,7 @@ class SlickTest extends AgentInstrumentationSpecification {
         span(0) {
           name "run query"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -34,7 +34,7 @@ class SlickTest extends AgentInstrumentationSpecification {
           name "SELECT ${SlickUtils.Db()}"
           kind CLIENT
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "h2"
             "$SemanticAttributes.DB_NAME.key" SlickUtils.Db()

--- a/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
@@ -26,7 +26,6 @@ class SlickTest extends AgentInstrumentationSpecification {
         span(0) {
           name "run query"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -34,7 +33,6 @@ class SlickTest extends AgentInstrumentationSpecification {
           name "SELECT ${SlickUtils.Db()}"
           kind CLIENT
           childOf span(0)
-          status UNSET
           attributes {
             "$SemanticAttributes.DB_SYSTEM.key" "h2"
             "$SemanticAttributes.DB_NAME.key" SlickUtils.Db()

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/JettyServlet2Test.groovy
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/JettyServlet2Test.groovy
@@ -81,7 +81,7 @@ class JettyServlet2Test extends HttpServerTest<Server> implements AgentTestTrait
     trace.span(index) {
       name endpoint == REDIRECT ? "Response.sendRedirect" : "Response.sendError"
       kind INTERNAL
-      errored false
+      status UNSET
       childOf((SpanData) parent)
       attributes {
       }

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/JettyServlet2Test.groovy
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/JettyServlet2Test.groovy
@@ -81,7 +81,6 @@ class JettyServlet2Test extends HttpServerTest<Server> implements AgentTestTrait
     trace.span(index) {
       name endpoint == REDIRECT ? "Response.sendRedirect" : "Response.sendError"
       kind INTERNAL
-      status UNSET
       childOf((SpanData) parent)
       attributes {
       }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServletMappingTest.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServletMappingTest.groovy
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
@@ -56,7 +59,9 @@ abstract class AbstractServletMappingTest<SERVER, CONTEXT> extends AgentInstrume
         span(0) {
           name getContextPath() + spanName
           kind SpanKind.SERVER
-          errored !success
+          if (!success) {
+            status ERROR
+          }
         }
         if (!success) {
           span(1) {
@@ -66,13 +71,13 @@ abstract class AbstractServletMappingTest<SERVER, CONTEXT> extends AgentInstrume
     }
 
     where:
-    path        | spanName    | success
-    'prefix'    | '/prefix/*' | true
-    'prefix/'   | '/prefix/*' | true
-    'prefix/a'  | '/prefix/*' | true
-    'prefixa'   | '/*'        | false
-    'a.suffix'  | '/*.suffix' | true
-    '.suffix'   | '/*.suffix' | true
-    'suffix'    | '/*'        | false
+    path       | spanName    | success
+    'prefix'   | '/prefix/*' | true
+    'prefix/'  | '/prefix/*' | true
+    'prefix/a' | '/prefix/*' | true
+    'prefixa'  | '/*'        | false
+    'a.suffix' | '/*.suffix' | true
+    '.suffix'  | '/*.suffix' | true
+    'suffix'   | '/*'        | false
   }
 }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServletMappingTest.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServletMappingTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.api.trace.SpanKind

--- a/instrumentation/servlet/servlet-javax-common/javaagent/src/test/groovy/HttpServletResponseTest.groovy
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/src/test/groovy/HttpServletResponseTest.groovy
@@ -108,7 +108,7 @@ class HttpServletResponseTest extends AgentInstrumentationSpecification {
         span(1) {
           name 'HttpServletResponseTest$2.sendRedirect'
           childOf span(0)
-          errored true
+          status ERROR
           errorEvent(ex.class, ex.message)
         }
       }

--- a/instrumentation/servlet/servlet-javax-common/javaagent/src/test/groovy/HttpServletResponseTest.groovy
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/src/test/groovy/HttpServletResponseTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static java.util.Collections.emptyEnumeration

--- a/instrumentation/servlet/servlet-javax-common/javaagent/src/test/groovy/RequestDispatcherTest.groovy
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/src/test/groovy/RequestDispatcherTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 

--- a/instrumentation/servlet/servlet-javax-common/javaagent/src/test/groovy/RequestDispatcherTest.groovy
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/src/test/groovy/RequestDispatcherTest.groovy
@@ -121,7 +121,7 @@ class RequestDispatcherTest extends AgentInstrumentationSpecification {
         span(1) {
           name "TestDispatcher.$operation"
           childOf span(0)
-          errored true
+          status ERROR
           errorEvent(ex.class, ex.message)
         }
         basicSpan(it, 2, "$operation-child", span(1))

--- a/instrumentation/spark-2.3/javaagent/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/instrumentation/spark-2.3/javaagent/src/test/groovy/SparkJavaBasedTest.groovy
@@ -48,7 +48,6 @@ class SparkJavaBasedTest extends AgentInstrumentationSpecification {
         span(0) {
           name "/param/:param"
           kind SERVER
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"

--- a/instrumentation/spark-2.3/javaagent/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/instrumentation/spark-2.3/javaagent/src/test/groovy/SparkJavaBasedTest.groovy
@@ -48,7 +48,7 @@ class SparkJavaBasedTest extends AgentInstrumentationSpecification {
         span(0) {
           name "/param/:param"
           kind SERVER
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/SpringBatchTest.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/SpringBatchTest.groovy
@@ -61,7 +61,7 @@ abstract class SpringBatchTest extends AgentInstrumentationSpecification {
           name "BatchJob taskletJob.step.Chunk"
           kind INTERNAL
           childOf span(1)
-          errored true
+          status ERROR
           errorEvent RuntimeException, "fail"
         }
       }

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/SpringBatchTest.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/SpringBatchTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static java.util.Collections.emptyMap
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/test/groovy/SpringJpaTest.groovy
@@ -61,7 +61,6 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         span(0) {
           name "JpaRepository.findAll"
           kind INTERNAL
-          status UNSET
           attributes {
           }
         }
@@ -94,7 +93,6 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CrudRepository.save"
           kind INTERNAL
-          status UNSET
           attributes {
           }
         }
@@ -127,7 +125,6 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CrudRepository.save"
           kind INTERNAL
-          status UNSET
           attributes {
           }
         }
@@ -172,7 +169,6 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         span(0) {
           name "JpaCustomerRepository.findByLastName"
           kind INTERNAL
-          status UNSET
           attributes {
           }
         }
@@ -203,7 +199,6 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CrudRepository.delete"
           kind INTERNAL
-          status UNSET
           attributes {
           }
         }

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/test/groovy/SpringJpaTest.groovy
@@ -61,7 +61,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         span(0) {
           name "JpaRepository.findAll"
           kind INTERNAL
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -94,7 +94,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CrudRepository.save"
           kind INTERNAL
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -127,7 +127,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CrudRepository.save"
           kind INTERNAL
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -172,7 +172,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         span(0) {
           name "JpaCustomerRepository.findByLastName"
           kind INTERNAL
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -203,7 +203,7 @@ class SpringJpaTest extends AgentInstrumentationSpecification {
         span(0) {
           name "CrudRepository.delete"
           kind INTERNAL
-          errored false
+          status UNSET
           attributes {
           }
         }

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
@@ -23,7 +23,6 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
         span(0) {
           name "TriggerTask.run"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -45,7 +44,6 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
         span(0) {
           name "IntervalTask.run"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }
@@ -67,7 +65,6 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
         span(0) {
           nameContains "LambdaTaskConfigurer\$\$Lambda\$"
           hasNoParent()
-          status UNSET
           attributes {
           }
         }

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
@@ -23,7 +23,7 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
         span(0) {
           name "TriggerTask.run"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -45,7 +45,7 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
         span(0) {
           name "IntervalTask.run"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -67,7 +67,7 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
         span(0) {
           nameContains "LambdaTaskConfigurer\$\$Lambda\$"
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
           }
         }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -161,7 +161,7 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
         span(2) {
           name "tracedMethod"
           childOf span(0)
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -249,7 +249,7 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
         span(2) {
           name "tracedMethod"
           childOf span(annotatedMethod ? 0 : 1)
-          errored false
+          status UNSET
           attributes {
           }
         }
@@ -278,7 +278,7 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
           name "/**"
           kind SERVER
           hasNoParent()
-          errored true
+          status ERROR
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -294,7 +294,7 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
           name "ResourceWebHandler.handle"
           kind INTERNAL
           childOf span(0)
-          errored true
+          status ERROR
           errorEvent(ResponseStatusException, String)
           attributes {
             "spring-webflux.handler.type" "org.springframework.web.reactive.resource.ResourceWebHandler"
@@ -370,7 +370,7 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
         span(0) {
           name urlPathWithVariables
           kind SERVER
-          errored true
+          status ERROR
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_PEER_IP.key}" "127.0.0.1"
@@ -393,7 +393,7 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
           }
           kind INTERNAL
           childOf span(0)
-          errored true
+          status ERROR
           errorEvent(RuntimeException, "bad things happen")
           attributes {
             if (annotatedMethod == null) {

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -5,6 +5,7 @@
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.OkHttpUtils

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -162,7 +162,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
         span(2) {
           name "tracedMethod"
           childOf span(0)
-          status UNSET
           attributes {
           }
         }
@@ -250,7 +249,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
         span(2) {
           name "tracedMethod"
           childOf span(annotatedMethod ? 0 : 1)
-          status UNSET
           attributes {
           }
         }

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -155,7 +155,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     trace.span(index) {
       name "BasicErrorController.error"
       kind INTERNAL
-      status UNSET
       attributes {
       }
     }
@@ -167,7 +166,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     trace.span(index) {
       name responseSpanName
       kind INTERNAL
-      status UNSET
       attributes {
       }
     }
@@ -178,7 +176,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     trace.span(index) {
       name "Render RedirectView"
       kind INTERNAL
-      status UNSET
       attributes {
         "spring-webmvc.view.type" RedirectView.simpleName
       }

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -7,7 +7,6 @@ package test.boot
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.LOGIN
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
@@ -15,6 +14,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -193,7 +193,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
       name handlerSpanName
       kind INTERNAL
       if (endpoint == EXCEPTION) {
-        status ERROR
+        status StatusCode.ERROR
         errorEvent(Exception, EXCEPTION.body)
       }
       childOf((SpanData) parent)

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -155,7 +155,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     trace.span(index) {
       name "BasicErrorController.error"
       kind INTERNAL
-      errored false
+      status UNSET
       attributes {
       }
     }
@@ -167,7 +167,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     trace.span(index) {
       name responseSpanName
       kind INTERNAL
-      errored false
+      status UNSET
       attributes {
       }
     }
@@ -178,7 +178,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     trace.span(index) {
       name "Render RedirectView"
       kind INTERNAL
-      errored false
+      status UNSET
       attributes {
         "spring-webmvc.view.type" RedirectView.simpleName
       }

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -7,6 +7,7 @@ package test.boot
 
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.LOGIN
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
@@ -191,8 +192,8 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     trace.span(index) {
       name handlerSpanName
       kind INTERNAL
-      errored endpoint == EXCEPTION
       if (endpoint == EXCEPTION) {
+        status ERROR
         errorEvent(Exception, EXCEPTION.body)
       }
       childOf((SpanData) parent)

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -107,7 +107,7 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> i
     trace.span(index) {
       name "ApplicationDispatcher.forward"
       kind INTERNAL
-      errored false
+      status UNSET
       childOf((SpanData) parent)
       attributes {
       }
@@ -115,7 +115,7 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> i
     trace.span(index + 1) {
       name "BasicErrorController.error"
       kind INTERNAL
-      errored false
+      status UNSET
       childOf(trace.span(index))
       attributes {
       }

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -107,7 +107,6 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> i
     trace.span(index) {
       name "ApplicationDispatcher.forward"
       kind INTERNAL
-      status UNSET
       childOf((SpanData) parent)
       attributes {
       }
@@ -115,7 +114,6 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> i
     trace.span(index + 1) {
       name "BasicErrorController.error"
       kind INTERNAL
-      status UNSET
       childOf(trace.span(index))
       attributes {
       }

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -84,9 +85,9 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> i
     trace.span(index) {
       name "TestController.${endpoint.name().toLowerCase()}"
       kind INTERNAL
-      errored endpoint == EXCEPTION
       childOf((SpanData) parent)
       if (endpoint == EXCEPTION) {
+        status StatusCode.ERROR
         errorEvent(Exception, EXCEPTION.body)
       }
     }

--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/test/groovy/test/boot/SpringWsTest.groovy
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/test/groovy/test/boot/SpringWsTest.groovy
@@ -5,6 +5,9 @@
 
 package test.boot
 
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -123,7 +126,9 @@ class SpringWsTest extends AgentInstrumentationSpecification implements HttpServ
       hasNoParent()
       name operation
       kind SpanKind.SERVER
-      errored exception != null
+      if (exception != null) {
+        status ERROR
+      }
     }
   }
 
@@ -135,9 +140,9 @@ class SpringWsTest extends AgentInstrumentationSpecification implements HttpServ
         childOf((SpanData) parentSpan)
       }
       name "HelloEndpoint." + methodName
-      kind SpanKind.INTERNAL
-      errored exception != null
+      kind INTERNAL
       if (exception) {
+        status ERROR
         errorEvent(exception.class, exception.message)
       }
       attributes {

--- a/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static net.spy.memcached.ConnectionFactoryBuilder.Protocol.BINARY
 
@@ -605,7 +607,9 @@ class SpymemcachedTest extends AgentInstrumentationSpecification {
 
       name operation
       kind CLIENT
-      errored(error != null && error != "canceled")
+      if (error != null && error != "canceled") {
+        status ERROR
+      }
 
       if (error == "timeout") {
         errorEvent(

--- a/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
@@ -592,7 +592,7 @@ class SpymemcachedTest extends AgentInstrumentationSpecification {
     return trace.span(index) {
       name parentOperation
       hasNoParent()
-      errored false
+      status UNSET
       attributes {
       }
     }

--- a/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace

--- a/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
@@ -592,7 +592,6 @@ class SpymemcachedTest extends AgentInstrumentationSpecification {
     return trace.span(index) {
       name parentOperation
       hasNoParent()
-      status UNSET
       attributes {
       }
     }

--- a/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
+++ b/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
@@ -10,7 +12,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicServerSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 
-import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -73,9 +75,9 @@ class Struts2ActionSpanTest extends HttpServerTest<Server> implements AgentTestT
   void handlerSpan(TraceAssert trace, int index, Object parent, String method, ServerEndpoint endpoint) {
     trace.span(index) {
       name "GreetingAction.${endpoint.name().toLowerCase()}"
-      kind SpanKind.INTERNAL
-      errored endpoint == EXCEPTION
+      kind INTERNAL
       if (endpoint == EXCEPTION) {
+        status StatusCode.ERROR
         errorEvent(Exception, EXCEPTION.body)
       }
       def expectedMethodName = endpoint.name().toLowerCase()

--- a/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
+++ b/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION

--- a/instrumentation/tapestry-5.4/javaagent/src/test/groovy/TapestryTest.groovy
+++ b/instrumentation/tapestry-5.4/javaagent/src/test/groovy/TapestryTest.groovy
@@ -123,7 +123,7 @@ class TapestryTest extends AgentInstrumentationSpecification implements HttpServ
           hasNoParent()
           kind SpanKind.SERVER
           name getContextPath() + "/Index"
-          errored true
+          status ERROR
         }
         basicSpan(it, 1, "activate/Index", span(0))
         basicSpan(it, 2, "action/Index:exception", span(0), new IllegalStateException("expected"))

--- a/instrumentation/tapestry-5.4/javaagent/src/test/groovy/TapestryTest.groovy
+++ b/instrumentation/tapestry-5.4/javaagent/src/test/groovy/TapestryTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 
 import io.opentelemetry.api.trace.SpanKind

--- a/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
@@ -135,7 +135,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
           }
@@ -143,7 +143,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
         span(1) {
           name "MessageCreator.create"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -179,7 +179,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
           }
@@ -187,7 +187,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
         span(1) {
           name "CallCreator.create"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Call"
             "twilio.account" "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -245,7 +245,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
           }
@@ -254,7 +254,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
           name "MessageCreator.create"
           kind CLIENT
           childOf(span(0))
-          errored false
+          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -327,7 +327,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
           }
@@ -336,7 +336,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
           name "MessageCreator.create"
           kind CLIENT
           childOf(span(0))
-          errored false
+          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -416,7 +416,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
           }
@@ -425,7 +425,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
           name "MessageCreator.createAsync"
           kind CLIENT
           childOf(span(0))
-          errored false
+          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -466,14 +466,14 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          errored true
+          status ERROR
           errorEvent(ApiException, "Testing Failure")
           hasNoParent()
         }
         span(1) {
           name "MessageCreator.create"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent(ApiException, "Testing Failure")
         }
       }
@@ -502,7 +502,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
           name "MessageCreator.create"
           kind CLIENT
           hasNoParent()
-          errored false
+          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -547,7 +547,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
           }
@@ -555,7 +555,7 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
         span(1) {
           name "MessageCreator.createAsync"
           kind CLIENT
-          errored false
+          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -607,14 +607,14 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          errored true
+          status ERROR
           errorEvent(ApiException, "Testing Failure")
           hasNoParent()
         }
         span(1) {
           name "MessageCreator.createAsync"
           kind CLIENT
-          errored true
+          status ERROR
           errorEvent(ApiException, "Testing Failure")
         }
       }

--- a/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
@@ -136,7 +136,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          status UNSET
           hasNoParent()
           attributes {
           }
@@ -144,7 +143,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
         span(1) {
           name "MessageCreator.create"
           kind CLIENT
-          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -180,7 +178,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          status UNSET
           hasNoParent()
           attributes {
           }
@@ -188,7 +185,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
         span(1) {
           name "CallCreator.create"
           kind CLIENT
-          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Call"
             "twilio.account" "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -246,7 +242,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          status UNSET
           hasNoParent()
           attributes {
           }
@@ -255,7 +250,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
           name "MessageCreator.create"
           kind CLIENT
           childOf(span(0))
-          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -328,7 +322,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          status UNSET
           hasNoParent()
           attributes {
           }
@@ -337,7 +330,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
           name "MessageCreator.create"
           kind CLIENT
           childOf(span(0))
-          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -417,7 +409,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          status UNSET
           hasNoParent()
           attributes {
           }
@@ -426,7 +417,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
           name "MessageCreator.createAsync"
           kind CLIENT
           childOf(span(0))
-          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -503,7 +493,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
           name "MessageCreator.create"
           kind CLIENT
           hasNoParent()
-          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -548,7 +537,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
       trace(0, 2) {
         span(0) {
           name "test"
-          status UNSET
           hasNoParent()
           attributes {
           }
@@ -556,7 +544,6 @@ class TwilioClientTest extends AgentInstrumentationSpecification {
         span(1) {
           name "MessageCreator.createAsync"
           kind CLIENT
-          status UNSET
           attributes {
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"

--- a/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
@@ -6,6 +6,7 @@
 package test
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/VertxReactivePropagationTest.groovy
@@ -53,7 +53,6 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
         span(0) {
           name "/listProducts"
           kind SERVER
-          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -72,7 +71,6 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
           name "SELECT test.products"
           kind CLIENT
           childOf span(2)
-          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "hsqldb"
             "${SemanticAttributes.DB_NAME.key}" "test"

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/test/groovy/VertxReactivePropagationTest.groovy
@@ -53,7 +53,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
         span(0) {
           name "/listProducts"
           kind SERVER
-          errored false
+          status UNSET
           hasNoParent()
           attributes {
             "${SemanticAttributes.NET_PEER_PORT.key}" Long
@@ -72,7 +72,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
           name "SELECT test.products"
           kind CLIENT
           childOf span(2)
-          errored false
+          status UNSET
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "hsqldb"
             "${SemanticAttributes.DB_NAME.key}" "test"

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/SpanAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/SpanAssert.groovy
@@ -125,16 +125,6 @@ class SpanAssert {
     checked.status = true
   }
 
-  def errored(boolean errored) {
-    if (errored) {
-      // comparing only canonical code, since description may be different
-      assert span.status.statusCode == StatusCode.ERROR
-    } else {
-      assert span.status.statusCode == StatusCode.UNSET
-    }
-    checked.status = true
-  }
-
   def errorEvent(Class<Throwable> errorType) {
     errorEvent(errorType, null)
   }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/SpanAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/SpanAssert.groovy
@@ -148,7 +148,7 @@ class SpanAssert {
 
   void assertDefaults() {
     if (!checked.status) {
-      errored(false)
+      status(StatusCode.UNSET)
     }
     if (!checked.kind) {
       kind(SpanKind.INTERNAL)

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/SpanAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/SpanAssert.groovy
@@ -120,6 +120,11 @@ class SpanAssert {
     assert found
   }
 
+  def status(StatusCode status) {
+    assert span.status.statusCode == status
+    checked.status = true
+  }
+
   def errored(boolean errored) {
     if (errored) {
       // comparing only canonical code, since description may be different

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/SpanAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/SpanAssert.groovy
@@ -120,11 +120,6 @@ class SpanAssert {
     assert found
   }
 
-  def status(StatusCode status) {
-    assert span.status.statusCode == status
-    checked.status = true
-  }
-
   def errored(boolean errored) {
     if (errored) {
       // comparing only canonical code, since description may be different

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -178,10 +178,10 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
 
   def "basic #method request #url"() {
     when:
-    def status = doRequest(method, url)
+    def responseCode = doRequest(method, url)
 
     then:
-    status == 200
+    responseCode == 200
     assertTraces(1) {
       trace(0, 2 + extraClientSpans()) {
         clientSpan(it, 0, null, method, url)
@@ -198,12 +198,12 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
 
   def "basic #method request with parent"() {
     when:
-    def status = runUnderTrace("parent") {
+    def responseCode = runUnderTrace("parent") {
       doRequest(method, server.address.resolve("/success"))
     }
 
     then:
-    status == 200
+    responseCode == 200
     assertTraces(1) {
       trace(0, 3 + extraClientSpans()) {
         basicSpan(it, 0, "parent")
@@ -221,12 +221,12 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     assumeTrue(testWithClientParent())
 
     when:
-    def status = runUnderParentClientSpan {
+    def responseCode = runUnderParentClientSpan {
       doRequest(method, server.address.resolve("/success"))
     }
 
     then:
-    status == 200
+    responseCode == 200
     // there should be 2 separate traces since the nested CLIENT span is suppressed
     // (and the span context propagation along with it)
     assertTraces(2) {
@@ -249,12 +249,12 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
 
   def "trace request without propagation"() {
     when:
-    def status = runUnderTrace("parent") {
+    def responseCode = runUnderTrace("parent") {
       doRequest(method, server.address.resolve("/success"), ["is-test-server": "false"])
     }
 
     then:
-    status == 200
+    responseCode == 200
     // only one trace (client).
     assertTraces(1) {
       trace(0, 2 + extraClientSpans()) {
@@ -272,18 +272,18 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     assumeTrue(testCallback())
     assumeTrue(testCallbackWithParent())
 
-    def status = new BlockingVariable<Integer>()
+    def responseCode = new BlockingVariable<Integer>()
 
     when:
     runUnderTrace("parent") {
       doRequestWithCallback(method, server.address.resolve("/success"), ["is-test-server": "false"]) {
         runUnderTrace("child") {}
-        status.set(it)
+        responseCode.set(it)
       }
     }
 
     then:
-    status.get() == 200
+    responseCode.get() == 200
     // only one trace (client).
     assertTraces(1) {
       trace(0, 3 + extraClientSpans()) {
@@ -301,17 +301,17 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     given:
     assumeTrue(testCallback())
 
-    def status = new BlockingVariable<Integer>()
+    def responseCode = new BlockingVariable<Integer>()
 
     when:
     doRequestWithCallback(method, server.address.resolve("/success"), ["is-test-server": "false"]) {
       runUnderTrace("callback") {
       }
-      status.set(it)
+      responseCode.set(it)
     }
 
     then:
-    status.get() == 200
+    responseCode.get() == 200
     // only one trace (client).
     assertTraces(2) {
       trace(0, 1 + extraClientSpans()) {
@@ -335,10 +335,10 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     def uri = server.address.resolve("/redirect")
 
     when:
-    def status = doRequest(method, uri)
+    def responseCode = doRequest(method, uri)
 
     then:
-    status == 200
+    responseCode == 200
     assertTraces(1) {
       trace(0, 3 + extraClientSpans()) {
         clientSpan(it, 0, null, method, uri)
@@ -357,10 +357,10 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     def uri = server.address.resolve("/another-redirect")
 
     when:
-    def status = doRequest(method, uri)
+    def responseCode = doRequest(method, uri)
 
     then:
-    status == 200
+    responseCode == 200
     assertTraces(1) {
       trace(0, 4 + extraClientSpans()) {
         clientSpan(it, 0, null, method, uri)
@@ -408,10 +408,10 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
 
     when:
 
-    def status = doRequest(method, uri, [(BASIC_AUTH_KEY): BASIC_AUTH_VAL])
+    def responseCode = doRequest(method, uri, [(BASIC_AUTH_KEY): BASIC_AUTH_VAL])
 
     then:
-    status == 200
+    responseCode == 200
     assertTraces(1) {
       trace(0, 3 + extraClientSpans()) {
         clientSpan(it, 0, null, method, uri)
@@ -429,10 +429,10 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     assumeTrue(testReusedRequest())
 
     when:
-    def status = doReusedRequest(method, url)
+    def responseCode = doReusedRequest(method, url)
 
     then:
-    status == 200
+    responseCode == 200
     assertTraces(2) {
       trace(0, 2 + extraClientSpans()) {
         clientSpan(it, 0, null, method, url)
@@ -533,10 +533,10 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     def uri = new URI("https://www.google.com/")
 
     when:
-    def status = doRequest(method, uri)
+    def responseCode = doRequest(method, uri)
 
     then:
-    status == 200
+    responseCode == 200
     assertTraces(1) {
       trace(0, 1 + extraClientSpans()) {
         clientSpan(it, 0, null, method, uri)

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.test.base
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.server.http.TestHttpServer.httpServer
 import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicClientSpan
@@ -664,8 +665,8 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
       }
       name expectedOperationName(method)
       kind CLIENT
-      errored exception != null
       if (exception) {
+        status ERROR
         errorEvent(exception.class, exception.message)
       }
       attributes {

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -164,7 +164,7 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     throw new UnsupportedOperationException()
   }
 
-  Integer statusOnRedirectError() {
+  Integer responseCodeOnRedirectError() {
     return null
   }
 
@@ -389,7 +389,7 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     and:
     assertTraces(1) {
       trace(0, 1 + extraClientSpans() + maxRedirects()) {
-        clientSpan(it, 0, null, method, uri, statusOnRedirectError(), thrownException)
+        clientSpan(it, 0, null, method, uri, responseCodeOnRedirectError(), thrownException)
         def start = 1 + extraClientSpans()
         for (int i = start; i < maxRedirects() + start; i++) {
           serverSpan(it, i, span(extraClientSpans()))
@@ -654,7 +654,7 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
   }
 
   // parent span must be cast otherwise it breaks debugging classloading (junit loads it early)
-  void clientSpan(TraceAssert trace, int index, Object parentSpan, String method = "GET", URI uri = server.address.resolve("/success"), Integer status = 200, Throwable exception = null, String httpFlavor = "1.1") {
+  void clientSpan(TraceAssert trace, int index, Object parentSpan, String method = "GET", URI uri = server.address.resolve("/success"), Integer responseCode = 200, Throwable exception = null, String httpFlavor = "1.1") {
     def userAgent = userAgent()
     def extraAttributes = extraAttributes()
     trace.span(index) {
@@ -688,8 +688,8 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
         if (userAgent) {
           "${SemanticAttributes.HTTP_USER_AGENT.key}" { it.startsWith(userAgent) }
         }
-        if (status) {
-          "${SemanticAttributes.HTTP_STATUS_CODE.key}" status
+        if (responseCode) {
+          "${SemanticAttributes.HTTP_STATUS_CODE.key}" responseCode
         }
 
         if (extraAttributes.contains(SemanticAttributes.HTTP_HOST)) {

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -127,17 +127,22 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
    * for example:
    *
    * @Override
-   * int sendRequest(Request request, String method, URI uri, Map<String, String headers = [:]) {*   HttpResponse response = client.execute(request)
+   * int sendRequest(Request request, String method, URI uri, Map<String, String headers = [:]) {
+   *   HttpResponse response = client.execute(request)
    *   return response.statusCode()
-   *}*
+   * }
+   *
    * If there is no synchronous API available at all, for example as in Vert.X, a CompletableFuture
    * can be used to block on a result, for example:
    *
    * @Override
-   * int sendRequest(Request request, String method, URI uri, Map<String, String> headers) {*   CompletableFuture<Integer> future = new CompletableFuture<>(
-   *   sendRequestWithCallback(request, method, uri, headers) {*     future.complete(it.statusCode())
-   *}*   return future.get()
-   *}
+   * int sendRequest(Request request, String method, URI uri, Map<String, String> headers) {
+   *   CompletableFuture<Integer> future = new CompletableFuture<>(
+   *   sendRequestWithCallback(request, method, uri, headers) {
+   *     future.complete(it.statusCode())
+   *   }
+   *   return future.get()
+   * }
    */
   abstract int sendRequest(REQUEST request, String method, URI uri, Map<String, String> headers)
 
@@ -150,12 +155,18 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
    * the context is propagated correctly to such callbacks.
    *
    * @Override
-   * void sendRequestWithCallback(Request request, String method, URI uri, Map<String, String> headers, Consumer<Integer> callback) {*   // Hypothetical client accepting a callback
-   *   client.executeAsync(request) {*     callback.accept(it.statusCode())
-   *}*
+   * void sendRequestWithCallback(Request request, String method, URI uri, Map<String, String> headers, Consumer<Integer> callback) {
+   *   // Hypothetical client accepting a callback
+   *   client.executeAsync(request) {
+   *     callback.accept(it.statusCode())
+   *   }
+   *
    *   // Hypothetical client returning a CompletableFuture
-   *   client.executeAsync(request).thenAccept {*     callback.accept(it.statusCode())
-   *}*}*
+   *   client.executeAsync(request).thenAccept {
+   *     callback.accept(it.statusCode())
+   *   }
+   * }
+   *
    * If the client offers no APIs that accept callbacks, then this method should not be implemented
    * and instead, {@link #testCallback} should be implemented to return false.
    */

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -716,7 +716,6 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     traces.span(index) {
       name "test-http-server"
       kind SERVER
-      status UNSET
       if (parentSpan == null) {
         hasNoParent()
       } else {

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -126,22 +126,17 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
    * for example:
    *
    * @Override
-   * int sendRequest(Request request, String method, URI uri, Map<String, String headers = [:]) {
-   *   HttpResponse response = client.execute(request)
+   * int sendRequest(Request request, String method, URI uri, Map<String, String headers = [:]) {*   HttpResponse response = client.execute(request)
    *   return response.statusCode()
-   * }
-   *
+   *}*
    * If there is no synchronous API available at all, for example as in Vert.X, a CompletableFuture
    * can be used to block on a result, for example:
    *
    * @Override
-   * int sendRequest(Request request, String method, URI uri, Map<String, String> headers) {
-   *   CompletableFuture<Integer> future = new CompletableFuture<>(
-   *   sendRequestWithCallback(request, method, uri, headers) {
-   *     future.complete(it.statusCode())
-   *   }
-   *   return future.get()
-   * }
+   * int sendRequest(Request request, String method, URI uri, Map<String, String> headers) {*   CompletableFuture<Integer> future = new CompletableFuture<>(
+   *   sendRequestWithCallback(request, method, uri, headers) {*     future.complete(it.statusCode())
+   *}*   return future.get()
+   *}
    */
   abstract int sendRequest(REQUEST request, String method, URI uri, Map<String, String> headers)
 
@@ -154,18 +149,12 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
    * the context is propagated correctly to such callbacks.
    *
    * @Override
-   * void sendRequestWithCallback(Request request, String method, URI uri, Map<String, String> headers, Consumer<Integer> callback) {
-   *   // Hypothetical client accepting a callback
-   *   client.executeAsync(request) {
-   *     callback.accept(it.statusCode())
-   *   }
-   *
+   * void sendRequestWithCallback(Request request, String method, URI uri, Map<String, String> headers, Consumer<Integer> callback) {*   // Hypothetical client accepting a callback
+   *   client.executeAsync(request) {*     callback.accept(it.statusCode())
+   *}*
    *   // Hypothetical client returning a CompletableFuture
-   *   client.executeAsync(request).thenAccept {
-   *     callback.accept(it.statusCode())
-   *   }
-   * }
-   *
+   *   client.executeAsync(request).thenAccept {*     callback.accept(it.statusCode())
+   *}*}*
    * If the client offers no APIs that accept callbacks, then this method should not be implemented
    * and instead, {@link #testCallback} should be implemented to return false.
    */
@@ -727,7 +716,7 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     traces.span(index) {
       name "test-http-server"
       kind SERVER
-      errored false
+      status UNSET
       if (parentSpan == null) {
         hasNoParent()
       } else {

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
@@ -514,7 +514,7 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
     trace.span(index) {
       name "controller"
       if (errorMessage) {
-        status ERROR
+        status StatusCode.ERROR
         errorEvent(exceptionClass, errorMessage)
       }
       childOf((SpanData) parent)

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.test.base
 
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -21,6 +22,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -511,8 +513,8 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
   void controllerSpan(TraceAssert trace, int index, Object parent, String errorMessage = null, Class exceptionClass = Exception) {
     trace.span(index) {
       name "controller"
-      errored errorMessage != null
       if (errorMessage) {
+        status ERROR
         errorEvent(exceptionClass, errorMessage)
       }
       childOf((SpanData) parent)
@@ -559,8 +561,8 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
     trace.span(index) {
       name ~/\.forward$/
       kind SpanKind.INTERNAL
-      errored errorMessage != null
       if (errorMessage) {
+        status StatusCode.ERROR
         errorEvent(exceptionClass, errorMessage)
       }
       childOf((SpanData) parent)
@@ -571,8 +573,8 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
     trace.span(index) {
       name ~/\.include$/
       kind SpanKind.INTERNAL
-      errored errorMessage != null
       if (errorMessage) {
+        status StatusCode.ERROR
         errorEvent(exceptionClass, errorMessage)
       }
       childOf((SpanData) parent)
@@ -585,7 +587,9 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
     trace.span(index) {
       name expectedServerSpanName(endpoint)
       kind SpanKind.SERVER // can't use static import because of SERVER type parameter
-      errored endpoint.errored
+      if (endpoint.errored) {
+        status StatusCode.ERROR
+      }
       if (parentID != null) {
         traceId traceID
         parentSpanId parentID

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
@@ -650,7 +650,6 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
     trace.span(1) {
       name expectedServerSpanName(endpoint)
       kind SpanKind.SERVER // can't use static import because of SERVER type parameter
-      status UNSET
       childOf((SpanData) parent)
       attributes {
         "${SemanticAttributes.NET_PEER_PORT.key}" { it == null || it instanceof Long }
@@ -668,7 +667,6 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
   void indexedControllerSpan(TraceAssert trace, int index, Object parent, int requestId) {
     trace.span(index) {
       name "controller"
-      status UNSET
       childOf((SpanData) parent)
       attributes {
         it."test.request.id" requestId

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
@@ -17,8 +17,8 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.basicSpan
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 import static org.junit.Assume.assumeTrue
 
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.context.Context
@@ -390,6 +390,7 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
 
   This way we verify that child span created by the server actually corresponds to the client request.
    */
+
   def "high concurrency test"() {
     setup:
     assumeTrue(testConcurrency())
@@ -649,7 +650,7 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
     trace.span(1) {
       name expectedServerSpanName(endpoint)
       kind SpanKind.SERVER // can't use static import because of SERVER type parameter
-      errored false
+      status UNSET
       childOf((SpanData) parent)
       attributes {
         "${SemanticAttributes.NET_PEER_PORT.key}" { it == null || it instanceof Long }
@@ -667,7 +668,7 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
   void indexedControllerSpan(TraceAssert trace, int index, Object parent, int requestId) {
     trace.span(index) {
       name "controller"
-      errored false
+      status UNSET
       childOf((SpanData) parent)
       attributes {
         it."test.request.id" requestId

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/server/http/TestHttpServer.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/server/http/TestHttpServer.groovy
@@ -117,7 +117,7 @@ class TestHttpServer implements AutoCloseable {
     trace.span(index) {
       name "test-http-server"
       kind SERVER
-      errored false
+      status UNSET
       if (parentSpan == null) {
         hasNoParent()
       } else {

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/server/http/TestHttpServer.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/server/http/TestHttpServer.groovy
@@ -117,7 +117,6 @@ class TestHttpServer implements AutoCloseable {
     trace.span(index) {
       name "test-http-server"
       kind SERVER
-      status UNSET
       if (parentSpan == null) {
         hasNoParent()
       } else {

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/utils/TraceUtils.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/utils/TraceUtils.groovy
@@ -89,8 +89,8 @@ class TraceUtils {
       }
       name operation
       kind spanKind
-      errored exception != null
       if (exception) {
+        status StatusCode.ERROR
         errorEvent(exception.class, exception.message)
       }
 


### PR DESCRIPTION
I think this closes #608 now that there are only 3 status codes, and auto-instrumentation should never set `OK`, leaving only `ERROR` or `UNSET`.