### PR TITLE
Fix Ratpack server context propagation and enable its concurrency test

### DIFF
--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaExecutorInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaExecutorInstrumentation.java
@@ -75,12 +75,11 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
     public static State enterJobSubmit(
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
       if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task)) {
-        Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
-        task = newTask;
+        task = RunnableWrapper.wrapIfNeeded(task);
         ContextStore<Runnable, State> contextStore =
             InstrumentationContext.get(Runnable.class, State.class);
         return ExecutorInstrumentationUtils.setupState(
-            contextStore, newTask, Java8BytecodeBridge.currentContext());
+            contextStore, task, Java8BytecodeBridge.currentContext());
       }
       return null;
     }
@@ -119,12 +118,11 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
     public static State enterJobSubmit(
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
       if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task)) {
-        Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
-        task = newTask;
+        task = RunnableWrapper.wrapIfNeeded(task);
         ContextStore<Runnable, State> contextStore =
             InstrumentationContext.get(Runnable.class, State.class);
         return ExecutorInstrumentationUtils.setupState(
-            contextStore, newTask, Java8BytecodeBridge.currentContext());
+            contextStore, task, Java8BytecodeBridge.currentContext());
       }
       return null;
     }
@@ -149,12 +147,11 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
     public static State enterJobSubmit(
         @Advice.Argument(value = 0, readOnly = false) Callable task) {
       if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task)) {
-        Callable newTask = CallableWrapper.wrapIfNeeded(task);
-        task = newTask;
+        task = CallableWrapper.wrapIfNeeded(task);
         ContextStore<Callable, State> contextStore =
             InstrumentationContext.get(Callable.class, State.class);
         return ExecutorInstrumentationUtils.setupState(
-            contextStore, newTask, Java8BytecodeBridge.currentContext());
+            contextStore, task, Java8BytecodeBridge.currentContext());
       }
       return null;
     }

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaExecutorInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaExecutorInstrumentation.java
@@ -74,8 +74,8 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static State enterJobSubmit(
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
-      Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
-      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(newTask)) {
+      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task)) {
+        Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
         task = newTask;
         ContextStore<Runnable, State> contextStore =
             InstrumentationContext.get(Runnable.class, State.class);
@@ -118,8 +118,8 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static State enterJobSubmit(
         @Advice.Argument(value = 0, readOnly = false) Runnable task) {
-      Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
-      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(newTask)) {
+      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task)) {
+        Runnable newTask = RunnableWrapper.wrapIfNeeded(task);
         task = newTask;
         ContextStore<Runnable, State> contextStore =
             InstrumentationContext.get(Runnable.class, State.class);
@@ -148,8 +148,8 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static State enterJobSubmit(
         @Advice.Argument(value = 0, readOnly = false) Callable task) {
-      Callable newTask = CallableWrapper.wrapIfNeeded(task);
-      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(newTask)) {
+      if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task)) {
+        Callable newTask = CallableWrapper.wrapIfNeeded(task);
         task = newTask;
         ContextStore<Callable, State> contextStore =
             InstrumentationContext.get(Callable.class, State.class);

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/server/RatpackAsyncHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/server/RatpackAsyncHttpServerTest.groovy
@@ -7,11 +7,13 @@ package server
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.api.trace.Span
 import ratpack.exec.Promise
 import ratpack.groovy.test.embed.GroovyEmbeddedApp
 import ratpack.test.embed.EmbeddedApp
@@ -36,6 +38,18 @@ class RatpackAsyncHttpServerTest extends RatpackHttpServerTest {
             } then { endpoint ->
               controller(endpoint) {
                 context.response.status(endpoint.status).send(endpoint.body)
+              }
+            }
+          }
+        }
+        prefix(INDEXED_CHILD.rawPath()) {
+          all {
+            Promise.sync {
+              INDEXED_CHILD
+            } then {
+              controller(INDEXED_CHILD) {
+                Span.current().setAttribute("test.request.id", request.queryParams.get("id") as long)
+                context.response.status(INDEXED_CHILD.status).send()
               }
             }
           }

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -8,11 +8,13 @@ package server
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -40,6 +42,14 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> implements Agent
           all {
             controller(SUCCESS) {
               context.response.status(SUCCESS.status).send(SUCCESS.body)
+            }
+          }
+        }
+        prefix(INDEXED_CHILD.rawPath()) {
+          all {
+            controller(INDEXED_CHILD) {
+              Span.current().setAttribute("test.request.id", request.queryParams.get("id") as long)
+              context.response.status(INDEXED_CHILD.status).send()
             }
           }
         }
@@ -105,6 +115,11 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> implements Agent
 
   @Override
   boolean testPathParam() {
+    true
+  }
+
+  @Override
+  boolean testConcurrency() {
     true
   }
 

--- a/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/ExecutorInstrumentationUtils.java
+++ b/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/ExecutorInstrumentationUtils.java
@@ -92,6 +92,15 @@ public class ExecutorInstrumentationUtils {
             return false;
           }
 
+          if (taskClass.getName().startsWith("ratpack.exec.internal.")) {
+            // Context is passed through Netty channels in Ratpack as executor instrumentation is
+            // not suitable. As the context that would be propagated via executor would be
+            // incorrect, skip the propagation. Not checking for concrete class names as this covers
+            // anonymous classes from ratpack.exec.internal.DefaultExecution and
+            // ratpack.exec.internal.DefaultExecController.
+            return false;
+          }
+
           return true;
         }
       };


### PR DESCRIPTION
Fixes #2648 

* Use context from Netty channel attributes as the parent context for `ratpack.handler` as executor instrumentation does not work correctly for it.
* Disable context propagation to Ratpack runnables and callables as the context they carry is not only unused, but also incorrect. As these are anonymous classes and created inside different classes, checking for exact classname does not work, so disabled it for the whole package.
* To do the above, made classname checking use the original task instead of wrapped task for anonymous classes.
* Enabled concurrency tests for Ratpack server.