### PR TITLE
Switch to grpc-netty-shaded

### DIFF
--- a/javaagent-tooling/javaagent-tooling.gradle
+++ b/javaagent-tooling/javaagent-tooling.gradle
@@ -53,7 +53,7 @@ dependencies {
   implementation deps.slf4j
   implementation deps.guava
 
-  implementation group: 'io.grpc', name: 'grpc-netty', version: '1.35.1'
+  implementation group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.35.1'
 
   testImplementation project(':testing-common')
   testImplementation deps.assertj


### PR DESCRIPTION
This way the javaagent is not subject to security advisories against netty which do not apply to the specific ways that grpc uses netty.

Otherwise we end up in weird place where a security advisory against netty can require us to upgrade to a newer version of netty than grpc supports.