### PR TITLE
Remove logging of context mismatch which will always be logged.

### DIFF
--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/ContextStorageBridge.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/ContextStorageBridge.java
@@ -59,18 +59,6 @@ public final class ContextStorageBridge extends Context.Storage {
 
   @Override
   public void detach(Context toDetach, Context toRestore) {
-    io.opentelemetry.context.Context otelContext = io.opentelemetry.context.Context.current();
-    Context current = otelContext.get(GRPC_CONTEXT);
-    if (current != toDetach) {
-      // Log a severe message instead of throwing an exception as the context to attach is assumed
-      // to be the correct one and the unbalanced state represents a coding mistake in a lower
-      // layer in the stack that cannot be recovered from here.
-      logger.log(
-          Level.SEVERE,
-          "Context was not attached when detaching",
-          new Throwable().fillInStackTrace());
-    }
-
     Scope scope = OTEL_SCOPE.get(toRestore);
     if (scope == null) {
       logger.log(


### PR DESCRIPTION
Because we return a new context with the scope attached, these references can never match. I thought so when writing the PR but never saw the log messages in tests so assumed I'm missing something, but it's probably because I used JUL for some reason, will fix that in a different PR.

`Scope.close`, or even better `StrictContextStorage` check for unbalanced context detaching themselves, there's no need to have it in the bridge