### PR TITLE
End span on cancellation of subscription to reactive publishers

### DIFF
--- a/instrumentation/lettuce/lettuce-5.1/library/src/test/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/test/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
@@ -9,8 +9,12 @@ import io.lettuce.core.RedisClient
 import io.lettuce.core.resource.ClientResources
 import io.opentelemetry.instrumentation.reactor.TracingOperator
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import spock.lang.Shared
 
 class LettuceReactiveClientTest extends AbstractLettuceReactiveClientTest implements LibraryTestTrait {
+  @Shared
+  TracingOperator tracingOperator = TracingOperator.create()
+
   @Override
   RedisClient createClient(String uri) {
     return RedisClient.create(
@@ -21,10 +25,10 @@ class LettuceReactiveClientTest extends AbstractLettuceReactiveClientTest implem
   }
 
   def setupSpec() {
-    TracingOperator.registerOnEachOperator()
+    tracingOperator.registerOnEachOperator()
   }
 
   def cleanupSpec() {
-    TracingOperator.resetOnEachOperator()
+    tracingOperator.resetOnEachOperator()
   }
 }

--- a/instrumentation/reactor-3.1/javaagent/reactor-3.1-javaagent.gradle
+++ b/instrumentation/reactor-3.1/javaagent/reactor-3.1-javaagent.gradle
@@ -9,6 +9,11 @@ muzzle {
   }
 }
 
