### PR TITLE
Sync spring-boot-autoconfigure property names with SDK property names

### DIFF
--- a/instrumentation/spring/README.md
+++ b/instrumentation/spring/README.md
@@ -678,15 +678,13 @@ The following tracer configurations can be used to customize your instrumentatio
 server.port=8081
 
 ## Set Tracer name
-opentelemetry.trace.tracer.name=time_service
-opentelemetry.trace.tracer.samplerProbability=1
+otel.traces.sampler.probability=1
 
 ## Default configurations
-#opentelemetry.trace.web.enabled=true
-#opentelemetry.trace.httpclients.enabled=true
-#opentelemetry.trace.tracer.samplingProbablity=1
-#opentelemetry.trace.exporter.loggin.enabled=true
-#opentelemetry.trace.aspects.enabled=true
+#otel.traces.sampler.probability=1
+#otel.instrumentation.web.enabled=true
+#otel.instrumentation.httpclients.enabled=true
+#otel.instrumentation.aspects.enabled=true
 
 ```
 
@@ -866,18 +864,14 @@ Add the following configurations to overwrite the default exporter values listed
 
 ```
 ## Default tracer configurations
-opentelemetry.trace.tracer.name=main_service
-#opentelemetry.trace.tracer.samplerProbability=1
+#otel.traces.sampler.probability=1
 
 ## Default exporter configurations
-#opentelemetry.trace.exporters.otlp.servicename=unknown
-#opentelemetry.trace.exporters.otlp.endpoint=localhost:55680
-#opentelemetry.trace.exporters.otlp.spantimeout=1s
-#opentelemetry.trace.exporters.jaeger.servicename=unknown
-#opentelemetry.trace.exporters.jaeger.endpoint=localhost:14250
-#opentelemetry.trace.exporters.jaeger.spantimeout=1s
-#opentelemetry.trace.exporters.zipkin.servicename=unknown
-#opentelemetry.trace.exporters.zipkin.endpoint=http://localhost:9411/api/v2/spans
+#otel.exporter.otlp.endpoint=localhost:55680
+#otel.exporter.otlp.timeout=10s
+#otel.exporter.jaeger.endpoint=localhost:14250
+#otel.exporter.jaeger.timeout=10s
+#otel.exporter.zipkin.endpoint=http://localhost:9411/api/v2/spans
 ```
 
 ### Sample Trace Zipkin

--- a/instrumentation/spring/README.md
+++ b/instrumentation/spring/README.md
@@ -682,9 +682,9 @@ otel.traces.sampler.probability=1
 
 ## Default configurations
 #otel.traces.sampler.probability=1
-#otel.instrumentation.web.enabled=true
-#otel.instrumentation.httpclients.enabled=true
-#otel.instrumentation.aspects.enabled=true
+#otel.springboot.web.enabled=true
+#otel.springboot.httpclients.enabled=true
+#otel.springboot.aspects.enabled=true
 
 ```
 

--- a/instrumentation/spring/README.md
+++ b/instrumentation/spring/README.md
@@ -677,9 +677,6 @@ The following tracer configurations can be used to customize your instrumentatio
 ## Setting the server port of MainService to 8081 will prevent conflicts
 server.port=8081
 
-## Set Tracer name
-otel.traces.sampler.probability=1
-
 ## Default configurations
 #otel.traces.sampler.probability=1
 #otel.springboot.web.enabled=true

--- a/instrumentation/spring/spring-boot-autoconfigure/README.md
+++ b/instrumentation/spring/spring-boot-autoconfigure/README.md
@@ -372,38 +372,34 @@ If an exporter is present in the classpath during runtime and a spring bean of t
 
 ##### Enabling/Disabling Features
 
-|Feature   				|Property   									|Default Value  |ConditionalOnClass
-|---					|---											|---			|---
-|spring-web  	 		|opentelemetry.trace.httpclients.enabled   		|true   		|RestTemplate
-|spring-webmvc   		|opentelemetry.trace.httpclients.enabled   		|true   		|OncePerRequestFilter
-|spring-webflux   		|opentelemetry.trace.httpclients.enabled 		|true   		|WebClient
-|@WithSpan   			|opentelemetry.trace.aspects.enabled 	 		|true   		|WithSpan, Aspect
-|Otlp Exporter		    |opentelemetry.trace.exporters.otlp.enabled		|true   		|OtlpGrpcSpanExporter
-|Jaeger Exporter		|opentelemetry.trace.exporters.jaeger.enabled	|true   		|JaegerGrpcSpanExporter
-|Zipkin Exporter		|opentelemetry.trace.exporters.zipkin.enabled	|true   		|ZipkinSpanExporter
-|Logging Exporter	    |opentelemetry.trace.exporters.logging.enabled	|true   		|LoggingSpanExporter
+| Feature          | Property                                 | Default Value | ConditionalOnClass     |
+|------------------|------------------------------------------|---------------|------------------------|
+| spring-web       | otel.instrumentation.httpclients.enabled | true          | RestTemplate           |
+| spring-webmvc    | otel.instrumentation.httpclients.enabled | true          | OncePerRequestFilter   |
+| spring-webflux   | otel.instrumentation.httpclients.enabled | true          | WebClient              |
+| @WithSpan        | otel.instrumentation.aspects.enabled     | true          | WithSpan, Aspect       |
+| Otlp Exporter    | otel.exporter.otlp.enabled               | true          | OtlpGrpcSpanExporter   |
+| Jaeger Exporter  | otel.exporter.jaeger.enabled             | true          | JaegerGrpcSpanExporter |
+| Zipkin Exporter  | otel.exporter.zipkin.enabled             | true          | ZipkinSpanExporter     |
+| Logging Exporter | otel.exporter.logging.enabled            | true          | LoggingSpanExporter    |
 
