### PR TITLE
Deprecate SpanExporterFactory in favor of ConfigurableSpanExporterProvider

### DIFF
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/spi/exporter/SpanExporterFactory.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/spi/exporter/SpanExporterFactory.java
@@ -13,7 +13,11 @@ import java.util.Set;
  * A {@link SpanExporterFactory} acts as the bootstrap for a {@link SpanExporter} implementation. An
  * exporter must register its implementation of a {@link SpanExporterFactory} through the Java SPI
  * framework.
+ *
+ * @deprecated Use {@code io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSpanExporterProvider}
+ *     from the {@code opentelemetry-sdk-extension-autoconfigure} instead.
  */
+@Deprecated
 public interface SpanExporterFactory {
   /**
    * Creates an instance of a {@link SpanExporter} based on the provided configuration.


### PR DESCRIPTION
I wanted to deprecate `MetricExporterFactory` too, but then I found out sdk-autoconfigure doesn't have anything like that yet 🤷 