+tasks.withType(Test).configureEach {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.reactor.experimental-span-attributes=true"
+}
+
 dependencies {
   implementation project(':instrumentation:reactor-3.1:library')
 

--- a/instrumentation/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/HooksInstrumentation.java
+++ b/instrumentation/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/HooksInstrumentation.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.reactor;
 import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.reactor.TracingOperator;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
@@ -31,7 +32,13 @@ public class HooksInstrumentation implements TypeInstrumentation {
   public static class ResetOnEachOperatorAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void postStaticInitializer() {
-      TracingOperator.registerOnEachOperator();
+      TracingOperator.newBuilder()
+          .setCaptureExperimentalSpanAttributes(
+              Config.get()
+                  .getBooleanProperty(
+                      "otel.instrumentation.reactor.experimental-span-attributes", false))
+          .build()
+          .registerOnEachOperator();
     }
   }
 }

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/ReactorAsyncSpanEndStrategy.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/ReactorAsyncSpanEndStrategy.java
@@ -5,18 +5,34 @@
 
 package io.opentelemetry.instrumentation.reactor;
 
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategy;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public enum ReactorAsyncSpanEndStrategy implements AsyncSpanEndStrategy {
-  INSTANCE;
+public final class ReactorAsyncSpanEndStrategy implements AsyncSpanEndStrategy {
+  private static final AttributeKey<Boolean> CANCELED_ATTRIBUTE_KEY =
+      AttributeKey.booleanKey("reactor.canceled");
+
+  public static ReactorAsyncSpanEndStrategy create() {
+    return newBuilder().build();
+  }
+
+  public static ReactorAsyncSpanEndStrategyBuilder newBuilder() {
+    return new ReactorAsyncSpanEndStrategyBuilder();
+  }
+
+  private final boolean captureExperimentalSpanAttributes;
+
+  ReactorAsyncSpanEndStrategy(boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+  }
 
   @Override
   public boolean supports(Class<?> returnType) {
@@ -46,7 +62,7 @@ public enum ReactorAsyncSpanEndStrategy implements AsyncSpanEndStrategy {
    * OnError notifications are received. Multiple notifications can happen anytime multiple
    * subscribers subscribe to the same publisher.
    */
-  private static final class EndOnFirstNotificationConsumer extends AtomicBoolean
+  private final class EndOnFirstNotificationConsumer extends AtomicBoolean
       implements Runnable, Consumer<Throwable> {
 
     private final BaseTracer tracer;
@@ -63,7 +79,12 @@ public enum ReactorAsyncSpanEndStrategy implements AsyncSpanEndStrategy {
     }
 
     public void onCancel() {
-      accept(new CancellationException());
+      if (compareAndSet(false, true)) {
+        if (captureExperimentalSpanAttributes) {
+          Span.fromContext(context).setAttribute(CANCELED_ATTRIBUTE_KEY, true);
+        }
+        tracer.end(context);
+      }
     }
 
     @Override

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/ReactorAsyncSpanEndStrategyBuilder.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/ReactorAsyncSpanEndStrategyBuilder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.reactor;
+
+public final class ReactorAsyncSpanEndStrategyBuilder {
+  private boolean captureExperimentalSpanAttributes;
+
+  ReactorAsyncSpanEndStrategyBuilder() {}
+
+  public ReactorAsyncSpanEndStrategyBuilder setCaptureExperimentalSpanAttributes(
+      boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    return this;
+  }
+
+  public ReactorAsyncSpanEndStrategy build() {
+    return new ReactorAsyncSpanEndStrategy(captureExperimentalSpanAttributes);
+  }
+}

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingOperator.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingOperator.java
@@ -87,6 +87,4 @@ public final class TracingOperator {
       return new TracingSubscriber<>(sub, sub.currentContext());
     }
   }
-
-  private TracingOperator() {}
 }

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingOperatorBuilder.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingOperatorBuilder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.reactor;
+
+public final class TracingOperatorBuilder {
+  private boolean captureExperimentalSpanAttributes;
+
+  TracingOperatorBuilder() {}
+
+  public TracingOperatorBuilder setCaptureExperimentalSpanAttributes(
+      boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    return this;
+  }
+
+  public TracingOperator build() {
+    return new TracingOperator(captureExperimentalSpanAttributes);
+  }
+}

--- a/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/HooksTest.groovy
+++ b/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/HooksTest.groovy
@@ -14,6 +14,7 @@ class HooksTest extends LibraryInstrumentationSpecification {
 
   def "can reset out hooks"() {
     setup:
+    def underTest = TracingOperator.create()
     AtomicReference<CoreSubscriber> subscriber = new AtomicReference<>()
 
     when: "no hook registered"
@@ -23,14 +24,14 @@ class HooksTest extends LibraryInstrumentationSpecification {
     !(subscriber.get() instanceof TracingSubscriber)
 
     when: "hook registered"
-    TracingOperator.registerOnEachOperator()
+    underTest.registerOnEachOperator()
     new CapturingMono(subscriber).map { it + 1 }.subscribe()
 
     then:
     subscriber.get() instanceof TracingSubscriber
 
     when: "hook reset"
-    TracingOperator.resetOnEachOperator()
+    underTest.resetOnEachOperator()
     new CapturingMono(subscriber).map { it + 1 }.subscribe()
 
     then:

--- a/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorAsyncSpanEndStrategyTest.groovy
+++ b/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorAsyncSpanEndStrategyTest.groovy
@@ -14,8 +14,6 @@ import reactor.core.publisher.UnicastProcessor
 import reactor.test.StepVerifier
 import spock.lang.Specification
 
-import java.util.concurrent.CancellationException
-
 class ReactorAsyncSpanEndStrategyTest extends Specification {
   BaseTracer tracer
 

--- a/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorCoreTest.groovy
+++ b/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorCoreTest.groovy
@@ -6,13 +6,17 @@
 package io.opentelemetry.instrumentation.reactor
 
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import spock.lang.Shared
 
 class ReactorCoreTest extends AbstractReactorCoreTest implements LibraryTestTrait {
+  @Shared
+  TracingOperator tracingOperator = TracingOperator.create()
+
   def setupSpec() {
-    TracingOperator.registerOnEachOperator()
+    tracingOperator.registerOnEachOperator()
   }
 
   def cleanupSpec() {
-    TracingOperator.resetOnEachOperator()
+    tracingOperator.resetOnEachOperator()
   }
 }

--- a/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/SubscriptionTest.groovy
+++ b/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/SubscriptionTest.groovy
@@ -6,13 +6,17 @@
 package io.opentelemetry.instrumentation.reactor
 
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import spock.lang.Shared
 
 class SubscriptionTest extends AbstractSubscriptionTest implements LibraryTestTrait {
+  @Shared
+  TracingOperator tracingOperator = TracingOperator.create()
+
   def setupSpec() {
-    TracingOperator.registerOnEachOperator()
+    tracingOperator.registerOnEachOperator()
   }
 
   def cleanupSpec() {
-    TracingOperator.resetOnEachOperator()
+    tracingOperator.resetOnEachOperator()
   }
 }

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/rxjava-2.0-javaagent.gradle
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/rxjava-2.0-javaagent.gradle
@@ -9,6 +9,11 @@ muzzle {
   }
 }
 
+tasks.withType(Test).configureEach {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.rxjava.experimental-span-attributes=true"
+}
+
 dependencies {
   library "io.reactivex.rxjava2:rxjava:2.0.6"
 

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/main/java/io/opentelemetry/instrumentation/rxjava2/TracingAssemblyActivation.java
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/main/java/io/opentelemetry/instrumentation/rxjava2/TracingAssemblyActivation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.rxjava2;
 
+import io.opentelemetry.instrumentation.api.config.Config;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class TracingAssemblyActivation {
@@ -19,7 +20,13 @@ public final class TracingAssemblyActivation {
 
   public static void activate(Class<?> clz) {
     if (activated.get(clz).compareAndSet(false, true)) {
-      TracingAssembly.enable();
+      TracingAssembly.newBuilder()
+          .setCaptureExperimentalSpanAttributes(
+              Config.get()
+                  .getBooleanProperty(
+                      "otel.instrumentation.rxjava.experimental-span-attributes", false))
+          .build()
+          .enable();
     }
   }
 

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava2/RxJava2InstrumentationModule.java
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava2/RxJava2InstrumentationModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.rxjava3;
+package io.opentelemetry.javaagent.instrumentation.rxjava2;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -12,10 +12,10 @@ import java.util.Collections;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class RxJava3InstrumentationModule extends InstrumentationModule {
+public class RxJava2InstrumentationModule extends InstrumentationModule {
 
-  public RxJava3InstrumentationModule() {
-    super("rxjava3");
+  public RxJava2InstrumentationModule() {
+    super("rxjava2");
   }
 
   @Override

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava2/RxJavaPluginsInstrumentation.java
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava2/RxJavaPluginsInstrumentation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.rxjava2;
+package io.opentelemetry.javaagent.instrumentation.rxjava2;
 
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava2/TracingAssemblyActivation.java
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava2/TracingAssemblyActivation.java
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.rxjava3;
+package io.opentelemetry.javaagent.instrumentation.rxjava2;
 
 import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.instrumentation.rxjava2.TracingAssembly;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class TracingAssemblyActivation {

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
@@ -136,6 +136,35 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
   }
 
+  def "should capture span for canceled Completable"() {
+    setup:
+    def source = CompletableSubject.create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .completable(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.cancel()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.completable"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
+          }
+        }
+      }
+    }
+  }
+
   def "should capture span for already completed Maybe"() {
     setup:
     def observer = new TestObserver()
@@ -271,6 +300,35 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
   }
 
+  def "should capture span for canceled Maybe"() {
+    setup:
+    def source = MaybeSubject.<String> create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .maybe(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.cancel()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.maybe"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
+          }
+        }
+      }
+    }
+  }
+
   def "should capture span for already completed Single"() {
     setup:
     def observer = new TestObserver()
@@ -377,6 +435,35 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for canceled Single"() {
+    setup:
+    def source = SingleSubject.<String> create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .single(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.cancel()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.single"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
           }
         }
       }
@@ -506,6 +593,41 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
   }
 
+  def "should capture span for canceled Observable"() {
+    setup:
+    def source = UnicastSubject.<String> create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .observable(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.cancel()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.observable"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
+          }
+        }
+      }
+    }
+  }
+
   def "should capture span for already completed Flowable"() {
     setup:
     def observer = new TestSubscriber()
@@ -623,6 +745,41 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for canceled Flowable"() {
+    setup:
+    def source = UnicastProcessor.<String> create()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .flowable(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.dispose()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.flowable"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
           }
         }
       }
