### PR TITLE
Don't set span status to unset

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.InstrumentationVersion;
@@ -156,7 +157,10 @@ public class Instrumenter<REQUEST, RESPONSE> {
       span.recordException(error);
     }
 
-    span.setStatus(spanStatusExtractor.extract(request, response, error));
+    StatusCode statusCode = spanStatusExtractor.extract(request, response, error);
+    if (statusCode != StatusCode.UNSET) {
+      span.setStatus(statusCode);
+    }
 
     if (endTimeExtractor != null) {
       span.end(endTimeExtractor.extract(response));

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpClientTracer.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.instrumentation.api.tracer.net.NetPeerAttributes;
@@ -211,7 +212,10 @@ public abstract class HttpClientTracer<REQUEST, CARRIER, RESPONSE> extends BaseT
       Integer status = status(response);
       if (status != null) {
         span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, (long) status);
-        span.setStatus(HttpStatusConverter.statusFromHttpStatus(status));
+        StatusCode statusCode = HttpStatusConverter.statusFromHttpStatus(status);
+        if (statusCode != StatusCode.UNSET) {
+          span.setStatus(statusCode);
+        }
       }
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -252,9 +253,10 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
 
   private static void setStatus(Span span, int status) {
     span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, (long) status);
-    // TODO status_message
-    // See https://github.com/open-telemetry/opentelemetry-specification/issues/950
-    span.setStatus(HttpStatusConverter.statusFromHttpStatus(status));
+    StatusCode statusCode = HttpStatusConverter.statusFromHttpStatus(status);
+    if (statusCode != StatusCode.UNSET) {
+      span.setStatus(statusCode);
+    }
   }
 
   @Nullable

--- a/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/HttpClientTracerTest.groovy
+++ b/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/HttpClientTracerTest.groovy
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.tracer
 
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.propagation.TextMapSetter
 import io.opentelemetry.instrumentation.api.tracer.net.NetPeerAttributes
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -110,6 +111,7 @@ class HttpClientTracerTest extends BaseTracerTest {
   def "test onResponse"() {
     setup:
     def tracer = newTracer()
+    def statusCode = status != null ? HttpStatusConverter.statusFromHttpStatus(status) : null
 
     when:
     tracer.onResponse(span, resp)
@@ -117,7 +119,9 @@ class HttpClientTracerTest extends BaseTracerTest {
     then:
     if (status) {
       1 * span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, status)
-      1 * span.setStatus(HttpStatusConverter.statusFromHttpStatus(status))
+    }
+    if (statusCode != null && statusCode != StatusCode.UNSET) {
+      1 * span.setStatus(statusCode)
     }
     0 * _
 

--- a/instrumentation/apache-dubbo/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTracer.java
+++ b/instrumentation/apache-dubbo/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTracer.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.api.trace.SpanKind.SERVER;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.tracer.RpcServerTracer;
@@ -46,7 +47,10 @@ class DubboTracer extends RpcServerTracer<RpcInvocation> {
 
   public void end(Context context, Result result) {
     Span span = Span.fromContext(context);
-    span.setStatus(DubboHelper.statusFromResult(result));
+    StatusCode statusCode = DubboHelper.statusFromResult(result);
+    if (statusCode != StatusCode.UNSET) {
+      span.setStatus(statusCode);
+    }
     end(context);
   }
 

--- a/instrumentation/apache-dubbo/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTracer.java
+++ b/instrumentation/apache-dubbo/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTracer.java
@@ -46,10 +46,9 @@ class DubboTracer extends RpcServerTracer<RpcInvocation> {
   }
 
   public void end(Context context, Result result) {
-    Span span = Span.fromContext(context);
     StatusCode statusCode = DubboHelper.statusFromResult(result);
     if (statusCode != StatusCode.UNSET) {
-      span.setStatus(statusCode);
+      Span.fromContext(context).setStatus(statusCode);
     }
     end(context);
   }

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentationModule.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentationModule.java
@@ -18,6 +18,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.tracer.HttpStatusConverter;
@@ -164,7 +165,10 @@ public class HttpUrlConnectionInstrumentationModule extends InstrumentationModul
       if (httpUrlState != null) {
         Span span = Java8BytecodeBridge.spanFromContext(httpUrlState.context);
         span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, returnValue);
-        span.setStatus(HttpStatusConverter.statusFromHttpStatus(returnValue));
+        StatusCode statusCode = HttpStatusConverter.statusFromHttpStatus(returnValue);
+        if (statusCode != StatusCode.UNSET) {
+          span.setStatus(statusCode);
+        }
       }
     }
   }

--- a/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
+++ b/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
@@ -13,6 +13,7 @@ import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTra
 
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -155,6 +156,7 @@ class UndertowServerTest extends HttpServerTest<Undertow> implements AgentTestTr
           hasNoParent()
           name "HTTP GET"
           kind SpanKind.SERVER
+          status StatusCode.ERROR
 
           event(0) {
             eventName "before-event"


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/2929
An alternative would be to ignore `UNSET` status in sdk.