### PR TITLE
Change a couple of Longs to Integers in Instrumenter API

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpAttributesExtractor.java
@@ -43,7 +43,10 @@ public abstract class HttpAttributesExtractor<REQUEST, RESPONSE>
         attributes,
         SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
         requestContentLengthUncompressed(request, response));
-    set(attributes, SemanticAttributes.HTTP_STATUS_CODE, statusCode(request, response));
+    Integer statusCode = statusCode(request, response);
+    if (statusCode != null) {
+      set(attributes, SemanticAttributes.HTTP_STATUS_CODE, (long) statusCode);
+    }
     set(attributes, SemanticAttributes.HTTP_FLAVOR, flavor(request, response));
     set(
         attributes,
@@ -89,7 +92,7 @@ public abstract class HttpAttributesExtractor<REQUEST, RESPONSE>
   protected abstract Long requestContentLengthUncompressed(REQUEST request, RESPONSE response);
 
   @Nullable
-  protected abstract Long statusCode(REQUEST request, RESPONSE response);
+  protected abstract Integer statusCode(REQUEST request, RESPONSE response);
 
   @Nullable
   protected abstract String flavor(REQUEST request, RESPONSE response);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractor.java
@@ -36,9 +36,9 @@ public final class HttpSpanStatusExtractor<REQUEST, RESPONSE>
 
   @Override
   public StatusCode extract(REQUEST request, RESPONSE response, Throwable error) {
-    Long statusCode = attributesExtractor.statusCode(request, response);
+    Integer statusCode = attributesExtractor.statusCode(request, response);
     if (statusCode != null) {
-      return HttpStatusConverter.statusFromHttpStatus(statusCode.intValue());
+      return HttpStatusConverter.statusFromHttpStatus(statusCode);
     }
     return SpanStatusExtractor.getDefault().extract(request, response, error);
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetAttributesExtractor.java
@@ -42,12 +42,12 @@ public abstract class InetSocketAddressNetAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   @Nullable
-  protected final Long peerPort(REQUEST request, @Nullable RESPONSE response) {
+  protected final Integer peerPort(REQUEST request, @Nullable RESPONSE response) {
     InetSocketAddress address = getAddress(request, response);
     if (address == null) {
       return null;
     }
-    return (long) address.getPort();
+    return address.getPort();
   }
 
   @Override

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetAttributesExtractor.java
@@ -24,14 +24,20 @@ public abstract class NetAttributesExtractor<REQUEST, RESPONSE>
     set(attributes, SemanticAttributes.NET_TRANSPORT, transport(request));
     set(attributes, SemanticAttributes.NET_PEER_IP, peerIp(request, null));
     set(attributes, SemanticAttributes.NET_PEER_NAME, peerName(request, null));
-    set(attributes, SemanticAttributes.NET_PEER_PORT, peerPort(request, null));
+    Integer peerPort = peerPort(request, null);
+    if (peerPort != null) {
+      set(attributes, SemanticAttributes.NET_PEER_PORT, (long) peerPort);
+    }
   }
 
   @Override
   protected final void onEnd(AttributesBuilder attributes, REQUEST request, RESPONSE response) {
     set(attributes, SemanticAttributes.NET_PEER_IP, peerIp(request, response));
     set(attributes, SemanticAttributes.NET_PEER_NAME, peerName(request, response));
-    set(attributes, SemanticAttributes.NET_PEER_PORT, peerPort(request, response));
+    Integer peerPort = peerPort(request, response);
+    if (peerPort != null) {
+      set(attributes, SemanticAttributes.NET_PEER_PORT, (long) peerPort);
+    }
   }
 
   @Nullable
@@ -51,7 +57,7 @@ public abstract class NetAttributesExtractor<REQUEST, RESPONSE>
    * phases of processing.
    */
   @Nullable
-  protected abstract Long peerPort(REQUEST request, @Nullable RESPONSE response);
+  protected abstract Integer peerPort(REQUEST request, @Nullable RESPONSE response);
 
   /**
    * This method will be called twice: both when the request starts ({@code response} is always null

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpAttributesExtractorTest.java
@@ -67,8 +67,8 @@ class HttpAttributesExtractorTest {
     }
 
     @Override
-    protected Long statusCode(Map<String, String> request, Map<String, String> response) {
-      return Long.parseLong(response.get("statusCode"));
+    protected Integer statusCode(Map<String, String> request, Map<String, String> response) {
+      return Integer.parseInt(response.get("statusCode"));
     }
 
     @Override

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractorTest.java
@@ -25,19 +25,19 @@ class HttpSpanStatusExtractorTest {
   @Mock private HttpAttributesExtractor<Map<String, String>, Map<String, String>> extractor;
 
   @ParameterizedTest
-  @ValueSource(longs = {1, 100, 101, 200, 201, 300, 301, 400, 401, 500, 501, 600, 601})
-  void hasStatus(long statusCode) {
+  @ValueSource(ints = {1, 100, 101, 200, 201, 300, 301, 400, 401, 500, 501, 600, 601})
+  void hasStatus(int statusCode) {
     when(extractor.statusCode(anyMap(), anyMap())).thenReturn(statusCode);
 
     assertThat(
             HttpSpanStatusExtractor.create(extractor)
                 .extract(Collections.emptyMap(), Collections.emptyMap(), null))
-        .isEqualTo(HttpStatusConverter.statusFromHttpStatus((int) statusCode));
+        .isEqualTo(HttpStatusConverter.statusFromHttpStatus(statusCode));
   }
 
   @ParameterizedTest
-  @ValueSource(longs = {1, 100, 101, 200, 201, 300, 301, 400, 401, 500, 501, 600, 601})
-  void hasStatus_ignoresException(long statusCode) {
+  @ValueSource(ints = {1, 100, 101, 200, 201, 300, 301, 400, 401, 500, 501, 600, 601})
+  void hasStatus_ignoresException(int statusCode) {
     when(extractor.statusCode(anyMap(), anyMap())).thenReturn(statusCode);
 
     // Presence of exception has no effect.
@@ -45,7 +45,7 @@ class HttpSpanStatusExtractorTest {
             HttpSpanStatusExtractor.create(extractor)
                 .extract(
                     Collections.emptyMap(), Collections.emptyMap(), new IllegalStateException()))
-        .isEqualTo(HttpStatusConverter.statusFromHttpStatus((int) statusCode));
+        .isEqualTo(HttpStatusConverter.statusFromHttpStatus(statusCode));
   }
 
   @Test

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetAttributesExtractorTest.java
@@ -34,11 +34,11 @@ class NetAttributesExtractorTest {
     }
 
     @Override
-    protected Long peerPort(Map<String, String> request, Map<String, String> response) {
+    protected Integer peerPort(Map<String, String> request, Map<String, String> response) {
       if (response != null) {
-        return Long.valueOf(response.get("peerPort"));
+        return Integer.valueOf(response.get("peerPort"));
       }
-      return Long.valueOf(request.get("peerPort"));
+      return Integer.valueOf(request.get("peerPort"));
     }
 
     @Override

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -75,9 +75,9 @@ final class ApacheHttpClientHttpAttributesExtractor
 
   @Override
   @Nullable
-  protected Long statusCode(HttpMethod httpMethod, Void unused) {
+  protected Integer statusCode(HttpMethod httpMethod, Void unused) {
     StatusLine statusLine = httpMethod.getStatusLine();
-    return statusLine == null ? null : (long) statusLine.getStatusCode();
+    return statusLine == null ? null : statusLine.getStatusCode();
   }
 
   @Override

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesExtractor.java
@@ -26,9 +26,9 @@ final class ApacheHttpClientNetAttributesExtractor
   }
 
   @Override
-  protected @Nullable Long peerPort(HttpMethod httpMethod, @Nullable Void unused) {
+  protected @Nullable Integer peerPort(HttpMethod httpMethod, @Nullable Void unused) {
     HostConfiguration hostConfiguration = httpMethod.getHostConfiguration();
-    return hostConfiguration != null ? (long) hostConfiguration.getPort() : null;
+    return hostConfiguration != null ? hostConfiguration.getPort() : null;
   }
 
   @Override

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpAttributesExtractor.java
@@ -65,10 +65,10 @@ final class ArmeriaHttpAttributesExtractor
 
   @Override
   @Nullable
-  protected Long statusCode(RequestContext ctx, RequestLog requestLog) {
+  protected Integer statusCode(RequestContext ctx, RequestLog requestLog) {
     HttpStatus status = requestLog.responseHeaders().status();
     if (!status.equals(HttpStatus.UNKNOWN)) {
-      return (long) status.code();
+      return status.code();
     }
     return null;
   }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcNetAttributesExtractor.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcNetAttributesExtractor.java
@@ -24,9 +24,8 @@ final class JdbcNetAttributesExtractor extends NetAttributesExtractor<DbRequest,
 
   @Nullable
   @Override
-  protected Long peerPort(DbRequest request, @Nullable Void response) {
-    Integer port = request.getDbInfo().getPort();
-    return port == null ? null : port.longValue();
+  protected Integer peerPort(DbRequest request, @Nullable Void response) {
+    return request.getDbInfo().getPort();
   }
 
   @Nullable


### PR DESCRIPTION
These two methods feel like they should return `Integer`, and it also makes implementing them a bit easier:

```
protected abstract Long peerPort(REQUEST request, RESPONSE response);

protected abstract Long statusCode(REQUEST request, RESPONSE response);
```