@@ -756,6 +913,42 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
   }
 
+  def "should capture span for eventually errored ParallelFlowable"() {
+    setup:
+    def source = UnicastProcessor.<String> create()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .parallelFlowable(source.parallel())
+      .sequential()
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.cancel()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.parallelFlowable"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
+          }
+        }
+      }
+    }
+  }
+
   def "should capture span for eventually completed Publisher"() {
     setup:
     def source = new CustomPublisher()
@@ -811,6 +1004,35 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for canceled Publisher"() {
+    setup:
+    def source = new CustomPublisher()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .publisher(source)
+      .subscribe(observer)
+    observer.assertSubscribed()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.cancel()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.publisher"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
           }
         }
       }

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
@@ -913,7 +913,7 @@ class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
   }
 
-  def "should capture span for eventually errored ParallelFlowable"() {
+  def "should capture span for canceled ParallelFlowable"() {
     setup:
     def source = UnicastProcessor.<String> create()
     def observer = new TestSubscriber()

--- a/instrumentation/rxjava/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategy.java
+++ b/instrumentation/rxjava/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategy.java
@@ -24,7 +24,7 @@ import org.reactivestreams.Publisher;
 
 public final class RxJava2AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
   private static final AttributeKey<Boolean> CANCELED_ATTRIBUTE_KEY =
-      AttributeKey.booleanKey("reactor.canceled");
+      AttributeKey.booleanKey("rxjava.canceled");
 
   public static RxJava2AsyncSpanEndStrategy create() {
     return newBuilder().build();

--- a/instrumentation/rxjava/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategyBuilder.java
+++ b/instrumentation/rxjava/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/RxJava2AsyncSpanEndStrategyBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rxjava2;
+
+public final class RxJava2AsyncSpanEndStrategyBuilder {
+
+  private boolean captureExperimentalSpanAttributes;
+
+  RxJava2AsyncSpanEndStrategyBuilder() {}
+
+  public RxJava2AsyncSpanEndStrategyBuilder setCaptureExperimentalSpanAttributes(
+      boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    return this;
+  }
+
+  public RxJava2AsyncSpanEndStrategy build() {
+    return new RxJava2AsyncSpanEndStrategy(captureExperimentalSpanAttributes);
+  }
+}

--- a/instrumentation/rxjava/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/TracingAssembly.java
+++ b/instrumentation/rxjava/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/TracingAssembly.java
@@ -24,6 +24,7 @@ package io.opentelemetry.instrumentation.rxjava2;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategies;
 import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
@@ -230,7 +231,14 @@ public final class TracingAssembly {
   }
 
   private static void enableWithSpanStrategy() {
-    AsyncSpanEndStrategies.getInstance().registerStrategy(RxJava2AsyncSpanEndStrategy.INSTANCE);
+    AsyncSpanEndStrategies.getInstance()
+        .registerStrategy(
+            RxJava2AsyncSpanEndStrategy.newBuilder()
+                .setCaptureExperimentalSpanAttributes(
+                    Config.get()
+                        .getBooleanProperty(
+                            "otel.instrumentation.rxjava.experimental-span-attributes", false))
+                .build());
   }
 
   private static void disableParallel() {
@@ -266,7 +274,7 @@ public final class TracingAssembly {
   }
 
   private static void disableWithSpanStrategy() {
-    AsyncSpanEndStrategies.getInstance().unregisterStrategy(RxJava2AsyncSpanEndStrategy.INSTANCE);
+    AsyncSpanEndStrategies.getInstance().unregisterStrategy(RxJava2AsyncSpanEndStrategy.class);
   }
 
   private static <T> Function<? super T, ? extends T> compose(

--- a/instrumentation/rxjava/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/TracingAssemblyBuilder.java
+++ b/instrumentation/rxjava/rxjava-2.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava2/TracingAssemblyBuilder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rxjava2;
+
+public final class TracingAssemblyBuilder {
+  private boolean captureExperimentalSpanAttributes;
+
+  TracingAssemblyBuilder() {}
+
+  public TracingAssemblyBuilder setCaptureExperimentalSpanAttributes(
+      boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    return this;
+  }
+
+  public TracingAssembly build() {
+    return new TracingAssembly(captureExperimentalSpanAttributes);
+  }
+}

--- a/instrumentation/rxjava/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
@@ -26,6 +26,8 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import spock.lang.Specification
 
+import java.util.concurrent.CancellationException
+
 class RxJava2AsyncSpanEndStrategyTest extends Specification {
   BaseTracer tracer
 
@@ -110,6 +112,25 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span when cancelled"() {
+      given:
+      def source = CompletableSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Completable) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -246,6 +267,25 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       observer.assertError(exception)
     }
 
+    def "ends span when cancelled"() {
+      given:
+      def source = MaybeSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Maybe<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
+    }
+
     def "ends span once for multiple subscribers"() {
       given:
       def source = MaybeSubject.create()
@@ -348,6 +388,25 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span when errored"() {
+      given:
+      def source = SingleSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Single<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -454,6 +513,25 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       observer.assertError(exception)
     }
 
+    def "ends span when cancelled"() {
+      given:
+      def source = UnicastSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Observable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
+    }
+
     def "ends span once for multiple subscribers"() {
       given:
       def source = ReplaySubject.create()
@@ -553,6 +631,25 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span when cancelled"() {
+      given:
+      def source = UnicastProcessor.create()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -655,6 +752,25 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       observer.assertError(exception)
       1 * tracer.endExceptionally(context, exception)
     }
+
+    def "ends span when cancelled"() {
+      given:
+      def source = UnicastProcessor.create()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (ParallelFlowable<?>) underTest.end(tracer, context, source.parallel())
+      result.sequential().subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
+    }
   }
 
   static class PublisherTest extends RxJava2AsyncSpanEndStrategyTest {
@@ -702,6 +818,25 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span when cancelled"() {
+      given:
+      def source = new CustomPublisher()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
     }
   }
 

--- a/instrumentation/rxjava/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/library/src/test/groovy/RxJava2AsyncSpanEndStrategyTest.groovy
@@ -390,7 +390,7 @@ class RxJava2AsyncSpanEndStrategyTest extends Specification {
       observer.assertError(exception)
     }
 
-    def "ends span when errored"() {
+    def "ends span when cancelled"() {
       given:
       def source = SingleSubject.create()
       def observer = new TestObserver()

--- a/instrumentation/rxjava/rxjava-2.0/library/src/test/groovy/RxJava2SubscriptionTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/library/src/test/groovy/RxJava2SubscriptionTest.groovy
@@ -6,10 +6,13 @@
 import io.opentelemetry.instrumentation.rxjava2.AbstractRxJava2SubscriptionTest
 import io.opentelemetry.instrumentation.rxjava2.TracingAssembly
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import spock.lang.Shared
 
 class RxJava2SubscriptionTest extends AbstractRxJava2SubscriptionTest implements LibraryTestTrait {
+  @Shared
+  TracingAssembly tracingAssembly = TracingAssembly.create()
 
   def setupSpec() {
-    TracingAssembly.enable()
+    tracingAssembly.enable()
   }
 }

--- a/instrumentation/rxjava/rxjava-2.0/library/src/test/groovy/RxJava2Test.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/library/src/test/groovy/RxJava2Test.groovy
@@ -6,10 +6,13 @@
 import io.opentelemetry.instrumentation.rxjava2.AbstractRxJava2Test
 import io.opentelemetry.instrumentation.rxjava2.TracingAssembly
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import spock.lang.Shared
 
 class RxJava2Test extends AbstractRxJava2Test implements LibraryTestTrait {
+  @Shared
+  TracingAssembly tracingAssembly = TracingAssembly.create()
 
   def setupSpec() {
-    TracingAssembly.enable()
+    tracingAssembly.enable()
   }
 }

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/rxjava-3.0-javaagent.gradle
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/rxjava-3.0-javaagent.gradle
@@ -9,6 +9,11 @@ muzzle {
   }
 }
 
+tasks.withType(Test).configureEach {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.rxjava.experimental-span-attributes=true"
+}
+
 dependencies {
   library "io.reactivex.rxjava3:rxjava:3.0.0"
 

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/main/java/io/opentelemetry/instrumentation/rxjava3/TracingAssemblyActivation.java
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/main/java/io/opentelemetry/instrumentation/rxjava3/TracingAssemblyActivation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.rxjava3;
 
+import io.opentelemetry.instrumentation.api.config.Config;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class TracingAssemblyActivation {
@@ -19,7 +20,13 @@ public final class TracingAssemblyActivation {
 
   public static void activate(Class<?> clz) {
     if (activated.get(clz).compareAndSet(false, true)) {
-      TracingAssembly.enable();
+      TracingAssembly.newBuilder()
+          .setCaptureExperimentalSpanAttributes(
+              Config.get()
+                  .getBooleanProperty(
+                      "otel.instrumentation.rxjava.experimental-span-attributes", false))
+          .build()
+          .enable();
     }
   }
 

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava3/RxJava3InstrumentationModule.java
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava3/RxJava3InstrumentationModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.rxjava2;
+package io.opentelemetry.javaagent.instrumentation.rxjava3;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -12,10 +12,10 @@ import java.util.Collections;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class RxJava2InstrumentationModule extends InstrumentationModule {
+public class RxJava3InstrumentationModule extends InstrumentationModule {
 
-  public RxJava2InstrumentationModule() {
-    super("rxjava2");
+  public RxJava3InstrumentationModule() {
+    super("rxjava3");
   }
 
   @Override

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava3/RxJavaPluginsInstrumentation.java
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava3/RxJavaPluginsInstrumentation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.rxjava3;
+package io.opentelemetry.javaagent.instrumentation.rxjava3;
 
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava3/TracingAssemblyActivation.java
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rxjava3/TracingAssemblyActivation.java
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.rxjava2;
+package io.opentelemetry.javaagent.instrumentation.rxjava3;
 
 import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.instrumentation.rxjava3.TracingAssembly;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class TracingAssemblyActivation {

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
@@ -737,7 +737,7 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
   }
 
-  def "should capture span for eventually errored Flowable"() {
+  def "should capture span for canceled Flowable"() {
     setup:
     def source = UnicastProcessor.<String> create()
     def observer = new TestSubscriber()

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
@@ -134,6 +134,34 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
   }
 
+  def "should capture span for canceled Completable"() {
+    setup:
+    def source = CompletableSubject.create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .completable(source)
+      .subscribe(observer)
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.dispose()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.completable"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
+          }
+        }
+      }
+    }
+  }
+
   def "should capture span for already completed Maybe"() {
     setup:
     def observer = new TestObserver()
@@ -267,6 +295,34 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
   }
 
+  def "should capture span for canceled Maybe"() {
+    setup:
+    def source = MaybeSubject.<String> create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .maybe(source)
+      .subscribe(observer)
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.dispose()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.maybe"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
+          }
+        }
+      }
+    }
+  }
+
   def "should capture span for already completed Single"() {
     setup:
     def observer = new TestObserver()
@@ -371,6 +427,34 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for canceled Single"() {
+    setup:
+    def source = SingleSubject.<String> create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .single(source)
+      .subscribe(observer)
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.dispose()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.single"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
           }
         }
       }
