### PR TITLE
Internal instrumentations should always be enabled by default

### DIFF
--- a/instrumentation/internal/internal-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/ClassLoaderInstrumentationModule.java
+++ b/instrumentation/internal/internal-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/ClassLoaderInstrumentationModule.java
@@ -19,6 +19,12 @@ public class ClassLoaderInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean defaultEnabled() {
+    // internal instrumentations are always enabled by default
+    return true;
+  }
+
+  @Override
   public boolean isHelperClass(String className) {
     return className.equals("io.opentelemetry.javaagent.tooling.Constants");
   }

--- a/instrumentation/internal/internal-eclipse-osgi-3.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/osgi/EclipseOsgiInstrumentationModule.java
+++ b/instrumentation/internal/internal-eclipse-osgi-3.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/osgi/EclipseOsgiInstrumentationModule.java
@@ -19,6 +19,12 @@ public class EclipseOsgiInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean defaultEnabled() {
+    // internal instrumentations are always enabled by default
+    return true;
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new EclipseOsgiInstrumentation());
   }

--- a/instrumentation/internal/internal-proxy/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/proxy/ProxyInstrumentationModule.java
+++ b/instrumentation/internal/internal-proxy/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/proxy/ProxyInstrumentationModule.java
@@ -19,6 +19,12 @@ public class ProxyInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean defaultEnabled() {
+    // internal instrumentations are always enabled by default
+    return true;
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new ProxyInstrumentation());
   }

--- a/instrumentation/internal/internal-url-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/urlclassloader/UrlClassLoaderInstrumentationModule.java
+++ b/instrumentation/internal/internal-url-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/urlclassloader/UrlClassLoaderInstrumentationModule.java
@@ -19,6 +19,12 @@ public class UrlClassLoaderInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean defaultEnabled() {
+    // internal instrumentations are always enabled by default
+    return true;
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return singletonList(new UrlClassLoaderInstrumentation());
   }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3221

It's still possible to disable one of those instrumentations if somebody wants to do it for some reason, but they have to do it one by one using the `otel.instrumentation.<name>.enabled` property.