### PR TITLE
Fix build and documentation typos related to autoconfigure SPI.

### DIFF
--- a/docs/contributing/javaagent-test-infra.md
+++ b/docs/contributing/javaagent-test-infra.md
@@ -10,9 +10,9 @@ There are a few key components that make this possible, described below.
 * shades the instrumentation
 * adds jvm args to the test configuration
   * -javaagent:[agent for testing]
-  * -Dotel.initializer.jar=[shaded instrumentation jar]
+  * -Dotel.javaagent.experimental.initializer.jar=[shaded instrumentation jar]
 
-The `otel.initializer.jar` property is used to load the shaded instrumentation jar into the
+The `otel.javaagent.experimental.initializer.jar` property is used to load the shaded instrumentation jar into the
 `AgentClassLoader`, so that the javaagent jar doesn't need to be re-built each time.
 
 ### :testing:agent-exporter

--- a/examples/distro/gradle/shadow.gradle
+++ b/examples/distro/gradle/shadow.gradle
@@ -10,7 +10,6 @@ ext.relocatePackages = { shadowJar ->
   // relocate OpenTelemetry API usage
   shadowJar.relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"
   shadowJar.relocate "io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv"
-  shadowJar.relocate "io.opentelemetry.spi", "io.opentelemetry.javaagent.shaded.io.opentelemetry.spi"
   shadowJar.relocate "io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context"
 
   // relocate the OpenTelemetry extensions that are used by instrumentation modules

--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -93,7 +93,6 @@ shadowJar {
   // relocate OpenTelemetry API usage
   relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"
   relocate "io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv"
-  relocate "io.opentelemetry.spi", "io.opentelemetry.javaagent.shaded.io.opentelemetry.spi"
   relocate "io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context"
 
   // relocate the OpenTelemetry extensions that are used by instrumentation modules

--- a/instrumentation/instrumentation.gradle
+++ b/instrumentation/instrumentation.gradle
@@ -70,7 +70,6 @@ shadowJar {
   // relocate OpenTelemetry API usage
   relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"
   relocate "io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv"
-  relocate "io.opentelemetry.spi", "io.opentelemetry.javaagent.shaded.io.opentelemetry.spi"
   relocate "io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context"
 
   // relocate the OpenTelemetry extensions that are used by instrumentation modules

--- a/javaagent/javaagent.gradle
+++ b/javaagent/javaagent.gradle
@@ -93,7 +93,6 @@ tasks.withType(ShadowJar).configureEach {
   // relocate OpenTelemetry API
   relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"
   relocate "io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv"
-  relocate "io.opentelemetry.spi", "io.opentelemetry.javaagent.shaded.io.opentelemetry.spi"
   relocate "io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context"
 
   // relocate the OpenTelemetry extensions that are used by instrumentation modules

--- a/testing/agent-exporter/agent-exporter.gradle
+++ b/testing/agent-exporter/agent-exporter.gradle
@@ -52,7 +52,6 @@ shadowJar {
   // relocate OpenTelemetry API usage
   relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"
   relocate "io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv"
-  relocate "io.opentelemetry.spi", "io.opentelemetry.javaagent.shaded.io.opentelemetry.spi"
   relocate "io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context"
 
   // relocate the OpenTelemetry extensions that are used by instrumentation modules

--- a/testing/agent-for-testing/agent-for-testing.gradle
+++ b/testing/agent-for-testing/agent-for-testing.gradle
@@ -65,7 +65,6 @@ shadowJar {
   // relocate OpenTelemetry API
   relocate "io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api"
   relocate "io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv"
-  relocate "io.opentelemetry.spi", "io.opentelemetry.javaagent.shaded.io.opentelemetry.spi"
   relocate "io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context"
 
   // this is for instrumentation on opentelemetry-api itself


### PR DESCRIPTION
Was exploring using the autoconfiguration SPI to configure the agent by building an initializer jar and specifying it via `otel.initializer.jar`.

Found that there was a typo in the documentation as `otel.initializer.jar` has been changed to `otel.javaagent.experimental.initializer.jar`.

Also found that various build's are relocating the `io.opentelemetry.spi` package which no longer exists after some recent refactoring of the `opentelemetry-java` project to move the SPI stuff into the SDK autoconfiguration module. I figured the right thing to do was to remove those relocations since there I didn't notice any other attempt to relocate SDK packages.