### PR TITLE
Remove span isRecording check from servlet advice

### DIFF
--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Advice.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Advice.java
@@ -11,6 +11,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.servlet.AppServerBridge;
 import io.opentelemetry.instrumentation.api.servlet.MappingResolver;
+import io.opentelemetry.instrumentation.api.tracer.ServerSpan;
 import io.opentelemetry.javaagent.instrumentation.api.CallDepthThreadLocalMap;
 import io.opentelemetry.javaagent.instrumentation.api.InstrumentationContext;
 import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
@@ -62,8 +63,7 @@ public class Servlet3Advice {
     }
 
     Context currentContext = Java8BytecodeBridge.currentContext();
-    if (attachedContext != null
-        || Java8BytecodeBridge.spanFromContext(currentContext).isRecording()) {
+    if (attachedContext != null || ServerSpan.fromContextOrNull(currentContext) != null) {
       // Update context with info from current request to ensure that server span gets the best
       // possible name.
       // In case server span was created by app server instrumentations calling updateContext

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/service/JakartaServletServiceAdvice.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/service/JakartaServletServiceAdvice.java
@@ -11,6 +11,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.servlet.AppServerBridge;
 import io.opentelemetry.instrumentation.api.servlet.MappingResolver;
+import io.opentelemetry.instrumentation.api.tracer.ServerSpan;
 import io.opentelemetry.javaagent.instrumentation.api.CallDepthThreadLocalMap;
 import io.opentelemetry.javaagent.instrumentation.api.InstrumentationContext;
 import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
@@ -63,8 +64,7 @@ public class JakartaServletServiceAdvice {
     }
 
     Context currentContext = Java8BytecodeBridge.currentContext();
-    if (attachedContext != null
-        || Java8BytecodeBridge.spanFromContext(currentContext).isRecording()) {
+    if (attachedContext != null || ServerSpan.fromContextOrNull(currentContext) != null) {
       // Update context with info from current request to ensure that server span gets the best
       // possible name.
       // In case server span was created by app server instrumentations calling updateContext


### PR DESCRIPTION
As far as I understand with sampling it is possible that there is a server span but it is not recording. Remove `isRecording` check so that we wouldn't create a new server span when sampling has decided not to record for the initial server span.