@@ -498,6 +582,40 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
   }
 
+  def "should capture span for canceled Observable"() {
+    setup:
+    def source = UnicastSubject.<String> create()
+    def observer = new TestObserver()
+    new TracedWithSpan()
+      .observable(source)
+      .subscribe(observer)
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.dispose()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.observable"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
+          }
+        }
+      }
+    }
+  }
+
   def "should capture span for already completed Flowable"() {
     setup:
     def observer = new TestSubscriber()
@@ -613,6 +731,40 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually errored Flowable"() {
+    setup:
+    def source = UnicastProcessor.<String> create()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .flowable(source)
+      .subscribe(observer)
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.cancel()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.flowable"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
           }
         }
       }
@@ -744,6 +896,41 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
     }
   }
 
+  def "should capture span for canceled ParallelFlowable"() {
+    setup:
+    def source = UnicastProcessor.<String> create()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .parallelFlowable(source.parallel())
+      .sequential()
+      .subscribe(observer)
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    observer.assertValue("Value")
+
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.cancel()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.parallelFlowable"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
+          }
+        }
+      }
+    }
+  }
+
   def "should capture span for eventually completed Publisher"() {
     setup:
     def source = new CustomPublisher()
@@ -797,6 +984,34 @@ class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecificati
           status ERROR
           errorEvent(IllegalArgumentException, "Boom")
           attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for canceled Publisher"() {
+    setup:
+    def source = new CustomPublisher()
+    def observer = new TestSubscriber()
+    new TracedWithSpan()
+      .publisher(source)
+      .subscribe(observer)
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    observer.cancel()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.publisher"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "rxjava.canceled" true
           }
         }
       }

