### PR TITLE
Instrument okhttp builder constructor instead of client

### DIFF
--- a/instrumentation/okhttp/okhttp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttp3InstrumentationModule.java
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttp3InstrumentationModule.java
@@ -9,11 +9,11 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.instrumentation.api.CallDepthThreadLocalMap;
 import java.util.List;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -37,20 +37,32 @@ public class OkHttp3InstrumentationModule extends InstrumentationModule {
   public static class OkHttpClientInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
-      return named("okhttp3.OkHttpClient");
+      return named("okhttp3.OkHttpClient$Builder");
     }
 
     @Override
     public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
       return singletonMap(
-          isConstructor().and(takesArgument(0, named("okhttp3.OkHttpClient$Builder"))),
-          OkHttp3InstrumentationModule.class.getName() + "$OkHttp3Advice");
+          isConstructor(), OkHttp3InstrumentationModule.class.getName() + "$OkHttp3Advice");
     }
   }
 
   public static class OkHttp3Advice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void addTracingInterceptor(@Advice.Argument(0) OkHttpClient.Builder builder) {
+    public static void trackCallDepth(@Advice.Local("callDepth") int callDepth) {
+      callDepth = CallDepthThreadLocalMap.incrementCallDepth(OkHttpClient.Builder.class);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void addTracingInterceptor(
+        @Advice.This OkHttpClient.Builder builder, @Advice.Local("callDepth") int callDepth) {
+      if (callDepth > 0) {
+        return;
+      }
+      CallDepthThreadLocalMap.reset(OkHttpClient.Builder.class);
+      if (builder.interceptors().contains(OkHttp3Interceptors.TRACING_INTERCEPTOR)) {
+        return;
+      }
       builder.addInterceptor(OkHttp3Interceptors.TRACING_INTERCEPTOR);
     }
   }

--- a/instrumentation/okhttp/okhttp-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/okhttp/v3_0/AbstractOkHttp3Test.groovy
+++ b/instrumentation/okhttp/okhttp-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/okhttp/v3_0/AbstractOkHttp3Test.groovy
@@ -67,4 +67,24 @@ abstract class AbstractOkHttp3Test extends HttpClientTest<Request> {
   boolean testCausality() {
     false
   }
+
+  def "reused builder has one interceptor"() {
+    when:
+    def builder = configureClient(new OkHttpClient.Builder()
+      .connectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+      .retryOnConnectionFailure(false))
+    builder.build()
+    def newClient = builder.build()
+
+    then:
+    newClient.interceptors().size() == 1
+  }
+
+  def "builder created from client has one interceptor"() {
+    when:
+    def newClient = client.newBuilder().build()
+
+    then:
+    newClient.interceptors().size() == 1
+  }
 }


### PR DESCRIPTION
@agoallikmaa Since we need to address #2886 for the release, I went ahead and sent this smaller PR to address https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2894#issuecomment-834080132

This does not change the behavior that the interceptor is somewhat exposed to users. I think the idea of making sure not to do so is interesting, but it does complicate the instrumentation quite a bit. Currently we don't do this in any other instrumentation, but it might only matter for okhttp, which actually has a getter for `interceptors` whereas most libraries I've seen have builders without such a getter. I think it makes sense to address this if we want separately from fixing the stack overflow bug we got.