### PR TITLE
Disable default resource providers in tests.

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -254,6 +254,9 @@ tasks.withType(Test).configureEach {
     jvmArgs "-Djavax.net.ssl.trustStore=${trustStore.absolutePath}"
     jvmArgs "-Djavax.net.ssl.trustStorePassword=testing"
   }
+
+  def resourceClassesCsv = ['Host', 'Os', 'Process', 'ProcessRuntime'].collect { "io.opentelemetry.sdk.extension.resources.${it}ResourceProvider" }.join(",")
+  jvmArgs "-Dotel.java.disabled.resource.providers=${resourceClassesCsv}"
 }
 
 tasks.withType(AbstractArchiveTask).configureEach {

--- a/javaagent-extension-api/src/test/groovy/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModuleTest.groovy
+++ b/javaagent-extension-api/src/test/groovy/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModuleTest.groovy
@@ -11,11 +11,6 @@ import spock.lang.Specification
 
 class InstrumentationModuleTest extends Specification {
 
-  def setup() {
-    assert System.getenv().findAll { it.key.startsWith("OTEL_") }.isEmpty()
-    assert System.getProperties().findAll { it.key.toString().startsWith("otel.") }.isEmpty()
-  }
-
   def "default enabled"() {
     setup:
     def target = new TestInstrumentationModule(["test"])


### PR DESCRIPTION
Adds spam to assertion failures / log messages with no benefit