### PR TITLE
A small test cleanup

### DIFF
--- a/instrumentation/jaxws/jaxws-2.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/jaxws/v2_0/JaxWsAnnotationsTest.groovy
+++ b/instrumentation/jaxws/jaxws-2.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/jaxws/v2_0/JaxWsAnnotationsTest.groovy
@@ -15,7 +15,7 @@ class JaxWsAnnotationsTest extends AgentInstrumentationSpecification {
     new SoapProvider().invoke(null)
 
     then:
-    assertTraces(1, {
+    assertTraces(1) {
       trace(0, 1) {
         span(0) {
           name 'SoapProvider.invoke'
@@ -25,6 +25,6 @@ class JaxWsAnnotationsTest extends AgentInstrumentationSpecification {
           }
         }
       }
-    })
+    }
   }
 }

--- a/instrumentation/jaxws/jws-1.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/jaxws/jws/v1_1/JwsAnnotationsTest.groovy
+++ b/instrumentation/jaxws/jws-1.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/jaxws/jws/v1_1/JwsAnnotationsTest.groovy
@@ -20,7 +20,7 @@ class JwsAnnotationsTest extends AgentInstrumentationSpecification {
     new WebServiceClass().doSomethingProtected()
 
     then:
-    assertTraces(1, {
+    assertTraces(1) {
       trace(0, 1) {
         span(0) {
           name "WebServiceClass.doSomethingPublic"
@@ -30,7 +30,7 @@ class JwsAnnotationsTest extends AgentInstrumentationSpecification {
           }
         }
       }
-    })
+    }
   }
 
   def "WebService via interface generates spans only for methods of the interface"() {
@@ -40,7 +40,7 @@ class JwsAnnotationsTest extends AgentInstrumentationSpecification {
     new WebServiceFromInterface().notPartOfAnything()
 
     then:
-    assertTraces(1, {
+    assertTraces(1) {
       trace(0, 1) {
         span(0) {
           name "WebServiceFromInterface.partOfPublicInterface"
@@ -50,7 +50,7 @@ class JwsAnnotationsTest extends AgentInstrumentationSpecification {
           }
         }
       }
-    })
+    }
   }
 
   def "WebService via proxy must have span attributes from actual implementation"() {
@@ -64,7 +64,7 @@ class JwsAnnotationsTest extends AgentInstrumentationSpecification {
 
     then:
     proxy.getClass() != WebServiceFromInterface
-    assertTraces(1, {
+    assertTraces(1) {
       trace(0, 1) {
         span(0) {
           name "WebServiceFromInterface.partOfPublicInterface"
@@ -74,6 +74,6 @@ class JwsAnnotationsTest extends AgentInstrumentationSpecification {
           }
         }
       }
-    })
+    }
   }
 }

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
@@ -162,7 +162,7 @@ class Jms2Test extends AgentInstrumentationSpecification {
     expect:
     receivedMessage == null
     // span is not created if no message is received
-    assertTraces(0, {})
+    assertTraces(0) {}
 
     cleanup:
     consumer.close()
@@ -183,7 +183,7 @@ class Jms2Test extends AgentInstrumentationSpecification {
     expect:
     receivedMessage == null
     // span is not created if no message is received
-    assertTraces(0, {})
+    assertTraces(0) {}
 
     cleanup:
     consumer.close()

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
@@ -137,7 +137,7 @@ class Jms1Test extends AgentInstrumentationSpecification {
     expect:
     receivedMessage == null
     // span is not created if no message is received
-    assertTraces(0, {})
+    assertTraces(0) {}
 
     cleanup:
     consumer.close()
@@ -158,7 +158,7 @@ class Jms1Test extends AgentInstrumentationSpecification {
     expect:
     receivedMessage == null
     // span is not created if no message is received
-    assertTraces(0, {})
+    assertTraces(0) {}
 
     cleanup:
     consumer.close()


### PR DESCRIPTION
There are only places that pass the spec to `assertTraces` inside the parentheses instead of after