### PR TITLE
Reduce smoke test timeout after split out

### DIFF
--- a/smoke-tests/smoke-tests.gradle
+++ b/smoke-tests/smoke-tests.gradle
@@ -39,7 +39,8 @@ test {
 
   testLogging.showStandardStreams = true
 
-  timeout.set(Duration.ofMinutes(60))
+  // TODO investigate why smoke tests occasionally hang
+  timeout.set(Duration.ofMinutes(30))
 
   //We enable/disable smoke tests based on the java version requests
   //In addition to that we disable them by default on local machines


### PR DESCRIPTION
I just had a smoke test hang, guessing this is what the timeout was added for.

This brings the timeout value back to what it was previously (now that we have split out the smoke tests and don't really need the larger value).