### PR TITLE
Limit latest dep version for glassfish test

### DIFF
--- a/instrumentation/servlet/glassfish-testing/glassfish-testing.gradle
+++ b/instrumentation/servlet/glassfish-testing/glassfish-testing.gradle
@@ -11,6 +11,8 @@ dependencies {
   testInstrumentation project(':instrumentation:grizzly-2.0:javaagent')
 
   testLibrary "org.glassfish.main.extras:glassfish-embedded-all:4.0"
+
+  latestDepTestLibrary "org.glassfish.main.extras:glassfish-embedded-all:5.1.0"
 }
 
 tasks.withType(Test).configureEach {


### PR DESCRIPTION
This test needs to use glassfish 5 that has javax.servlet api. For some reason gradle refused to resolve dependencies with `5.+` so I set version to `5.1.0` which is the latest 5.x version.
Resolves one of 2 issues in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3102