### PR TITLE
Fix jaxrs cxf latest dep tests

### DIFF
--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/javaagent/jaxrs-2.0-cxf-3.2-javaagent.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/javaagent/jaxrs-2.0-cxf-3.2-javaagent.gradle
@@ -34,6 +34,7 @@ dependencies {
 
   testLibrary group: 'org.apache.cxf', name: 'cxf-rt-transports-http-jetty', version: '3.2.0'
   testLibrary group: 'org.apache.cxf', name: 'cxf-rt-ws-policy', version: '3.2.0'
+
   latestDepTestLibrary group: 'org.eclipse.jetty', name: 'jetty-webapp', version: '9.+'
 }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/javaagent/jaxrs-2.0-cxf-3.2-javaagent.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/javaagent/jaxrs-2.0-cxf-3.2-javaagent.gradle
@@ -34,6 +34,7 @@ dependencies {
 
   testLibrary group: 'org.apache.cxf', name: 'cxf-rt-transports-http-jetty', version: '3.2.0'
   testLibrary group: 'org.apache.cxf', name: 'cxf-rt-ws-policy', version: '3.2.0'
+  latestDepTestLibrary group: 'org.eclipse.jetty', name: 'jetty-webapp', version: '9.+'
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
Hopefully ensures that all jetty jars come from the same version when running with `-PtestLatestDeps=true`