### PR TITLE
Rename some extractor request/response params

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -18,29 +18,29 @@ final class ApacheHttpClientHttpAttributesExtractor
     extends HttpAttributesExtractor<HttpMethod, HttpMethod> {
 
   @Override
-  protected String method(HttpMethod httpMethod) {
-    return httpMethod.getName();
+  protected String method(HttpMethod request) {
+    return request.getName();
   }
 
   @Override
-  protected String url(HttpMethod httpMethod) {
-    return getUrl(httpMethod);
+  protected String url(HttpMethod request) {
+    return getUrl(request);
   }
 
   @Override
-  protected String target(HttpMethod httpMethod) {
-    String queryString = httpMethod.getQueryString();
-    return queryString != null ? httpMethod.getPath() + "?" + queryString : httpMethod.getPath();
+  protected String target(HttpMethod request) {
+    String queryString = request.getQueryString();
+    return queryString != null ? request.getPath() + "?" + queryString : request.getPath();
   }
 
   @Override
   @Nullable
-  protected String host(HttpMethod httpMethod) {
-    Header header = httpMethod.getRequestHeader("Host");
+  protected String host(HttpMethod request) {
+    Header header = request.getRequestHeader("Host");
     if (header != null) {
       return header.getValue();
     }
-    HostConfiguration hostConfiguration = httpMethod.getHostConfiguration();
+    HostConfiguration hostConfiguration = request.getHostConfiguration();
     if (hostConfiguration != null) {
       return hostConfiguration.getVirtualHost();
     }
@@ -49,28 +49,28 @@ final class ApacheHttpClientHttpAttributesExtractor
 
   @Override
   @Nullable
-  protected String scheme(HttpMethod httpMethod) {
-    HostConfiguration hostConfiguration = httpMethod.getHostConfiguration();
+  protected String scheme(HttpMethod request) {
+    HostConfiguration hostConfiguration = request.getHostConfiguration();
     return hostConfiguration != null ? hostConfiguration.getProtocol().getScheme() : null;
   }
 
   @Override
   @Nullable
-  protected String userAgent(HttpMethod httpMethod) {
-    Header header = httpMethod.getRequestHeader("User-Agent");
+  protected String userAgent(HttpMethod request) {
+    Header header = request.getRequestHeader("User-Agent");
     return header != null ? header.getValue() : null;
   }
 
   @Override
   @Nullable
-  protected Long requestContentLength(HttpMethod httpMethod, @Nullable HttpMethod response) {
+  protected Long requestContentLength(HttpMethod request, @Nullable HttpMethod response) {
     return null;
   }
 
   @Override
   @Nullable
   protected Long requestContentLengthUncompressed(
-      HttpMethod httpMethod, @Nullable HttpMethod response) {
+      HttpMethod request, @Nullable HttpMethod response) {
     return null;
   }
 
@@ -83,9 +83,9 @@ final class ApacheHttpClientHttpAttributesExtractor
 
   @Override
   @Nullable
-  protected String flavor(HttpMethod httpMethod, @Nullable HttpMethod response) {
-    if (httpMethod instanceof HttpMethodBase) {
-      return ((HttpMethodBase) httpMethod).isHttp11()
+  protected String flavor(HttpMethod request, @Nullable HttpMethod response) {
+    if (request instanceof HttpMethodBase) {
+      return ((HttpMethodBase) request).isHttp11()
           ? SemanticAttributes.HttpFlavorValues.HTTP_1_1
           : SemanticAttributes.HttpFlavorValues.HTTP_1_0;
     }
@@ -94,43 +94,43 @@ final class ApacheHttpClientHttpAttributesExtractor
 
   @Override
   @Nullable
-  protected Long responseContentLength(HttpMethod httpMethod, HttpMethod response) {
+  protected Long responseContentLength(HttpMethod request, HttpMethod response) {
     return null;
   }
 
   @Override
   @Nullable
-  protected Long responseContentLengthUncompressed(HttpMethod httpMethod, HttpMethod response) {
+  protected Long responseContentLengthUncompressed(HttpMethod request, HttpMethod response) {
     return null;
   }
 
   @Override
   @Nullable
-  protected String serverName(HttpMethod httpMethod, @Nullable HttpMethod response) {
+  protected String serverName(HttpMethod request, @Nullable HttpMethod response) {
     return null;
   }
 
   @Override
   @Nullable
-  protected String route(HttpMethod httpMethod) {
+  protected String route(HttpMethod request) {
     return null;
   }
 
   @Override
   @Nullable
-  protected String clientIp(HttpMethod httpMethod, @Nullable HttpMethod response) {
+  protected String clientIp(HttpMethod request, @Nullable HttpMethod response) {
     return null;
   }
 
   // mirroring implementation HttpMethodBase.getURI(), to avoid converting to URI and back to String
-  private static String getUrl(HttpMethod httpMethod) {
-    HostConfiguration hostConfiguration = httpMethod.getHostConfiguration();
+  private static String getUrl(HttpMethod request) {
+    HostConfiguration hostConfiguration = request.getHostConfiguration();
     if (hostConfiguration == null) {
-      String queryString = httpMethod.getQueryString();
+      String queryString = request.getQueryString();
       if (queryString == null) {
-        return httpMethod.getPath();
+        return request.getPath();
       } else {
-        return httpMethod.getPath() + "?" + httpMethod.getQueryString();
+        return request.getPath() + "?" + request.getQueryString();
       }
     } else {
       StringBuilder url = new StringBuilder();
@@ -142,11 +142,11 @@ final class ApacheHttpClientHttpAttributesExtractor
         url.append(":");
         url.append(port);
       }
-      url.append(httpMethod.getPath());
-      String queryString = httpMethod.getQueryString();
+      url.append(request.getPath());
+      String queryString = request.getQueryString();
       if (queryString != null) {
         url.append("?");
-        url.append(httpMethod.getQueryString());
+        url.append(request.getQueryString());
       }
       return url.toString();
     }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetAttributesExtractor.java
@@ -17,15 +17,14 @@ final class ArmeriaNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<RequestContext, RequestLog> {
 
   @Override
-  public String transport(RequestContext requestContext) {
+  public String transport(RequestContext ctx) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getAddress(
-      RequestContext requestContext, @Nullable RequestLog requestLog) {
-    SocketAddress address = requestContext.remoteAddress();
+  public InetSocketAddress getAddress(RequestContext ctx, @Nullable RequestLog requestLog) {
+    SocketAddress address = ctx.remoteAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;
     }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraKeyspaceExtractor.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraKeyspaceExtractor.java
@@ -21,5 +21,5 @@ final class CassandraKeyspaceExtractor
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, CassandraRequest request, ExecutionInfo response) {}
+      AttributesBuilder attributes, CassandraRequest request, ExecutionInfo executionInfo) {}
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetAttributesExtractor.java
@@ -21,7 +21,7 @@ final class CassandraNetAttributesExtractor
 
   @Override
   public @Nullable InetSocketAddress getAddress(
-      CassandraRequest request, @Nullable ExecutionInfo response) {
-    return response == null ? null : response.getQueriedHost().getSocketAddress();
+      CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
+    return executionInfo == null ? null : executionInfo.getQueriedHost().getSocketAddress();
   }
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraAttributesExtractor.java
@@ -29,12 +29,14 @@ final class CassandraAttributesExtractor
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, CassandraRequest request, @Nullable ExecutionInfo response) {
-    if (response == null) {
+      AttributesBuilder attributes,
+      CassandraRequest request,
+      @Nullable ExecutionInfo executionInfo) {
+    if (executionInfo == null) {
       return;
     }
 
-    Node coordinator = response.getCoordinator();
+    Node coordinator = executionInfo.getCoordinator();
     if (coordinator != null) {
       if (coordinator.getDatacenter() != null) {
         set(
@@ -52,9 +54,9 @@ final class CassandraAttributesExtractor
     set(
         attributes,
         SemanticAttributes.DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT,
-        (long) response.getSpeculativeExecutionCount());
+        (long) executionInfo.getSpeculativeExecutionCount());
 
-    Statement<?> statement = response.getStatement();
+    Statement<?> statement = executionInfo.getStatement();
     DriverExecutionProfile config =
         request.getSession().getContext().getConfig().getDefaultProfile();
     if (statement.getConsistencyLevel() != null) {

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetAttributesExtractor.java
@@ -23,11 +23,11 @@ final class CassandraNetAttributesExtractor
 
   @Override
   public @Nullable InetSocketAddress getAddress(
-      CassandraRequest request, @Nullable ExecutionInfo response) {
-    if (response == null) {
+      CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
+    if (executionInfo == null) {
       return null;
     }
-    Node coordinator = response.getCoordinator();
+    Node coordinator = executionInfo.getCoordinator();
     if (coordinator == null) {
       return null;
     }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcAttributesExtractor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcAttributesExtractor.java
@@ -18,8 +18,7 @@ final class GrpcAttributesExtractor extends AttributesExtractor<GrpcRequest, Sta
   }
 
   @Override
-  protected void onEnd(
-      AttributesBuilder attributes, GrpcRequest grpcRequest, @Nullable Status status) {
+  protected void onEnd(AttributesBuilder attributes, GrpcRequest request, @Nullable Status status) {
     if (status != null) {
       attributes.put(SemanticAttributes.RPC_GRPC_STATUS_CODE, status.getCode().value());
     }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcNetAttributesExtractor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcNetAttributesExtractor.java
@@ -16,8 +16,8 @@ final class GrpcNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<GrpcRequest, Status> {
   @Override
   @Nullable
-  public InetSocketAddress getAddress(GrpcRequest grpcRequest, @Nullable Status status) {
-    SocketAddress address = grpcRequest.getRemoteAddress();
+  public InetSocketAddress getAddress(GrpcRequest request, @Nullable Status status) {
+    SocketAddress address = request.getRemoteAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;
     }
@@ -25,8 +25,7 @@ final class GrpcNetAttributesExtractor
   }
 
   @Override
-  @Nullable
-  public String transport(GrpcRequest grpcRequest) {
+  public String transport(GrpcRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcSpanNameExtractor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcSpanNameExtractor.java
@@ -10,7 +10,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 // Small optimization to avoid RpcSpanNameExtractor because gRPC provides the span name directly.
 final class GrpcSpanNameExtractor implements SpanNameExtractor<GrpcRequest> {
   @Override
-  public String extract(GrpcRequest grpcRequest) {
-    return grpcRequest.getMethod().getFullMethodName();
+  public String extract(GrpcRequest request) {
+    return request.getMethod().getFullMethodName();
   }
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcSpanStatusExtractor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcSpanStatusExtractor.java
@@ -14,7 +14,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class GrpcSpanStatusExtractor implements SpanStatusExtractor<GrpcRequest, Status> {
   @Override
-  public StatusCode extract(GrpcRequest grpcRequest, Status status, @Nullable Throwable error) {
+  public StatusCode extract(GrpcRequest request, Status status, @Nullable Throwable error) {
     if (status == null) {
       if (error instanceof StatusRuntimeException) {
         status = ((StatusRuntimeException) error).getStatus();
@@ -28,6 +28,6 @@ final class GrpcSpanStatusExtractor implements SpanStatusExtractor<GrpcRequest, 
       }
       return StatusCode.ERROR;
     }
-    return SpanStatusExtractor.getDefault().extract(grpcRequest, status, error);
+    return SpanStatusExtractor.getDefault().extract(request, status, error);
   }
 }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcAttributesExtractor.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcAttributesExtractor.java
@@ -13,27 +13,27 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class JdbcAttributesExtractor extends SqlAttributesExtractor<DbRequest, Void> {
   @Nullable
   @Override
-  protected String system(DbRequest dbRequest) {
-    return dbRequest.getDbInfo().getSystem();
+  protected String system(DbRequest request) {
+    return request.getDbInfo().getSystem();
   }
 
   @Nullable
   @Override
-  protected String user(DbRequest dbRequest) {
-    return dbRequest.getDbInfo().getUser();
+  protected String user(DbRequest request) {
+    return request.getDbInfo().getUser();
   }
 
   @Nullable
   @Override
-  protected String name(DbRequest dbRequest) {
-    DbInfo dbInfo = dbRequest.getDbInfo();
+  protected String name(DbRequest request) {
+    DbInfo dbInfo = request.getDbInfo();
     return dbInfo.getName() == null ? dbInfo.getDb() : dbInfo.getName();
   }
 
   @Nullable
   @Override
-  protected String connectionString(DbRequest dbRequest) {
-    return dbRequest.getDbInfo().getShortUrl();
+  protected String connectionString(DbRequest request) {
+    return request.getDbInfo().getShortUrl();
   }
 
   @Override
@@ -43,7 +43,7 @@ final class JdbcAttributesExtractor extends SqlAttributesExtractor<DbRequest, Vo
 
   @Nullable
   @Override
-  protected String rawStatement(DbRequest dbRequest) {
-    return dbRequest.getStatement();
+  protected String rawStatement(DbRequest request) {
+    return request.getStatement();
   }
 }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcNetAttributesExtractor.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcNetAttributesExtractor.java
@@ -12,25 +12,25 @@ final class JdbcNetAttributesExtractor extends NetAttributesExtractor<DbRequest,
 
   @Nullable
   @Override
-  public String transport(DbRequest dbRequest) {
+  public String transport(DbRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(DbRequest request, @Nullable Void response) {
+  public String peerName(DbRequest request, @Nullable Void unused) {
     return request.getDbInfo().getHost();
   }
 
   @Nullable
   @Override
-  public Integer peerPort(DbRequest request, @Nullable Void response) {
+  public Integer peerPort(DbRequest request, @Nullable Void unused) {
     return request.getDbInfo().getPort();
   }
 
   @Nullable
   @Override
-  public String peerIp(DbRequest request, @Nullable Void response) {
+  public String peerIp(DbRequest request, @Nullable Void unused) {
     return null;
   }
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetAttributesExtractor.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetAttributesExtractor.java
@@ -17,18 +17,18 @@ final class JedisNetAttributesExtractor extends NetAttributesExtractor<JedisRequ
   }
 
   @Override
-  public String peerName(JedisRequest request, @Nullable Void response) {
+  public String peerName(JedisRequest request, @Nullable Void unused) {
     return request.getConnection().getHost();
   }
 
   @Override
-  public Integer peerPort(JedisRequest request, @Nullable Void response) {
+  public Integer peerPort(JedisRequest request, @Nullable Void unused) {
     return request.getConnection().getPort();
   }
 
   @Override
   @Nullable
-  public String peerIp(JedisRequest request, @Nullable Void response) {
+  public String peerIp(JedisRequest request, @Nullable Void unused) {
     return null;
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetAttributesExtractor.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetAttributesExtractor.java
@@ -17,18 +17,18 @@ final class JedisNetAttributesExtractor extends NetAttributesExtractor<JedisRequ
   }
 
   @Override
-  public String peerName(JedisRequest request, @Nullable Void response) {
+  public String peerName(JedisRequest request, @Nullable Void unused) {
     return request.getConnection().getHost();
   }
 
   @Override
-  public Integer peerPort(JedisRequest request, @Nullable Void response) {
+  public Integer peerPort(JedisRequest request, @Nullable Void unused) {
     return request.getConnection().getPort();
   }
 
   @Override
   @Nullable
-  public String peerIp(JedisRequest request, @Nullable Void response) {
+  public String peerIp(JedisRequest request, @Nullable Void unused) {
     return null;
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectAttributesExtractor.java
@@ -23,5 +23,5 @@ final class LettuceConnectAttributesExtractor extends AttributesExtractor<RedisU
   }
 
   @Override
-  protected void onEnd(AttributesBuilder attributes, RedisURI redisUri, Void ignored) {}
+  protected void onEnd(AttributesBuilder attributes, RedisURI redisUri, Void unused) {}
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetAttributesExtractor.java
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
+package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
 
-import io.lettuce.core.RedisURI;
+import com.lambdaworks.redis.RedisURI;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetAttributesExtractor;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class LettuceNetAttributesExtractor extends NetAttributesExtractor<RedisURI, Void> {
+final class LettuceConnectNetAttributesExtractor extends NetAttributesExtractor<RedisURI, Void> {
 
   @Override
   @Nullable
@@ -18,18 +18,18 @@ final class LettuceNetAttributesExtractor extends NetAttributesExtractor<RedisUR
   }
 
   @Override
-  public String peerName(RedisURI redisUri, @Nullable Void ignored) {
+  public String peerName(RedisURI redisUri, @Nullable Void unused) {
     return redisUri.getHost();
   }
 
   @Override
-  public Integer peerPort(RedisURI redisUri, @Nullable Void ignored) {
+  public Integer peerPort(RedisURI redisUri, @Nullable Void unused) {
     return redisUri.getPort();
   }
 
   @Override
   @Nullable
-  public String peerIp(RedisURI redisUri, @Nullable Void ignored) {
+  public String peerIp(RedisURI redisUri, @Nullable Void unused) {
     return null;
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceInstrumenters.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceInstrumenters.java
@@ -34,12 +34,14 @@ public final class LettuceInstrumenters {
             .addAttributesExtractor(attributesExtractor)
             .newInstrumenter(SpanKindExtractor.alwaysClient());
 
-    LettuceNetAttributesExtractor netAttributesExtractor = new LettuceNetAttributesExtractor();
+    LettuceConnectNetAttributesExtractor connectNetAttributesExtractor =
+        new LettuceConnectNetAttributesExtractor();
     CONNECT_INSTRUMENTER =
         Instrumenter.<RedisURI, Void>newBuilder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, redisUri -> "CONNECT")
-            .addAttributesExtractor(netAttributesExtractor)
-            .addAttributesExtractor(PeerServiceAttributesExtractor.create(netAttributesExtractor))
+            .addAttributesExtractor(connectNetAttributesExtractor)
+            .addAttributesExtractor(
+                PeerServiceAttributesExtractor.create(connectNetAttributesExtractor))
             .addAttributesExtractor(new LettuceConnectAttributesExtractor())
             .newInstrumenter(SpanKindExtractor.alwaysClient());
   }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/EndConnectAsyncBiFunction.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/EndConnectAsyncBiFunction.java
@@ -31,11 +31,11 @@ public class EndConnectAsyncBiFunction<T, U extends Throwable, R>
           .getBooleanProperty("otel.instrumentation.lettuce.experimental-span-attributes", false);
 
   private final Context context;
-  private final RedisURI request;
+  private final RedisURI redisUri;
 
-  public EndConnectAsyncBiFunction(Context context, RedisURI request) {
+  public EndConnectAsyncBiFunction(Context context, RedisURI redisUri) {
     this.context = context;
-    this.request = request;
+    this.redisUri = redisUri;
   }
 
   @Override
@@ -47,7 +47,7 @@ public class EndConnectAsyncBiFunction<T, U extends Throwable, R>
       // and don't report this as an error
       throwable = null;
     }
-    connectInstrumenter().end(context, request, null, throwable);
+    connectInstrumenter().end(context, redisUri, null, throwable);
     return null;
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectAttributesExtractor.java
@@ -23,5 +23,5 @@ final class LettuceConnectAttributesExtractor extends AttributesExtractor<RedisU
   }
 
   @Override
-  protected void onEnd(AttributesBuilder attributes, RedisURI redisUri, Void ignored) {}
+  protected void onEnd(AttributesBuilder attributes, RedisURI redisUri, Void unused) {}
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetAttributesExtractor.java
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
+package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
-import com.lambdaworks.redis.RedisURI;
+import io.lettuce.core.RedisURI;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetAttributesExtractor;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class LettuceNetAttributesExtractor extends NetAttributesExtractor<RedisURI, Void> {
+final class LettuceConnectNetAttributesExtractor extends NetAttributesExtractor<RedisURI, Void> {
 
   @Override
   @Nullable
@@ -18,18 +18,18 @@ final class LettuceNetAttributesExtractor extends NetAttributesExtractor<RedisUR
   }
 
   @Override
-  public String peerName(RedisURI redisUri, @Nullable Void ignored) {
+  public String peerName(RedisURI redisUri, @Nullable Void unused) {
     return redisUri.getHost();
   }
 
   @Override
-  public Integer peerPort(RedisURI redisUri, @Nullable Void ignored) {
+  public Integer peerPort(RedisURI redisUri, @Nullable Void unused) {
     return redisUri.getPort();
   }
 
   @Override
   @Nullable
-  public String peerIp(RedisURI redisUri, @Nullable Void ignored) {
+  public String peerIp(RedisURI redisUri, @Nullable Void unused) {
     return null;
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceInstrumenters.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceInstrumenters.java
@@ -34,12 +34,14 @@ public final class LettuceInstrumenters {
             .addAttributesExtractor(attributesExtractor)
             .newInstrumenter(SpanKindExtractor.alwaysClient());
 
-    LettuceNetAttributesExtractor netAttributesExtractor = new LettuceNetAttributesExtractor();
+    LettuceConnectNetAttributesExtractor connectNetAttributesExtractor =
+        new LettuceConnectNetAttributesExtractor();
     CONNECT_INSTRUMENTER =
         Instrumenter.<RedisURI, Void>newBuilder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, redisUri -> "CONNECT")
-            .addAttributesExtractor(netAttributesExtractor)
-            .addAttributesExtractor(PeerServiceAttributesExtractor.create(netAttributesExtractor))
+            .addAttributesExtractor(connectNetAttributesExtractor)
+            .addAttributesExtractor(
+                PeerServiceAttributesExtractor.create(connectNetAttributesExtractor))
             .addAttributesExtractor(new LettuceConnectAttributesExtractor())
             .newInstrumenter(SpanKindExtractor.alwaysClient());
   }


### PR DESCRIPTION
Some renames as I was staring at the extractors:

* `dbRequest` -> `request` (shorter, consistent with super params)
* `grpcRequest` -> `request` (shorter, consistent with super params)
* `httpMethod` -> `request` (shorter, consistent with super params)
* Cassandra `response` -> `executionInfo` (it's not really a "response")
* `Void` params -> `unused`

And a couple other misc changes (no public API changes).