### PR TITLE
Better support for wrapping premain

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -176,7 +176,7 @@ public final class OpenTelemetryAgent {
   private static void verifyJarManifestMainClassIsThis(File jarFile, JarFile agentJar)
       throws IOException {
     Manifest manifest = agentJar.getManifest();
-    if (!manifest.getMainAttributes().containsKey("Premain-Class")) {
+    if (manifest.getMainAttributes().getValue("Premain-Class") == null) {
       throw new IllegalStateException(
           "The agent was not installed, because the agent was found in '"
               + jarFile

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -167,12 +167,16 @@ public final class OpenTelemetryAgent {
     }
   }
 
-  // this is to protect against someone by mistake adding the content of the agent jar to an
-  // application level "uber.jar"
+  // this protects against the case where someone adds the contents of opentelemetry-javaagent.jar
+  // by mistake to their application's "uber.jar"
   //
-  // because if they add the agent jar to their uber jar, and we proceed with adding the uber jar
-  // file to the bootstrap classpath, we can cause problems in user code that never expects
-  // Class.getClassLoader() to return null
+  // the reason this can cause issues is because we locate the agent jar based on the CodeSource of
+  // the OpenTelemetryAgent class, and then we add that jar file to the bootstrap class path
+  //
+  // but if we find the OpenTelemetryAgent class in an uber jar file, and we add that (whole) uber
+  // jar file to the bootstrap class loader, that can cause some applications to break, as there's a
+  // lot of application and library code that doesn't handle getClassLoader() returning null
+  // (e.g. https://github.com/qos-ch/logback/pull/291)
   private static void verifyJarManifestMainClassIsThis(File jarFile, JarFile agentJar)
       throws IOException {
     Manifest manifest = agentJar.getManifest();

--- a/javaagent/src/test/groovy/io/opentelemetry/javaagent/AgentLoadedIntoBootstrapTest.groovy
+++ b/javaagent/src/test/groovy/io/opentelemetry/javaagent/AgentLoadedIntoBootstrapTest.groovy
@@ -24,10 +24,10 @@ class AgentLoadedIntoBootstrapTest extends Specification {
   // to their application's "uber.jar"
   //
   // the reason this can cause issues is because we locate the agent jar based on the CodeSource of
-  // the AgentBootstrap class, and then we add that jar file to the bootstrap class path
+  // the OpenTelemetryAgent class, and then we add that jar file to the bootstrap class path
   //
-  // but if we find the AgentBootstrap class in an uber jar file, and we add that (whole) uber jar
-  // file to the bootstrap class loader, that can cause some applications to break, as there's a
+  // but if we find the OpenTelemetryAgent class in an uber jar file, and we add that (whole) uber
+  // jar file to the bootstrap class loader, that can cause some applications to break, as there's a
   // lot of application and library code that doesn't handle getClassLoader() returning null
   // (e.g. https://github.com/qos-ch/logback/pull/291)
   def "application uber jar should not be added to the bootstrap class loader"() {

--- a/javaagent/src/test/java/io/opentelemetry/javaagent/IntegrationTestUtils.java
+++ b/javaagent/src/test/java/io/opentelemetry/javaagent/IntegrationTestUtils.java
@@ -90,7 +90,6 @@ public class IntegrationTestUtils {
       Attributes mainAttributes = manifest.getMainAttributes();
       mainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
       mainAttributes.put(Attributes.Name.MAIN_CLASS, mainClassname);
-      mainAttributes.put(new Attributes.Name("Premain-Class"), mainClassname);
     }
     JarOutputStream target = new JarOutputStream(new FileOutputStream(tmpJar), manifest);
     for (Class<?> clazz : classes) {


### PR DESCRIPTION
I see that splunk distro is wrapping `OpenTelemetryAgent` also:

https://github.com/signalfx/splunk-otel-java/blob/8c72622c552796c15aacfbefa9d04c666e3c3ab9/agent/src/main/java/com/splunk/opentelemetry/SplunkAgent.java#L32

so I think this change is justified to better support this usage.

The change in this PR is just changing the check from verifying `Premain-Class` (or `Agent-Class` or `Main-Class`) is a specific class, to verifying that it is just present.

This should achieve the purpose of the check (added some doc about what this purpose is, because I had to look it up 😄).