### PR TITLE
Do not use arrays in InstrumentationModule

### DIFF
--- a/docs/contributing/writing-instrumentation-module.md
+++ b/docs/contributing/writing-instrumentation-module.md
@@ -81,8 +81,8 @@ service provider files, but it needs to be told which ones explicitly:
 
 ```java
 @Override
-public String[] helperResourceNames() {
-  return new String[] {"META-INF/services/org.my.library.SpiClass"};
+public List<String> helperResourceNames() {
+  return singletonList("META-INF/services/org.my.library.SpiClass");
 }
 ```
 

--- a/instrumentation/apache-dubbo/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/DubboInstrumentationModule.java
+++ b/instrumentation/apache-dubbo/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/DubboInstrumentationModule.java
@@ -6,13 +6,13 @@
 package io.opentelemetry.javaagent.instrumentation.apachedubbo.v2_7;
 
 import static io.opentelemetry.javaagent.extension.matcher.ClassLoaderMatcher.hasClassesNamed;
+import static java.util.Collections.singletonList;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import java.util.Collections;
 import java.util.List;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -24,10 +24,8 @@ public class DubboInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
-  public String[] helperResourceNames() {
-    return new String[] {
-      "META-INF/services/org.apache.dubbo.rpc.Filter",
-    };
+  public List<String> helperResourceNames() {
+    return singletonList("META-INF/services/org.apache.dubbo.rpc.Filter");
   }
 
   @Override
@@ -37,7 +35,7 @@ public class DubboInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return Collections.singletonList(new ResourceInjectingTypeInstrumentation());
+    return singletonList(new ResourceInjectingTypeInstrumentation());
   }
 
   // A type instrumentation is needed to trigger resource injection.

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsSdkInstrumentationModule.java
@@ -6,13 +6,13 @@
 package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
 
 import static io.opentelemetry.javaagent.extension.matcher.ClassLoaderMatcher.hasClassesNamed;
