### PR TITLE
Single connection concurrency test on ratpack

### DIFF
--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/client/RatpackForkedHttpClientTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/client/RatpackForkedHttpClientTest.groovy
@@ -6,11 +6,12 @@
 package client
 
 import ratpack.exec.Promise
+import ratpack.http.client.HttpClient
 
 class RatpackForkedHttpClientTest extends RatpackHttpClientTest {
 
   @Override
-  Promise<Integer> internalSendRequest(String method, URI uri, Map<String, String> headers) {
+  Promise<Integer> internalSendRequest(HttpClient client, String method, URI uri, Map<String, String> headers) {
     def resp = client.request(uri) { spec ->
       spec.method(method)
       spec.headers { headersSpec ->

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/client/RatpackHttpClientTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/client/RatpackHttpClientTest.groovy
@@ -9,9 +9,13 @@ import io.netty.channel.ConnectTimeoutException
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.SpanAssert
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
+import io.opentelemetry.instrumentation.test.base.SingleConnection
 import java.time.Duration
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeoutException
 import ratpack.exec.Operation
 import ratpack.exec.Promise
+import ratpack.func.Action
 import ratpack.http.client.HttpClient
 import ratpack.http.client.HttpClientSpec
 import ratpack.test.exec.ExecHarness
@@ -24,18 +28,32 @@ class RatpackHttpClientTest extends HttpClientTest<Void> implements AgentTestTra
   @Shared
   ExecHarness exec = ExecHarness.harness()
 
+  @AutoCleanup
   @Shared
-  def client = HttpClient.of {
-    it.readTimeout(Duration.ofSeconds(2))
-    // Connect timeout added in 1.5
-    // execController method added in 1.9
-    if (HttpClientSpec.metaClass.getMetaMethod("execController") != null) {
-      it.execController(exec.getController())
-    }
-    configureClient(it)
+  def client = buildHttpClient()
+
+  @AutoCleanup
+  @Shared
+  def singleConnectionClient = buildHttpClient({spec ->
+    spec.poolSize(1)
+  })
+
+  HttpClient buildHttpClient() {
+    return buildHttpClient(null)
   }
 
-  void configureClient(HttpClientSpec spec) {
+  HttpClient buildHttpClient(Action<? super HttpClientSpec> action) {
+    HttpClient.of {
+      it.readTimeout(Duration.ofSeconds(2))
+      // Connect timeout added in 1.5
+      // execController method added in 1.9
+      if (HttpClientSpec.metaClass.getMetaMethod("execController") != null) {
+        it.execController(exec.getController())
+      }
+      if (action != null) {
+        action.execute(it)
+      }
+    }
   }
 
   @Override
@@ -46,21 +64,21 @@ class RatpackHttpClientTest extends HttpClientTest<Void> implements AgentTestTra
   @Override
   int sendRequest(Void request, String method, URI uri, Map<String, String> headers) {
     return exec.yield {
-      internalSendRequest(method, uri, headers)
+      internalSendRequest(client, method, uri, headers)
     }.valueOrThrow
   }
 
   @Override
   void sendRequestWithCallback(Void request, String method, URI uri, Map<String, String> headers, RequestResult requestResult) {
     exec.execute(Operation.of {
-      internalSendRequest(method, uri, headers).result {result ->
+      internalSendRequest(client, method, uri, headers).result {result ->
         requestResult.complete({ result.value }, result.throwable)
       }
     })
   }
 
   // overridden in RatpackForkedHttpClientTest
-  Promise<Integer> internalSendRequest(String method, URI uri, Map<String, String> headers) {
+  Promise<Integer> internalSendRequest(HttpClient client, String method, URI uri, Map<String, String> headers) {
     def resp = client.request(uri) { spec ->
       spec.connectTimeout(Duration.ofSeconds(2))
       spec.method(method)
@@ -72,6 +90,19 @@ class RatpackHttpClientTest extends HttpClientTest<Void> implements AgentTestTra
     }
     return resp.map {
       it.status.code
+    }
+  }
+
+  @Override
+  SingleConnection createSingleConnection(String host, int port) {
+    return new SingleConnection() {
+      @Override
+      int doRequest(String path, Map<String, String> headers) throws ExecutionException, InterruptedException, TimeoutException {
+        def uri = server.address.resolve(path)
+        return exec.yield {
+          internalSendRequest(singleConnectionClient, "GET", uri, headers)
+        }.valueOrThrow
+      }
     }
   }
 

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/client/RatpackPooledHttpClientTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/client/RatpackPooledHttpClientTest.groovy
@@ -5,12 +5,22 @@
 
 package client
 
-import ratpack.http.client.HttpClientSpec
+import io.opentelemetry.instrumentation.test.base.SingleConnection
+import ratpack.http.client.HttpClient
 
 class RatpackPooledHttpClientTest extends RatpackHttpClientTest {
 
   @Override
-  void configureClient(HttpClientSpec spec) {
-    spec.poolSize(5)
+  HttpClient buildHttpClient() {
+    return buildHttpClient({spec ->
+      spec.poolSize(5)
+    })
+  }
+
+  @Override
+  SingleConnection createSingleConnection(String host, int port) {
+    // this test is already run for RatpackHttpClientTest
+    // returning null here to avoid running the same test twice
+    return null
   }
 }


### PR DESCRIPTION
Setting pool size to 1 allows only one connection to each host which should satisfy the requirements of single connection concurrency http client test.