-<!-- Slf4j Log Correlation  opentelemetry.trace.loggers.slf4j.enabled		true   		org.slf4j.MDC -->
+<!-- Slf4j Log Correlation  otel.instrumentation.loggers.slf4j.enabled		true   		org.slf4j.MDC -->
 
 ##### Exporter Properties
 
-|Feature   				|Property   										|Default Value
-|---					|---												|---
-|Otlp Exporter  	 	|opentelemetry.trace.exporters.otlp.servicename 	|unknown
-|				  		|opentelemetry.trace.exporters.otlp.endpoint		|localhost:55680
-|				   		|opentelemetry.trace.exporters.otlp.spantimeout		|1s
-|Jaeger Exporter  	 	|opentelemetry.trace.exporters.jaeger.servicename 	|unknown
-|				  		|opentelemetry.trace.exporters.jaeger.endpoint		|localhost:14250
-|				   		|opentelemetry.trace.exporters.jaeger.spantimeout	|1s
-|Zipkin Exporter 		|opentelemetry.trace.exporters.jaeger.servicename	|unknown
-|				 		|opentelemetry.trace.exporters.jaeger.endpoint		|http://localhost:9411/api/v2/spans
+| Feature         | Property                      | Default Value                      |
+|-----------------|-------------------------------|------------------------------------|
+| Otlp Exporter   | otel.exporter.otlp.endpoint   | localhost:55680                    |
+|                 | otel.exporter.otlp.timeout    | 1s                                 |
+| Jaeger Exporter | otel.exporter.jaeger.endpoint | localhost:14250                    |
+|                 | otel.exporter.jaeger.timeout  | 1s                                 |
+| Zipkin Exporter | otel.exporter.jaeger.endpoint | http://localhost:9411/api/v2/spans |
 
 ##### Tracer Properties
 
-|Feature   				|Property   										|Default Value
-|---					|---												|---
-|Tracer			 |opentelemetry.trace.tracer.samplerprobability 		|1.0
-
+| Feature | Property                       | Default Value |
+|---------|--------------------------------|---------------|
+| Tracer  | otel.traces.sampler.probability | 1.0           |
 
 ### Starter Guide
 

--- a/instrumentation/spring/spring-boot-autoconfigure/README.md
+++ b/instrumentation/spring/spring-boot-autoconfigure/README.md
@@ -374,16 +374,16 @@ If an exporter is present in the classpath during runtime and a spring bean of t
 
 | Feature          | Property                                 | Default Value | ConditionalOnClass     |
 |------------------|------------------------------------------|---------------|------------------------|
-| spring-web       | otel.instrumentation.httpclients.enabled | true          | RestTemplate           |
-| spring-webmvc    | otel.instrumentation.httpclients.enabled | true          | OncePerRequestFilter   |
-| spring-webflux   | otel.instrumentation.httpclients.enabled | true          | WebClient              |
-| @WithSpan        | otel.instrumentation.aspects.enabled     | true          | WithSpan, Aspect       |
+| spring-web       | otel.springboot.httpclients.enabled | true          | RestTemplate           |
+| spring-webmvc    | otel.springboot.httpclients.enabled | true          | OncePerRequestFilter   |
+| spring-webflux   | otel.springboot.httpclients.enabled | true          | WebClient              |
+| @WithSpan        | otel.springboot.aspects.enabled     | true          | WithSpan, Aspect       |
 | Otlp Exporter    | otel.exporter.otlp.enabled               | true          | OtlpGrpcSpanExporter   |
 | Jaeger Exporter  | otel.exporter.jaeger.enabled             | true          | JaegerGrpcSpanExporter |
 | Zipkin Exporter  | otel.exporter.zipkin.enabled             | true          | ZipkinSpanExporter     |
 | Logging Exporter | otel.exporter.logging.enabled            | true          | LoggingSpanExporter    |
 
-<!-- Slf4j Log Correlation  otel.instrumentation.loggers.slf4j.enabled		true   		org.slf4j.MDC -->
+<!-- Slf4j Log Correlation  otel.springboot.loggers.slf4j.enabled		true   		org.slf4j.MDC -->
 
 ##### Exporter Properties
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
@@ -29,13 +29,14 @@ import org.springframework.context.annotation.Configuration;
  * <p>Updates the sampler probability for the configured {@link TracerProvider}.
  */
 @Configuration
-@EnableConfigurationProperties(TracerProperties.class)
+@EnableConfigurationProperties(SamplerProperties.class)
 public class OpenTelemetryAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
   public OpenTelemetry openTelemetry(
-      TracerProperties tracerProperties, ObjectProvider<List<SpanExporter>> spanExportersProvider) {
+      SamplerProperties samplerProperties,
+      ObjectProvider<List<SpanExporter>> spanExportersProvider) {
     SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder();
 
     spanExportersProvider.getIfAvailable(Collections::emptyList).stream()
@@ -45,7 +46,7 @@ public class OpenTelemetryAutoConfiguration {
 
     SdkTracerProvider tracerProvider =
         tracerProviderBuilder
-            .setSampler(Sampler.traceIdRatioBased(tracerProperties.getSamplerProbability()))
+            .setSampler(Sampler.traceIdRatioBased(samplerProperties.getProbability()))
             .build();
     return OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).buildAndRegisterGlobal();
   }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/SamplerProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/SamplerProperties.java