+import static java.util.Collections.singletonList;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import java.util.Collections;
 import java.util.List;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -33,10 +33,8 @@ public class AwsSdkInstrumentationModule extends InstrumentationModule {
    * service loading mechanism to pick it up.
    */
   @Override
-  public String[] helperResourceNames() {
-    return new String[] {
-      "software/amazon/awssdk/global/handlers/execution.interceptors",
-    };
+  public List<String> helperResourceNames() {
+    return singletonList("software/amazon/awssdk/global/handlers/execution.interceptors");
   }
 
   @Override
@@ -48,7 +46,7 @@ public class AwsSdkInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return Collections.singletonList(new ResourceInjectingTypeInstrumentation());
+    return singletonList(new ResourceInjectingTypeInstrumentation());
   }
 
   // A type instrumentation is needed to trigger resource injection.

--- a/instrumentation/internal/internal-class-loader/javaagent-integration-tests/src/main/java/instrumentation/TestInstrumentationModule.java
+++ b/instrumentation/internal/internal-class-loader/javaagent-integration-tests/src/main/java/instrumentation/TestInstrumentationModule.java
@@ -29,8 +29,8 @@ public class TestInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
-  public String[] helperResourceNames() {
-    return new String[] {"test-resources/test-resource.txt"};
+  public List<String> helperResourceNames() {
+    return singletonList("test-resources/test-resource.txt");
   }
 
   public static class TestTypeInstrumentation implements TypeInstrumentation {

--- a/instrumentation/log4j/log4j-2.13.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v2_13_2/Log4j2InstrumentationModule.java
+++ b/instrumentation/log4j/log4j-2.13.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/v2_13_2/Log4j2InstrumentationModule.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.log4j.v2_13_2;
 
 import static io.opentelemetry.javaagent.extension.matcher.ClassLoaderMatcher.hasClassesNamed;
+import static java.util.Collections.singletonList;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
@@ -24,10 +25,9 @@ public class Log4j2InstrumentationModule extends InstrumentationModule {
   }
 
   @Override
-  public String[] helperResourceNames() {
-    return new String[] {
-      "META-INF/services/org.apache.logging.log4j.core.util.ContextDataProvider",
-    };
+  public List<String> helperResourceNames() {
+    return singletonList(
+        "META-INF/services/org.apache.logging.log4j.core.util.ContextDataProvider");
   }
 
   @Override

--- a/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodInstrumentationModule.java
+++ b/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodInstrumentationModule.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.methods;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 import com.google.auto.service.AutoService;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -47,10 +50,10 @@ public class MethodInstrumentationModule extends InstrumentationModule {
   // the default configuration has empty "otel.instrumentation.methods.include", and so doesn't
   // generate any TypeInstrumentation for muzzle to analyze
   @Override
-  public String[] getMuzzleHelperClassNames() {
+  public List<String> getMuzzleHelperClassNames() {
     return typeInstrumentations.isEmpty()
-        ? new String[0]
-        : new String[] {"io.opentelemetry.javaagent.instrumentation.methods.MethodTracer"};
+        ? emptyList()
+        : singletonList("io.opentelemetry.javaagent.instrumentation.methods.MethodTracer");
   }
 
   @Override

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
@@ -31,9 +31,6 @@ import net.bytebuddy.matcher.ElementMatcher;
  * java.util.ServiceLoader} for more details.
  */
 public abstract class InstrumentationModule {
-  private static final String[] EMPTY = new String[0];
-  private static final ClassRef[] EMPTY_REFS = new ClassRef[0];
-
   private static final boolean DEFAULT_ENABLED =
       Config.get().getBooleanProperty("otel.instrumentation.common.default-enabled", true);
 
@@ -128,9 +125,9 @@ public abstract class InstrumentationModule {
     return false;
   }
 
-  /** Returns resource names to inject into the user's classloader. */
-  public String[] helperResourceNames() {
-    return EMPTY;
+  /** Returns a list of resource names to inject into the user's classloader. */
+  public List<String> helperResourceNames() {
+    return Collections.emptyList();
   }
 
   /**
@@ -152,8 +149,8 @@ public abstract class InstrumentationModule {
   public abstract List<TypeInstrumentation> typeInstrumentations();
 
   /**
-   * Returns a list of references to helper and library classes used in this module's type
-   * instrumentation advices.
+   * Returns references to helper and library classes used in this module's type instrumentation
+   * advices, grouped by {@link ClassRef#getClassName()}.
    *
    * <p>The actual implementation of this method is generated automatically during compilation by
    * the {@code io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin}
@@ -162,8 +159,8 @@ public abstract class InstrumentationModule {
    * <p><b>This method is generated automatically</b>: if you override it, the muzzle compile plugin
    * will not generate a new implementation, it will leave the existing one.
    */
-  public ClassRef[] getMuzzleReferences() {
-    return EMPTY_REFS;
+  public Map<String, ClassRef> getMuzzleReferences() {
+    return Collections.emptyMap();
   }
 
   /**
@@ -177,8 +174,8 @@ public abstract class InstrumentationModule {
    * <p><b>This method is generated automatically</b>: if you override it, the muzzle compile plugin
    * will not generate a new implementation, it will leave the existing one.
    */
-  public String[] getMuzzleHelperClassNames() {
-    return EMPTY;
+  public List<String> getMuzzleHelperClassNames() {
+    return Collections.emptyList();
   }
 
   /**

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.tooling.instrumentation;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.failSafe;
-import static java.util.Arrays.asList;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -49,8 +48,8 @@ public final class InstrumentationModuleInstaller {
       log.debug("Instrumentation {} is disabled", instrumentationModule.instrumentationName());
       return parentAgentBuilder;
     }
-    List<String> helperClassNames = asList(instrumentationModule.getMuzzleHelperClassNames());
-    List<String> helperResourceNames = asList(instrumentationModule.helperResourceNames());
+    List<String> helperClassNames = instrumentationModule.getMuzzleHelperClassNames();
+    List<String> helperResourceNames = instrumentationModule.helperResourceNames();
     List<TypeInstrumentation> typeInstrumentations = instrumentationModule.typeInstrumentations();
     if (typeInstrumentations.isEmpty()) {
       if (!helperClassNames.isEmpty() || !helperResourceNames.isEmpty()) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/collector/MuzzleCodeGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/collector/MuzzleCodeGenerator.java
@@ -358,7 +358,7 @@ class MuzzleCodeGenerator implements AsmVisitorWrapper {
       // stack: map, map
       // pass bigger size to avoid resizes; same formula as in e.g. HashSet(Collection)
       // 0.75 is the default load factor
-      mv.visitLdcInsn((size / 0.75f) + 1);
+      mv.visitLdcInsn((int) (size / 0.75f) + 1);
       // stack: map, map, size
       mv.visitLdcInsn(0.75f);
       // stack: map, map, size, loadFactor

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.tooling.muzzle.matcher;
 
 import static java.lang.System.lineSeparator;
-import static java.util.Arrays.asList;
 
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.muzzle.ClassRef;
@@ -56,7 +55,7 @@ public final class MuzzleGradlePluginUtil {
         ServiceLoader.load(InstrumentationModule.class, agentClassLoader)) {
       ReferenceMatcher muzzle =
           new ReferenceMatcher(
-              asList(instrumentationModule.getMuzzleHelperClassNames()),
+              instrumentationModule.getMuzzleHelperClassNames(),
               instrumentationModule.getMuzzleReferences(),
               instrumentationModule::isHelperClass);
       List<Mismatch> mismatches = muzzle.getMismatchedReferenceSources(userClassLoader);
@@ -95,7 +94,7 @@ public final class MuzzleGradlePluginUtil {
           ServiceLoader.load(InstrumentationModule.class, agentClassLoader)) {
         try {
           // verify helper injector works
-          List<String> allHelperClasses = asList(instrumentationModule.getMuzzleHelperClassNames());
+          List<String> allHelperClasses = instrumentationModule.getMuzzleHelperClassNames();
           if (!allHelperClasses.isEmpty()) {
             new HelperInjector(
                     MuzzleGradlePluginUtil.class.getSimpleName(),
@@ -138,7 +137,7 @@ public final class MuzzleGradlePluginUtil {
         ServiceLoader.load(InstrumentationModule.class, instrumentationClassLoader)) {
       try {
         System.out.println(instrumentationModule.getClass().getName());
-        for (ClassRef ref : instrumentationModule.getMuzzleReferences()) {
+        for (ClassRef ref : instrumentationModule.getMuzzleReferences().values()) {
           System.out.print(prettyPrint(ref));
         }
       } catch (Exception e) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
@@ -21,7 +21,6 @@ import io.opentelemetry.javaagent.tooling.muzzle.matcher.HelperReferenceWrapper.
 import io.opentelemetry.javaagent.tooling.muzzle.matcher.HelperReferenceWrapper.Method;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -45,12 +44,9 @@ public final class ReferenceMatcher {
 
   public ReferenceMatcher(
       List<String> helperClassNames,
-      ClassRef[] references,
+      Map<String, ClassRef> references,
       Predicate<String> libraryInstrumentationPredicate) {
-    this.references = new HashMap<>(references.length);
-    for (ClassRef reference : references) {
-      this.references.put(reference.getClassName(), reference);
-    }
+    this.references = references;
     this.helperClassNames = new HashSet<>(helperClassNames);
     this.instrumentationClassPredicate =
         new InstrumentationClassPredicate(libraryInstrumentationPredicate);

--- a/testing-common/src/test/groovy/muzzle/ReferenceMatcherTest.groovy
+++ b/testing-common/src/test/groovy/muzzle/ReferenceMatcherTest.groovy
@@ -54,7 +54,7 @@ class ReferenceMatcherTest extends Specification {
     setup:
     def collector = new ReferenceCollector({ false })
     collector.collectReferencesFromAdvice(MethodBodyAdvice.name)
-    def refMatcher = createMatcher(collector.getReferences().values())
+    def refMatcher = createMatcher(collector.getReferences())
 
     expect:
     getMismatchClassSet(refMatcher.getMismatchedReferenceSources(safeClasspath)).empty
@@ -92,8 +92,8 @@ class ReferenceMatcherTest extends Specification {
     def collector = new ReferenceCollector({ false })
     collector.collectReferencesFromAdvice(MethodBodyAdvice.name)
 
-    def refMatcher1 = createMatcher(collector.getReferences().values())
-    def refMatcher2 = createMatcher(collector.getReferences().values())
+    def refMatcher1 = createMatcher(collector.getReferences())
+    def refMatcher2 = createMatcher(collector.getReferences())
     assert getMismatchClassSet(refMatcher1.getMismatchedReferenceSources(cl)).empty
     int countAfterFirstMatch = cl.count
     // the second matcher should be able to used cached type descriptions from the first
@@ -110,7 +110,7 @@ class ReferenceMatcherTest extends Specification {
       .build()
 
     when:
-    def mismatches = createMatcher([ref]).getMismatchedReferenceSources(this.class.classLoader)
+    def mismatches = createMatcher([(ref.className): ref]).getMismatchedReferenceSources(this.class.classLoader)
 
     then:
     getMismatchClassSet(mismatches) == expectedMismatches as Set
@@ -129,7 +129,7 @@ class ReferenceMatcherTest extends Specification {
       .build()
 
     when:
-    def mismatches = createMatcher([reference])
+    def mismatches = createMatcher([(reference.className): reference])
       .getMismatchedReferenceSources(this.class.classLoader)
 
     then:
@@ -153,7 +153,7 @@ class ReferenceMatcherTest extends Specification {
       .build()
 
     when:
-    def mismatches = createMatcher([reference])
+    def mismatches = createMatcher([(reference.className): reference])
       .getMismatchedReferenceSources(this.class.classLoader)
 
     then:
@@ -180,7 +180,7 @@ class ReferenceMatcherTest extends Specification {
       .build()
 
     when:
-    def mismatches = createMatcher([reference], [reference.className])
+    def mismatches = createMatcher([(reference.className): reference], [reference.className])
       .getMismatchedReferenceSources(this.class.classLoader)
 
     then:
@@ -200,7 +200,7 @@ class ReferenceMatcherTest extends Specification {
       .build()
 
     when:
-    def mismatches = createMatcher([reference], [reference.className])
+    def mismatches = createMatcher([(reference.className): reference], [reference.className])
       .getMismatchedReferenceSources(this.class.classLoader)
 
     then:
@@ -220,7 +220,7 @@ class ReferenceMatcherTest extends Specification {
       .build()
 
     when:
-    def mismatches = createMatcher([reference], [reference.className])
+    def mismatches = createMatcher([(reference.className): reference], [reference.className])
       .getMismatchedReferenceSources(this.class.classLoader)
 
     then:
@@ -242,7 +242,9 @@ class ReferenceMatcherTest extends Specification {
       .build()
 
     when:
-    def mismatches = createMatcher([reference, emptySuperClassRef], [reference.className, emptySuperClassRef.className])
+    def mismatches = createMatcher(
+      [(reference.className): reference, (emptySuperClassRef.className): emptySuperClassRef],
+      [reference.className, emptySuperClassRef.className])
       .getMismatchedReferenceSources(this.class.classLoader)
 
     then:
@@ -269,7 +271,9 @@ class ReferenceMatcherTest extends Specification {
       .build()
 
     when:
-    def mismatches = createMatcher([helper, baseHelper], [helper.className, baseHelper.className])
+    def mismatches = createMatcher(
+      [(helper.className): helper, (baseHelper.className): baseHelper],
+      [helper.className, baseHelper.className])
       .getMismatchedReferenceSources(this.class.classLoader)
 
     then:
@@ -289,7 +293,7 @@ class ReferenceMatcherTest extends Specification {
       .build()
 
     when:
-    def mismatches = createMatcher([helper], [helper.className])
+    def mismatches = createMatcher([(helper.className): helper], [helper.className])
       .getMismatchedReferenceSources(this.class.classLoader)
 
     then:
@@ -309,7 +313,7 @@ class ReferenceMatcherTest extends Specification {
       .build()
 
     when:
-    def mismatches = createMatcher([helper], [helper.className])
+    def mismatches = createMatcher([(helper.className): helper], [helper.className])
       .getMismatchedReferenceSources(this.class.classLoader)
 
     then:
@@ -323,9 +327,9 @@ class ReferenceMatcherTest extends Specification {
     "external helper, different field type" | "${TEST_EXTERNAL_INSTRUMENTATION_PACKAGE}.Helper" | "field"          | "Lcom/external/DifferentType;"
   }
 
-  private static ReferenceMatcher createMatcher(Collection<ClassRef> references = [],
+  private static ReferenceMatcher createMatcher(Map<String, ClassRef> references = [:],
                                                 List<String> helperClasses = []) {
-    new ReferenceMatcher(helperClasses, references as ClassRef[], { it.startsWith(TEST_EXTERNAL_INSTRUMENTATION_PACKAGE) })
+    new ReferenceMatcher(helperClasses, references, { it.startsWith(TEST_EXTERNAL_INSTRUMENTATION_PACKAGE) })
   }
 
   private static Set<Class> getMismatchClassSet(List<Mismatch> mismatches) {

--- a/testing-common/src/test/java/muzzle/MuzzleWeakReferenceTest.java
+++ b/testing-common/src/test/java/muzzle/MuzzleWeakReferenceTest.java
@@ -6,7 +6,6 @@
 package muzzle;
 
 import io.opentelemetry.instrumentation.test.utils.GcUtils;
-import io.opentelemetry.javaagent.extension.muzzle.ClassRef;
 import io.opentelemetry.javaagent.tooling.muzzle.collector.ReferenceCollector;
 import io.opentelemetry.javaagent.tooling.muzzle.matcher.ReferenceMatcher;
 import java.lang.ref.WeakReference;
@@ -25,9 +24,9 @@ public class MuzzleWeakReferenceTest {
     WeakReference<ClassLoader> clRef = new WeakReference<>(loader);
     ReferenceCollector collector = new ReferenceCollector(className -> false);
     collector.collectReferencesFromAdvice(TestClasses.MethodBodyAdvice.class.getName());
-    ClassRef[] refs = collector.getReferences().values().toArray(new ClassRef[0]);
     ReferenceMatcher refMatcher =
-        new ReferenceMatcher(Collections.emptyList(), refs, className -> false);
+        new ReferenceMatcher(
+            Collections.emptyList(), collector.getReferences(), className -> false);
     refMatcher.getMismatchedReferenceSources(loader);
     loader = null;
     GcUtils.awaitGc(clRef);


### PR DESCRIPTION
* Removed arrays from `InstrumentationModule`, it now uses lists & maps.
* Removed generating the `muzzleReferences` field: `MuzzleMatcher` maintains a reference to `ReferenceMatcher`, there's no need to keep the reference to the collection of classrefs anymore.
* Extracted duplicated code fragments in `MuzzleCodeGenerator` to private methods.