### PR TITLE
Fix enabling gradle configure on demand

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
+
 /**
  * muzzle task plugin which runs muzzle validation against a range of dependencies.
  */
@@ -43,14 +44,15 @@ class MuzzlePlugin implements Plugin<Project> {
 
   @Override
   void apply(Project project) {
-    def bootstrapProject = project.rootProject.getChildProjects().get('javaagent-bootstrap')
-    def toolingProject = project.rootProject.getChildProjects().get('javaagent-tooling')
     project.extensions.create("muzzle", MuzzleExtension, project.objects)
 
     // compileMuzzle compiles all projects required to run muzzle validation.
     // Not adding group and description to keep this task from showing in `gradle tasks`.
-    def compileMuzzle = project.task('compileMuzzle')
-    compileMuzzle.dependsOn(bootstrapProject.tasks.classes, toolingProject.tasks.classes, project.tasks.classes)
+    def compileMuzzle = project.task('compileMuzzle') {
+      dependsOn(':javaagent-bootstrap:classes')
+      dependsOn(':javaagent-tooling:classes')
+      dependsOn(project.tasks.classes)
+    }
 
     def muzzle = project.task('muzzle') {
       group = 'Muzzle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.configureondemand=true
 
 org.gradle.priority=low
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configureondemand=true
 
 org.gradle.priority=low
 


### PR DESCRIPTION
Relates to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2651
See https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:configuration_on_demand
As this is an incubating feature strange things may happen, but it definitely does make running tests a bit less painful.