### PR TITLE
Build windows collector test image with otel-collector-contrib

### DIFF
--- a/smoke-tests/fake-backend/build.gradle
+++ b/smoke-tests/fake-backend/build.gradle
@@ -69,7 +69,7 @@ task windowsCollectorBinaryDownload(type: Download) {
     collectorDockerBuildDir.mkdirs()
   }
 
-  src("https://github.com/open-telemetry/opentelemetry-collector/releases/latest/download/otelcol_windows_amd64.exe")
+  src("https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/latest/download/otelcontribcol_windows_amd64.exe")
   dest(collectorDockerBuildDir)
 }
 

--- a/smoke-tests/fake-backend/src/docker/collector/windows.dockerfile
+++ b/smoke-tests/fake-backend/src/docker/collector/windows.dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
-COPY otelcol_windows_amd64.exe /otelcol_windows_amd64.exe
+COPY otelcontribcol_windows_amd64.exe /otelcontribcol_windows_amd64.exe
 ENV NO_WINDOWS_SERVICE=1
-ENTRYPOINT /otelcol_windows_amd64.exe
+ENTRYPOINT /otelcontribcol_windows_amd64.exe


### PR DESCRIPTION
Vendors will be able to reuse this image in their tests that depend on contrib components