### PR TITLE
Fix flaky smoke tests

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -25,6 +25,7 @@ import io.opentelemetry.javaagent.tooling.config.ConfigInitializer;
 import io.opentelemetry.javaagent.tooling.context.FieldBackedProvider;
 import io.opentelemetry.javaagent.tooling.matcher.GlobalClassloaderIgnoresMatcher;
 import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -82,6 +83,9 @@ public class AgentInstaller {
     BootstrapPackagePrefixesHolder.setBoostrapPackagePrefixes(loadBootstrapPackagePrefixes());
     // this needs to be done as early as possible - before the first Config.get() call
     ConfigInitializer.initialize();
+    // ensure java.lang.reflect.Proxy is loaded, as transformation code uses it internally
+    // loading it after bytebuddy transformer is set up can cause a ClassCircularityError
+    Proxy.class.getName();
   }
 
   public static void installBytebuddyAgent(Instrumentation inst) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -84,7 +84,11 @@ public class AgentInstaller {
     // this needs to be done as early as possible - before the first Config.get() call
     ConfigInitializer.initialize();
     // ensure java.lang.reflect.Proxy is loaded, as transformation code uses it internally
-    // loading it after bytebuddy transformer is set up can cause a ClassCircularityError
+    // loading java.lang.reflect.Proxy after the bytebuddy transformer is set up causes
+    // the internal-proxy instrumentation module to transform it, and then the bytebuddy
+    // transformation code also tries to load it, which leads to a ClassCircularityError
+    // loading java.lang.reflect.Proxy early here still allows it to be retransformed by the
+    // internal-proxy instrumentation module after the bytebuddy transformer is set up
     Proxy.class.getName();
   }
 

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -43,7 +43,7 @@ abstract class AppServerTest extends SmokeTest {
   @Override
   protected String getTargetImage(String jdk, String serverVersion, boolean windows) {
     String platformSuffix = windows ? "-windows" : ""
-    String extraTag = "20210427.788400023"
+    String extraTag = "20210428.792292726"
     String fullSuffix = "-${serverVersion}-jdk$jdk$platformSuffix-$extraTag"
     return getTargetImagePrefix() + fullSuffix
   }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -43,7 +43,7 @@ abstract class AppServerTest extends SmokeTest {
   @Override
   protected String getTargetImage(String jdk, String serverVersion, boolean windows) {
     String platformSuffix = windows ? "-windows" : ""
-    String extraTag = "20210405.720145828"
+    String extraTag = "20210427.788400023"
     String fullSuffix = "-${serverVersion}-jdk$jdk$platformSuffix-$extraTag"
     return getTargetImagePrefix() + fullSuffix
   }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GlassFishSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GlassFishSmokeTest.groovy
@@ -23,6 +23,11 @@ class GlassFishSmokeTest extends AppServerTest {
   }
 
   @Override
+  protected String getJvmArgsEnvVarName() {
+    return "JVM_ARGS"
+  }
+
+  @Override
   protected TargetWaitStrategy getWaitStrategy() {
     return new TargetWaitStrategy.Log(Duration.ofMinutes(3), ".*(app was successfully deployed|deployed with name app).*")
   }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
@@ -34,11 +34,19 @@ abstract class SmokeTest extends Specification {
   protected String agentPath = System.getProperty("io.opentelemetry.smoketest.agent.shadowJar.path")
 
   /**
+   * Subclasses can override this method to pass jvm arguments in another environment variable
+   */
+  protected String getJvmArgsEnvVarName() {
+    return "JAVA_TOOL_OPTIONS"
+  }
+
+  /**
    * Subclasses can override this method to customise target application's environment
    */
   protected Map<String, String> getExtraEnv() {
     return Collections.emptyMap()
   }
+
   /**
    * Subclasses can override this method to provide additional files to copy to target container
    */
@@ -57,7 +65,7 @@ abstract class SmokeTest extends Specification {
 
   def startTarget(String jdk, String serverVersion, boolean windows) {
     def targetImage = getTargetImage(jdk, serverVersion, windows)
-    return containerManager.startTarget(targetImage, agentPath, extraEnv, extraResources, getWaitStrategy())
+    return containerManager.startTarget(targetImage, agentPath, jvmArgsEnvVarName, extraEnv, extraResources, getWaitStrategy())
   }
 
   protected abstract String getTargetImage(String jdk)

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
@@ -28,7 +28,7 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
     environment.put("OTEL_EXPORTER_OTLP_ENDPOINT", "http://" + COLLECTOR_ALIAS + ":55680");
     environment.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=smoke-test");
     environment.put("OTEL_JAVAAGENT_DEBUG", "true");
-    environment.put("RANDOM_CHANGE_TO_TRIGGER_RERUN_OF_ALL_TESTS", "1");
+    environment.put("RANDOM_CHANGE_TO_TRIGGER_RERUN_OF_ALL_TESTS", "2");
     return environment;
   }
 

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
@@ -27,6 +27,7 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
     environment.put("OTEL_IMR_EXPORT_INTERVAL", "1000");
     environment.put("OTEL_EXPORTER_OTLP_ENDPOINT", "http://" + COLLECTOR_ALIAS + ":55680");
     environment.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=smoke-test");
+    environment.put("OTEL_JAVAAGENT_DEBUG", "true");
     return environment;
   }
 

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
@@ -28,7 +28,6 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
     environment.put("OTEL_EXPORTER_OTLP_ENDPOINT", "http://" + COLLECTOR_ALIAS + ":55680");
     environment.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=smoke-test");
     environment.put("OTEL_JAVAAGENT_DEBUG", "true");
-    environment.put("RANDOM_CHANGE_TO_TRIGGER_RERUN_OF_ALL_TESTS", "2");
     return environment;
   }
 

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
@@ -19,9 +19,9 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
 
   private boolean started = false;
 
-  protected Map<String, String> getAgentEnvironment() {
+  protected Map<String, String> getAgentEnvironment(String jvmArgsEnvVarName) {
     Map<String, String> environment = new HashMap<>();
-    environment.put("JAVA_TOOL_OPTIONS", "-javaagent:/" + TARGET_AGENT_FILENAME);
+    environment.put(jvmArgsEnvVarName, "-javaagent:/" + TARGET_AGENT_FILENAME);
     environment.put("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1");
     environment.put("OTEL_BSP_SCHEDULE_DELAY", "10ms");
     environment.put("OTEL_IMR_EXPORT_INTERVAL", "1000");

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
@@ -28,6 +28,7 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
     environment.put("OTEL_EXPORTER_OTLP_ENDPOINT", "http://" + COLLECTOR_ALIAS + ":55680");
     environment.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=smoke-test");
     environment.put("OTEL_JAVAAGENT_DEBUG", "true");
+    environment.put("RANDOM_CHANGE_TO_TRIGGER_RERUN_OF_ALL_TESTS", "1");
     return environment;
   }
 

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/LinuxTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/LinuxTestContainerManager.java
@@ -83,6 +83,7 @@ public class LinuxTestContainerManager extends AbstractTestContainerManager {
   public Consumer<OutputFrame> startTarget(
       String targetImageName,
       String agentPath,
+      String jvmArgsEnvVarName,
       Map<String, String> extraEnv,
       Map<String, String> extraResources,
       TargetWaitStrategy waitStrategy) {
@@ -97,7 +98,7 @@ public class LinuxTestContainerManager extends AbstractTestContainerManager {
             .withLogConsumer(new Slf4jLogConsumer(logger))
             .withCopyFileToContainer(
                 MountableFile.forHostPath(agentPath), "/" + TARGET_AGENT_FILENAME)
-            .withEnv(getAgentEnvironment())
+            .withEnv(getAgentEnvironment(jvmArgsEnvVarName))
             .withEnv(extraEnv);
 
     extraResources.forEach(

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/TestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/TestContainerManager.java
@@ -20,6 +20,7 @@ public interface TestContainerManager {
   Consumer<OutputFrame> startTarget(
       String targetImageName,
       String agentPath,
+      String jvmArgsEnvVarName,
       Map<String, String> extraEnv,
       Map<String, String> extraResources,
       TargetWaitStrategy waitStrategy);

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/windows/WindowsTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/windows/WindowsTestContainerManager.java
@@ -77,7 +77,7 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
             .exec()
             .getId();
 
-    String backendSuffix = "-windows-20210401.709152102";
+    String backendSuffix = "-windows-20210427.788400024";
 
     String backendImageName =
         "ghcr.io/open-telemetry/java-test-containers:smoke-fake-backend" + backendSuffix;

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/windows/WindowsTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/windows/WindowsTestContainerManager.java
@@ -165,6 +165,7 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
   public Consumer<OutputFrame> startTarget(
       String targetImageName,
       String agentPath,
+      String jvmArgsEnvVarName,
       Map<String, String> extraEnv,
       Map<String, String> extraResources,
       TargetWaitStrategy waitStrategy) {
@@ -175,7 +176,7 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
     }
 
     List<String> environment = new ArrayList<>();
-    getAgentEnvironment().forEach((key, value) -> environment.add(key + "=" + value));
+    getAgentEnvironment(jvmArgsEnvVarName).forEach((key, value) -> environment.add(key + "=" + value));
     extraEnv.forEach((key, value) -> environment.add(key + "=" + value));
 
     target =

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/windows/WindowsTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/windows/WindowsTestContainerManager.java
@@ -176,7 +176,8 @@ public class WindowsTestContainerManager extends AbstractTestContainerManager {
     }
 
     List<String> environment = new ArrayList<>();
-    getAgentEnvironment(jvmArgsEnvVarName).forEach((key, value) -> environment.add(key + "=" + value));
+    getAgentEnvironment(jvmArgsEnvVarName)
+        .forEach((key, value) -> environment.add(key + "=" + value));
     extraEnv.forEach((key, value) -> environment.add(key + "=" + value));
 
     target =


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2820 Class transformations sometimes fail with `ClassCircularityError: java/lang/reflect/Proxy` due to which instrumentation is not applied and spans are not generated. I was able to reproduce `ClassCircularityError` by commenting out some agent code, but I wasn't able to reproduce the exact same behaviour as in failing tests. Maybe it requires something that isn't deterministic to happen in specific order (depends on iteration order of `HashMap` or something like that). It definitely depends of timing because `Proxy` is loaded from grpc background thread and this can happen before or after byte buddy has been set up.

Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2785 `JAVA_TOOL_OPTIONS` is also applied to a sub process that is started from glassfish launcher. My hypothesis is that due to our agent this sub process produces more output than it would normally. Subprocess blocks because it has filled its output buffer and as the output of this process is read only after it has finished it will hang until build times out. Enabling debug logging for our agent makes this issue reproducible.

This pr also enable debug logging for smoke tests so that such issues would be easier to debug in the future.