### PR TITLE
Bring back Guava to javaagent-tooling (it's actually used here)

### DIFF
--- a/javaagent-tooling/javaagent-tooling.gradle
+++ b/javaagent-tooling/javaagent-tooling.gradle
@@ -51,6 +51,7 @@ dependencies {
   annotationProcessor deps.autoservice
   implementation deps.autoservice
   implementation deps.slf4j
+  implementation deps.guava
 
   implementation group: 'io.grpc', name: 'grpc-netty', version: '1.35.1'
 


### PR DESCRIPTION
It's used in

* `AgentCachingPoolStrategy` - Guava cache, should we migrate it to caffeine?
* `ReferenceCollector` - graph API

Javaagent worked without this dep because it was provided by grpc in the runtime:

```
+--- io.opentelemetry:opentelemetry-exporter-jaeger:1.1.0
|    +--- io.opentelemetry:opentelemetry-sdk:1.1.0 (*)
|    +--- io.opentelemetry:opentelemetry-semconv:1.1.0-alpha (*)
|    +--- io.grpc:grpc-protobuf:1.36.1
|    |    +--- io.grpc:grpc-api:1.36.1
|    |    |    +--- io.grpc:grpc-context:1.36.1
|    |    |    +--- com.google.code.findbugs:jsr305:3.0.2
|    |    |    +--- com.google.guava:guava:30.0-android
```