### PR TITLE
Disable smoke tests in release build since we can't run them inline w…

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           job-id: jdk11
           remote-build-cache-proxy-enabled: false
-          arguments: build final closeAndReleaseRepository --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+          arguments: build final closeAndReleaseRepository --stacktrace -x :smoke-tests:test -Prelease.version=${{ github.event.inputs.version }}
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           job-id: jdk11
           remote-build-cache-proxy-enabled: false
-          arguments: build final closeAndReleaseSonatypeStagingRepository --stacktrace -Prelease.version=${{ github.event.inputs.version }}
+          arguments: build final closeAndReleaseSonatypeStagingRepository --stacktrace -x :smoke-tests:test -Prelease.version=${{ github.event.inputs.version }}
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}


### PR DESCRIPTION
…ith other builds effectively.