### PR TITLE
Fix reactor netty latest dep test

### DIFF
--- a/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/ReactorNettyHttpClientTest.groovy
@@ -14,7 +14,7 @@ class ReactorNettyHttpClientTest extends AbstractReactorNettyHttpClientTest {
   HttpClient createHttpClient() {
     return HttpClient.create().tcpConfiguration({ tcpClient ->
       tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MS)
-    })
+    }).resolver(getAddressResolverGroup())
   }
 
   @Override

--- a/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/ReactorNettyHttpClientUsingFromTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/ReactorNettyHttpClientUsingFromTest.groovy
@@ -12,6 +12,6 @@ class ReactorNettyHttpClientUsingFromTest extends AbstractReactorNettyHttpClient
   HttpClient createHttpClient() {
     return HttpClient.from(TcpClient.create()).tcpConfiguration({ tcpClient ->
       tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MS)
-    })
+    }).resolver(getAddressResolverGroup())
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3204
I have no idea why this started failing now because latest version was already released in may. The issue seems to be that when connecting fails there is a retry with different address (surprisingly this doesn't happen for all tests that expect connection to fail) which creates extra spans and changes expected exception. This pr changes name resolver used in test to only return one address for each host which seems to stop retry from happening.