### PR TITLE
Remove redundant buildscript block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ plugins {
 
   id "com.diffplug.spotless"
   id "com.github.spotbugs" apply false
-
   id "net.ltgt.errorprone" apply false
 }
 

--- a/instrumentation/instrumentation.gradle
+++ b/instrumentation/instrumentation.gradle
@@ -1,15 +1,4 @@
 // this project will run in isolation under the agent's classloader
-buildscript {
-
-  repositories {
-    mavenLocal()
-    mavenCentral()
-  }
-
-  dependencies {
-    classpath "net.bytebuddy:byte-buddy-gradle-plugin:${versions.bytebuddy}"
-  }
-}
 plugins {
   id "com.github.johnrengelman.shadow"
 }


### PR DESCRIPTION
The bytebuddy plugin is already a dependency of `buildSrc` so is on the classpath anyways