### PR TITLE
Enable JAX-RS 2.0 server concurrency tests

### DIFF
--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
@@ -125,6 +125,11 @@ abstract class JaxRsHttpServerTest<S> extends HttpServerTest<S> implements Agent
     true
   }
 
+  @Override
+  boolean testConcurrency() {
+    true
+  }
+
   boolean asyncCancelHasSendError() {
     false
   }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/test/JaxRsTestResource.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/test/JaxRsTestResource.groovy
@@ -7,12 +7,14 @@ package test
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static java.util.concurrent.TimeUnit.SECONDS
 
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
@@ -82,6 +84,17 @@ class JaxRsTestResource {
     HttpServerTest.controller(PATH_PARAM) {
       id
     }
+  }
+
+  @Path("/child")
+  @GET
+  void indexed_child(@Suspended AsyncResponse response, @QueryParam("id") long id) {
+    CompletableFuture.runAsync({
+      HttpServerTest.controller(INDEXED_CHILD) {
+        Span.current().setAttribute("test.request.id", id)
+        response.resume("")
+      }
+    })
   }
 
   static final BARRIER = new CyclicBarrier(2)

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
@@ -428,7 +428,7 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
     then:
     assertTraces(count) {
       (0..count - 1).each {
-        trace(it, 3) {
+        trace(it, hasHandlerSpan(endpoint) ? 4 : 3) {
           def rootSpan = it.span(0)
           //Traces can be in arbitrary order, let us find out the request id of the current one
           def requestId = Integer.parseInt(rootSpan.name.substring("client ".length()))
@@ -437,7 +437,15 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
             it."test.request.id" requestId
           }
           indexedServerSpan(it, span(0), requestId)
-          indexedControllerSpan(it, 2, span(1), requestId)
+
+          def controllerSpanIndex = 2
+
+          if (hasHandlerSpan(endpoint)) {
+            handlerSpan(it, 2, span(1), "GET", endpoint)
+            controllerSpanIndex++
+          }
+
+          indexedControllerSpan(it, controllerSpanIndex, span(controllerSpanIndex - 1), requestId)
         }
       }
     }


### PR DESCRIPTION
Enabled JAX-RS 2.0 server concurrency tests. As this is the first time concurrency tests are enabled on a server with handler spans, added checking for handler span when verifying collected spans.