### PR TITLE
Populate the InstrumentationVersion.VERSION from a file 

### DIFF
--- a/instrumentation-api/.gitignore
+++ b/instrumentation-api/.gitignore
@@ -1,0 +1,1 @@
+src/main/resources/instrumentation-version.txt

--- a/instrumentation-api/instrumentation-api.gradle
+++ b/instrumentation-api/instrumentation-api.gradle
@@ -35,3 +35,11 @@ dependencies {
   testImplementation deps.awaitility
   testImplementation deps.opentelemetrySdkTesting
 }
+
+task createVersionFile {
+  def dir = 'src/main/resources/io/opentelemetry/instrumentation/api'
+  file(dir).mkdirs()
+  new File(projectDir, "${dir}/instrumentation-version.txt").text = "${project.version}"
+}
+
+jar.dependsOn createVersionFile

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/InstrumentationVersion.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/InstrumentationVersion.java
@@ -5,7 +5,29 @@
 
 package io.opentelemetry.instrumentation.api;
 
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class InstrumentationVersion {
-  public static final String VERSION =
-      InstrumentationVersion.class.getPackage().getImplementationVersion();
+  private static final Logger log = LoggerFactory.getLogger(InstrumentationVersion.class);
+  private static final String VERSION_FILE = "/io/opentelemetry/javaagent/shaded/instrumentation/api/instrumentation-version.txt";
+
+  public static final String VERSION = findVersion();
+
+  private static String findVersion() {
+      try {
+        InputStream in = InstrumentationVersion.class.getResourceAsStream(VERSION_FILE);
+        char[] buff = new char[256];
+        int ct = new InputStreamReader(in).read(buff);
+        return new String(buff, 0, ct);
+      } catch (Exception e) {
+        log.warn("Error reading instrumentation version", e);
+        return "UNKNOWN";
+      }
+  }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/InstrumentationVersion.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/InstrumentationVersion.java
@@ -7,27 +7,25 @@ package io.opentelemetry.instrumentation.api;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class InstrumentationVersion {
   private static final Logger log = LoggerFactory.getLogger(InstrumentationVersion.class);
-  private static final String VERSION_FILE = "/io/opentelemetry/javaagent/shaded/instrumentation/api/instrumentation-version.txt";
+  private static final String VERSION_FILE =
+      "/io/opentelemetry/javaagent/shaded/instrumentation/api/instrumentation-version.txt";
 
   public static final String VERSION = findVersion();
 
   private static String findVersion() {
-      try {
-        InputStream in = InstrumentationVersion.class.getResourceAsStream(VERSION_FILE);
-        char[] buff = new char[256];
-        int ct = new InputStreamReader(in).read(buff);
-        return new String(buff, 0, ct);
-      } catch (Exception e) {
-        log.warn("Error reading instrumentation version", e);
-        return "UNKNOWN";
-      }
+    try {
+      InputStream in = InstrumentationVersion.class.getResourceAsStream(VERSION_FILE);
+      char[] buff = new char[256];
+      int ct = new InputStreamReader(in).read(buff);
+      return new String(buff, 0, ct);
+    } catch (Exception e) {
+      log.warn("Error reading instrumentation version", e);
+      return "UNKNOWN";
+    }
   }
 }


### PR DESCRIPTION
Read a file within the jar to obtain the version number of instrumentation, instead of reading from the manifest.  The file is generated at build time and contains the project version number.  This works around the case where the agent jar has been shaded into another agent jar, which is the case for android and for vendor distributions.

This fixes #2761