### PR TITLE
Consistent job ordering within yaml files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,61 +31,6 @@ jobs:
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         run: ./gradlew build --stacktrace -x :smoke-tests:test
 
-  example-distro:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 11 for running checks
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 11
-
-      - name: Restore cache
-        uses: burrunan/gradle-cache-action@v1.10
-        with:
-          job-id: jdk11
-
-      - name: Build
-        run: ./gradlew build --stacktrace
-        working-directory: examples/distro
-
-  smoke-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ windows-latest, ubuntu-latest ]
-        suite: [ "glassfish", "jetty", "liberty", "tomcat", "tomee", "wildfly", "other" ]
-      fail-fast: false
-    steps:
-      - name: Support longpaths
-        run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
-
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 11 for running Gradle
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 11
-
-      - name: Restore cache
-        uses: burrunan/gradle-cache-action@v1.10
-        with:
-          job-id: smokeTests
-
-      - name: Test
-        env:
-          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
-          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.suite }}
-
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -142,6 +87,61 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         run: ./gradlew test -x :smoke-tests:test -PtestLatestDeps=true --stacktrace
+
+  smoke-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+        suite: [ "glassfish", "jetty", "liberty", "tomcat", "tomee", "wildfly", "other" ]
+      fail-fast: false
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+        if: matrix.os == 'windows-latest'
+
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11 for running Gradle
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+      - name: Restore cache
+        uses: burrunan/gradle-cache-action@v1.10
+        with:
+          job-id: smokeTests
+
+      - name: Test
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.suite }}
+
+  example-distro:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11 for running checks
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+      - name: Restore cache
+        uses: burrunan/gradle-cache-action@v1.10
+        with:
+          job-id: jdk11
+
+      - name: Build
+        run: ./gradlew build --stacktrace
+        working-directory: examples/distro
 
   snapshot:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-no-cache.yaml
+++ b/.github/workflows/nightly-no-cache.yaml
@@ -24,48 +24,6 @@ jobs:
       - name: Build
         run: ./gradlew build --stacktrace -x :smoke-tests:test --no-build-cache
 
-  example-distro:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 11 for running checks
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 11
-
-      - name: Build
-        run: ./gradlew build --stacktrace --no-build-cache
-        working-directory: examples/distro
-
-  smoke-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ windows-latest, ubuntu-latest ]
-        suite: [ "glassfish", "jetty", "liberty", "tomcat", "tomee", "wildfly", "other" ]
-      fail-fast: false
-    steps:
-      - name: Support longpaths
-        run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
-
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 11 for running Gradle
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 11
-
-      - name: Test
-        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.suite }} --no-build-cache
-
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -92,9 +50,51 @@ jobs:
       - name: Test
         run: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -x :smoke-tests:test -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false --no-build-cache
 
+  smoke-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+        suite: [ "glassfish", "jetty", "liberty", "tomcat", "tomee", "wildfly", "other" ]
+      fail-fast: false
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+        if: matrix.os == 'windows-latest'
+
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11 for running Gradle
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+      - name: Test
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.suite }} --no-build-cache
+
+  example-distro:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11 for running checks
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+      - name: Build
+        run: ./gradlew build --stacktrace --no-build-cache
+        working-directory: examples/distro
+
   issue:
     name: Open issue on failure
-    needs: [ build, test, example-distro, smoke-test]
+    needs: [ build, test, example-distro, smoke-test ]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,39 +31,6 @@ jobs:
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         run: ./gradlew build --stacktrace -x :smoke-tests:test
 
-  smoke-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ windows-latest, ubuntu-latest ]
-        suite: [ "glassfish", "jetty", "liberty", "tomcat", "tomee", "wildfly", "other" ]
-      fail-fast: false
-    steps:
-      - name: Support longpaths
-        run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
-
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 11 for running Gradle
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 11
-
-      - name: Restore cache
-        uses: burrunan/gradle-cache-action@v1.10
-        with:
-          job-id: smokeTests
-
-      - name: Test
-        env:
-          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
-          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.suite }}
-
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -120,6 +87,39 @@ jobs:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         run: ./gradlew test -x :smoke-tests:test -PtestLatestDeps=true --stacktrace
+
+  smoke-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+        suite: [ "glassfish", "jetty", "liberty", "tomcat", "tomee", "wildfly", "other" ]
+      fail-fast: false
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+        if: matrix.os == 'windows-latest'
+
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11 for running Gradle
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+      - name: Restore cache
+        uses: burrunan/gradle-cache-action@v1.10
+        with:
+          job-id: smokeTests
+
+      - name: Test
+        env:
+          S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
+          S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.suite }}
 
   issue:
     name: Open issue on failure

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,28 +35,6 @@ jobs:
           path: /tmp/deadlock-detector-*
           if-no-files-found: ignore
 
-  example-distro:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 11 for running checks
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 11
-
-      - name: Restore cache
-        uses: burrunan/gradle-cache-action@v1.10
-        with:
-          job-id: jdk11
-
-      - name: Build
-        run: ./gradlew build --stacktrace
-        working-directory: examples/distro
-
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -162,6 +140,28 @@ jobs:
           java-version: 11
       - name: Run muzzle
         run: ./gradlew ${{ matrix.module }}:muzzle
+
+  example-distro:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11 for running checks
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+      - name: Restore cache
+        uses: burrunan/gradle-cache-action@v1.10
+        with:
+          job-id: jdk11
+
+      - name: Build
+        run: ./gradlew build --stacktrace
+        working-directory: examples/distro
 
   accept-pr:
     needs: [ build, test, smoke-test, muzzle ]


### PR DESCRIPTION
This is step 1, just re-ordering the jobs within the yaml files (no other changes).

This is the ordering:

* build
* test
* testLatestDep
* setup-muzzle-matrix
* muzzle
* smoke-tests
* example-distro
* snapshot/issue/accept-pr

I want to follow up with another PR to compare and propose changes where the yaml files are out of sync, but wanted to get the re-ordering out of the way in a standalone PR, otherwise diff will be painful.