### PR TITLE
Preload AtomicReferenceArray

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -92,6 +93,10 @@ public class AgentInstaller {
     // not to get transformed itself.
     // loading it early here still allows it to be retransformed as part of agent installation below
     ForkJoinPool.class.getName();
+
+    // caffeine uses AtomicReferenceArray, ensure it is loaded to avoid ClassCircularityError during
+    // transform.
+    AtomicReferenceArray.class.getName();
   }
 
   public static void installBytebuddyAgent(Instrumentation inst) {


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3311 Has a lot of stack traces like
```
2021-06-15T05:43:06.8477286Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: java.lang.ClassCircularityError: java/util/concurrent/atomic/AtomicReferenceArray
2021-06-15T05:43:06.8710395Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.shaded.caffeine.cache.BoundedBuffer$RingBuffer.<init>(BoundedBuffer.java:61)
2021-06-15T05:43:06.8821568Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.shaded.caffeine.cache.BoundedBuffer.create(BoundedBuffer.java:53)
2021-06-15T05:43:06.8943334Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.shaded.caffeine.cache.StripedBuffer.expandOrRetry(StripedBuffer.java:265)
2021-06-15T05:43:06.9041115Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.shaded.caffeine.cache.StripedBuffer.offer(StripedBuffer.java:149)
2021-06-15T05:43:06.9136436Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.shaded.caffeine.cache.BoundedLocalCache.afterRead(BoundedLocalCache.java:1159)
2021-06-15T05:43:06.9419179Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.shaded.caffeine.cache.BoundedLocalCache.getIfPresent(BoundedLocalCache.java:1931)
2021-06-15T05:43:06.9482425Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.shaded.caffeine.cache.LocalManualCache.getIfPresent(LocalManualCache.java:57)
2021-06-15T05:43:06.9574690Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.shaded.instrumentation.api.caching.CaffeineCache.get(CaffeineCache.java:26)
2021-06-15T05:43:06.9592063Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.tooling.bytebuddy.AgentCachingPoolStrategy$SharedResolutionCacheAdapter.find(AgentCachingPoolStrategy.java:214)
2021-06-15T05:43:06.9688423Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at net.bytebuddy.pool.TypePool$AbstractBase.describe(TypePool.java:524)
2021-06-15T05:43:06.9775358Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at net.bytebuddy.pool.TypePool$AbstractBase$Hierarchical.describe(TypePool.java:608)
2021-06-15T05:43:06.9869975Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at net.bytebuddy.agent.builder.AgentBuilder$DescriptionStrategy$Default$2.apply(AgentBuilder.java:4065)
2021-06-15T05:43:06.9958477Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy$Collector.consider(AgentBuilder.java:7529)
2021-06-15T05:43:07.0052698Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy.apply(AgentBuilder.java:5439)
2021-06-15T05:43:07.0260203Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at net.bytebuddy.agent.builder.AgentBuilder$Default.doInstall(AgentBuilder.java:10134)
2021-06-15T05:43:07.0290935Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at net.bytebuddy.agent.builder.AgentBuilder$Default.installOn(AgentBuilder.java:10047)
2021-06-15T05:43:07.0321924Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at net.bytebuddy.agent.builder.AgentBuilder$Default$Delegator.installOn(AgentBuilder.java:11553)
2021-06-15T05:43:07.0415019Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:178)
2021-06-15T05:43:07.0509056Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:102)
2021-06-15T05:43:07.0591643Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2021-06-15T05:43:07.0821275Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
2021-06-15T05:43:07.0912472Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2021-06-15T05:43:07.1466524Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
2021-06-15T05:43:07.1688128Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.bootstrap.AgentInitializer.initialize(AgentInitializer.java:40)
2021-06-15T05:43:07.2598933Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.OpenTelemetryAgent.agentmain(OpenTelemetryAgent.java:56)
2021-06-15T05:43:07.2700242Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at io.opentelemetry.javaagent.OpenTelemetryAgent.premain(OpenTelemetryAgent.java:50)
2021-06-15T05:43:07.3302315Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2021-06-15T05:43:07.3622000Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
2021-06-15T05:43:07.3922793Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2021-06-15T05:43:07.3966003Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
2021-06-15T05:43:07.4299439Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
2021-06-15T05:43:07.4498420Z     05:42:56.386 ERROR i.o.s.w.WindowsTestContainerManager - STDERR: 	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
```