--- a/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/RxJava3AsyncSpanEndStrategy.java
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/RxJava3AsyncSpanEndStrategy.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.rxjava3;
 
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategy;
@@ -17,12 +19,26 @@ import io.reactivex.rxjava3.functions.Action;
 import io.reactivex.rxjava3.functions.BiConsumer;
 import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.parallel.ParallelFlowable;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.reactivestreams.Publisher;
 
-public enum RxJava3AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
-  INSTANCE;
+public final class RxJava3AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
+  private static final AttributeKey<Boolean> CANCELED_ATTRIBUTE_KEY =
+      AttributeKey.booleanKey("rxjava.canceled");
+
+  public static RxJava3AsyncSpanEndStrategy create() {
+    return newBuilder().build();
+  }
+
+  public static RxJava3AsyncSpanEndStrategyBuilder newBuilder() {
+    return new RxJava3AsyncSpanEndStrategyBuilder();
+  }
+
+  private final boolean captureExperimentalSpanAttributes;
+
+  RxJava3AsyncSpanEndStrategy(boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+  }
 
   @Override
   public boolean supports(Class<?> returnType) {
@@ -107,7 +123,7 @@ public enum RxJava3AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
    * OnError notifications are received. Multiple notifications can happen anytime multiple
    * subscribers subscribe to the same publisher.
    */
-  private static final class EndOnFirstNotificationConsumer<T> extends AtomicBoolean
+  private final class EndOnFirstNotificationConsumer<T> extends AtomicBoolean
       implements Action, Consumer<Throwable>, BiConsumer<T, Throwable> {
 
     private final BaseTracer tracer;
@@ -120,7 +136,12 @@ public enum RxJava3AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
     }
 
     public void onCancelOrDispose() {
-      accept(new CancellationException());
+      if (compareAndSet(false, true)) {
+        if (captureExperimentalSpanAttributes) {
+          Span.fromContext(context).setAttribute(CANCELED_ATTRIBUTE_KEY, true);
+        }
+        tracer.end(context);
+      }
     }
 
     @Override

--- a/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/RxJava3AsyncSpanEndStrategy.java
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/RxJava3AsyncSpanEndStrategy.java
@@ -17,6 +17,7 @@ import io.reactivex.rxjava3.functions.Action;
 import io.reactivex.rxjava3.functions.BiConsumer;
 import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.parallel.ParallelFlowable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.reactivestreams.Publisher;
 
@@ -55,7 +56,9 @@ public enum RxJava3AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
 
   private static Completable endWhenComplete(
       Completable completable, EndOnFirstNotificationConsumer<?> notificationConsumer) {
-    return completable.doOnEvent(notificationConsumer);
+    return completable
+        .doOnEvent(notificationConsumer)
+        .doOnDispose(notificationConsumer::onCancelOrDispose);
   }
 
   private static <T> Maybe<T> endWhenMaybeComplete(
@@ -63,7 +66,7 @@ public enum RxJava3AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
     @SuppressWarnings("unchecked")
     EndOnFirstNotificationConsumer<T> typedConsumer =
         (EndOnFirstNotificationConsumer<T>) notificationConsumer;
-    return maybe.doOnEvent(typedConsumer);
+    return maybe.doOnEvent(typedConsumer).doOnDispose(notificationConsumer::onCancelOrDispose);
   }
 
   private static <T> Single<T> endWhenSingleComplete(
@@ -71,25 +74,32 @@ public enum RxJava3AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
     @SuppressWarnings("unchecked")
     EndOnFirstNotificationConsumer<T> typedConsumer =
         (EndOnFirstNotificationConsumer<T>) notificationConsumer;
-    return single.doOnEvent(typedConsumer);
+    return single.doOnEvent(typedConsumer).doOnDispose(notificationConsumer::onCancelOrDispose);
   }
 
   private static Observable<?> endWhenObservableComplete(
       Observable<?> observable, EndOnFirstNotificationConsumer<?> notificationConsumer) {
-    return observable.doOnComplete(notificationConsumer).doOnError(notificationConsumer);
+    return observable
+        .doOnComplete(notificationConsumer)
+        .doOnError(notificationConsumer)
+        .doOnDispose(notificationConsumer::onCancelOrDispose);
   }
 
   private static ParallelFlowable<?> endWhenFirstComplete(
       ParallelFlowable<?> parallelFlowable,
       EndOnFirstNotificationConsumer<?> notificationConsumer) {
-    return parallelFlowable.doOnComplete(notificationConsumer).doOnError(notificationConsumer);
+    return parallelFlowable
+        .doOnComplete(notificationConsumer)
+        .doOnError(notificationConsumer)
+        .doOnCancel(notificationConsumer::onCancelOrDispose);
   }
 
   private static Flowable<?> endWhenPublisherComplete(
       Publisher<?> publisher, EndOnFirstNotificationConsumer<?> notificationConsumer) {
     return Flowable.fromPublisher(publisher)
         .doOnComplete(notificationConsumer)
-        .doOnError(notificationConsumer);
+        .doOnError(notificationConsumer)
+        .doOnCancel(notificationConsumer::onCancelOrDispose);
   }
 
   /**
@@ -109,11 +119,13 @@ public enum RxJava3AsyncSpanEndStrategy implements AsyncSpanEndStrategy {
       this.context = context;
     }
 
+    public void onCancelOrDispose() {
+      accept(new CancellationException());
+    }
+
     @Override
     public void run() {
-      if (compareAndSet(false, true)) {
-        tracer.end(context);
-      }
+      accept(null);
     }
 
     @Override

--- a/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/RxJava3AsyncSpanEndStrategyBuilder.java
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/RxJava3AsyncSpanEndStrategyBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rxjava3;
+
+public final class RxJava3AsyncSpanEndStrategyBuilder {
+
+  private boolean captureExperimentalSpanAttributes;
+
+  RxJava3AsyncSpanEndStrategyBuilder() {}
+
+  public RxJava3AsyncSpanEndStrategyBuilder setCaptureExperimentalSpanAttributes(
+      boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    return this;
+  }
+
+  public RxJava3AsyncSpanEndStrategy build() {
+    return new RxJava3AsyncSpanEndStrategy(captureExperimentalSpanAttributes);
+  }
+}

--- a/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/TracingAssembly.java
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/TracingAssembly.java
@@ -24,6 +24,7 @@ package io.opentelemetry.instrumentation.rxjava3;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategies;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.CompletableObserver;
@@ -228,7 +229,14 @@ public final class TracingAssembly {
   }
 
   private static void enableWithSpanStrategy() {
-    AsyncSpanEndStrategies.getInstance().registerStrategy(RxJava3AsyncSpanEndStrategy.INSTANCE);
+    AsyncSpanEndStrategies.getInstance()
+        .registerStrategy(
+            RxJava3AsyncSpanEndStrategy.newBuilder()
+                .setCaptureExperimentalSpanAttributes(
+                    Config.get()
+                        .getBooleanProperty(
+                            "otel.instrumentation.rxjava.experimental-span-attributes", false))
+                .build());
   }
 
   private static void disableParallel() {
@@ -264,7 +272,7 @@ public final class TracingAssembly {
   }
 
   private static void disableWithSpanStrategy() {
-    AsyncSpanEndStrategies.getInstance().unregisterStrategy(RxJava3AsyncSpanEndStrategy.INSTANCE);
+    AsyncSpanEndStrategies.getInstance().unregisterStrategy(RxJava3AsyncSpanEndStrategy.class);
   }
 
   private static <T> Function<? super T, ? extends T> compose(

--- a/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/TracingAssembly.java
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/TracingAssembly.java
@@ -24,7 +24,6 @@ package io.opentelemetry.instrumentation.rxjava3;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategies;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.CompletableObserver;
@@ -97,50 +96,66 @@ public final class TracingAssembly {
   @GuardedBy("TracingAssembly.class")
   private static boolean enabled;
 
-  private TracingAssembly() {}
-
-  public static synchronized void enable() {
-    if (enabled) {
-      return;
-    }
-
-    enableObservable();
-
-    enableCompletable();
-
-    enableSingle();
-
-    enableMaybe();
-
-    enableFlowable();
-
-    enableParallel();
-
-    enableWithSpanStrategy();
-
-    enabled = true;
+  public static TracingAssembly create() {
+    return newBuilder().build();
   }
 
-  public static synchronized void disable() {
-    if (!enabled) {
-      return;
+  public static TracingAssemblyBuilder newBuilder() {
+    return new TracingAssemblyBuilder();
+  }
+
+  private final boolean captureExperimentalSpanAttributes;
+
+  TracingAssembly(boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+  }
+
+  public void enable() {
+    synchronized (TracingAssembly.class) {
+      if (enabled) {
+        return;
+      }
+
+      enableObservable();
+
+      enableCompletable();
+
+      enableSingle();
+
+      enableMaybe();
+
+      enableFlowable();
+
+      enableParallel();
+
+      enableWithSpanStrategy(captureExperimentalSpanAttributes);
+
+      enabled = true;
     }
+  }
 
-    disableObservable();
+  public void disable() {
+    synchronized (TracingAssembly.class) {
+      if (!enabled) {
+        return;
+      }
 
-    disableCompletable();
+      disableObservable();
 
-    disableSingle();
+      disableCompletable();
 
-    disableMaybe();
+      disableSingle();
 
-    disableFlowable();
+      disableMaybe();
 
-    disableParallel();
+      disableFlowable();
 
-    disableWithSpanStrategy();
+      disableParallel();
 
-    enabled = false;
+      disableWithSpanStrategy();
+
+      enabled = false;
+    }
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
@@ -228,14 +243,11 @@ public final class TracingAssembly {
                     }));
   }
 
-  private static void enableWithSpanStrategy() {
+  private static void enableWithSpanStrategy(boolean captureExperimentalSpanAttributes) {
     AsyncSpanEndStrategies.getInstance()
         .registerStrategy(
             RxJava3AsyncSpanEndStrategy.newBuilder()
-                .setCaptureExperimentalSpanAttributes(
-                    Config.get()
-                        .getBooleanProperty(
-                            "otel.instrumentation.rxjava.experimental-span-attributes", false))
+                .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes)
                 .build());
   }
 

--- a/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/TracingAssemblyBuilder.java
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava3/TracingAssemblyBuilder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rxjava3;
+
+public final class TracingAssemblyBuilder {
+  private boolean captureExperimentalSpanAttributes;
+
+  TracingAssemblyBuilder() {}
+
+  public TracingAssemblyBuilder setCaptureExperimentalSpanAttributes(
+      boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    return this;
+  }
+
+  public TracingAssembly build() {
+    return new TracingAssembly(captureExperimentalSpanAttributes);
+  }
+}

--- a/instrumentation/rxjava/rxjava-3.0/library/src/test/groovy/RxJava3AsyncSpanEndStrategyTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/test/groovy/RxJava3AsyncSpanEndStrategyTest.groovy
@@ -26,6 +26,8 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import spock.lang.Specification
 
+import java.util.concurrent.CancellationException
+
 class RxJava3AsyncSpanEndStrategyTest extends Specification {
   BaseTracer tracer
 
@@ -110,6 +112,25 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span when cancelled"() {
+      given:
+      def source = CompletableSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Completable) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.dispose()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -246,6 +267,25 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       observer.assertError(exception)
     }
 
+    def "ends span when cancelled"() {
+      given:
+      def source = MaybeSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Maybe<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.dispose()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
+    }
+
     def "ends span once for multiple subscribers"() {
       given:
       def source = MaybeSubject.create()
@@ -348,6 +388,25 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span when cancelled"() {
+      given:
+      def source = SingleSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Single<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.dispose()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -454,6 +513,25 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       observer.assertError(exception)
     }
 
+    def "ends span when cancelled"() {
+      given:
+      def source = UnicastSubject.create()
+      def observer = new TestObserver()
+
+      when:
+      def result = (Observable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.dispose()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
+    }
+
     def "ends span once for multiple subscribers"() {
       given:
       def source = ReplaySubject.create()
@@ -553,6 +631,25 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span when cancelled"() {
+      given:
+      def source = UnicastProcessor.create()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -655,6 +752,25 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       observer.assertError(exception)
       1 * tracer.endExceptionally(context, exception)
     }
+
+    def "ends span when cancelled"() {
+      given:
+      def source = UnicastProcessor.create()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (ParallelFlowable<?>) underTest.end(tracer, context, source.parallel())
+      result.sequential().subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
+    }
   }
 
   static class PublisherTest extends RxJava3AsyncSpanEndStrategyTest {
@@ -702,6 +818,25 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       then:
       1 * tracer.endExceptionally(context, exception)
       observer.assertError(exception)
+    }
+
+    def "ends span when cancelled"() {
+      given:
+      def source = new CustomPublisher()
+      def observer = new TestSubscriber()
+
+      when:
+      def result = (Flowable<?>) underTest.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.endExceptionally(context, _ as CancellationException)
     }
   }
 

--- a/instrumentation/rxjava/rxjava-3.0/library/src/test/groovy/RxJava3AsyncSpanEndStrategyTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/test/groovy/RxJava3AsyncSpanEndStrategyTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer
 import io.opentelemetry.instrumentation.rxjava3.RxJava3AsyncSpanEndStrategy
@@ -26,18 +27,24 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import spock.lang.Specification
 
-import java.util.concurrent.CancellationException
-
 class RxJava3AsyncSpanEndStrategyTest extends Specification {
   BaseTracer tracer
 
   Context context
 
-  def underTest = RxJava3AsyncSpanEndStrategy.INSTANCE
+  Span span
+
+  def underTest = RxJava3AsyncSpanEndStrategy.create()
+
+  def underTestWithExperimentalAttributes = RxJava3AsyncSpanEndStrategy.newBuilder()
+    .setCaptureExperimentalSpanAttributes(true)
+    .build()
 
   void setup() {
     tracer = Mock()
     context = Mock()
+    span = Mock()
+    span.storeInContext(_) >> { callRealMethod() }
   }
 
   static class CompletableTest extends RxJava3AsyncSpanEndStrategyTest {
@@ -118,6 +125,7 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       given:
       def source = CompletableSubject.create()
       def observer = new TestObserver()
+      def context = span.storeInContext(Context.root())
 
       when:
       def result = (Completable) underTest.end(tracer, context, source)
@@ -125,12 +133,36 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
 
       then:
       0 * tracer._
+      0 * span._
 
       when:
       observer.dispose()
 
       then:
-      1 * tracer.endExceptionally(context, _ as CancellationException)
+      1 * tracer.end(context)
+      0 * span.setAttribute(_)
+    }
+
+    def "ends span when cancelled and capturing experimental span attributes"() {
+      given:
+      def source = CompletableSubject.create()
+      def observer = new TestObserver()
+      def context = span.storeInContext(Context.root())
+
+      when:
+      def result = (Completable) underTestWithExperimentalAttributes.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+      0 * span._
+
+      when:
+      observer.dispose()
+
+      then:
+      1 * tracer.end(context)
+      1 * span.setAttribute({ it.getKey() == "rxjava.canceled" }, true)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -271,6 +303,7 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       given:
       def source = MaybeSubject.create()
       def observer = new TestObserver()
+      def context = span.storeInContext(Context.root())
 
       when:
       def result = (Maybe<?>) underTest.end(tracer, context, source)
@@ -283,7 +316,30 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       observer.dispose()
 
       then:
-      1 * tracer.endExceptionally(context, _ as CancellationException)
+      1 * tracer.end(context)
+      0 * span.setAttribute(_)
+    }
+
+    def "ends span when cancelled and capturing experimental span attributes"() {
+      given:
+      def source = MaybeSubject.create()
+      def observer = new TestObserver()
+      def context = span.storeInContext(Context.root())
+
+      when:
+      def result = (Maybe<?>) underTestWithExperimentalAttributes.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+      0 * span._
+
+      when:
+      observer.dispose()
+
+      then:
+      1 * tracer.end(context)
+      1 * span.setAttribute({ it.getKey() == "rxjava.canceled" }, true)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -394,6 +450,7 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       given:
       def source = SingleSubject.create()
       def observer = new TestObserver()
+      def context = span.storeInContext(Context.root())
 
       when:
       def result = (Single<?>) underTest.end(tracer, context, source)
@@ -406,7 +463,30 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       observer.dispose()
 
       then:
-      1 * tracer.endExceptionally(context, _ as CancellationException)
+      1 * tracer.end(context)
+      0 * span.setAttribute(_)
+    }
+
+    def "ends span when cancelled and capturing experimental span attributes"() {
+      given:
+      def source = SingleSubject.create()
+      def observer = new TestObserver()
+      def context = span.storeInContext(Context.root())
+
+      when:
+      def result = (Single<?>) underTestWithExperimentalAttributes.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+      0 * span._
+
+      when:
+      observer.dispose()
+
+      then:
+      1 * tracer.end(context)
+      1 * span.setAttribute({ it.getKey() == "rxjava.canceled" }, true)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -517,6 +597,7 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       given:
       def source = UnicastSubject.create()
       def observer = new TestObserver()
+      def context = span.storeInContext(Context.root())
 
       when:
       def result = (Observable<?>) underTest.end(tracer, context, source)
@@ -529,7 +610,30 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       observer.dispose()
 
       then:
-      1 * tracer.endExceptionally(context, _ as CancellationException)
+      1 * tracer.end(context)
+      0 * span.setAttribute(_)
+    }
+
+    def "ends span when cancelled and capturing experimental span attributes"() {
+      given:
+      def source = UnicastSubject.create()
+      def observer = new TestObserver()
+      def context = span.storeInContext(Context.root())
+
+      when:
+      def result = (Observable<?>) underTestWithExperimentalAttributes.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+      0 * span._
+
+      when:
+      observer.dispose()
+
+      then:
+      1 * tracer.end(context)
+      1 * span.setAttribute({ it.getKey() == "rxjava.canceled" }, true)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -637,6 +741,7 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       given:
       def source = UnicastProcessor.create()
       def observer = new TestSubscriber()
+      def context = span.storeInContext(Context.root())
 
       when:
       def result = (Flowable<?>) underTest.end(tracer, context, source)
@@ -649,7 +754,30 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       observer.cancel()
 
       then:
-      1 * tracer.endExceptionally(context, _ as CancellationException)
+      1 * tracer.end(context)
+      0 * span.setAttribute(_)
+    }
+
+    def "ends span when cancelled and capturing experimental span attributes"() {
+      given:
+      def source = UnicastProcessor.create()
+      def observer = new TestSubscriber()
+      def context = span.storeInContext(Context.root())
+
+      when:
+      def result = (Flowable<?>) underTestWithExperimentalAttributes.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+      0 * span._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.end(context)
+      1 * span.setAttribute({ it.getKey() == "rxjava.canceled" }, true)
     }
 
     def "ends span once for multiple subscribers"() {
@@ -757,6 +885,7 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       given:
       def source = UnicastProcessor.create()
       def observer = new TestSubscriber()
+      def context = span.storeInContext(Context.root())
 
       when:
       def result = (ParallelFlowable<?>) underTest.end(tracer, context, source.parallel())
@@ -769,7 +898,30 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       observer.cancel()
 
       then:
-      1 * tracer.endExceptionally(context, _ as CancellationException)
+      1 * tracer.end(context)
+      0 * span.setAttribute(_)
+    }
+
+    def "ends span when cancelled and capturing experimental span attributes"() {
+      given:
+      def source = UnicastProcessor.create()
+      def observer = new TestSubscriber()
+      def context = span.storeInContext(Context.root())
+
+      when:
+      def result = (ParallelFlowable<?>) underTestWithExperimentalAttributes.end(tracer, context, source.parallel())
+      result.sequential().subscribe(observer)
+
+      then:
+      0 * tracer._
+      0 * span._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.end(context)
+      1 * span.setAttribute({ it.getKey() == "rxjava.canceled" }, true)
     }
   }
 
@@ -824,6 +976,7 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       given:
       def source = new CustomPublisher()
       def observer = new TestSubscriber()
+      def context = span.storeInContext(Context.root())
 
       when:
       def result = (Flowable<?>) underTest.end(tracer, context, source)
@@ -836,7 +989,30 @@ class RxJava3AsyncSpanEndStrategyTest extends Specification {
       observer.cancel()
 
       then:
-      1 * tracer.endExceptionally(context, _ as CancellationException)
+      1 * tracer.end(context)
+      0 * span.setAttribute(_)
+    }
+
+    def "ends span when cancelled and capturing experimental span attributes"() {
+      given:
+      def source = new CustomPublisher()
+      def observer = new TestSubscriber()
+      def context = span.storeInContext(Context.root())
+
+      when:
+      def result = (Flowable<?>) underTestWithExperimentalAttributes.end(tracer, context, source)
+      result.subscribe(observer)
+
+      then:
+      0 * tracer._
+      0 * span._
+
+      when:
+      observer.cancel()
+
+      then:
+      1 * tracer.end(context)
+      1 * span.setAttribute({ it.getKey() == "rxjava.canceled" }, true)
     }
   }
 

--- a/instrumentation/rxjava/rxjava-3.0/library/src/test/groovy/RxJava3SubscriptionTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/test/groovy/RxJava3SubscriptionTest.groovy
@@ -6,10 +6,13 @@
 import io.opentelemetry.instrumentation.rxjava3.AbstractRxJava3SubscriptionTest
 import io.opentelemetry.instrumentation.rxjava3.TracingAssembly
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import spock.lang.Shared
 
 class RxJava3SubscriptionTest extends AbstractRxJava3SubscriptionTest implements LibraryTestTrait {
+  @Shared
+  TracingAssembly tracingAssembly = TracingAssembly.create()
 
   def setupSpec() {
-    TracingAssembly.enable()
+    tracingAssembly.enable()
   }
 }

--- a/instrumentation/rxjava/rxjava-3.0/library/src/test/groovy/RxJava3Test.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/test/groovy/RxJava3Test.groovy
@@ -6,10 +6,13 @@
 import io.opentelemetry.instrumentation.rxjava3.AbstractRxJava3Test
 import io.opentelemetry.instrumentation.rxjava3.TracingAssembly
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import spock.lang.Shared
 
 class RxJava3Test extends AbstractRxJava3Test implements LibraryTestTrait {
+  @Shared
+  TracingAssembly tracingAssembly = TracingAssembly.create()
 
   def setupSpec() {
-    TracingAssembly.enable()
+    tracingAssembly.enable()
   }
 }


### PR DESCRIPTION
Updates the AsyncSpanEndStrategy for Reactor, RxJava 2 and RxJava 3 so that the Span is ended if the subscription to the publisher is canceled by the consumer.  Optionally a semantic attribute will also be added to the Span to indicate that the subscription was canceled.