### PR TITLE
Pass jvm arguments from env var on windows payara

### DIFF
--- a/examples/distro/smoke-tests/build.gradle
+++ b/examples/distro/smoke-tests/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 tasks.test {
   useJUnitPlatform()
 
+  testLogging.showStandardStreams = true
+
   def shadowTask = project(":agent").tasks.shadowJar
   inputs.files(layout.files(shadowTask))
 

--- a/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
+++ b/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
@@ -55,7 +55,7 @@ abstract class SmokeTest {
   static void setupSpec() {
     backend =
         new GenericContainer<>(
-            "open-telemetry-docker-dev.bintray.io/java/smoke-fake-backend:latest")
+            "ghcr.io/open-telemetry/java-test-containers:smoke-fake-backend-20210324.684269693")
             .withExposedPorts(8080)
             .waitingFor(Wait.forHttp("/health").forPort(8080))
             .withNetwork(network)
@@ -172,7 +172,7 @@ abstract class SmokeTest {
 
       Request request =
           new Request.Builder()
-              .url(String.format("http://localhost:%d/get-requests", backend.getMappedPort(8080)))
+              .url(String.format("http://localhost:%d/get-traces", backend.getMappedPort(8080)))
               .build();
 
       try (ResponseBody body = client.newCall(request).execute().body()) {

--- a/examples/distro/smoke-tests/src/test/resources/logback.xml
+++ b/examples/distro/smoke-tests/src/test/resources/logback.xml
@@ -13,5 +13,10 @@
 
   <logger name="io.opentelemetry" level="debug"/>
   <logger name="com.example.javaagent" level="debug"/>
+  <logger name="org.testcontainers" level="debug"/>
+  <logger name="org.testcontainers.shaded" level="warn"/>
+  <logger name="org.testcontainers.containers.output.WaitingConsumer" level="warn"/>
+  <logger name="Collector" level="debug"/>
+  <logger name="Backend" level="debug"/>
 
 </configuration>

--- a/smoke-tests/fake-backend/src/docker/backend/windows.dockerfile
+++ b/smoke-tests/fake-backend/src/docker/backend/windows.dockerfile
@@ -1,3 +1,3 @@
-FROM winamd64/openjdk:11.0.10-jdk-windowsservercore-1809
+FROM winamd64/openjdk:11.0.11-jdk-windowsservercore-1809
 COPY fake-backend.jar /fake-backend.jar
 CMD ["java", "-jar", "/fake-backend.jar"]

--- a/smoke-tests/matrix/src/main/docker/payara/launch.bat
+++ b/smoke-tests/matrix/src/main/docker/payara/launch.bat
@@ -1,2 +1,1 @@
-java -jar glassfish/lib/client/appserver-cli.jar start-domain domain1
-powershell -command "Get-Content /server/glassfish/domains/domain1/logs/server.log -Wait"
+java %JVM_ARGS% -jar glassfish/lib/client/appserver-cli.jar start-domain --verbose domain1


### PR DESCRIPTION
Linux payara image support passing jvm arguments in `JVM_ARGS` env variable, make windows image do the same. This is needed for https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2785 We can't use `JAVA_TOOL_OPTIONS` because during startup payara launches a java process to detect java version and parses its output. As this process also gets our agent from `JAVA_TOOL_OPTIONS` it produces more output than expected which can block that process when it fills its output buffer. The output of that process is read only after it has completed so if it creates too much output it will hang permanently.
Also update windows fake backend java version so that image would get rebuilt agains the latest windows image which should make windows tests a bit faster again.