### PR TITLE
Run glassfish tests with headless

### DIFF
--- a/instrumentation/servlet/glassfish-testing/glassfish-testing.gradle
+++ b/instrumentation/servlet/glassfish-testing/glassfish-testing.gradle
@@ -12,3 +12,7 @@ dependencies {
 
   testLibrary group: 'org.glassfish.main.extras', name: 'glassfish-embedded-all', version: '4.0'
 }
+
+tasks.withType(Test) {
+  jvmArgs "-Djava.awt.headless=true"
+}


### PR DESCRIPTION
Avoids ui window popping up while running tests