### PR TITLE
Akka propagation fix and concurrency tests

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/ContextPropagationDebug.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/ContextPropagationDebug.java
@@ -20,7 +20,7 @@ public final class ContextPropagationDebug {
 
   // locations where the context was propagated to another thread (tracking multiple steps is
   // helpful in akka where there is so much recursive async spawning of new work)
-  private static final ContextKey<List<StackTraceElement[]>> THREAD_PROPAGATION_LOCATIONS =
+  private static final ContextKey<List<Propagation>> THREAD_PROPAGATION_LOCATIONS =
       ContextKey.named("thread-propagation-locations");
 
   private static final boolean THREAD_PROPAGATION_DEBUGGER =
@@ -36,13 +36,14 @@ public final class ContextPropagationDebug {
     return THREAD_PROPAGATION_DEBUGGER;
   }
 
-  public static Context appendLocations(Context context, StackTraceElement[] locations) {
-    List<StackTraceElement[]> currentLocations = ContextPropagationDebug.getLocations(context);
+  public static Context appendLocations(
+      Context context, StackTraceElement[] locations, Object carrier) {
+    List<Propagation> currentLocations = ContextPropagationDebug.getLocations(context);
     if (currentLocations == null) {
       currentLocations = new CopyOnWriteArrayList<>();
       context = context.with(THREAD_PROPAGATION_LOCATIONS, currentLocations);
     }
-    currentLocations.add(0, locations);
+    currentLocations.add(0, new Propagation(carrier.getClass().getName(), locations));
     return context;
   }
 
@@ -67,18 +68,20 @@ public final class ContextPropagationDebug {
     }
   }
 
-  private static List<StackTraceElement[]> getLocations(Context context) {
+  private static List<Propagation> getLocations(Context context) {
     return context.get(THREAD_PROPAGATION_LOCATIONS);
   }
 
   private static void debugContextPropagation(Context context) {
-    List<StackTraceElement[]> locations = getLocations(context);
+    List<Propagation> locations = getLocations(context);
     if (locations != null) {
       StringBuilder sb = new StringBuilder();
-      Iterator<StackTraceElement[]> i = locations.iterator();
+      Iterator<Propagation> i = locations.iterator();
       while (i.hasNext()) {
-        for (StackTraceElement ste : i.next()) {
-          sb.append("\n");
+        Propagation entry = i.next();
+        sb.append("\ncarrier of type: ").append(entry.carrierClassName);
+        for (StackTraceElement ste : entry.location) {
+          sb.append("\n    ");
           sb.append(ste);
         }
         if (i.hasNext()) {
@@ -86,6 +89,16 @@ public final class ContextPropagationDebug {
         }
       }
       log.error("a context leak was detected. it was propagated from:{}", sb);
+    }
+  }
+
+  private static class Propagation {
+    public final String carrierClassName;
+    public final StackTraceElement[] location;
+
+    public Propagation(String carrierClassName, StackTraceElement[] location) {
+      this.carrierClassName = carrierClassName;
+      this.location = location;
     }
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/ContextPropagationDebug.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/ContextPropagationDebug.java
@@ -38,7 +38,7 @@ public final class ContextPropagationDebug {
 
   public static Context appendLocations(
       Context context, StackTraceElement[] locations, Object carrier) {
-    List<Propagation> currentLocations = ContextPropagationDebug.getLocations(context);
+    List<Propagation> currentLocations = ContextPropagationDebug.getPropagations(context);
     if (currentLocations == null) {
       currentLocations = new CopyOnWriteArrayList<>();
       context = context.with(THREAD_PROPAGATION_LOCATIONS, currentLocations);
@@ -68,15 +68,15 @@ public final class ContextPropagationDebug {
     }
   }
 
-  private static List<Propagation> getLocations(Context context) {
+  private static List<Propagation> getPropagations(Context context) {
     return context.get(THREAD_PROPAGATION_LOCATIONS);
   }
 
   private static void debugContextPropagation(Context context) {
-    List<Propagation> locations = getLocations(context);
-    if (locations != null) {
+    List<Propagation> propagations = getPropagations(context);
+    if (propagations != null) {
       StringBuilder sb = new StringBuilder();
-      Iterator<Propagation> i = locations.iterator();
+      Iterator<Propagation> i = propagations.iterator();
       while (i.hasNext()) {
         Propagation entry = i.next();
         sb.append("\ncarrier of type: ").append(entry.carrierClassName);

--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -14,6 +14,7 @@ import akka.http.javadsl.model.headers.RawHeader
 import akka.stream.ActorMaterializer
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
+import io.opentelemetry.instrumentation.test.base.SingleConnection
 import spock.lang.Shared
 
 class AkkaHttpClientInstrumentationTest extends HttpClientTest<HttpRequest> implements AgentTestTrait {
@@ -67,8 +68,10 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<HttpRequest> impl
   }
 
   @Override
-  boolean testCausality() {
-    false
+  SingleConnection createSingleConnection(String host, int port) {
+    // singleConnection test would require instrumentation to support requests made through pools
+    // (newHostConnectionPool, superPool, etc), which is currently not supported.
+    return null
   }
 
   def "singleRequest exception trace"() {

--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -23,6 +23,11 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> 
   String expectedServerSpanName(ServerEndpoint endpoint) {
     return "akka.request"
   }
+
+  @Override
+  boolean testConcurrency() {
+    return true
+  }
 }
 
 class AkkaHttpServerInstrumentationTestSync extends AkkaHttpServerInstrumentationTest {

--- a/instrumentation/akka-http-10.0/javaagent/src/test/scala/AkkaHttpTestAsyncWebServer.scala
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/scala/AkkaHttpTestAsyncWebServer.scala
@@ -12,6 +12,7 @@ import akka.stream.ActorMaterializer
 import groovy.lang.Closure
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint._
+import io.opentelemetry.javaagent.testing.common.Java8BytecodeBridge
 
 import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 
@@ -31,7 +32,15 @@ object AkkaHttpTestAsyncWebServer {
             def doCall(): HttpResponse = {
               val resp = HttpResponse(status = endpoint.getStatus) //.withHeaders(headers.Type)resp.contentType = "text/plain"
               endpoint match {
-                case SUCCESS     => resp.withEntity(endpoint.getBody)
+                case SUCCESS => resp.withEntity(endpoint.getBody)
+                case INDEXED_CHILD =>
+                  Java8BytecodeBridge
+                    .currentSpan()
+                    .setAttribute(
+                      "test.request.id",
+                      uri.query().get("id").orNull.toLong
+                    )
+                  resp.withEntity("")
                 case QUERY_PARAM => resp.withEntity(uri.queryString().orNull)
                 case REDIRECT =>
                   resp.withHeaders(headers.Location(endpoint.getBody))

--- a/instrumentation/akka-http-10.0/javaagent/src/test/scala/AkkaHttpTestAsyncWebServer.scala
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/scala/AkkaHttpTestAsyncWebServer.scala
@@ -12,7 +12,6 @@ import akka.stream.ActorMaterializer
 import groovy.lang.Closure
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint._
-import io.opentelemetry.javaagent.testing.common.Java8BytecodeBridge
 
 import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 
@@ -34,12 +33,10 @@ object AkkaHttpTestAsyncWebServer {
               endpoint match {
                 case SUCCESS => resp.withEntity(endpoint.getBody)
                 case INDEXED_CHILD =>
-                  Java8BytecodeBridge
-                    .currentSpan()
-                    .setAttribute(
-                      "test.request.id",
-                      uri.query().get("id").orNull.toLong
-                    )
+                  INDEXED_CHILD.collectSpanAttributes(new UrlParameterProvider {
+                    override def getParameter(name: String): String =
+                      uri.query().get(name).orNull
+                  })
                   resp.withEntity("")
                 case QUERY_PARAM => resp.withEntity(uri.queryString().orNull)
                 case REDIRECT =>

--- a/instrumentation/akka-http-10.0/javaagent/src/test/scala/AkkaHttpTestSyncWebServer.scala
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/scala/AkkaHttpTestSyncWebServer.scala
@@ -12,7 +12,6 @@ import akka.stream.ActorMaterializer
 import groovy.lang.Closure
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint._
-import io.opentelemetry.javaagent.testing.common.Java8BytecodeBridge
 
 import scala.concurrent.Await
 
@@ -32,12 +31,10 @@ object AkkaHttpTestSyncWebServer {
             endpoint match {
               case SUCCESS => resp.withEntity(endpoint.getBody)
               case INDEXED_CHILD =>
-                Java8BytecodeBridge
-                  .currentSpan()
-                  .setAttribute(
-                    "test.request.id",
-                    uri.query().get("id").orNull.toLong
-                  )
+                INDEXED_CHILD.collectSpanAttributes(new UrlParameterProvider {
+                  override def getParameter(name: String): String =
+                    uri.query().get(name).orNull
+                })
                 resp.withEntity("")
               case QUERY_PARAM => resp.withEntity(uri.queryString().orNull)
               case REDIRECT =>

--- a/testing-common/src/main/java/io/opentelemetry/javaagent/testing/common/Java8BytecodeBridge.java
+++ b/testing-common/src/main/java/io/opentelemetry/javaagent/testing/common/Java8BytecodeBridge.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.testing.common;
 
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 
 /**
@@ -17,5 +18,10 @@ public final class Java8BytecodeBridge {
   /** Calls {@link Context#current()}. */
   public static Context currentContext() {
     return Context.current();
+  }
+
+  /** Calls {@link Span#current()}. */
+  public static Span currentSpan() {
+    return Span.current();
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/javaagent/testing/common/Java8BytecodeBridge.java
+++ b/testing-common/src/main/java/io/opentelemetry/javaagent/testing/common/Java8BytecodeBridge.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.testing.common;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 
 /**
@@ -18,10 +17,5 @@ public final class Java8BytecodeBridge {
   /** Calls {@link Context#current()}. */
   public static Context currentContext() {
     return Context.current();
-  }
-
-  /** Calls {@link Span#current()}. */
-  public static Span currentSpan() {
-    return Span.current();
   }
 }


### PR DESCRIPTION
* We previously propagated context to an Akka `Mailbox` which caused context leak and broke concurrency tests due to the validation in `ContextPropagationDebug`. The class name of the `Mailbox` is `akka.dispatch.Dispatcher$$anon$1` as it is created in `akka.dispatch.Dispatcher#createMailbox` using `with <trait>` syntax which actually creates an anonymous class. Excluded it based on that name for now as for the versions currently being tested, this is the only anonymous class present in that file.
* Enabled `high concurrency test` for Akka `HttpServerTest` and `HttpClientTest` implementations.
* Changed `ContextPropagationDebug` to record not just the stack trace of each propagation, but the name of the class that carried the context. This made it much simpler to debug what classes we actually attach the context to.