### PR TITLE
Sort traces to reduce flakiness

### DIFF
--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/TracerTest.groovy
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/TracerTest.groovy
@@ -180,6 +180,7 @@ class TracerTest extends AgentInstrumentationSpecification {
 
     then:
     assertTraces(2) {
+      traces.sort(orderByRootSpanName("parent", "test"))
       trace(0, 1) {
         span(0) {
           name "parent"


### PR DESCRIPTION
Due to the way trace start time is computed it is possible that a later traces has a smaller timestamp than an earlier trace when these traces were created really close to each other (like in the same ms).