### PR TITLE
Make dubbo and camel use loopback address

### DIFF
--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesConfig.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesConfig.groovy
@@ -28,7 +28,7 @@ class TwoServicesConfig {
           .log("Service One request: \${body}")
           .delay(simple("\${random(1000,2000)}"))
           .transform(simple("Service-One-\${body}"))
-          .to("http://0.0.0.0:{{service.two.port}}/serviceTwo")
+          .to("http://127.0.0.1:{{service.two.port}}/serviceTwo")
           .log("Service One response: \${body}")
       }
     }

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
@@ -112,9 +112,9 @@ class TwoServicesWithDirectClientCamelTest extends AgentInstrumentationSpecifica
           parentSpanId(span(2).spanId)
           attributes {
             "$SemanticAttributes.HTTP_METHOD.key" "POST"
-            "$SemanticAttributes.HTTP_URL.key" "http://0.0.0.0:$portTwo/serviceTwo"
+            "$SemanticAttributes.HTTP_URL.key" "http://127.0.0.1:$portTwo/serviceTwo"
             "$SemanticAttributes.HTTP_STATUS_CODE.key" 200
-            "apache-camel.uri" "http://0.0.0.0:$portTwo/serviceTwo"
+            "apache-camel.uri" "http://127.0.0.1:$portTwo/serviceTwo"
           }
         }
         it.span(4) {
@@ -124,13 +124,12 @@ class TwoServicesWithDirectClientCamelTest extends AgentInstrumentationSpecifica
           attributes {
             "$SemanticAttributes.HTTP_METHOD.key" "POST"
             "$SemanticAttributes.HTTP_STATUS_CODE.key" 200
-            "$SemanticAttributes.HTTP_URL.key" "http://0.0.0.0:$portTwo/serviceTwo"
+            "$SemanticAttributes.HTTP_URL.key" "http://127.0.0.1:$portTwo/serviceTwo"
             "$SemanticAttributes.NET_PEER_PORT.key" Number
-            "$SemanticAttributes.NET_PEER_IP.key" InetAddress.getLocalHost().getHostAddress().toString()
+            "$SemanticAttributes.NET_PEER_IP.key" "127.0.0.1"
             "$SemanticAttributes.HTTP_USER_AGENT.key" "Jakarta Commons-HttpClient/3.1"
             "$SemanticAttributes.HTTP_FLAVOR.key" "1.1"
-            "$SemanticAttributes.HTTP_CLIENT_IP.key" InetAddress.getLocalHost().getHostAddress().toString()
-
+            "$SemanticAttributes.HTTP_CLIENT_IP.key" "127.0.0.1"
           }
         }
         it.span(5) {
@@ -139,7 +138,7 @@ class TwoServicesWithDirectClientCamelTest extends AgentInstrumentationSpecifica
           parentSpanId(span(4).spanId)
           attributes {
             "$SemanticAttributes.HTTP_METHOD.key" "POST"
-            "$SemanticAttributes.HTTP_URL.key" "http://0.0.0.0:$portTwo/serviceTwo"
+            "$SemanticAttributes.HTTP_URL.key" "http://127.0.0.1:$portTwo/serviceTwo"
             "apache-camel.uri" "jetty:http://0.0.0.0:$portTwo/serviceTwo?arg=value"
           }
         }

--- a/instrumentation/apache-dubbo/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.groovy
+++ b/instrumentation/apache-dubbo/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.groovy
@@ -10,6 +10,7 @@ import io.opentelemetry.instrumentation.apachedubbo.v2_7.impl.HelloServiceImpl
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import org.apache.dubbo.common.utils.NetUtils
 import org.apache.dubbo.config.ApplicationConfig
 import org.apache.dubbo.config.ProtocolConfig
 import org.apache.dubbo.config.ReferenceConfig
@@ -31,6 +32,10 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
 
   @Shared
   def protocolConfig = new ProtocolConfig()
+
+  def setupSpec() {
+    NetUtils.LOCAL_ADDRESS = InetAddress.getLoopbackAddress()
+  }
 
   ReferenceConfig<HelloService> configureClient(int port) {
     ReferenceConfig<HelloService> reference = new ReferenceConfig<>()


### PR DESCRIPTION
Dubbo and camel use a random local ip address, sometimes connecting to it seems to hang. Perhaps these addresses are something that docker uses? idk. Hopefully using loopback address will reduce flakiness of these tests.