### PR TITLE
Move app servers to runtime dependencies.

### DIFF
--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-payara-testing/jaxrs-2.0-payara-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-payara-testing/jaxrs-2.0-payara-testing.gradle
@@ -13,8 +13,8 @@ repositories {
 
 dependencies {
   testImplementation project(':instrumentation:jaxrs:jaxrs-2.0:jaxrs-2.0-arquillian-testing')
-  testImplementation "fish.payara.arquillian:arquillian-payara-server-embedded:2.4.1"
-  testImplementation 'fish.payara.extras:payara-embedded-web:5.2021.2'
+  testRuntimeOnly "fish.payara.arquillian:arquillian-payara-server-embedded:2.4.1"
+  testRuntimeOnly 'fish.payara.extras:payara-embedded-web:5.2021.2'
 
   testInstrumentation project(':instrumentation:servlet:servlet-3.0:javaagent')
   testInstrumentation project(':instrumentation:jaxrs:jaxrs-2.0:jaxrs-2.0-common:javaagent')

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-tomee-testing/jaxrs-2.0-tomee-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-tomee-testing/jaxrs-2.0-tomee-testing.gradle
@@ -13,6 +13,7 @@ repositories {
 
 dependencies {
   testImplementation project(':instrumentation:jaxrs:jaxrs-2.0:jaxrs-2.0-arquillian-testing')
+  testCompileOnly "jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2"
   testRuntimeOnly "org.apache.tomee:arquillian-tomee-embedded:8.0.6"
   testRuntimeOnly "org.apache.tomee:tomee-embedded:8.0.6"
   testRuntimeOnly "org.apache.tomee:tomee-jaxrs:8.0.6"

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-tomee-testing/jaxrs-2.0-tomee-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-tomee-testing/jaxrs-2.0-tomee-testing.gradle
@@ -13,9 +13,9 @@ repositories {
 
 dependencies {
   testImplementation project(':instrumentation:jaxrs:jaxrs-2.0:jaxrs-2.0-arquillian-testing')
-  testImplementation "org.apache.tomee:arquillian-tomee-embedded:8.0.6"
-  testImplementation "org.apache.tomee:tomee-embedded:8.0.6"
-  testImplementation "org.apache.tomee:tomee-jaxrs:8.0.6"
+  testRuntimeOnly "org.apache.tomee:arquillian-tomee-embedded:8.0.6"
+  testRuntimeOnly "org.apache.tomee:tomee-embedded:8.0.6"
+  testRuntimeOnly "org.apache.tomee:tomee-jaxrs:8.0.6"
 
   testInstrumentation project(':instrumentation:servlet:servlet-3.0:javaagent')
   testInstrumentation project(':instrumentation:jaxrs:jaxrs-2.0:jaxrs-2.0-common:javaagent')

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-wildfly-testing/jaxrs-2.0-wildfly-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-wildfly-testing/jaxrs-2.0-wildfly-testing.gradle
@@ -19,7 +19,7 @@ dependencies {
   testImplementation "javax:javaee-api:7.0"
 
   testImplementation project(':instrumentation:jaxrs:jaxrs-2.0:jaxrs-2.0-arquillian-testing')
-  testImplementation "org.wildfly.arquillian:wildfly-arquillian-container-embedded:2.2.0.Final"
+  testRuntimeOnly "org.wildfly.arquillian:wildfly-arquillian-container-embedded:2.2.0.Final"
 
   testInstrumentation project(':instrumentation:servlet:servlet-3.0:javaagent')
   testInstrumentation project(':instrumentation:jaxrs:jaxrs-2.0:jaxrs-2.0-common:javaagent')

--- a/instrumentation/servlet/glassfish-testing/glassfish-testing.gradle
+++ b/instrumentation/servlet/glassfish-testing/glassfish-testing.gradle
@@ -10,10 +10,14 @@ dependencies {
   testInstrumentation project(':instrumentation:servlet:servlet-javax-common:javaagent')
   testInstrumentation project(':instrumentation:grizzly-2.0:javaagent')
 
-  // NB: testLibrary fails for some reason.
-  testImplementation "org.glassfish.main.extras:glassfish-embedded-all:4.0"
-
-  latestDepTestLibrary "org.glassfish.main.extras:glassfish-embedded-all:5.1.0"
+  testCompileOnly "org.glassfish.main.common:scattered-archive-api:4.0"
+  testCompileOnly "org.glassfish.main.common:simple-glassfish-api:4.0"
+  testCompileOnly "javax.servlet:javax.servlet-api:3.0.1"
+  if (!testLatestDeps) {
+    testRuntimeOnly "org.glassfish.main.extras:glassfish-embedded-all:4.0"
+  } else {
+    testRuntimeOnly "org.glassfish.main.extras:glassfish-embedded-all:5.1.0"
+  }
 }
 
 tasks.withType(Test).configureEach {


### PR DESCRIPTION
When staring at IntelliJ indexing, I noticed glassfish and payara take excessive time because they're huge JARs. Was hoping moving them to runtime might prevent IntelliJ from indexing them but no go. Oh well, probably still a reasonable change anyways.