### PR TITLE
Start migrating Muzzle plugin to Java

### DIFF
--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/muzzle/MuzzleDirective.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/muzzle/MuzzleDirective.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.gradle.muzzle;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+
+public abstract class MuzzleDirective {
+
+  private static final Pattern NORMALIZE_NAME_SLUG = Pattern.compile("[^a-zA-Z0-9]+");
+
+  public MuzzleDirective() {
+    getName().convention("");
+    getSkipVersions().convention(Collections.emptySet());
+    getAdditionalDependencies().convention(Collections.emptyList());
+    getAssertPass().convention(false);
+    getAssertInverse().convention(false);
+    getCoreJdk().convention(false);
+  }
+
+  public abstract Property<String> getName();
+
+  public abstract Property<String> getGroup();
+
+  public abstract Property<String> getModule();
+
+  public abstract Property<String> getVersions();
+
+  public abstract SetProperty<String> getSkipVersions();
+
+  public abstract ListProperty<String> getAdditionalDependencies();
+
+  public abstract Property<Boolean> getAssertPass();
+
+  public abstract Property<Boolean> getAssertInverse();
+
+  public abstract Property<Boolean> getCoreJdk();
+
+  public void coreJdk() {
+    getCoreJdk().set(true);
+  }
+
+  /**
+   * Adds extra dependencies to the current muzzle test.
+   *
+   * @param compileString An extra dependency in the gradle canonical form:
+   *     '<group_id>:<artifact_id>:<version_id>'.
+   */
+  public void extraDependency(String compileString) {
+    getAdditionalDependencies().add(compileString);
+  }
+
+  public void skip(String... version) {
+    getSkipVersions().addAll(version);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    if (getCoreJdk().getOrElse(false)) {
+      if (getAssertPass().getOrElse(false)) {
+        sb.append("Pass");
+      } else {
+        sb.append("Fail");
+      }
+      sb.append("-core-jdk");
+    } else {
+      if (getAssertPass().getOrElse(false)) {
+        sb.append("pass");
+      } else {
+        sb.append("fail");
+      }
+      sb.append(getGroup().get())
+          .append(':')
+          .append(getModule().get())
+          .append(':')
+          .append(getVersions().get());
+    }
+    return sb.toString();
+  }
+
+  String getNameSlug() {
+    return NORMALIZE_NAME_SLUG.matcher(getName().get().trim()).replaceAll("-");
+  }
+
+  Set<String> getNormalizedSkipVersions() {
+    return getSkipVersions().getOrElse(Collections.emptySet()).stream()
+        .map(String::toLowerCase)
+        .collect(Collectors.toSet());
+  }
+}

--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/muzzle/MuzzleExtension.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/muzzle/MuzzleExtension.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.gradle.muzzle;
+
+import javax.inject.Inject;
+import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+
+public abstract class MuzzleExtension {
+
+  private final ObjectFactory objectFactory;
+
+  @Inject
+  public MuzzleExtension(ObjectFactory objectFactory) {
+    this.objectFactory = objectFactory;
+  }
+
+  public abstract ListProperty<MuzzleDirective> getDirectives();
+
+  public void pass(Action<? super MuzzleDirective> action) {
+    MuzzleDirective pass = objectFactory.newInstance(MuzzleDirective.class);
+    action.execute(pass);
+    pass.getAssertPass().set(true);
+    getDirectives().add(pass);
+  }
+
+  public void fail(Action<? super MuzzleDirective> action) {
+    MuzzleDirective fail = objectFactory.newInstance(MuzzleDirective.class);
+    action.execute(fail);
+    fail.getAssertPass().set(false);
+    getDirectives().add(fail);
+  }
+}

