### PR TITLE
Use gradle-nullaway-plugin for nullaway.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
   id "com.diffplug.spotless"
   id "com.github.spotbugs" apply false
   id "net.ltgt.errorprone" apply false
+  id "net.ltgt.nullaway" apply false
 }
 
 release {
@@ -69,6 +70,31 @@ allprojects {
     module {
       downloadJavadoc = false
       downloadSources = false
+    }
+  }
+
+  plugins.withId('net.ltgt.errorprone') {
+    plugins.apply('net.ltgt.nullaway')
+    dependencies {
+      errorprone "com.google.errorprone:error_prone_core"
+      errorprone "com.uber.nullaway:nullaway"
+    }
+
+    nullaway {
+      annotatedPackages.addAll("io.opentelemetry", "com.linecorp.armeria,com.google.common")
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+      if (!name.toLowerCase().contains("test")) {
+        options.errorprone {
+          nullaway {
+            severity = net.ltgt.gradle.errorprone.CheckSeverity.ERROR
+          }
+
+          // Doesn't work well with Java 8
+          disable("FutureReturnValueIgnored")
+        }
+      }
     }
   }
 }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -240,23 +240,3 @@ tasks.withType(AbstractArchiveTask).configureEach {
   preserveFileTimestamps = false
   reproducibleFileOrder = true
 }
-
-plugins.withId('net.ltgt.errorprone') {
-  dependencies {
-    annotationProcessor "com.uber.nullaway:nullaway"
-    errorprone "com.google.errorprone:error_prone_core"
-  }
-
-  tasks.withType(JavaCompile).configureEach {
-    if (!name.toLowerCase().contains("test")) {
-      options.errorprone {
-        error("NullAway")
-
-        // Doesn't work well with Java 8
-        disable("FutureReturnValueIgnored")
-
-        option("NullAway:AnnotatedPackages", "io.opentelemetry,com.linecorp.armeria,com.google.common")
-      }
-    }
-  }
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ pluginManagement {
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
     id "me.champeau.jmh" version "0.6.4"
     id "net.ltgt.errorprone" version "1.3.0"
+    id "net.ltgt.nullaway" version "1.1.0"
     id 'org.jetbrains.kotlin.jvm' version '1.5.10'
     id 'org.unbroken-dome.test-sets' version '4.0.0'
     id "nebula.release" version "15.3.0"


### PR DESCRIPTION
This will allow me to followup by decoupling error prone and nullaway, allowing us to replace spotbugs with error prone.