### PR TITLE
End span with attribute on cancellation of Guava future

### DIFF
--- a/instrumentation/guava-10.0/javaagent/guava-10.0-javaagent.gradle
+++ b/instrumentation/guava-10.0/javaagent/guava-10.0-javaagent.gradle
@@ -9,6 +9,11 @@ muzzle {
   }
 }
 
+tasks.withType(Test).configureEach {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs "-Dotel.instrumentation.guava.experimental-span-attributes=true"
+}
+
 dependencies {
   library "com.google.guava:guava:10.0"
 

--- a/instrumentation/guava-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/guava/InstrumentationHelper.java
+++ b/instrumentation/guava-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/guava/InstrumentationHelper.java
@@ -5,12 +5,24 @@
 
 package io.opentelemetry.javaagent.instrumentation.guava;
 
+import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategies;
 import io.opentelemetry.instrumentation.guava.GuavaAsyncSpanEndStrategy;
 
 public final class InstrumentationHelper {
   static {
-    AsyncSpanEndStrategies.getInstance().registerStrategy(GuavaAsyncSpanEndStrategy.INSTANCE);
+    registerAsyncSpanEndStrategy();
+  }
+
+  private static void registerAsyncSpanEndStrategy() {
+    AsyncSpanEndStrategies.getInstance()
+        .registerStrategy(
+            GuavaAsyncSpanEndStrategy.newBuilder()
+                .setCaptureExperimentalSpanAttributes(
+                    Config.get()
+                        .getBooleanProperty(
+                            "otel.instrumentation.guava.experimental-span-attributes", false))
+                .build());
   }
 
   /**

--- a/instrumentation/guava-10.0/library/src/main/java/io/opentelemetry/instrumentation/guava/GuavaAsyncSpanEndStrategy.java
+++ b/instrumentation/guava-10.0/library/src/main/java/io/opentelemetry/instrumentation/guava/GuavaAsyncSpanEndStrategy.java
@@ -7,12 +7,29 @@ package io.opentelemetry.instrumentation.guava;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
 import io.opentelemetry.instrumentation.api.tracer.async.AsyncSpanEndStrategy;
 
-public enum GuavaAsyncSpanEndStrategy implements AsyncSpanEndStrategy {
-  INSTANCE;
+public final class GuavaAsyncSpanEndStrategy implements AsyncSpanEndStrategy {
+  private static final AttributeKey<Boolean> CANCELED_ATTRIBUTE_KEY =
+      AttributeKey.booleanKey("guava.canceled");
+
+  public static GuavaAsyncSpanEndStrategy create() {
+    return newBuilder().build();
+  }
+
+  public static GuavaAsyncSpanEndStrategyBuilder newBuilder() {
+    return new GuavaAsyncSpanEndStrategyBuilder();
+  }
+
+  private final boolean captureExperimentalSpanAttributes;
+
+  GuavaAsyncSpanEndStrategy(boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+  }
 
   @Override
   public boolean supports(Class<?> returnType) {
@@ -30,12 +47,19 @@ public enum GuavaAsyncSpanEndStrategy implements AsyncSpanEndStrategy {
     return future;
   }
 
-  private static void endSpan(BaseTracer tracer, Context context, ListenableFuture<?> future) {
-    try {
-      Uninterruptibles.getUninterruptibly(future);
+  private void endSpan(BaseTracer tracer, Context context, ListenableFuture<?> future) {
+    if (future.isCancelled()) {
+      if (captureExperimentalSpanAttributes) {
+        Span.fromContext(context).setAttribute(CANCELED_ATTRIBUTE_KEY, true);
+      }
       tracer.end(context);
-    } catch (Throwable exception) {
-      tracer.endExceptionally(context, exception);
+    } else {
+      try {
+        Uninterruptibles.getUninterruptibly(future);
+        tracer.end(context);
+      } catch (Throwable exception) {
+        tracer.endExceptionally(context, exception);
+      }
     }
   }
 }

--- a/instrumentation/guava-10.0/library/src/main/java/io/opentelemetry/instrumentation/guava/GuavaAsyncSpanEndStrategyBuilder.java
+++ b/instrumentation/guava-10.0/library/src/main/java/io/opentelemetry/instrumentation/guava/GuavaAsyncSpanEndStrategyBuilder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.guava;
+
+public final class GuavaAsyncSpanEndStrategyBuilder {
+  private boolean captureExperimentalSpanAttributes = false;
+
+  GuavaAsyncSpanEndStrategyBuilder() {}
+
+  public GuavaAsyncSpanEndStrategyBuilder setCaptureExperimentalSpanAttributes(
+      boolean captureExperimentalSpanAttributes) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    return this;
+  }
+
+  public GuavaAsyncSpanEndStrategy build() {
+    return new GuavaAsyncSpanEndStrategy(captureExperimentalSpanAttributes);
+  }
+}


### PR DESCRIPTION
Changes the AsyncSpanEndStrategy for Guava ListenableFuture when canceled to end the Span without an error status and with a semantic attribute indicating cancellation.

See https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3153 for similar with Reactor, RxJava2 and RxJava3