### PR TITLE
Run gRPC tests with Netty instrumentation

### DIFF
--- a/instrumentation/grpc-1.6/javaagent/grpc-1.6-javaagent.gradle
+++ b/instrumentation/grpc-1.6/javaagent/grpc-1.6-javaagent.gradle
@@ -31,6 +31,8 @@ dependencies {
   implementation project(':instrumentation:grpc-1.6:library')
 
   library "io.grpc:grpc-core:${grpcVersion}"
+  
+  testInstrumentation project(':instrumentation:netty:netty-4.1:javaagent')
 
   testLibrary "io.grpc:grpc-netty:${grpcVersion}"
   testLibrary "io.grpc:grpc-protobuf:${grpcVersion}"


### PR DESCRIPTION
Since gRPC uses Netty we should run tests with Netty instrumentation on. I'm actually not sure why it works, Netty should be making server spans I thought. Seems ok for some reason though (something about gRPC's Netty implementation that doesn't trigger our matchers? 🤷 )