### PR TITLE
Raise lambda flush timeout to 10 seconds

### DIFF
--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/WrapperConfiguration.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/WrapperConfiguration.java
@@ -13,7 +13,7 @@ public final class WrapperConfiguration {
 
   public static final String OTEL_LAMBDA_FLUSH_TIMEOUT_ENV_KEY =
       "OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT";
-  public static final Duration OTEL_LAMBDA_FLUSH_TIMEOUT_DEFAULT = Duration.ofSeconds(1);
+  public static final Duration OTEL_LAMBDA_FLUSH_TIMEOUT_DEFAULT = Duration.ofSeconds(10);
 
   public static final Duration flushTimeout() {
     String lambdaFlushTimeout = System.getenv(OTEL_LAMBDA_FLUSH_TIMEOUT_ENV_KEY);


### PR DESCRIPTION
@kubawach Please check this out :)

I've been playing the the wrapper recently (much more than I want...) and it generally works quite well. However, I notice that with the current 1s timeout, it takes many requests before the JVM has warmed up enough for any traces to be sent, maybe around 5+. Raising it allows the first request to be traced. I don't know a great value for this timeout but wondering if you have any ideas on raising it so first request can also be traced? In particular, I'm worried about very low QPS functions - a customer may not care about cold start time and have a function that is always cold started. Such a function effectively can't be traced with the default timeout. Though it becomes a tradeoff between "defaults allow as many use cases as possible" to "majority use case may prefer the safety of a lower timeout on flush since they'll be warm anyways".

Edit: I'm also worried about people thinking tracing isn't working since requiring 5+ requests to get them is a lot.