### PR TITLE
Use loopback address for rmi tests

### DIFF
--- a/instrumentation/rmi/javaagent/rmi-javaagent.gradle
+++ b/instrumentation/rmi/javaagent/rmi-javaagent.gradle
@@ -38,3 +38,6 @@ tasks.withType(JavaCompile) {
 tasks.withType(GroovyCompile) {
   options.release = null
 }
+tasks.withType(Test) {
+  jvmArgs "-Djava.rmi.server.hostname=127.0.0.1"
+}


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2734 I don't really know whether this will fix the flakiness of rmi tests. The strange thing about this failure is that it attempts to connect to `10.1.1.4` but it seems that the ip for github actions runners is usually `10.1.0.4`.