### PR TITLE
Fix netty muzzle

### DIFF
--- a/instrumentation/netty/netty-4.0/javaagent/netty-4.0-javaagent.gradle
+++ b/instrumentation/netty/netty-4.0/javaagent/netty-4.0-javaagent.gradle
@@ -19,12 +19,6 @@ muzzle {
     module = "netty"
     versions = "[,]"
   }
-  pass {
-    group = "io.vertx"
-    module = "vertx-core"
-    versions = "[2.0.0,3.3.0)"
-    assertInverse = true
-  }
 }
 
 dependencies {

--- a/instrumentation/netty/netty-4.1/javaagent/netty-4.1-javaagent.gradle
+++ b/instrumentation/netty/netty-4.1/javaagent/netty-4.1-javaagent.gradle
@@ -19,12 +19,6 @@ muzzle {
     module = "netty"
     versions = "[,]"
   }
-  pass {
-    group = "io.vertx"
-    module = "vertx-core"
-    versions = "[3.3.0,)"
-    assertInverse = true
-  }
 }
 
 dependencies {


### PR DESCRIPTION
Resolves #3189

I think it broke because vertx-core `2.0.0-CR1` depends on netty `4.0.0.CR5` and so muzzle was expected to fail, but the new dependency version management is causing the netty dependency to resolve to `4.0.0.Final` and so it was passing.

I don't think we need the vertx-core muzzle constraints in netty instrumentation modules anyways, so just removing them.

Not sure if we also want to (can?) disable dependency management for muzzle?