### PR TITLE
Add annotated parameters as attributes to spans created by Spring WithSpanAspect

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/AttributeBinding.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/AttributeBinding.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.tracer;
+
+import io.opentelemetry.api.trace.SpanBuilder;
+
+@FunctionalInterface
+public interface AttributeBinding {
+  SpanBuilder apply(SpanBuilder builder, Object arg);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/AttributeBindings.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/AttributeBindings.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.tracer;
+
+import io.opentelemetry.api.trace.SpanBuilder;
+
+public interface AttributeBindings {
+  boolean isEmpty();
+
+  SpanBuilder apply(SpanBuilder builder, Object[] args);
+
+  default AttributeBindings and(int index, AttributeBinding binding) {
+    return new AttributeBindings() {
+      @Override
+      public boolean isEmpty() {
+        return false;
+      }
+
+      @Override
+      public SpanBuilder apply(SpanBuilder builder, Object[] args) {
+        Object arg = args[index];
+        if (arg != null) {
+          return binding.apply(AttributeBindings.this.apply(builder, args), arg);
+        } else {
+          return AttributeBindings.this.apply(builder, args);
+        }
+      }
+    };
+  }
+
+  static final AttributeBindings EMPTY =
+      new AttributeBindings() {
+        @Override
+        public boolean isEmpty() {
+          return true;
+        }
+
+        @Override
+        public SpanBuilder apply(SpanBuilder builder, Object[] args) {
+          return builder;
+        }
+      };
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseAttributeBinder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseAttributeBinder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.tracer;
+
+import io.opentelemetry.api.common.AttributeKey;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public abstract class BaseAttributeBinder {
+
+  public AttributeBindings bind(Method method) {
+    Parameter[] parameters = method.getParameters();
+    AttributeBindings bindings = AttributeBindings.EMPTY;
+
+    if (parameters == null || parameters.length == 0) {
+      return bindings;
+    }
+
+    String[] attributeNames = attributeNamesForParameters(method, parameters);
+    if (attributeNames == null || attributeNames.length != parameters.length) {
+      return bindings;
+    }
+
+    for (int i = 0; i < parameters.length; i++) {
+      Parameter parameter = parameters[i];
+      String attributeName = attributeNames[i];
+      if (attributeName == null || attributeName.isEmpty()) {
+        continue;
+      }
+
+      AttributeBinding binding = creatingBinding(attributeName, parameter.getParameterizedType());
+      bindings = bindings.and(i, binding);
+    }
+
+    return bindings;
+  }
+
+  @Nullable
+  protected abstract String[] attributeNamesForParameters(Method method, Parameter[] parameters);
+
+  protected AttributeBinding creatingBinding(String name, Type type) {
+
+    // TODO: Support more attribute types based on the parameter type
+    AttributeKey<String> key = AttributeKey.stringKey(name);
+    return (builder, arg) -> builder.setAttribute(key, arg.toString());
+  }
+}

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/opentelemetry-annotations-1.0-javaagent.gradle
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/opentelemetry-annotations-1.0-javaagent.gradle
@@ -13,6 +13,10 @@ dependencies {
   testImplementation "net.bytebuddy:byte-buddy:${versions["net.bytebuddy"]}"
 }
 
+tasks.withType(JavaCompile) {
+  options.compilerArgs << '-parameters'
+}
+
 test {
   jvmArgs "-Dotel.instrumentation.opentelemetry-annotations.exclude-methods=io.opentelemetry.test.annotation.TracedWithSpan[ignored]"
 }

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/SpanAttribute.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/SpanAttribute.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.otelannotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SpanAttribute {
+  String value() default "";
+}

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanAttributeBinder.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanAttributeBinder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.otelannotations;
+
+import io.opentelemetry.instrumentation.api.tracer.BaseAttributeBinder;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class WithSpanAttributeBinder extends BaseAttributeBinder {
+
+  @Override
+  protected @Nullable String[] attributeNamesForParameters(Method method, Parameter[] parameters) {
+    String[] attributeNames = new String[parameters.length];
+    for (int i = 0; i < parameters.length; i++) {
+      attributeNames[i] = attributeName(parameters[i]);
+    }
+    return attributeNames;
+  }
+
+  @Nullable
+  private static String attributeName(Parameter parameter) {
+    SpanAttribute annotation = parameter.getDeclaredAnnotation(SpanAttribute.class);
+    if (annotation == null) {
+      return null;
+    }
+    String value = annotation.value();
+    if (!value.isEmpty()) {
+      return value;
+    } else if (parameter.isNamePresent()) {
+      return parameter.getName();
+    } else {
+      return null;
+    }
+  }
+}

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanInstrumentation.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanInstrumentation.java
@@ -7,11 +7,13 @@ package io.opentelemetry.javaagent.instrumentation.otelannotations;
 
 import static io.opentelemetry.javaagent.instrumentation.otelannotations.WithSpanTracer.tracer;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.hasParameters;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.whereAny;
 
 import application.io.opentelemetry.extension.annotations.WithSpan;
 import io.opentelemetry.api.trace.SpanKind;
@@ -40,12 +42,19 @@ public class WithSpanInstrumentation implements TypeInstrumentation {
       "otel.instrumentation.opentelemetry-annotations.exclude-methods";
 
   private final ElementMatcher.Junction<AnnotationSource> annotatedMethodMatcher;
+  private final ElementMatcher.Junction<MethodDescription> annotatedParametersMatcher;
   // this matcher matches all methods that should be excluded from transformation
   private final ElementMatcher.Junction<MethodDescription> excludedMethodsMatcher;
 
   WithSpanInstrumentation() {
     annotatedMethodMatcher =
         isAnnotatedWith(named("application.io.opentelemetry.extension.annotations.WithSpan"));
+    annotatedParametersMatcher =
+        hasParameters(
+            whereAny(
+                isAnnotatedWith(
+                    named(
+                        "application.io.opentelemetry.javaagent.instrumentation.otelannotations.SpanAttribute"))));
     excludedMethodsMatcher = configureExcludedMethods();
   }
 
@@ -56,9 +65,26 @@ public class WithSpanInstrumentation implements TypeInstrumentation {
 
   @Override
   public void transform(TypeTransformer transformer) {
+    ElementMatcher.Junction<MethodDescription> tracedMethods =
+        annotatedMethodMatcher.and(not(excludedMethodsMatcher));
+
+    ElementMatcher.Junction<MethodDescription> tracedMethodsWithParameters =
+        tracedMethods.and(annotatedParametersMatcher);
+    ElementMatcher.Junction<MethodDescription> tracedMethodsWithoutParameters =
+        tracedMethods.and(not(annotatedParametersMatcher));
+
     transformer.applyAdviceToMethod(
-        annotatedMethodMatcher.and(not(excludedMethodsMatcher)),
+        tracedMethods, WithSpanInstrumentation.class.getName() + "$WithSpanAttributesAdvice");
+
+    // TODO: To avoid copying/boxing parameters only use WithSpanAttributesAdvice
+    //      if method has any parameters annotated with @SpanAttribute
+    /*
+    transformer.applyAdviceToMethod(tracedMethodsWithoutParameters,
         WithSpanInstrumentation.class.getName() + "$WithSpanAdvice");
+
+    transformer.applyAdviceToMethod(tracedMethodsWithParameters,
+        WithSpanInstrumentation.class.getName() + "$WithSpanAttributesAdvice");
+     */
   }
 
   /*
@@ -101,7 +127,47 @@ public class WithSpanInstrumentation implements TypeInstrumentation {
 
       // don't create a nested span if you're not supposed to.
       if (tracer().shouldStartSpan(current, kind)) {
-        context = tracer().startSpan(current, applicationAnnotation, method, kind);
+        context = tracer().startSpan(current, applicationAnnotation, method, kind, null);
+        scope = context.makeCurrent();
+      }
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void stopSpan(
+        @Advice.Origin Method method,
+        @Advice.Local("otelContext") Context context,
+        @Advice.Local("otelScope") Scope scope,
+        @Advice.Return(typing = Assigner.Typing.DYNAMIC, readOnly = false) Object returnValue,
+        @Advice.Thrown Throwable throwable) {
+      if (scope == null) {
+        return;
+      }
+      scope.close();
+
+      if (throwable != null) {
+        tracer().endExceptionally(context, throwable);
+      } else {
+        returnValue = tracer().end(context, method.getReturnType(), returnValue);
+      }
+    }
+  }
+
+  public static class WithSpanAttributesAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+        @Advice.Origin Method method,
+        @Advice.AllArguments(readOnly = true, typing = Assigner.Typing.DYNAMIC) Object[] args,
+        @Advice.Local("otelContext") Context context,
+        @Advice.Local("otelScope") Scope scope) {
+      WithSpan applicationAnnotation = method.getAnnotation(WithSpan.class);
+
+      SpanKind kind = tracer().extractSpanKind(applicationAnnotation);
+      Context current = Java8BytecodeBridge.currentContext();
+
+      // don't create a nested span if you're not supposed to.
+      if (tracer().shouldStartSpan(current, kind)) {
+        context = tracer().startSpan(current, applicationAnnotation, method, kind, args);
         scope = context.makeCurrent();
       }
     }

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanTracer.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanTracer.java
@@ -7,8 +7,10 @@ package io.opentelemetry.javaagent.instrumentation.otelannotations;
 
 import application.io.opentelemetry.extension.annotations.WithSpan;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.tracer.AttributeBindings;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategies;
 import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategy;
@@ -25,15 +27,22 @@ public class WithSpanTracer extends BaseTracer {
 
   private static final Logger log = LoggerFactory.getLogger(WithSpanTracer.class);
 
+  private final WithSpanAttributeBinder attributeBinder = new WithSpanAttributeBinder();
   private final AsyncSpanEndStrategies asyncSpanEndStrategies =
       AsyncSpanEndStrategies.getInstance();
 
   public Context startSpan(
-      Context parentContext, WithSpan applicationAnnotation, Method method, SpanKind kind) {
-    Span span =
+      Context parentContext,
+      WithSpan applicationAnnotation,
+      Method method,
+      SpanKind kind,
+      Object[] args) {
+
+    SpanBuilder spanBuilder =
         spanBuilder(
-                parentContext, spanNameForMethodWithAnnotation(applicationAnnotation, method), kind)
-            .startSpan();
+            parentContext, spanNameForMethodWithAnnotation(applicationAnnotation, method), kind);
+    Span span = withSpanAttributes(spanBuilder, method, args).startSpan();
+
     if (kind == SpanKind.SERVER) {
       return withServerSpan(parentContext, span);
     }
@@ -72,6 +81,14 @@ public class WithSpanTracer extends BaseTracer {
       log.debug("unexpected span kind: {}", applicationSpanKind.name());
       return SpanKind.INTERNAL;
     }
+  }
+
+  public SpanBuilder withSpanAttributes(SpanBuilder spanBuilder, Method method, Object[] args) {
+    if (args == null) {
+      return spanBuilder;
+    }
+    AttributeBindings bindings = attributeBinder.bind(method);
+    return bindings.isEmpty() ? spanBuilder : bindings.apply(spanBuilder, args);
   }
 
   /**

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -419,4 +419,24 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
       }
     }
   }
+
+  def "should capture attributes"() {
+    setup:
+    new TracedWithSpan().withSpanAttributes("foo", "bar", null, "baz")
+
+    expect:
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.withSpanAttributes"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "implicitName" "foo"
+            "explicitName" "bar"
+          }
+        }
+      }
+    }
+  }
 }

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/TracedWithSpan.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/TracedWithSpan.java
@@ -7,6 +7,7 @@ package io.opentelemetry.test.annotation;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.extension.annotations.WithSpan;
+import io.opentelemetry.javaagent.instrumentation.otelannotations.SpanAttribute;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -54,6 +55,16 @@ public class TracedWithSpan {
 
   @WithSpan(kind = SpanKind.CLIENT)
   public String innerClient() {
+    return "hello!";
+  }
+
+  @WithSpan
+  public String withSpanAttributes(
+      @SpanAttribute String implicitName,
+      @SpanAttribute("explicitName") String parameter,
+      @SpanAttribute("nullAttribute") String nullAttribute,
+      String notTraced) {
+
     return "hello!";
   }
 


### PR DESCRIPTION
Extends the `WithSpanAspect` in the Spring Autoconfigure instrumentation to add attributes to the newly-created `Span` based on parameters annotated by the `WithSpanAttribute` annotation.

See: https://github.com/open-telemetry/opentelemetry-java/pull/3168

I've probably gone a bit overboard in attempting to support different parameter types and coercing those values into one of the possible attribute types.  Also, the `WithSpanAttributeBinding` instances are intended to support memoization to avoid having to constantly reflect over the method parameters but I have not added the implementation of that memoization.  As presumably this same functionality, if accepted, would be added to the `opentelemetry-annotations-1.0` module the plan should be that the binding code should be abstracted to the `instrumentation-api` module.