### PR TITLE
Akka: clean up state on exception

### DIFF
--- a/instrumentation/akka-actor-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaDispatcherInstrumentation.java
+++ b/instrumentation/akka-actor-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaDispatcherInstrumentation.java
@@ -50,5 +50,10 @@ public class AkkaDispatcherInstrumentation implements TypeInstrumentation {
       }
       return null;
     }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void exitDispatch(@Advice.Enter State state, @Advice.Thrown Throwable throwable) {
+      ExecutorInstrumentationUtils.cleanUpOnMethodExit(state, throwable);
+    }
   }
 }


### PR DESCRIPTION
Instrumentations that use `ExecutorInstrumentationUtils.setupState` usually call `ExecutorInstrumentationUtils.cleanUpOnMethodExit` to clear state when there was an exception. Make akka dispatcher instrumentation do the same.