### PR TITLE
Fix resteasy test latest deps

### DIFF
--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/jaxrs-2.0-resteasy-3.1-javaagent.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/jaxrs-2.0-resteasy-3.1-javaagent.gradle
@@ -39,7 +39,8 @@ dependencies {
   testLibrary "org.jboss.resteasy:resteasy-servlet-initializer:3.1.0.Final"
 
   // artifact name changed from 'resteasy-jaxrs' to 'resteasy-core' starting from version 4.0.0
-  latestDepTestLibrary "org.jboss.resteasy:resteasy-core:+"
+  // TODO (trask) 4.6.1.Beta3 appears broken, revisit after next release
+  latestDepTestLibrary "org.jboss.resteasy:resteasy-core:4.6.1.Beta2"
 }
 
 test {


### PR DESCRIPTION
I'm not sure what happened, but 4.6.3.Beta3 is failing with a weird `MediaType` error, which persists even if I remove the one reference to `javax.ws.rs.core.MediaType`.

Intellij also says something is up with the bytecode for `org.jboss.resteasy.mock.MockHttpRequest`, not matching the source, and no import for used type `javax.ws.rs.core.MediaType`.

There's no tag for this release (or Beta.2) at https://github.com/resteasy/Resteasy/tags.

I suspect it's just a problem release, and opened #3267 to remove the upper bound after the next resteasy release.