### PR TITLE
fix db.operation in semantic-conventions.md

### DIFF
--- a/docs/semantic-conventions.md
+++ b/docs/semantic-conventions.md
@@ -76,7 +76,7 @@ not values defined by spec.
 | `db.mssql.instance_name`   | N | - |
 | `db.name`   | N | only set of JDBC, Mongo, Geode and MongoDB |
 | `db.statement`   | N | +, except for ElasticSearch and Memcached, see `db.operation` |
-| `db.operation`   | N | only set of ElasticSearch, Memcached and JDBC |
+| `db.operation`   | N | only set for ElasticSearch, Memcached and JDBC |
 | `db.cassandra.keyspace`   | Y | + |
 | `db.hbase`   | Y | -, HBase is not supported |
 | `db.redis.database_index`   | N | only set for Lettuce driver, not for Jedis |

--- a/docs/semantic-conventions.md
+++ b/docs/semantic-conventions.md
@@ -76,7 +76,7 @@ not values defined by spec.
 | `db.mssql.instance_name`   | N | - |
 | `db.name`   | N | only set of JDBC, Mongo, Geode and MongoDB |
 | `db.statement`   | N | +, except for ElasticSearch and Memcached, see `db.operation` |
-| `db.operation`   | N | only set of ElasticSearch and Memcached |
+| `db.operation`   | N | only set of ElasticSearch, Memcached and JDBC |
 | `db.cassandra.keyspace`   | Y | + |
 | `db.hbase`   | Y | -, HBase is not supported |
 | `db.redis.database_index`   | N | only set for Lettuce driver, not for Jedis |


### PR DESCRIPTION
I have found all spans provided by JDBC instrumentation have the attribute `db.operation` and I check code found is actually provided . But according to the doc, JDBC is not support to add this attribute. Maybe the doc need to be fixed.