### PR TITLE
Move logic to redisson request object

### DIFF
--- a/instrumentation/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonDbAttributesExtractor.java
+++ b/instrumentation/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonDbAttributesExtractor.java
@@ -5,23 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.redisson;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-
-import io.netty.buffer.ByteBuf;
-import io.opentelemetry.instrumentation.api.db.RedisCommandSanitizer;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.redisson.client.protocol.CommandData;
-import org.redisson.client.protocol.CommandsData;
 
 final class RedissonDbAttributesExtractor extends DbAttributesExtractor<RedissonRequest, Void> {
-
-  private static final String UNKNOWN_COMMAND = "Redis Command";
 
   @Override
   protected String system(RedissonRequest request) {
@@ -47,66 +35,12 @@ final class RedissonDbAttributesExtractor extends DbAttributesExtractor<Redisson
 
   @Override
   protected String statement(RedissonRequest request) {
-    List<String> sanitizedStatements = sanitizeStatement(request);
-    switch (sanitizedStatements.size()) {
-      case 0:
-        return UNKNOWN_COMMAND;
-        // optimize for the most common case
-      case 1:
-        return sanitizedStatements.get(0);
-      default:
-        return String.join(";", sanitizedStatements);
-    }
+    return request.getStatement();
   }
 
   @Nullable
   @Override
   protected String operation(RedissonRequest request) {
-    Object command = request.getCommand();
-    if (command instanceof CommandData) {
-      return ((CommandData<?, ?>) command).getCommand().getName();
-    } else if (command instanceof CommandsData) {
-      CommandsData commandsData = (CommandsData) command;
-      if (commandsData.getCommands().size() == 1) {
-        return commandsData.getCommands().get(0).getCommand().getName();
-      }
-    }
-    return null;
-  }
-
-  private List<String> sanitizeStatement(RedissonRequest request) {
-    Object command = request.getCommand();
-    // get command
-    if (command instanceof CommandsData) {
-      List<CommandData<?, ?>> commands = ((CommandsData) command).getCommands();
-      return commands.stream().map(this::normalizeSingleCommand).collect(Collectors.toList());
-    } else if (command instanceof CommandData) {
-      return singletonList(normalizeSingleCommand((CommandData<?, ?>) command));
-    }
-    return emptyList();
-  }
-
-  private String normalizeSingleCommand(CommandData<?, ?> command) {
-    Object[] commandParams = command.getParams();
-    List<Object> args = new ArrayList<>(commandParams.length + 1);
-    if (command.getCommand().getSubName() != null) {
-      args.add(command.getCommand().getSubName());
-    }
-    for (Object param : commandParams) {
-      if (param instanceof ByteBuf) {
-        try {
-          // slice() does not copy the actual byte buffer, it only returns a readable/writable
-          // "view" of the original buffer (i.e. read and write marks are not shared)
-          ByteBuf buf = ((ByteBuf) param).slice();
-          // state can be null here: no Decoders used by Codecs use it
-          args.add(command.getCodec().getValueDecoder().decode(buf, null));
-        } catch (Exception ignored) {
-          args.add("?");
-        }
-      } else {
-        args.add(param);
-      }
-    }
-    return RedisCommandSanitizer.sanitize(command.getCommand().getName(), args);
+    return request.getOperation();
   }
 }

--- a/instrumentation/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonRequest.java
+++ b/instrumentation/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonRequest.java
@@ -5,17 +5,91 @@
 
 package io.opentelemetry.javaagent.instrumentation.redisson;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 import com.google.auto.value.AutoValue;
+import io.netty.buffer.ByteBuf;
+import io.opentelemetry.instrumentation.api.db.RedisCommandSanitizer;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.redisson.client.protocol.CommandData;
+import org.redisson.client.protocol.CommandsData;
 
 @AutoValue
 public abstract class RedissonRequest {
+
+  public static RedissonRequest create(InetSocketAddress address, Object command) {
+    return new AutoValue_RedissonRequest(address, command);
+  }
 
   public abstract InetSocketAddress getAddress();
 
   public abstract Object getCommand();
 
-  public static RedissonRequest create(InetSocketAddress address, Object command) {
-    return new AutoValue_RedissonRequest(address, command);
+  public String getOperation() {
+    Object command = getCommand();
+    if (command instanceof CommandData) {
+      return ((CommandData<?, ?>) command).getCommand().getName();
+    } else if (command instanceof CommandsData) {
+      CommandsData commandsData = (CommandsData) command;
+      if (commandsData.getCommands().size() == 1) {
+        return commandsData.getCommands().get(0).getCommand().getName();
+      }
+    }
+    return null;
+  }
+
+  public String getStatement() {
+    List<String> sanitizedStatements = sanitizeStatement();
+    switch (sanitizedStatements.size()) {
+      case 0:
+        return null;
+        // optimize for the most common case
+      case 1:
+        return sanitizedStatements.get(0);
+      default:
+        return String.join(";", sanitizedStatements);
+    }
+  }
+
+  private List<String> sanitizeStatement() {
+    Object command = getCommand();
+    // get command
+    if (command instanceof CommandsData) {
+      List<CommandData<?, ?>> commands = ((CommandsData) command).getCommands();
+      return commands.stream()
+          .map(RedissonRequest::normalizeSingleCommand)
+          .collect(Collectors.toList());
+    } else if (command instanceof CommandData) {
+      return singletonList(normalizeSingleCommand((CommandData<?, ?>) command));
+    }
+    return emptyList();
+  }
+
+  private static String normalizeSingleCommand(CommandData<?, ?> command) {
+    Object[] commandParams = command.getParams();
+    List<Object> args = new ArrayList<>(commandParams.length + 1);
+    if (command.getCommand().getSubName() != null) {
+      args.add(command.getCommand().getSubName());
+    }
+    for (Object param : commandParams) {
+      if (param instanceof ByteBuf) {
+        try {
+          // slice() does not copy the actual byte buffer, it only returns a readable/writable
+          // "view" of the original buffer (i.e. read and write marks are not shared)
+          ByteBuf buf = ((ByteBuf) param).slice();
+          // state can be null here: no Decoders used by Codecs use it
+          args.add(command.getCodec().getValueDecoder().decode(buf, null));
+        } catch (Exception ignored) {
+          args.add("?");
+        }
+      } else {
+        args.add(param);
+      }
+    }
+    return RedisCommandSanitizer.sanitize(command.getCommand().getName(), args);
   }
 }


### PR DESCRIPTION
Based on @anuraaga's comment https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3064#discussion_r637676791, it generally makes sense to move logic from extractors into request objects when those request objects are our own objects.