### PR TITLE
Remove jboss maven repo

### DIFF
--- a/instrumentation/jms-1.1/javaagent/jms-1.1-javaagent.gradle
+++ b/instrumentation/jms-1.1/javaagent/jms-1.1-javaagent.gradle
@@ -27,13 +27,6 @@ testSets {
 // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/919
 jms2Test.forkEvery 1
 test.dependsOn jms2Test
-
-repositories {
-  mavenCentral()
-  maven { url "https://repository.jboss.org/nexus/content/groups/public/" }
-  mavenLocal()
-}
-
 dependencies {
   compileOnly "javax.jms:jms-api:1.1-rev-1"
 
@@ -44,5 +37,8 @@ dependencies {
   }
 
   jms2TestImplementation "org.hornetq:hornetq-jms-client:2.4.7.Final"
-  jms2TestImplementation "org.hornetq:hornetq-jms-server:2.4.7.Final"
+  jms2TestImplementation("org.hornetq:hornetq-jms-server:2.4.7.Final") {
+    // this doesn't exist in maven central, and doesn't seem to be needed anyways
+    exclude group: 'org.jboss.naming', module: 'jnpserver'
+  }
 }

--- a/instrumentation/jms-1.1/javaagent/jms-1.1-javaagent.gradle
+++ b/instrumentation/jms-1.1/javaagent/jms-1.1-javaagent.gradle
@@ -24,8 +24,6 @@ testSets {
   }
 }
 
-// https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/919
-jms2Test.forkEvery 1
 test.dependsOn jms2Test
 dependencies {
   compileOnly "javax.jms:jms-api:1.1-rev-1"


### PR DESCRIPTION
https://repository.jboss.org is down. Looks like we can remove it safely and further trim our maven repo dependencies.