### PR TITLE
Fix using Tomcat version in smoke test images that has no official Docker image

### DIFF
--- a/smoke-tests/matrix/build.gradle
+++ b/smoke-tests/matrix/build.gradle
@@ -37,7 +37,7 @@ def linuxTargets = [
   "tomcat": [
     [version: ["7.0.107"], vm: ["hotspot", "openj9"], jdk: ["8"]],
     [version: ["8.5.60", "9.0.40"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]],
-    [version: ["10.0.0"], vm: ["hotspot", "openj9"], jdk: ["11", "15"], war: "servlet-5.0"]
+    [version: ["10.0.4"], vm: ["hotspot", "openj9"], jdk: ["11", "15"], war: "servlet-5.0"]
   ],
   "tomee": [
     [version: ["7.0.0"], vm: ["hotspot"], jdk: ["8"]],
@@ -69,7 +69,7 @@ def windowsTargets = [
     [version: ["7.0.107"], vm: ["hotspot", "openj9"], jdk: ["8"], args: [majorVersion: "7"]],
     [version: ["8.5.60"], vm: ["hotspot", "openj9"], jdk: ["8", "11"], args: [majorVersion: "8"]],
     [version: ["9.0.40"], vm: ["hotspot", "openj9"], jdk: ["8", "11"], args: [majorVersion: "9"]],
-    [version: ["10.0.0"], vm: ["hotspot", "openj9"], jdk: ["11", "15"], args: [majorVersion: "10"], war: "servlet-5.0"]
+    [version: ["10.0.4"], vm: ["hotspot", "openj9"], jdk: ["11", "15"], args: [majorVersion: "10"], war: "servlet-5.0"]
   ],
   "tomee" : [
     [version: ["7.0.0"], vm: ["hotspot", "openj9"], jdk: ["8"]],


### PR DESCRIPTION
When adding Tomcat 10 images to smoke test image list, accidentally changed the version to one for which there is no official image available, failing the image creation CI task. Changed the version number to fix that.