### PR TITLE
Fix some raw types warnings

### DIFF
--- a/instrumentation/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaForkJoinTaskInstrumentation.java
+++ b/instrumentation/akka-actor-fork-join-2.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaForkJoinTaskInstrumentation.java
@@ -62,8 +62,8 @@ public class AkkaForkJoinTaskInstrumentation implements TypeInstrumentation {
      * need to use that state.
      */
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope enter(@Advice.This ForkJoinTask thiz) {
-      ContextStore<ForkJoinTask, State> contextStore =
+    public static Scope enter(@Advice.This ForkJoinTask<?> thiz) {
+      ContextStore<ForkJoinTask<?>, State> contextStore =
           InstrumentationContext.get(ForkJoinTask.class, State.class);
       Scope scope = AdviceUtils.startTaskScope(contextStore, thiz);
       if (thiz instanceof Runnable) {
@@ -79,9 +79,9 @@ public class AkkaForkJoinTaskInstrumentation implements TypeInstrumentation {
         }
       }
       if (thiz instanceof Callable) {
-        ContextStore<Callable, State> callableContextStore =
+        ContextStore<Callable<?>, State> callableContextStore =
             InstrumentationContext.get(Callable.class, State.class);
-        Scope newScope = AdviceUtils.startTaskScope(callableContextStore, (Callable) thiz);
+        Scope newScope = AdviceUtils.startTaskScope(callableContextStore, (Callable<?>) thiz);
         if (null != newScope) {
           if (null != scope) {
             newScope.close();

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/ResponseInstrumentation.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/ResponseInstrumentation.java
@@ -56,7 +56,7 @@ public class ResponseInstrumentation implements TypeInstrumentation {
     public static Scope onEnter(
         @Advice.This AsyncCompletionHandler<?> handler, @Advice.Argument(0) Response response) {
 
-      ContextStore<AsyncHandler, Pair> contextStore =
+      ContextStore<AsyncHandler<?>, Pair<?, ?>> contextStore =
           InstrumentationContext.get(AsyncHandler.class, Pair.class);
       Pair<Context, Context> parentAndChildContext = contextStore.get(handler);
       if (parentAndChildContext == null) {
@@ -82,7 +82,7 @@ public class ResponseInstrumentation implements TypeInstrumentation {
     public static Scope onEnter(
         @Advice.This AsyncCompletionHandler<?> handler, @Advice.Argument(0) Throwable throwable) {
 
-      ContextStore<AsyncHandler, Pair> contextStore =
+      ContextStore<AsyncHandler<?>, Pair> contextStore =
           InstrumentationContext.get(AsyncHandler.class, Pair.class);
       Pair<Context, Context> parentAndChildContext = contextStore.get(handler);
       if (parentAndChildContext == null) {

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/ResponseInstrumentation.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/ResponseInstrumentation.java
@@ -56,7 +56,7 @@ public class ResponseInstrumentation implements TypeInstrumentation {
     public static Scope onEnter(
         @Advice.This AsyncCompletionHandler<?> handler, @Advice.Argument(0) Response response) {
 
-      ContextStore<AsyncHandler<?>, Pair<?, ?>> contextStore =
+      ContextStore<AsyncHandler, Pair> contextStore =
           InstrumentationContext.get(AsyncHandler.class, Pair.class);
       Pair<Context, Context> parentAndChildContext = contextStore.get(handler);
       if (parentAndChildContext == null) {

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncCompletionHandlerInstrumentation.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncCompletionHandlerInstrumentation.java
@@ -55,7 +55,7 @@ public class AsyncCompletionHandlerInstrumentation implements TypeInstrumentatio
     public static Scope onEnter(
         @Advice.This AsyncCompletionHandler<?> handler, @Advice.Argument(0) Response response) {
 
-      ContextStore<AsyncHandler, AsyncHandlerData> contextStore =
+      ContextStore<AsyncHandler<?>, AsyncHandlerData> contextStore =
           InstrumentationContext.get(AsyncHandler.class, AsyncHandlerData.class);
       AsyncHandlerData data = contextStore.get(handler);
       if (data == null) {
@@ -81,7 +81,7 @@ public class AsyncCompletionHandlerInstrumentation implements TypeInstrumentatio
     public static Scope onEnter(
         @Advice.This AsyncCompletionHandler<?> handler, @Advice.Argument(0) Throwable throwable) {
 
-      ContextStore<AsyncHandler, AsyncHandlerData> contextStore =
+      ContextStore<AsyncHandler<?>, AsyncHandlerData> contextStore =
           InstrumentationContext.get(AsyncHandler.class, AsyncHandlerData.class);
       AsyncHandlerData data = contextStore.get(handler);
       if (data == null) {

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/CallableInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/CallableInstrumentation.java
@@ -40,8 +40,8 @@ public class CallableInstrumentation implements TypeInstrumentation {
   public static class CallableAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope enter(@Advice.This Callable thiz) {
-      ContextStore<Callable, State> contextStore =
+    public static Scope enter(@Advice.This Callable<?> thiz) {
+      ContextStore<Callable<?>, State> contextStore =
           InstrumentationContext.get(Callable.class, State.class);
       return AdviceUtils.startTaskScope(contextStore, thiz);
     }

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
@@ -102,7 +102,7 @@ public class FutureInstrumentation implements TypeInstrumentation {
       // Try to clear parent span even if future was not cancelled:
       // the expectation is that parent span should be cleared after 'cancel'
       // is called, one way or another
-      ContextStore<Future, State> contextStore =
+      ContextStore<Future<?>, State> contextStore =
           InstrumentationContext.get(Future.class, State.class);
       State state = contextStore.get(future);
       if (state != null) {

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaExecutorInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaExecutorInstrumentation.java
@@ -95,7 +95,7 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
     public static State enterJobSubmit(
         @Advice.Argument(value = 0, readOnly = false) ForkJoinTask<?> task) {
       if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task)) {
-        ContextStore<ForkJoinTask, State> contextStore =
+        ContextStore<ForkJoinTask<?>, State> contextStore =
             InstrumentationContext.get(ForkJoinTask.class, State.class);
         return ExecutorInstrumentationUtils.setupState(
             contextStore, task, Java8BytecodeBridge.currentContext());
@@ -132,7 +132,7 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
         @Advice.Thrown Throwable throwable,
         @Advice.Return Future<?> future) {
       if (state != null && future != null) {
-        ContextStore<Future, State> contextStore =
+        ContextStore<Future<?>, State> contextStore =
             InstrumentationContext.get(Future.class, State.class);
         contextStore.put(future, state);
       }
@@ -148,7 +148,7 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
         @Advice.Argument(value = 0, readOnly = false) Callable<?> task) {
       if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task)) {
         task = CallableWrapper.wrapIfNeeded(task);
-        ContextStore<Callable, State> contextStore =
+        ContextStore<Callable<?>, State> contextStore =
             InstrumentationContext.get(Callable.class, State.class);
         return ExecutorInstrumentationUtils.setupState(
             contextStore, task, Java8BytecodeBridge.currentContext());
@@ -162,7 +162,7 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
         @Advice.Thrown Throwable throwable,
         @Advice.Return Future<?> future) {
       if (state != null && future != null) {
-        ContextStore<Future, State> contextStore =
+        ContextStore<Future<?>, State> contextStore =
             InstrumentationContext.get(Future.class, State.class);
         contextStore.put(future, state);
       }
@@ -180,9 +180,9 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
         Collection<Callable<?>> wrappedTasks = new ArrayList<>(tasks.size());
         for (Callable<?> task : tasks) {
           if (task != null) {
-            Callable newTask = CallableWrapper.wrapIfNeeded(task);
+            Callable<?> newTask = CallableWrapper.wrapIfNeeded(task);
             wrappedTasks.add(newTask);
-            ContextStore<Callable, State> contextStore =
+            ContextStore<Callable<?>, State> contextStore =
                 InstrumentationContext.get(Callable.class, State.class);
             ExecutorInstrumentationUtils.setupState(
                 contextStore, newTask, Java8BytecodeBridge.currentContext());
@@ -210,7 +210,7 @@ public class JavaExecutorInstrumentation extends AbstractExecutorInstrumentation
       if (null != throwable) {
         for (Callable<?> task : wrappedTasks) {
           if (task != null) {
-            ContextStore<Callable, State> contextStore =
+            ContextStore<Callable<?>, State> contextStore =
                 InstrumentationContext.get(Callable.class, State.class);
             State state = contextStore.get(task);
             if (state != null) {

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaForkJoinTaskInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/JavaForkJoinTaskInstrumentation.java
@@ -55,8 +55,8 @@ public class JavaForkJoinTaskInstrumentation implements TypeInstrumentation {
      * need to use that state.
      */
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Scope enter(@Advice.This ForkJoinTask thiz) {
-      ContextStore<ForkJoinTask, State> contextStore =
+    public static Scope enter(@Advice.This ForkJoinTask<?> thiz) {
+      ContextStore<ForkJoinTask<?>, State> contextStore =
           InstrumentationContext.get(ForkJoinTask.class, State.class);
       Scope scope = AdviceUtils.startTaskScope(contextStore, thiz);
       if (thiz instanceof Runnable) {
@@ -72,9 +72,9 @@ public class JavaForkJoinTaskInstrumentation implements TypeInstrumentation {
         }
       }
       if (thiz instanceof Callable) {
-        ContextStore<Callable, State> callableContextStore =
+        ContextStore<Callable<?>, State> callableContextStore =
             InstrumentationContext.get(Callable.class, State.class);
-        Scope newScope = AdviceUtils.startTaskScope(callableContextStore, (Callable) thiz);
+        Scope newScope = AdviceUtils.startTaskScope(callableContextStore, (Callable<?>) thiz);
         if (null != newScope) {
           if (null != scope) {
             newScope.close();

--- a/instrumentation/scala-executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/scalaexecutors/ScalaForkJoinPoolInstrumentation.java
+++ b/instrumentation/scala-executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/scalaexecutors/ScalaForkJoinPoolInstrumentation.java
@@ -52,7 +52,7 @@ public class ScalaForkJoinPoolInstrumentation implements TypeInstrumentation {
     public static State enterJobSubmit(
         @Advice.Argument(value = 0, readOnly = false) ForkJoinTask<?> task) {
       if (ExecutorInstrumentationUtils.shouldAttachStateToTask(task)) {
-        ContextStore<ForkJoinTask, State> contextStore =
+        ContextStore<ForkJoinTask<?>, State> contextStore =
             InstrumentationContext.get(ForkJoinTask.class, State.class);
         return ExecutorInstrumentationUtils.setupState(
             contextStore, task, Java8BytecodeBridge.currentContext());

--- a/instrumentation/scala-executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/scalaexecutors/ScalaForkJoinTaskInstrumentation.java
+++ b/instrumentation/scala-executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/scalaexecutors/ScalaForkJoinTaskInstrumentation.java
@@ -64,7 +64,7 @@ public class ScalaForkJoinTaskInstrumentation implements TypeInstrumentation {
      */
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Scope enter(@Advice.This ForkJoinTask<?> thiz) {
-      ContextStore<ForkJoinTask, State> contextStore =
+      ContextStore<ForkJoinTask<?>, State> contextStore =
           InstrumentationContext.get(ForkJoinTask.class, State.class);
       Scope scope = AdviceUtils.startTaskScope(contextStore, thiz);
       if (thiz instanceof Runnable) {
@@ -80,9 +80,9 @@ public class ScalaForkJoinTaskInstrumentation implements TypeInstrumentation {
         }
       }
       if (thiz instanceof Callable) {
-        ContextStore<Callable, State> callableContextStore =
+        ContextStore<Callable<?>, State> callableContextStore =
             InstrumentationContext.get(Callable.class, State.class);
-        Scope newScope = AdviceUtils.startTaskScope(callableContextStore, (Callable) thiz);
+        Scope newScope = AdviceUtils.startTaskScope(callableContextStore, (Callable<?>) thiz);
         if (null != newScope) {
           if (null != scope) {
             newScope.close();

--- a/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/InstrumentationContext.java
+++ b/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/InstrumentationContext.java
@@ -26,7 +26,8 @@ public class InstrumentationContext {
    * @param <C> context class
    * @return The instance of context store for given arguments.
    */
-  public static <K, C> ContextStore<K, C> get(Class<K> keyClass, Class<C> contextClass) {
+  public static <Q extends K, K, C> ContextStore<Q, C> get(
+      Class<K> keyClass, Class<C> contextClass) {
     throw new IllegalStateException(
         "Calls to this method will be rewritten by Instrumentation Context Provider (e.g. FieldBackedProvider)");
   }

--- a/testing-common/integration-tests/src/main/java/context/ContextTestInstrumentation.java
+++ b/testing-common/integration-tests/src/main/java/context/ContextTestInstrumentation.java
@@ -38,6 +38,7 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
         named("removeContextCount"), this.getClass().getName() + "$RemoveApiUsageAdvice");
   }
 
+  @SuppressWarnings("unused")
   public static class MarkInstrumentedAdvice {
     @Advice.OnMethodExit
     public static void methodExit(@Advice.Return(readOnly = false) boolean isInstrumented) {
@@ -45,6 +46,7 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
     }
   }
 
+  @SuppressWarnings("unused")
   public static class StoreAndIncrementApiUsageAdvice {
     @Advice.OnMethodExit
     public static void methodExit(
@@ -56,6 +58,7 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
     }
   }
 
+  @SuppressWarnings("unused")
   public static class StoreAndIncrementWithFactoryApiUsageAdvice {
     @Advice.OnMethodExit
     public static void methodExit(
@@ -67,6 +70,7 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
     }
   }
 
+  @SuppressWarnings("unused")
   public static class GetApiUsageAdvice {
     @Advice.OnMethodExit
     public static void methodExit(
@@ -78,6 +82,7 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
     }
   }
 
+  @SuppressWarnings("unused")
   public static class PutApiUsageAdvice {
     @Advice.OnMethodExit
     public static void methodExit(@Advice.This KeyClass thiz, @Advice.Argument(0) int value) {
@@ -89,6 +94,7 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
     }
   }
 
+  @SuppressWarnings("unused")
   public static class RemoveApiUsageAdvice {
     @Advice.OnMethodExit
     public static void methodExit(@Advice.This KeyClass thiz) {


### PR DESCRIPTION
By changing the signature of `InstrumentationContext.get()` from

```
<K, C> ContextStore<K, C> get(Class<K> keyClass, Class<C> contextClass)
```

to

```
<Q extends K, K, C> ContextStore<Q, C> get(Class<K> keyClass, Class<C> contextClass)`
```

we can avoid a nice set of generic raw types warnings.