### PR TITLE
Bump smoke test timeout

### DIFF
--- a/smoke-tests/smoke-tests.gradle
+++ b/smoke-tests/smoke-tests.gradle
@@ -39,8 +39,9 @@ test {
 
   testLogging.showStandardStreams = true
 
-  // TODO investigate why smoke tests occasionally hang
-  timeout.set(Duration.ofMinutes(30))
+  // TODO investigate why smoke tests occasionally hang forever
+  //  this needs to be long enough so that smoke tests that are just running slow don't time out
+  timeout.set(Duration.ofMinutes(45))
 
   //We enable/disable smoke tests based on the java version requests
   //In addition to that we disable them by default on local machines


### PR DESCRIPTION
Ran across a smoke test (windows-latest, wildfly) that timed out but wasn't really hung (just slower than usual), so bumping the timeout a bit to avoid unnecessary failures.

[GitHub Action log](https://github.com/open-telemetry/opentelemetry-java-instrumentation/files/6307262/21.txt) in case anyone is interested.