### PR TITLE
Prevent AgentClassLoader from loading ContextStorageOverride

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentClassLoader.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentClassLoader.java
@@ -82,6 +82,17 @@ public class AgentClassLoader extends URLClassLoader {
   }
 
   @Override
+  public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    // ContextStorageOverride is meant for library instrumentation we don't want it to apply to our
+    // bundled grpc
+    if ("io.grpc.override.ContextStorageOverride".equals(name)) {
+      throw new ClassNotFoundException(name);
+    }
+
+    return super.loadClass(name, resolve);
+  }
+
+  @Override
   public URL getResource(String resourceName) {
     URL bootstrapResource = bootstrapProxy.getResource(resourceName);
     if (null == bootstrapResource) {


### PR DESCRIPTION
As far as I can tell `ContextStorageOverride` should be only used by library instrumentation so it might be cleaner to exclude that class from agent, but it would still be possible to add `ContextStorageOverride` to bootclasspath and that would affect grpc inside the agent. Perhaps `AgentClassLoader` should load in child first oder to prevent accidentally loading stuff from boot loader?