### PR TITLE
Add an optimized Attributes implementation for instrumenter

### DIFF
--- a/benchmark/benchmark.gradle
+++ b/benchmark/benchmark.gradle
@@ -6,6 +6,8 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
+  jmh platform(project(":dependencyManagement"))
+
   jmh "io.opentelemetry:opentelemetry-api"
   jmh "net.bytebuddy:byte-buddy-agent"
 

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/InstrumenterBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/InstrumenterBenchmark.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.benchmark;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetAttributesExtractor;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Fork(3)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 5, time = 1)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Thread)
+public class InstrumenterBenchmark {
+
+  private static final Instrumenter<Void, Void> INSTRUMENTER =
+      Instrumenter.<Void, Void>newBuilder(
+              OpenTelemetry.noop(),
+              "benchmark",
+              HttpSpanNameExtractor.create(ConstantHttpAttributesExtractor.INSTANCE))
+          .addAttributesExtractor(ConstantHttpAttributesExtractor.INSTANCE)
+          .addAttributesExtractor(new ConstantNetAttributesExtractor())
+          .newInstrumenter();
+
+  @Benchmark
+  public Context start() {
+    return INSTRUMENTER.start(Context.root(), null);
+  }
+
+  @Benchmark
+  public Context startEnd() {
+    Context context = INSTRUMENTER.start(Context.root(), null);
+    INSTRUMENTER.end(context, null, null, null);
+    return context;
+  }
+
+  static class ConstantHttpAttributesExtractor extends HttpAttributesExtractor<Void, Void> {
+    static HttpAttributesExtractor<Void, Void> INSTANCE = new ConstantHttpAttributesExtractor();
+
+    @Override
+    protected @Nullable String method(Void unused) {
+      return "GET";
+    }
+
+    @Override
+    protected @Nullable String url(Void unused) {
+      return "https://opentelemetry.io/benchmark";
+    }
+
+    @Override
+    protected @Nullable String target(Void unused) {
+      return "/benchmark";
+    }
+
+    @Override
+    protected @Nullable String host(Void unused) {
+      return "opentelemetry.io";
+    }
+
+    @Override
+    protected @Nullable String route(Void unused) {
+      return "/benchmark";
+    }
+
+    @Override
+    protected @Nullable String scheme(Void unused) {
+      return "https";
+    }
+
+    @Override
+    protected @Nullable String userAgent(Void unused) {
+      return "OpenTelemetryBot";
+    }
+
+    @Override
+    protected @Nullable Long requestContentLength(Void unused, @Nullable Void unused2) {
+      return 100L;
+    }
+
+    @Override
+    protected @Nullable Long requestContentLengthUncompressed(Void unused, @Nullable Void unused2) {
+      return null;
+    }
+
+    @Override
+    protected @Nullable String flavor(Void unused, @Nullable Void unused2) {
+      return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
+    }
+
+    @Override
+    protected @Nullable String serverName(Void unused, @Nullable Void unused2) {
+      return null;
+    }
+
+    @Override
+    protected @Nullable String clientIp(Void unused, @Nullable Void unused2) {
+      return null;
+    }
+
+    @Override
+    protected @Nullable Integer statusCode(Void unused, Void unused2) {
+      return 200;
+    }
+
+    @Override
+    protected @Nullable Long responseContentLength(Void unused, Void unused2) {
+      return 100L;
+    }
+
+    @Override
+    protected @Nullable Long responseContentLengthUncompressed(Void unused, Void unused2) {
+      return null;
+    }
+  }
+
+  static class ConstantNetAttributesExtractor
+      extends InetSocketAddressNetAttributesExtractor<Void, Void> {
+
+    private static final InetSocketAddress ADDRESS =
+        InetSocketAddress.createUnresolved("localhost", 8080);
+
+    @Override
+    public @Nullable InetSocketAddress getAddress(Void unused, @Nullable Void unused2) {
+      return ADDRESS;
+    }
+
+    @Override
+    public @Nullable String transport(Void unused) {
+      return SemanticAttributes.NetTransportValues.IP_TCP;
+    }
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/UnsafeAttributes.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/UnsafeAttributes.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The {@link AttributesBuilder} and {@link Attributes} used by the instrumentation API. We are able
+ * to take advantage of the fact that we know our attributes builder cannot be reused to create
+ * multiple Attributes instances. So we use just one storage for both the builder and attributes. A
+ * couple of methods still require copying to satisfy the interface contracts, but in practice
+ * should never be called by user code even though they can.
+ */
+final class UnsafeAttributes extends HashMap<AttributeKey<?>, Object>
+    implements Attributes, AttributesBuilder {
+
+  // Attributes
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T get(AttributeKey<T> key) {
+    return (T) super.get(key);
+  }
+
+  @Override
+  public Map<AttributeKey<?>, Object> asMap() {
+    return this;
+  }
+
+  // This can be called by user code in a RequestListener so copy. In practice, it should not be
+  // called as there is no real use case.
+  @Override
+  public AttributesBuilder toBuilder() {
+    return Attributes.builder().putAll(this);
+  }
+
+  // AttributesBuilder
+
+  // This can be called by user code in an AttributesExtractor so copy. In practice, it should not
+  // be called as there is no real use case.
+  @Override
+  public Attributes build() {
+    return toBuilder().build();
+  }
+
+  @Override
+  public <T> AttributesBuilder put(AttributeKey<Long> key, int value) {
+    return put(key, (long) value);
+  }
+
+  @Override
+  public <T> AttributesBuilder put(AttributeKey<T> key, T value) {
+    super.put(key, value);
+    return this;
+  }
+
+  @Override
+  public AttributesBuilder putAll(Attributes attributes) {
+    attributes.forEach(this::put);
+    return this;
+  }
+}

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/UnsafeAttributesTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/UnsafeAttributesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import org.junit.jupiter.api.Test;
+
+class UnsafeAttributesTest {
+
+  @Test
+  void buildAndUse() {
+    Attributes previous =
+        new UnsafeAttributes().put("world", "earth").put("country", "japan").build();
+
+    UnsafeAttributes attributes = new UnsafeAttributes();
+    attributes.put(AttributeKey.stringKey("animal"), "cat");
+    attributes.put("needs_catnip", false);
+    // Overwrites
+    attributes.put("needs_catnip", true);
+    attributes.put(AttributeKey.longKey("lives"), 9);
+    attributes.putAll(previous);
+
+    assertThat((Attributes) attributes)
+        .containsOnly(
+            attributeEntry("world", "earth"),
+            attributeEntry("country", "japan"),
+            attributeEntry("animal", "cat"),
+            attributeEntry("needs_catnip", true),
+            attributeEntry("lives", 9L));
+
+    Attributes built = attributes.build();
+    assertThat(built)
+        .containsOnly(
+            attributeEntry("world", "earth"),
+            attributeEntry("country", "japan"),
+            attributeEntry("animal", "cat"),
+            attributeEntry("needs_catnip", true),
+            attributeEntry("lives", 9L));
+
+    attributes.put("clothes", "fur");
+    assertThat((Attributes) attributes)
+        .containsOnly(
+            attributeEntry("world", "earth"),
+            attributeEntry("country", "japan"),
+            attributeEntry("animal", "cat"),
+            attributeEntry("needs_catnip", true),
+            attributeEntry("lives", 9L),
+            attributeEntry("clothes", "fur"));
+
+    // Unmodified
+    assertThat(built)
+        .containsOnly(
+            attributeEntry("world", "earth"),
+            attributeEntry("country", "japan"),
+            attributeEntry("animal", "cat"),
+            attributeEntry("needs_catnip", true),
+            attributeEntry("lives", 9L));
+
+    Attributes modified = attributes.toBuilder().put("country", "us").build();
+    assertThat(modified)
+        .containsOnly(
+            attributeEntry("world", "earth"),
+            attributeEntry("country", "us"),
+            attributeEntry("animal", "cat"),
+            attributeEntry("needs_catnip", true),
+            attributeEntry("lives", 9L),
+            attributeEntry("clothes", "fur"));
+
+    // Unmodified
+    assertThat((Attributes) attributes)
+        .containsOnly(
+            attributeEntry("world", "earth"),
+            attributeEntry("country", "japan"),
+            attributeEntry("animal", "cat"),
+            attributeEntry("needs_catnip", true),
+            attributeEntry("lives", 9L),
+            attributeEntry("clothes", "fur"));
+  }
+}


### PR DESCRIPTION
Now that this is being used in much of our instrumentation better fix the performance regression :)

After
```
Benchmark                                                    Mode  Cnt          Score          Error   Units
InstrumenterBenchmark.start                                  avgt   15          0.229 ±        0.021   us/op
InstrumenterBenchmark.start:heap.total.after                 avgt   15  203703364.267 ± 36000273.266   bytes
InstrumenterBenchmark.start:heap.total.before                avgt   15   30129083.733 ±  2825338.757   bytes
InstrumenterBenchmark.start:heap.used.after                  avgt   15   62447095.467 ± 42848479.032   bytes
InstrumenterBenchmark.start:heap.used.before                 avgt   15    7324172.800 ±     8812.281   bytes
InstrumenterBenchmark.start:·gc.alloc.rate                   avgt   15       1553.595 ±      222.391  MB/sec
InstrumenterBenchmark.start:·gc.alloc.rate.norm              avgt   15        554.667 ±       41.732    B/op
InstrumenterBenchmark.start:·gc.churn.G1_Eden_Space          avgt   15       1522.278 ±      214.994  MB/sec
InstrumenterBenchmark.start:·gc.churn.G1_Eden_Space.norm     avgt   15        543.720 ±       42.457    B/op
InstrumenterBenchmark.start:·gc.churn.G1_Old_Gen             avgt   15          0.669 ±        0.004  MB/sec
InstrumenterBenchmark.start:·gc.churn.G1_Old_Gen.norm        avgt   15          0.241 ±        0.022    B/op
InstrumenterBenchmark.start:·gc.count                        avgt   15        492.000                 counts
InstrumenterBenchmark.start:·gc.time                         avgt   15        140.000                     ms
InstrumenterBenchmark.startEnd                               avgt   15          0.375 ±        0.007   us/op
InstrumenterBenchmark.startEnd:heap.total.after              avgt   15  197831338.667 ± 15409141.526   bytes
InstrumenterBenchmark.startEnd:heap.total.before             avgt   15   30198988.800 ±  1705339.089   bytes
InstrumenterBenchmark.startEnd:heap.used.after               avgt   15   61750949.867 ± 34775705.363   bytes
InstrumenterBenchmark.startEnd:heap.used.before              avgt   15    7325356.267 ±     8920.324   bytes
InstrumenterBenchmark.startEnd:·gc.alloc.rate                avgt   15       1395.926 ±       26.107  MB/sec
InstrumenterBenchmark.startEnd:·gc.alloc.rate.norm           avgt   15        824.000 ±        0.001    B/op
InstrumenterBenchmark.startEnd:·gc.churn.G1_Eden_Space       avgt   15       1364.868 ±       31.175  MB/sec
InstrumenterBenchmark.startEnd:·gc.churn.G1_Eden_Space.norm  avgt   15        805.695 ±       12.931    B/op
InstrumenterBenchmark.startEnd:·gc.churn.G1_Old_Gen          avgt   15          0.667 ±        0.004  MB/sec
InstrumenterBenchmark.startEnd:·gc.churn.G1_Old_Gen.norm     avgt   15          0.394 ±        0.008    B/op
InstrumenterBenchmark.startEnd:·gc.count                     avgt   15        474.000                 counts
InstrumenterBenchmark.startEnd:·gc.time                      avgt   15        131.000                     ms
```

Before
```
Benchmark                                                    Mode  Cnt          Score          Error   Units
InstrumenterBenchmark.start                                  avgt   15          0.755 ±        0.035   us/op
InstrumenterBenchmark.start:heap.total.after                 avgt   15  149177412.267 ±   513120.009   bytes
InstrumenterBenchmark.start:heap.total.before                avgt   15   29150412.800 ±  1539360.028   bytes
InstrumenterBenchmark.start:heap.used.after                  avgt   15   49199561.600 ± 26731691.947   bytes
InstrumenterBenchmark.start:heap.used.before                 avgt   15    7330857.600 ±     7877.344   bytes
InstrumenterBenchmark.start:·gc.alloc.rate                   avgt   15        535.930 ±       23.192  MB/sec
InstrumenterBenchmark.start:·gc.alloc.rate.norm              avgt   15        637.334 ±       41.732    B/op
InstrumenterBenchmark.start:·gc.churn.G1_Eden_Space          avgt   15        507.477 ±       36.403  MB/sec
InstrumenterBenchmark.start:·gc.churn.G1_Eden_Space.norm     avgt   15        603.467 ±       51.943    B/op
InstrumenterBenchmark.start:·gc.churn.G1_Old_Gen             avgt   15          0.662 ±        0.002  MB/sec
InstrumenterBenchmark.start:·gc.churn.G1_Old_Gen.norm        avgt   15          0.787 ±        0.037    B/op
InstrumenterBenchmark.start:·gc.count                        avgt   15        339.000                 counts
InstrumenterBenchmark.start:·gc.time                         avgt   15         86.000                     ms
InstrumenterBenchmark.startEnd                               avgt   15          1.008 ±        0.031   us/op
InstrumenterBenchmark.startEnd:heap.total.after              avgt   15  133868202.667 ± 43551357.060   bytes
InstrumenterBenchmark.startEnd:heap.total.before             avgt   15   30059178.667 ±  2346316.128   bytes
InstrumenterBenchmark.startEnd:heap.used.after               avgt   15   45406940.267 ± 22520874.174   bytes
InstrumenterBenchmark.startEnd:heap.used.before              avgt   15    7333456.000 ±     8444.228   bytes
InstrumenterBenchmark.startEnd:·gc.alloc.rate                avgt   15        554.537 ±       26.649  MB/sec
InstrumenterBenchmark.startEnd:·gc.alloc.rate.norm           avgt   15        880.000 ±       50.078    B/op
InstrumenterBenchmark.startEnd:·gc.churn.G1_Eden_Space       avgt   15        532.234 ±       35.156  MB/sec
InstrumenterBenchmark.startEnd:·gc.churn.G1_Eden_Space.norm  avgt   15        844.567 ±       60.364    B/op
InstrumenterBenchmark.startEnd:·gc.churn.G1_Old_Gen          avgt   15          0.663 ±        0.002  MB/sec
InstrumenterBenchmark.startEnd:·gc.churn.G1_Old_Gen.norm     avgt   15          1.052 ±        0.034    B/op
InstrumenterBenchmark.startEnd:·gc.count                     avgt   15        349.000                 counts
InstrumenterBenchmark.startEnd:·gc.time                      avgt   15         88.000                     ms
```