### PR TITLE
Fix non-unique test case names

### DIFF
--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -291,7 +291,7 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     method << BODY_METHODS
   }
 
-  def "should suppress nested CLIENT span if already under parent CLIENT span"() {
+  def "should suppress nested CLIENT span if already under parent CLIENT span (#method)"() {
     given:
     assumeTrue(testWithClientParent())
 


### PR DESCRIPTION
Fixes errors like this:

```
* What went wrong:
Execution failed for task ':instrumentation:java-http-client:javaagent:test'.
> Received a failure event for test with unknown id '22.22'. Registered test ids: '[:instrumentation:java-http-client:javaagent:test, 22.2, 22.1]'
```