--- a/docs/contributing/muzzle.md
+++ b/docs/contributing/muzzle.md
@@ -98,7 +98,7 @@ muzzle {
     // versions from this range are checked
     versions = "[,4.0)"
     // this version is not checked by muzzle
-    skipVersions += '3.1-jenkins-1'
+    skip('3.1-jenkins-1')
   }
   // it is expected that muzzle passes the runtime check for this component
   pass {
@@ -106,8 +106,8 @@ muzzle {
     module = 'spring-webmvc'
     versions = "[3.1.0.RELEASE,]"
     // except these versions
-    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4']
-    skipVersions += '3.2.1.RELEASE'
+    skip('1.2.1', '1.2.2', '1.2.3', '1.2.4')
+    skip('3.2.1.RELEASE')
     // this dependency will be added to the classpath when muzzle check is run
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
     // verify that all other versions - [,3.1.0.RELEASE) in this case - fail the muzzle runtime check

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/couchbase-2.6-javaagent.gradle
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/couchbase-2.6-javaagent.gradle
@@ -6,7 +6,7 @@ muzzle {
     module = 'java-client'
     versions = "[2.6.0,3)"
     // these versions were released as ".bundle" instead of ".jar"
-    skipVersions += ['2.7.5', '2.7.8']
+    skip('2.7.5', '2.7.8')
     assertInverse = true
   }
   fail {

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/couchbase-3.1-javaagent.gradle
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/couchbase-3.1-javaagent.gradle
@@ -6,7 +6,7 @@ muzzle {
     module = "java-client"
     versions = "[3.1,)"
     // these versions were released as ".bundle" instead of ".jar"
-    skipVersions += ['2.7.5', '2.7.8']
+    skip('2.7.5', '2.7.8')
     assertInverse = true
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/elasticsearch-transport-5.0-javaagent.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/elasticsearch-transport-5.0-javaagent.gradle
@@ -7,7 +7,7 @@ muzzle {
     versions = "[5.0.0,5.3.0)"
     // version 7.11.0 depends on org.elasticsearch:elasticsearch:7.11.0 which depends on
     // org.elasticsearch:elasticsearch-plugin-classloader:7.11.0 which does not exist
-    skipVersions += ['7.11.0']
+    skip('7.11.0')
     assertInverse = true
   }
   pass {
@@ -16,7 +16,7 @@ muzzle {
     versions = "[5.0.0,5.3.0)"
     // version 7.11.0 depends on org.elasticsearch:elasticsearch:7.11.0 which depends on
     // org.elasticsearch:elasticsearch-plugin-classloader:7.11.0 which does not exist
-    skipVersions += ['7.11.0']
+    skip('7.11.0')
     assertInverse = true
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/elasticsearch-transport-5.3-javaagent.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/elasticsearch-transport-5.3-javaagent.gradle
@@ -7,7 +7,7 @@ muzzle {
     versions = "[5.3.0,6.0.0)"
     // version 7.11.0 depends on org.elasticsearch:elasticsearch:7.11.0 which depends on
     // org.elasticsearch:elasticsearch-plugin-classloader:7.11.0 which does not exist
-    skipVersions += ['7.11.0']
+    skip('7.11.0')
     assertInverse = true
   }
   pass {
@@ -16,7 +16,7 @@ muzzle {
     versions = "[5.3.0,6.0.0)"
     // version 7.11.0 depends on org.elasticsearch:elasticsearch-plugin-classloader:7.11.0
     // which does not exist
-    skipVersions += ['7.11.0']
+    skip('7.11.0')
     assertInverse = true
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/elasticsearch-transport-6.0-javaagent.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/elasticsearch-transport-6.0-javaagent.gradle
@@ -7,7 +7,7 @@ muzzle {
     versions = "[6.0.0,)"
     // version 7.11.0 depends on org.elasticsearch:elasticsearch:7.11.0 which depends on
     // org.elasticsearch:elasticsearch-plugin-classloader:7.11.0 which does not exist
-    skipVersions += ['7.11.0']
+    skip('7.11.0')
     assertInverse = true
   }
   pass {
@@ -16,7 +16,7 @@ muzzle {
     versions = "[6.0.0,)"
     // version 7.11.0 depends on org.elasticsearch:elasticsearch:7.11.0 which depends on
     // org.elasticsearch:elasticsearch-plugin-classloader:7.11.0 which does not exist
-    skipVersions += ['7.11.0']
+    skip('7.11.0')
     assertInverse = true
   }
 }

--- a/instrumentation/grails-3.0/javaagent/grails-3.0-javaagent.gradle
+++ b/instrumentation/grails-3.0/javaagent/grails-3.0-javaagent.gradle
@@ -9,7 +9,7 @@ muzzle {
     // which (obviously) does not exist
     // version 3.3.6 depends on org.grails:grails-datastore-core:6.1.10.BUILD-SNAPSHOT
     // which (also obviously) does not exist
-    skipVersions += ['3.1.15', '3.3.6']
+    skip('3.1.15', '3.3.6')
     assertInverse = true
   }
 }

--- a/instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent/jaxws-2.0-axis2-1.6-javaagent.gradle
+++ b/instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent/jaxws-2.0-axis2-1.6-javaagent.gradle
@@ -10,7 +10,7 @@ muzzle {
     // which depends on org.apache.neethi:neethi:2.0.1 which does not exist
     // version 1.3 depends on org.apache.axis2:axis2-kernel:1.3
     // which depends on org.apache.woden:woden:1.0-incubating-M7b which does not exist
-    skipVersions += ['1.2', '1.3']
+    skip('1.2', '1.3')
   }
 }
 

--- a/instrumentation/jaxws/jaxws-2.0-metro-2.2/javaagent/jaxws-2.0-metro-2.2-javaagent.gradle
+++ b/instrumentation/jaxws/jaxws-2.0-metro-2.2/javaagent/jaxws-2.0-metro-2.2-javaagent.gradle
@@ -6,7 +6,7 @@ muzzle {
     module = "jaxws-rt"
     versions = "[2.2.0.1,3)"
     // version 2.3.4 depends on org.glassfish.gmbal:gmbal-api-only:4.0.3 which does not exist
-    skipVersions += "2.3.4"
+    skip('2.3.4')
     assertInverse = true
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
   }

--- a/instrumentation/jsp-2.3/javaagent/jsp-2.3-javaagent.gradle
+++ b/instrumentation/jsp-2.3/javaagent/jsp-2.3-javaagent.gradle
@@ -8,7 +8,7 @@ muzzle {
     // tomcat 10 uses JSP 3.0
     versions = "[7.0.19,10)"
     // version 8.0.9 depends on org.eclipse.jdt.core.compiler:ecj:4.4RC4 which does not exist
-    skipVersions += '8.0.9'
+    skip('8.0.9')
   }
 }
 

--- a/instrumentation/log4j/log4j-1.2/javaagent/log4j-1.2-javaagent.gradle
+++ b/instrumentation/log4j/log4j-1.2/javaagent/log4j-1.2-javaagent.gradle
@@ -6,7 +6,7 @@ muzzle {
     module = "log4j"
     versions = "[1.2,)"
     // version 1.2.15 has a bad dependency on javax.jms:jms:1.1 which was released as pom only
-    skipVersions += '1.2.15'
+    skip('1.2.15')
   }
 }
 

--- a/instrumentation/play-ws/play-ws-2.0/javaagent/play-ws-2.0-javaagent.gradle
+++ b/instrumentation/play-ws/play-ws-2.0/javaagent/play-ws-2.0-javaagent.gradle
@@ -14,7 +14,7 @@ muzzle {
     module = 'play-ahc-ws-standalone_2.12'
     versions = '[2.0.0,2.1.0)'
     // 2.0.5 is missing play.shaded.ahc.org.asynchttpclient.AsyncHandler#onTlsHandshakeSuccess()V
-    skipVersions += '2.0.5'
+    skip('2.0.5')
     assertInverse = true
   }
 

--- a/instrumentation/play-ws/play-ws-2.1/javaagent/play-ws-2.1-javaagent.gradle
+++ b/instrumentation/play-ws/play-ws-2.1/javaagent/play-ws-2.1-javaagent.gradle
@@ -12,7 +12,7 @@ muzzle {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.12'
     versions = '[2.1.0,]'
-    skipVersions += '2.0.5' // muzzle passes but expecting failure, see play-ws-2.0-javaagent.gradle
+    skip('2.0.5') // muzzle passes but expecting failure, see play-ws-2.0-javaagent.gradle
     assertInverse = true
   }
 
@@ -20,7 +20,7 @@ muzzle {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.13'
     versions = '[2.1.0,]'
-    skipVersions += '2.0.5' // muzzle passes but expecting failure, see play-ws-2.0-javaagent.gradle
+    skip('2.0.5') // muzzle passes but expecting failure, see play-ws-2.0-javaagent.gradle
     assertInverse = true
   }
 }

--- a/instrumentation/play/play-2.4/javaagent/play-2.4-javaagent.gradle
+++ b/instrumentation/play/play-2.4/javaagent/play-2.4-javaagent.gradle
@@ -13,7 +13,7 @@ muzzle {
     assertInverse = true
     // versions 2.3.9 and 2.3.10 depends on com.typesafe.netty:netty-http-pipelining:1.1.2
     // which does not exist
-    skipVersions += ['2.3.9', '2.3.10']
+    skip('2.3.9', '2.3.10')
   }
   fail {
     group = 'com.typesafe.play'

--- a/instrumentation/play/play-2.6/javaagent/play-2.6-javaagent.gradle
+++ b/instrumentation/play/play-2.6/javaagent/play-2.6-javaagent.gradle
@@ -16,7 +16,7 @@ muzzle {
     assertInverse = true
     // versions 2.3.9 and 2.3.10 depends on com.typesafe.netty:netty-http-pipelining:1.1.2
     // which does not exist
-    skipVersions += ['2.3.9', '2.3.10']
+    skip('2.3.9', '2.3.10')
   }
   pass {
     group = 'com.typesafe.play'

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/rxjava-2.0-javaagent.gradle
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/rxjava-2.0-javaagent.gradle
@@ -5,7 +5,7 @@ muzzle {
     group = "io.reactivex.rxjava2"
     module = "rxjava"
     versions = "[2.0.6,)"
-    assertInverse true
+    assertInverse = true
   }
 }
 

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/rxjava-3.0-javaagent.gradle
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/rxjava-3.0-javaagent.gradle
@@ -5,7 +5,7 @@ muzzle {
     group = "io.reactivex.rxjava3"
     module = "rxjava"
     versions = "[3.0.0,)"
-    assertInverse true
+    assertInverse = true
   }
 }
 

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/spring-webmvc-3.1-javaagent.gradle
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/spring-webmvc-3.1-javaagent.gradle
@@ -7,9 +7,9 @@ muzzle {
     versions = "[3.1.0.RELEASE,]"
     // these versions depend on org.springframework:spring-web which has a bad dependency on
     // javax.faces:jsf-api:1.1 which was released as pom only
-    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4']
+    skip('1.2.1', '1.2.2', '1.2.3', '1.2.4')
     // 3.2.1.RELEASE has transitive dependencies like spring-web as "provided" instead of "compile"
-    skipVersions += '3.2.1.RELEASE'
+    skip('3.2.1.RELEASE')
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
     assertInverse = true
   }
@@ -21,7 +21,7 @@ muzzle {
     versions = "[,]"
     // these versions depend on org.springframework:spring-web which has a bad dependency on
     // javax.faces:jsf-api:1.1 which was released as pom only
-    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4']
+    skip('1.2.1', '1.2.2', '1.2.3', '1.2.4')
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
   }
 }


### PR DESCRIPTION
When working on lazy configuration, it was painful to not have good compile time checking of muzzle plugin. Since we'll want to publish it to plugin portal, switching to Java so its same code as all our others seems like a good direction. I've migrated the extension objects in this one and will follow up with migrating Plugin.

While migrating, I switched to Gradle's modern `Property` API