### PR TITLE
Renamed min java for test property to better reflect its purpose

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -33,8 +33,8 @@ if (applyCodeCoverage) {
   apply from: "$rootDir/gradle/jacoco.gradle"
 }
 
-if (project.hasProperty("minJavaVersionForTests")) {
-  project.ext.release = project.getProperty("minJavaVersionForTests")
+if (project.hasProperty("minJavaVersionSupported")) {
+  project.ext.release = project.getProperty("minJavaVersionSupported")
 } else {
   project.ext.release = JavaVersion.VERSION_1_8
 }
@@ -171,7 +171,7 @@ project.afterEvaluate {
 }
 
 def isJavaVersionAllowed(JavaVersion version) {
-  if (project.hasProperty('minJavaVersionForTests') && project.getProperty('minJavaVersionForTests').compareTo(version) > 0) {
+  if (project.hasProperty('minJavaVersionSupported') && project.getProperty('minJavaVersionSupported').compareTo(version) > 0) {
     return false
   }
   if (project.hasProperty('maxJavaVersionForTests') && project.getProperty('maxJavaVersionForTests').compareTo(version) < 0) {

--- a/instrumentation/java-http-client/javaagent/java-http-client-javaagent.gradle
+++ b/instrumentation/java-http-client/javaagent/java-http-client-javaagent.gradle
@@ -1,5 +1,5 @@
 ext {
-  minJavaVersionForTests = JavaVersion.VERSION_11
+  minJavaVersionSupported = JavaVersion.VERSION_11
 }
 
 apply from: "$rootDir/gradle/instrumentation.gradle"

--- a/instrumentation/jetty/jetty-11.0/javaagent/jetty-11.0-javaagent.gradle
+++ b/instrumentation/jetty/jetty-11.0/javaagent/jetty-11.0-javaagent.gradle
@@ -1,5 +1,5 @@
 ext {
-  minJavaVersionForTests = JavaVersion.VERSION_11
+  minJavaVersionSupported = JavaVersion.VERSION_11
 }
 
 apply from: "$rootDir/gradle/instrumentation.gradle"

--- a/smoke-tests/smoke-tests.gradle
+++ b/smoke-tests/smoke-tests.gradle
@@ -4,7 +4,7 @@ ext {
   // we only need to run the Spock test itself under a single Java version, and the Spock test in
   // turn is parameterized and runs the test using different docker containers that run different
   // Java versions
-  minJavaVersionForTests = JavaVersion.VERSION_11
+  minJavaVersionSupported = JavaVersion.VERSION_11
   maxJavaVersionForTests = JavaVersion.VERSION_11
 }
 


### PR DESCRIPTION
Renamed "minJavaVersionForTests" to "minJavaVersionSupported" as the property is used to generate the binaries (as well as run tests). In other words modules annotated with the property won't run with Java < minJavaVersionSupported.