### PR TITLE
Directly initialize OkHttp without using test util.

### DIFF
--- a/examples/distro/instrumentation/servlet-3/build.gradle
+++ b/examples/distro/instrumentation/servlet-3/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }
 
-  testImplementation "com.squareup.okhttp3:okhttp:4.9.1"
+  testImplementation "com.squareup.okhttp3:okhttp:3.12.12"
   testImplementation "javax.servlet:javax.servlet-api:3.0.1"
   testImplementation "org.eclipse.jetty:jetty-server:8.0.0.v20110901"
   testImplementation "org.eclipse.jetty:jetty-servlet:8.0.0.v20110901"

--- a/examples/distro/instrumentation/servlet-3/build.gradle
+++ b/examples/distro/instrumentation/servlet-3/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     exclude group: 'org.eclipse.jetty', module: 'jetty-server'
   }
 
+  testImplementation "com.squareup.okhttp3:okhttp:4.9.1"
   testImplementation "javax.servlet:javax.servlet-api:3.0.1"
   testImplementation "org.eclipse.jetty:jetty-server:8.0.0.v20110901"
   testImplementation "org.eclipse.jetty:jetty-servlet:8.0.0.v20110901"

--- a/examples/distro/instrumentation/servlet-3/src/test/java/com/example/javaagent/instrumentation/DemoServlet3InstrumentationTest.java
+++ b/examples/distro/instrumentation/servlet-3/src/test/java/com/example/javaagent/instrumentation/DemoServlet3InstrumentationTest.java
@@ -4,7 +4,6 @@ import static io.opentelemetry.sdk.testing.assertj.TracesAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.instrumentation.test.utils.OkHttpUtils;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import java.io.IOException;
@@ -31,7 +30,7 @@ class DemoServlet3InstrumentationTest {
   static final AgentInstrumentationExtension instrumentation = AgentInstrumentationExtension
       .create();
 
-  static final OkHttpClient httpClient = OkHttpUtils.client();
+  static final OkHttpClient httpClient = new OkHttpClient();
 
   static int port;
   static Server server;


### PR DESCRIPTION
A generic HTTP client is too much API for us to expose in our testing util. The main job is base classes like `HttpServerTest`, `HttpClientTest`, some small utils like `findOpenPort` is probably OK, but users can bring in their favorite HTTP client instead of us providing it.

I'll move Armeria to an `implementation` dependency in a separate PR too.