### PR TITLE
Tomcat 10 and Jetty 11 smoke tests

### DIFF
--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -42,7 +42,7 @@ abstract class AppServerTest extends SmokeTest {
   @Override
   protected String getTargetImage(String jdk, String serverVersion, boolean windows) {
     String platformSuffix = windows ? "-windows" : ""
-    String extraTag = "20210316.657616194"
+    String extraTag = "20210405.720145828"
     String fullSuffix = "-${serverVersion}-jdk$jdk$platformSuffix-$extraTag"
     return getTargetImagePrefix() + fullSuffix
   }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
@@ -13,6 +13,10 @@ package io.opentelemetry.smoketest
 @AppServer(version = "10.0.0", jdk = "11-openj9")
 @AppServer(version = "10.0.0", jdk = "15")
 @AppServer(version = "10.0.0", jdk = "15-openj9")
+@AppServer(version = "11.0.1", jdk = "11")
+@AppServer(version = "11.0.1", jdk = "11-openj9")
+@AppServer(version = "11.0.1", jdk = "15")
+@AppServer(version = "11.0.1", jdk = "15-openj9")
 class JettySmokeTest extends AppServerTest {
 
   protected String getTargetImagePrefix() {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TomcatSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TomcatSmokeTest.groovy
@@ -15,6 +15,10 @@ package io.opentelemetry.smoketest
 @AppServer(version = "9.0.40", jdk = "8-openj9")
 @AppServer(version = "9.0.40", jdk = "11")
 @AppServer(version = "9.0.40", jdk = "11-openj9")
+@AppServer(version = "10.0.4", jdk = "11")
+@AppServer(version = "10.0.4", jdk = "11-openj9")
+@AppServer(version = "10.0.4", jdk = "15")
+@AppServer(version = "10.0.4", jdk = "15-openj9")
 class TomcatSmokeTest extends AppServerTest {
 
   protected String getTargetImagePrefix() {


### PR DESCRIPTION
Add Tomcat 10 and Jetty 11 smoke test configurations as the images for them have been pushed by the CI task now.