### PR TITLE
Only reset server context if there is a leak.

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
@@ -298,10 +298,19 @@ public abstract class BaseTracer {
   public <C> Context extract(C carrier, TextMapGetter<C> getter) {
     ContextPropagationDebug.debugContextLeakIfEnabled();
 
-    // Using Context.root() here may be quite unexpected, but the reason is simple.
-    // We want either span context extracted from the carrier or invalid one.
-    // We DO NOT want any span context potentially lingering in the current context.
-    return propagators.getTextMapPropagator().extract(Context.root(), carrier, getter);
+    Context parent = Context.current();
+    if (Span.fromContextOrNull(parent) != null) {
+      // A span has leaked from another thread.
+      // We want either span context extracted from the carrier or invalid one.
+      // We DO NOT want any span context potentially lingering in the current context.
+      // We reset to the root context, which may not always be appropriate (e.g., a framework added
+      // an item to the context before we create a span) but it is safer than removing all the
+      // possible spans that instrumentation may have added and such frameworks as of now do not
+      // have leaks.
+      parent = Context.root();
+    }
+
+    return propagators.getTextMapPropagator().extract(parent, carrier, getter);
   }
 
   /**

--- a/instrumentation/grpc-1.5/javaagent/grpc-1.5-javaagent.gradle
+++ b/instrumentation/grpc-1.5/javaagent/grpc-1.5-javaagent.gradle
@@ -33,6 +33,7 @@ dependencies {
 
   testLibrary group: 'io.grpc', name: 'grpc-netty', version: grpcVersion
   testLibrary group: 'io.grpc', name: 'grpc-protobuf', version: grpcVersion
+  testLibrary group: 'io.grpc', name: 'grpc-services', version: grpcVersion
   testLibrary group: 'io.grpc', name: 'grpc-stub', version: grpcVersion
 
   testImplementation project(':instrumentation:grpc-1.5:testing')

--- a/instrumentation/grpc-1.5/library/grpc-1.5-library.gradle
+++ b/instrumentation/grpc-1.5/library/grpc-1.5-library.gradle
@@ -7,6 +7,7 @@ dependencies {
 
   testLibrary group: 'io.grpc', name: 'grpc-netty', version: grpcVersion
   testLibrary group: 'io.grpc', name: 'grpc-protobuf', version: grpcVersion
+  testLibrary group: 'io.grpc', name: 'grpc-services', version: grpcVersion
   testLibrary group: 'io.grpc', name: 'grpc-stub', version: grpcVersion
 
   testImplementation deps.assertj

--- a/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/GrpcServerTracer.java
+++ b/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/GrpcServerTracer.java
@@ -14,6 +14,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.instrumentation.api.internal.ContextPropagationDebug;
 import io.opentelemetry.instrumentation.api.tracer.RpcServerTracer;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 

--- a/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/GrpcServerTracer.java
+++ b/instrumentation/grpc-1.5/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_5/GrpcServerTracer.java
@@ -14,7 +14,6 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
-import io.opentelemetry.instrumentation.api.internal.ContextPropagationDebug;
 import io.opentelemetry.instrumentation.api.tracer.RpcServerTracer;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 

--- a/instrumentation/grpc-1.5/testing/grpc-1.5-testing.gradle
+++ b/instrumentation/grpc-1.5/testing/grpc-1.5-testing.gradle
@@ -25,6 +25,7 @@ dependencies {
 
   api group: 'io.grpc', name: 'grpc-core', version: grpcVersion
   api group: 'io.grpc', name: 'grpc-protobuf', version: grpcVersion
+  api group: 'io.grpc', name: 'grpc-services', version: grpcVersion
   api group: 'io.grpc', name: 'grpc-stub', version: grpcVersion
 
   implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'


### PR DESCRIPTION
Resetting to root was always a hack that we accepted out of necessity for leaking instrumentations. But we reached the end of the line :) Context is a shared resource and who knows what's been added to it before we get a chance to create a span, resetting it arbitrarily isn't really allowed. This new version is still not ideal but at least improves the situation a bit.

Fixes #2853 