@@ -10,24 +10,24 @@ import javax.validation.constraints.DecimalMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * Configuration for OpenTelemetry Tracer.
+ * Configuration for OpenTelemetry Sampler.
  *
  * <p>Get Sampling Probability
  */
-@ConfigurationProperties(prefix = "opentelemetry.trace.tracer")
-public final class TracerProperties {
+@ConfigurationProperties(prefix = "otel.traces.sampler")
+public final class SamplerProperties {
 
   // if Sample probability == 1: always sample
   // if Sample probability == 0: never sample
   @DecimalMin("0.0")
   @DecimalMax("1.0")
-  private double samplerProbability = 1.0;
+  private double probability = 1.0;
 
-  public double getSamplerProbability() {
-    return samplerProbability;
+  public double getProbability() {
+    return probability;
   }
 
-  public void setSamplerProbability(double samplerProbability) {
-    this.samplerProbability = samplerProbability;
+  public void setProbability(double probability) {
+    this.probability = probability;
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectAutoConfiguration.java
@@ -17,10 +17,7 @@ import org.springframework.context.annotation.Configuration;
 /** Configures {@link WithSpanAspect} to trace bean methods annotated with {@link WithSpan}. */
 @Configuration
 @EnableConfigurationProperties(TraceAspectProperties.class)
-@ConditionalOnProperty(
-    prefix = "otel.instrumentation.aspects",
-    name = "enabled",
-    matchIfMissing = true)
+@ConditionalOnProperty(prefix = "otel.springboot.aspects", name = "enabled", matchIfMissing = true)
 @ConditionalOnClass({Aspect.class, WithSpan.class})
 public class TraceAspectAutoConfiguration {
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectAutoConfiguration.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties(TraceAspectProperties.class)
 @ConditionalOnProperty(
-    prefix = "opentelemetry.trace.aspects",
+    prefix = "otel.instrumentation.aspects",
     name = "enabled",
     matchIfMissing = true)
 @ConditionalOnClass({Aspect.class, WithSpan.class})

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectProperties.java
@@ -8,7 +8,7 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.aspects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Configuration for enabling tracing aspects. */
-@ConfigurationProperties(prefix = "opentelemetry.trace.aspects")
+@ConfigurationProperties(prefix = "otel.instrumentation.aspects")
 public final class TraceAspectProperties {
   private boolean enabled;
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectProperties.java
@@ -8,7 +8,7 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.aspects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Configuration for enabling tracing aspects. */
-@ConfigurationProperties(prefix = "otel.instrumentation.aspects")
+@ConfigurationProperties(prefix = "otel.springboot.aspects")
 public final class TraceAspectProperties {
   private boolean enabled;
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterAutoConfiguration.java
@@ -25,24 +25,20 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @AutoConfigureBefore(OpenTelemetryAutoConfiguration.class)
 @EnableConfigurationProperties(JaegerSpanExporterProperties.class)
-@ConditionalOnProperty(
-    prefix = "opentelemetry.trace.exporter.jaeger",
-    name = "enabled",
-    matchIfMissing = true)
+@ConditionalOnProperty(prefix = "otel.exporter.jaeger", name = "enabled", matchIfMissing = true)
 @ConditionalOnClass({JaegerGrpcSpanExporter.class, ManagedChannel.class})
 public class JaegerSpanExporterAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public JaegerGrpcSpanExporter otelJaegerSpanExporter(
-      JaegerSpanExporterProperties jaegerSpanExporterProperties) {
+  public JaegerGrpcSpanExporter otelJaegerSpanExporter(JaegerSpanExporterProperties properties) {
 
     JaegerGrpcSpanExporterBuilder builder = JaegerGrpcSpanExporter.builder();
-    if (jaegerSpanExporterProperties.getEndpoint() != null) {
-      builder.setEndpoint(jaegerSpanExporterProperties.getEndpoint());
+    if (properties.getEndpoint() != null) {
+      builder.setEndpoint(properties.getEndpoint());
     }
-    if (jaegerSpanExporterProperties.getSpanTimeout() != null) {
-      builder.setTimeout(jaegerSpanExporterProperties.getSpanTimeout());
+    if (properties.getTimeout() != null) {
+      builder.setTimeout(properties.getTimeout());
     }
     return builder.build();
   }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/jaeger/JaegerSpanExporterProperties.java
@@ -18,12 +18,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * <p>Get max wait time for Collector to process Span Batches
  */
-@ConfigurationProperties(prefix = "opentelemetry.trace.exporter.jaeger")
+@ConfigurationProperties(prefix = "otel.exporter.jaeger")
 public final class JaegerSpanExporterProperties {
 
   private boolean enabled = true;
   @Nullable private String endpoint;
-  @Nullable private Duration spanTimeout;
+  @Nullable private Duration timeout;
 
   public boolean isEnabled() {
     return enabled;
@@ -43,11 +43,11 @@ public final class JaegerSpanExporterProperties {
   }
 
   @Nullable
-  public Duration getSpanTimeout() {
-    return spanTimeout;
+  public Duration getTimeout() {
+    return timeout;
   }
 
-  public void setSpanTimeout(Duration spanTimeout) {
-    this.spanTimeout = spanTimeout;
+  public void setTimeout(Duration timeout) {
+    this.timeout = timeout;
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
@@ -19,10 +19,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties(LoggingSpanExporterProperties.class)
 @AutoConfigureBefore(OpenTelemetryAutoConfiguration.class)
-@ConditionalOnProperty(
-    prefix = "opentelemetry.trace.exporter.logging",
-    name = "enabled",
-    matchIfMissing = true)
+@ConditionalOnProperty(prefix = "otel.exporter.logging", name = "enabled", matchIfMissing = true)
 @ConditionalOnClass(LoggingSpanExporter.class)
 public class LoggingSpanExporterAutoConfiguration {
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterProperties.java
@@ -8,7 +8,7 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.exporters.logging;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Configuration for {@link io.opentelemetry.exporter.logging.LoggingSpanExporter}. */
-@ConfigurationProperties(prefix = "opentelemetry.trace.exporter.logging")
+@ConfigurationProperties(prefix = "otel.exporter.logging")
 public final class LoggingSpanExporterProperties {
   private boolean enabled = true;
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterAutoConfiguration.java
@@ -25,24 +25,20 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @AutoConfigureBefore(OpenTelemetryAutoConfiguration.class)
 @EnableConfigurationProperties(OtlpGrpcSpanExporterProperties.class)
-@ConditionalOnProperty(
-    prefix = "opentelemetry.trace.exporter.otlp",
-    name = "enabled",
-    matchIfMissing = true)
+@ConditionalOnProperty(prefix = "otel.exporter.otlp", name = "enabled", matchIfMissing = true)
 @ConditionalOnClass({OtlpGrpcSpanExporter.class, ManagedChannel.class})
 public class OtlpGrpcSpanExporterAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public OtlpGrpcSpanExporter otelOtlpGrpcSpanExporter(
-      OtlpGrpcSpanExporterProperties otlpGrpcSpanExporterProperties) {
+  public OtlpGrpcSpanExporter otelOtlpGrpcSpanExporter(OtlpGrpcSpanExporterProperties properties) {
 
     OtlpGrpcSpanExporterBuilder builder = OtlpGrpcSpanExporter.builder();
-    if (otlpGrpcSpanExporterProperties.getEndpoint() != null) {
-      builder.setEndpoint(otlpGrpcSpanExporterProperties.getEndpoint());
+    if (properties.getEndpoint() != null) {
+      builder.setEndpoint(properties.getEndpoint());
     }
-    if (otlpGrpcSpanExporterProperties.getSpanTimeout() != null) {
-      builder.setTimeout(otlpGrpcSpanExporterProperties.getSpanTimeout());
+    if (properties.getTimeout() != null) {
+      builder.setTimeout(properties.getTimeout());
     }
     return builder.build();
   }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpGrpcSpanExporterProperties.java
@@ -18,12 +18,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * <p>Get max wait time for Collector to process Span Batches
  */
-@ConfigurationProperties(prefix = "opentelemetry.trace.exporter.otlp")
+@ConfigurationProperties(prefix = "otel.exporter.otlp")
 public final class OtlpGrpcSpanExporterProperties {
 
   private boolean enabled = true;
   @Nullable private String endpoint;
-  @Nullable private Duration spanTimeout;
+  @Nullable private Duration timeout;
 
   public boolean isEnabled() {
     return enabled;
@@ -43,11 +43,11 @@ public final class OtlpGrpcSpanExporterProperties {
   }
 
   @Nullable
-  public Duration getSpanTimeout() {
-    return spanTimeout;
+  public Duration getTimeout() {
+    return timeout;
   }
 
-  public void setSpanTimeout(Duration spanTimeout) {
-    this.spanTimeout = spanTimeout;
+  public void setTimeout(Duration timeout) {
+    this.timeout = timeout;
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
@@ -24,21 +24,17 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @AutoConfigureBefore(OpenTelemetryAutoConfiguration.class)
 @EnableConfigurationProperties(ZipkinSpanExporterProperties.class)
-@ConditionalOnProperty(
-    prefix = "opentelemetry.trace.exporter.zipkin",
-    name = "enabled",
-    matchIfMissing = true)
+@ConditionalOnProperty(prefix = "otel.exporter.zipkin", name = "enabled", matchIfMissing = true)
 @ConditionalOnClass(ZipkinSpanExporter.class)
 public class ZipkinSpanExporterAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public ZipkinSpanExporter otelZipkinSpanExporter(
-      ZipkinSpanExporterProperties zipkinSpanExporterProperties) {
+  public ZipkinSpanExporter otelZipkinSpanExporter(ZipkinSpanExporterProperties properties) {
 
     ZipkinSpanExporterBuilder builder = ZipkinSpanExporter.builder();
-    if (zipkinSpanExporterProperties.getEndpoint() != null) {
-      builder.setEndpoint(zipkinSpanExporterProperties.getEndpoint());
+    if (properties.getEndpoint() != null) {
+      builder.setEndpoint(properties.getEndpoint());
     }
     return builder.build();
   }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterProperties.java
@@ -13,7 +13,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * <p>Get Exporter Endpoint
  */
-@ConfigurationProperties(prefix = "opentelemetry.trace.exporter.zipkin")
+@ConfigurationProperties(prefix = "otel.exporter.zipkin")
 public class ZipkinSpanExporterProperties {
 
   private boolean enabled = true;

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/HttpClientsProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/HttpClientsProperties.java
@@ -10,10 +10,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Configuration for the tracing instrumentation of HTTP clients.
  *
- * <p>Sets default value of otel.instrumentation.httpclients.enabled to true if the configuration
- * does not exist in application context.
+ * <p>Sets default value of otel.springboot.httpclients.enabled to true if the configuration does
+ * not exist in application context.
  */
-@ConfigurationProperties(prefix = "otel.instrumentation.httpclients")
+@ConfigurationProperties(prefix = "otel.springboot.httpclients")
 public final class HttpClientsProperties {
   private boolean enabled = true;
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/HttpClientsProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/HttpClientsProperties.java
@@ -10,10 +10,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Configuration for the tracing instrumentation of HTTP clients.
  *
- * <p>Sets default value of opentelemetry.trace.httpclients.enabled to true if the configuration
+ * <p>Sets default value of otel.instrumentation.httpclients.enabled to true if the configuration
  * does not exist in application context.
  */
-@ConfigurationProperties(prefix = "opentelemetry.trace.httpclients")
+@ConfigurationProperties(prefix = "otel.instrumentation.httpclients")
 public final class HttpClientsProperties {
   private boolean enabled = true;
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/resttemplate/RestTemplateAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/resttemplate/RestTemplateAutoConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.web.client.RestTemplate;
 @ConditionalOnClass(RestTemplate.class)
 @EnableConfigurationProperties(HttpClientsProperties.class)
 @ConditionalOnProperty(
-    prefix = "otel.instrumentation.httpclients",
+    prefix = "otel.springboot.httpclients",
     name = "enabled",
     matchIfMissing = true)
 public class RestTemplateAutoConfiguration {

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/resttemplate/RestTemplateAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/resttemplate/RestTemplateAutoConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.web.client.RestTemplate;
 @ConditionalOnClass(RestTemplate.class)
 @EnableConfigurationProperties(HttpClientsProperties.class)
 @ConditionalOnProperty(
-    prefix = "opentelemetry.trace.httpclients",
+    prefix = "otel.instrumentation.httpclients",
     name = "enabled",
     matchIfMissing = true)
 public class RestTemplateAutoConfiguration {

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/webclient/WebClientAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/webclient/WebClientAutoConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @ConditionalOnClass(WebClient.class)
 @EnableConfigurationProperties(HttpClientsProperties.class)
 @ConditionalOnProperty(
-    prefix = "otel.instrumentation.httpclients",
+    prefix = "otel.springboot.httpclients",
     name = "enabled",
     matchIfMissing = true)
 public class WebClientAutoConfiguration {

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/webclient/WebClientAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/webclient/WebClientAutoConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @ConditionalOnClass(WebClient.class)
 @EnableConfigurationProperties(HttpClientsProperties.class)
 @ConditionalOnProperty(
-    prefix = "opentelemetry.trace.httpclients",
+    prefix = "otel.instrumentation.httpclients",
     name = "enabled",
     matchIfMissing = true)
 public class WebClientAutoConfiguration {

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 /** Configures {@link WebMvcTracingFilter} for tracing. */
 @Configuration
 @EnableConfigurationProperties(WebMvcProperties.class)
-@ConditionalOnProperty(prefix = "otel.instrumentation.web", name = "enabled", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "otel.springboot.web", name = "enabled", matchIfMissing = true)
 @ConditionalOnClass(OncePerRequestFilter.class)
 public class WebMvcFilterAutoConfiguration {
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 /** Configures {@link WebMvcTracingFilter} for tracing. */
 @Configuration
 @EnableConfigurationProperties(WebMvcProperties.class)
-@ConditionalOnProperty(prefix = "opentelemetry.trace.web", name = "enabled", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "otel.instrumentation.web", name = "enabled", matchIfMissing = true)
 @ConditionalOnClass(OncePerRequestFilter.class)
 public class WebMvcFilterAutoConfiguration {
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcProperties.java
@@ -10,10 +10,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Configuration for the tracing instrumentation of Spring WebMVC
  *
- * <p>Sets default value of opentelemetry.trace.web.enabled to true if the configuration does not
+ * <p>Sets default value of otel.instrumentation.web.enabled to true if the configuration does not
  * exist in application context
  */
-@ConfigurationProperties(prefix = "opentelemetry.trace.web")
+@ConfigurationProperties(prefix = "otel.instrumentation.web")
 public final class WebMvcProperties {
   private boolean enabled = true;
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcProperties.java
@@ -10,10 +10,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Configuration for the tracing instrumentation of Spring WebMVC
  *
- * <p>Sets default value of otel.instrumentation.web.enabled to true if the configuration does not
- * exist in application context
+ * <p>Sets default value of otel.springboot.web.enabled to true if the configuration does not exist
+ * in application context
  */
-@ConfigurationProperties(prefix = "otel.instrumentation.web")
+@ConfigurationProperties(prefix = "otel.springboot.web")
 public final class WebMvcProperties {
   private boolean enabled = true;
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectAutoConfigurationTest.java
@@ -33,7 +33,7 @@ public class TraceAspectAutoConfigurationTest {
   @DisplayName("when aspects are ENABLED should initialize WithSpanAspect bean")
   void aspectsEnabled() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.aspects.enabled=true")
+        .withPropertyValues("otel.instrumentation.aspects.enabled=true")
         .run(
             (context) -> {
               assertThat(context.getBean("withSpanAspect", WithSpanAspect.class)).isNotNull();
@@ -44,7 +44,7 @@ public class TraceAspectAutoConfigurationTest {
   @DisplayName("when aspects are DISABLED should NOT initialize WithSpanAspect bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.aspects.enabled=false")
+        .withPropertyValues("otel.instrumentation.aspects.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("withSpanAspect")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectAutoConfigurationTest.java
@@ -33,7 +33,7 @@ public class TraceAspectAutoConfigurationTest {
   @DisplayName("when aspects are ENABLED should initialize WithSpanAspect bean")
   void aspectsEnabled() {
     this.contextRunner
-        .withPropertyValues("otel.instrumentation.aspects.enabled=true")
+        .withPropertyValues("otel.springboot.aspects.enabled=true")
         .run(
             (context) -> {
               assertThat(context.getBean("withSpanAspect", WithSpanAspect.class)).isNotNull();
@@ -44,7 +44,7 @@ public class TraceAspectAutoConfigurationTest {
   @DisplayName("when aspects are DISABLED should NOT initialize WithSpanAspect bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("otel.instrumentation.aspects.enabled=false")
+        .withPropertyValues("otel.springboot.aspects.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("withSpanAspect")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/JaegerSpanExporterAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/JaegerSpanExporterAutoConfigurationTest.java
@@ -36,7 +36,7 @@ class JaegerSpanExporterAutoConfigurationTest {
   @DisplayName("when exporters are ENABLED should initialize JaegerGrpcSpanExporter bean")
   void exportersEnabled() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.exporters.jaeger.enabled=true")
+        .withPropertyValues("otel.exporter.jaeger.enabled=true")
         .run(
             (context) -> {
               assertThat(context.getBean("otelJaegerSpanExporter", JaegerGrpcSpanExporter.class))
@@ -46,20 +46,20 @@ class JaegerSpanExporterAutoConfigurationTest {
 
   @Test
   @DisplayName(
-      "when opentelemetry.trace.exporter.jaeger properties are set should initialize JaegerSpanExporterProperties")
+      "when otel.exporter.jaeger properties are set should initialize JaegerSpanExporterProperties")
   void handlesProperties() {
     this.contextRunner
         .withPropertyValues(
-            "opentelemetry.trace.exporter.jaeger.enabled=true",
-            "opentelemetry.trace.exporter.jaeger.endpoint=http://localhost:8080/test",
-            "opentelemetry.trace.exporter.jaeger.spantimeout=420ms")
+            "otel.exporter.jaeger.enabled=true",
+            "otel.exporter.jaeger.endpoint=http://localhost:8080/test",
+            "otel.exporter.jaeger.timeout=420ms")
         .run(
             (context) -> {
               JaegerSpanExporterProperties jaegerSpanExporterProperties =
                   context.getBean(JaegerSpanExporterProperties.class);
               assertThat(jaegerSpanExporterProperties.getEndpoint())
                   .isEqualTo("http://localhost:8080/test");
-              assertThat(jaegerSpanExporterProperties.getSpanTimeout()).hasMillis(420);
+              assertThat(jaegerSpanExporterProperties.getTimeout()).hasMillis(420);
             });
   }
 
@@ -67,7 +67,7 @@ class JaegerSpanExporterAutoConfigurationTest {
   @DisplayName("when exporters are DISABLED should NOT initialize JaegerGrpcSpanExporter bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.exporter.jaeger.enabled=false")
+        .withPropertyValues("otel.exporter.jaeger.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("otelJaegerSpanExporter")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/LoggingSpanExporterAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/LoggingSpanExporterAutoConfigurationTest.java
@@ -36,7 +36,7 @@ class LoggingSpanExporterAutoConfigurationTest {
   @DisplayName("when exporters are ENABLED should initialize LoggingSpanExporter bean")
   void exportersEnabled() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.exporters.logging.enabled=true")
+        .withPropertyValues("otel.exporter.logging.enabled=true")
         .run(
             (context) -> {
               assertThat(context.getBean("otelLoggingSpanExporter", LoggingSpanExporter.class))
@@ -48,7 +48,7 @@ class LoggingSpanExporterAutoConfigurationTest {
   @DisplayName("when exporters are DISABLED should NOT initialize LoggingSpanExporter bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.exporter.logging.enabled=false")
+        .withPropertyValues("otel.exporter.logging.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("otelLoggingSpanExporter")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/OtlpGrpcSpanExporterAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/OtlpGrpcSpanExporterAutoConfigurationTest.java
@@ -32,7 +32,7 @@ class OtlpGrpcSpanExporterAutoConfigurationTest {
   @DisplayName("when exporters are ENABLED should initialize OtlpGrpcSpanExporter bean")
   void exportersEnabled() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.exporters.otlp.enabled=true")
+        .withPropertyValues("otel.exporter.otlp.enabled=true")
         .run(
             (context) -> {
               assertThat(context.getBean("otelOtlpGrpcSpanExporter", OtlpGrpcSpanExporter.class))
@@ -47,20 +47,20 @@ class OtlpGrpcSpanExporterAutoConfigurationTest {
 
   @Test
   @DisplayName(
-      "when opentelemetry.trace.exporter.otlp properties are set should initialize OtlpGrpcSpanExporterProperties")
+      "when otel.exporter.otlp properties are set should initialize OtlpGrpcSpanExporterProperties")
   void handlesProperties() {
     this.contextRunner
         .withPropertyValues(
-            "opentelemetry.trace.exporter.otlp.enabled=true",
-            "opentelemetry.trace.exporter.otlp.endpoint=http://localhost:8080/test",
-            "opentelemetry.trace.exporter.otlp.spantimeout=69ms")
+            "otel.exporter.otlp.enabled=true",
+            "otel.exporter.otlp.endpoint=http://localhost:8080/test",
+            "otel.exporter.otlp.timeout=69ms")
         .run(
             (context) -> {
               OtlpGrpcSpanExporterProperties otlpSpanExporterProperties =
                   context.getBean(OtlpGrpcSpanExporterProperties.class);
               assertThat(otlpSpanExporterProperties.getEndpoint())
                   .isEqualTo("http://localhost:8080/test");
-              assertThat(otlpSpanExporterProperties.getSpanTimeout()).hasMillis(69);
+              assertThat(otlpSpanExporterProperties.getTimeout()).hasMillis(69);
             });
   }
 
@@ -68,7 +68,7 @@ class OtlpGrpcSpanExporterAutoConfigurationTest {
   @DisplayName("when exporters are DISABLED should NOT initialize OtlpGrpcSpanExporter bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.exporter.otlp.enabled=false")
+        .withPropertyValues("otel.exporter.otlp.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("otelOtlpGrpcSpanExporter")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/ZipkinSpanExporterAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/ZipkinSpanExporterAutoConfigurationTest.java
@@ -36,7 +36,7 @@ class ZipkinSpanExporterAutoConfigurationTest {
   @DisplayName("when exporters are ENABLED should initialize ZipkinSpanExporter bean")
   void exportersEnabled() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.exporters.zipkin.enabled=true")
+        .withPropertyValues("otel.exporter.zipkin.enabled=true")
         .run(
             (context) -> {
               assertThat(context.getBean("otelZipkinSpanExporter", ZipkinSpanExporter.class))
@@ -46,12 +46,12 @@ class ZipkinSpanExporterAutoConfigurationTest {
 
   @Test
   @DisplayName(
-      "when opentelemetry.trace.exporter.zipkin properties are set should initialize ZipkinSpanExporterProperties with property values")
+      "when otel.exporter.zipkin properties are set should initialize ZipkinSpanExporterProperties with property values")
   void handlesProperties() {
     this.contextRunner
         .withPropertyValues(
-            "opentelemetry.trace.exporter.zipkin.enabled=true",
-            "opentelemetry.trace.exporter.zipkin.endpoint=http://localhost:8080/test")
+            "otel.exporter.zipkin.enabled=true",
+            "otel.exporter.zipkin.endpoint=http://localhost:8080/test")
         .run(
             (context) -> {
               ZipkinSpanExporterProperties zipkinSpanExporterProperties =
@@ -65,7 +65,7 @@ class ZipkinSpanExporterAutoConfigurationTest {
   @DisplayName("when exporters are DISABLED should NOT initialize ZipkinSpanExporter bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.exporter.zipkin.enabled=false")
+        .withPropertyValues("otel.exporter.zipkin.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("otelZipkinSpanExporter")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/resttemplate/RestTemplateAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/resttemplate/RestTemplateAutoConfigurationTest.java
@@ -33,7 +33,7 @@ class RestTemplateAutoConfigurationTest {
   @DisplayName("when httpclients are ENABLED should initialize RestTemplateInterceptor bean")
   void httpClientsEnabled() {
     this.contextRunner
-        .withPropertyValues("otel.instrumentation.httpclients.enabled=true")
+        .withPropertyValues("otel.springboot.httpclients.enabled=true")
         .run(
             (context) -> {
               assertThat(
@@ -47,7 +47,7 @@ class RestTemplateAutoConfigurationTest {
   @DisplayName("when httpclients are DISABLED should NOT initialize RestTemplateInterceptor bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("otel.instrumentation.httpclients.enabled=false")
+        .withPropertyValues("otel.springboot.httpclients.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("otelRestTemplateBeanPostProcessor")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/resttemplate/RestTemplateAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/resttemplate/RestTemplateAutoConfigurationTest.java
@@ -33,7 +33,7 @@ class RestTemplateAutoConfigurationTest {
   @DisplayName("when httpclients are ENABLED should initialize RestTemplateInterceptor bean")
   void httpClientsEnabled() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.httpclients.enabled=true")
+        .withPropertyValues("otel.instrumentation.httpclients.enabled=true")
         .run(
             (context) -> {
               assertThat(
@@ -47,7 +47,7 @@ class RestTemplateAutoConfigurationTest {
   @DisplayName("when httpclients are DISABLED should NOT initialize RestTemplateInterceptor bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.httpclients.enabled=false")
+        .withPropertyValues("otel.instrumentation.httpclients.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("otelRestTemplateBeanPostProcessor")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/webclient/WebClientAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/webclient/WebClientAutoConfigurationTest.java
@@ -33,7 +33,7 @@ class WebClientAutoConfigurationTest {
   @DisplayName("when httpclients are ENABLED should initialize WebClientBeanPostProcessor bean")
   void httpClientsEnabled() {
     this.contextRunner
-        .withPropertyValues("otel.instrumentation.httpclients.enabled=true")
+        .withPropertyValues("otel.springboot.httpclients.enabled=true")
         .run(
             (context) -> {
               assertThat(
@@ -48,7 +48,7 @@ class WebClientAutoConfigurationTest {
       "when httpclients are DISABLED should NOT initialize WebClientBeanPostProcessor bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("otel.instrumentation.httpclients.enabled=false")
+        .withPropertyValues("otel.springboot.httpclients.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("otelWebClientBeanPostProcessor")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/webclient/WebClientAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/httpclients/webclient/WebClientAutoConfigurationTest.java
@@ -33,7 +33,7 @@ class WebClientAutoConfigurationTest {
   @DisplayName("when httpclients are ENABLED should initialize WebClientBeanPostProcessor bean")
   void httpClientsEnabled() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.httpclients.enabled=true")
+        .withPropertyValues("otel.instrumentation.httpclients.enabled=true")
         .run(
             (context) -> {
               assertThat(
@@ -48,7 +48,7 @@ class WebClientAutoConfigurationTest {
       "when httpclients are DISABLED should NOT initialize WebClientBeanPostProcessor bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.httpclients.enabled=false")
+        .withPropertyValues("otel.instrumentation.httpclients.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("otelWebClientBeanPostProcessor")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfigurationTest.java
@@ -33,7 +33,7 @@ class WebMvcFilterAutoConfigurationTest {
   @DisplayName("when web is ENABLED should initialize WebMvcTracingFilter bean")
   void webEnabled() {
     this.contextRunner
-        .withPropertyValues("otel.instrumentation.web.enabled=true")
+        .withPropertyValues("otel.springboot.web.enabled=true")
         .run(
             (context) -> {
               assertThat(context.getBean("otelWebMvcTracingFilter", WebMvcTracingFilter.class))
@@ -45,7 +45,7 @@ class WebMvcFilterAutoConfigurationTest {
   @DisplayName("when web is DISABLED should NOT initialize WebMvcTracingFilter bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("otel.instrumentation.web.enabled=false")
+        .withPropertyValues("otel.springboot.web.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("otelWebMvcTracingFilter")).isFalse();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfigurationTest.java
@@ -33,7 +33,7 @@ class WebMvcFilterAutoConfigurationTest {
   @DisplayName("when web is ENABLED should initialize WebMvcTracingFilter bean")
   void webEnabled() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.web.enabled=true")
+        .withPropertyValues("otel.instrumentation.web.enabled=true")
         .run(
             (context) -> {
               assertThat(context.getBean("otelWebMvcTracingFilter", WebMvcTracingFilter.class))
@@ -45,7 +45,7 @@ class WebMvcFilterAutoConfigurationTest {
   @DisplayName("when web is DISABLED should NOT initialize WebMvcTracingFilter bean")
   void disabledProperty() {
     this.contextRunner
-        .withPropertyValues("opentelemetry.trace.web.enabled=false")
+        .withPropertyValues("otel.instrumentation.web.enabled=false")
         .run(
             (context) -> {
               assertThat(context.containsBean("otelWebMvcTracingFilter")).isFalse();


### PR DESCRIPTION
Resolves #864

Renames exporter properties to match SDK properties:
* `opentelemetry.trace.exporters.otlp.endpoint` -> `otel.exporter.otlp.endpoint`
* `opentelemetry.trace.exporters.otlp.spantimeout` -> `otel.exporter.otlp.timeout`
* `opentelemetry.trace.exporters.jaeger.endpoint` -> `otel.exporter.jaeger.endpoint`
* `opentelemetry.trace.exporters.jaeger.spantimeout` -> `otel.exporter.jaeger.timeout`
* `opentelemetry.trace.exporters.zipkin.endpoint` -> `otel.exporter.zipkin.endpoint`

Renames exporter enablement properties:
* `opentelemetry.trace.exporters.otlp.enabled` -> `otel.exporter.otlp.enabled`
* `opentelemetry.trace.exporters.jaeger.enabled` -> `otel.exporter.jaeger.enabled`
* `opentelemetry.trace.exporters.zipkin.enabled` -> `otel.exporter.zipkin.enabled`
* `opentelemetry.trace.exporters.logging.enabled` -> `otel.exporter.logging.enabled`

Renames sampling probability property:
* `opentelemetry.trace.tracer.samplerProbability` -> `otel.traces.sampler.probability`

^^ this still does not match SDK property, which is `otel.traces.sampler.arg`

Renames instrumentation enablement properties:
* `opentelemetry.trace.web.enabled` -> `otel.springboot.web.enabled`
* `opentelemetry.trace.httpclients.enabled` -> `otel.springboot.httpclients.enabled`
* `opentelemetry.trace.aspects.enabled` -> `otel.springboot.aspects.enabled`

^^ initially I thought about `otel.instrumentation.web.enabled`, etc, but was concerned that's confusing with javaagent's `otel.instrumentation.[id].enabled`