### PR TITLE
Use configured NetPeerAttributes in OkHttp3 client tracer

### DIFF
--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpClientTracer.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpClientTracer.java
@@ -18,7 +18,7 @@ import okhttp3.Response;
 final class OkHttpClientTracer extends HttpClientTracer<Request, Request.Builder, Response> {
 
   OkHttpClientTracer(OpenTelemetry openTelemetry) {
-    super(openTelemetry, new NetPeerAttributes());
+    super(openTelemetry, NetPeerAttributes.INSTANCE);
   }
 
   @Override


### PR DESCRIPTION
This will make it notice the peer-service-mapping settings to set peer.service span attribute

I know this approach is deprecated but I hope to follow this up with another change to use the
new Instrumenter API.

Fixes #3009