### PR TITLE
Remove comment about Oracle > 8 having issues with LogManager (please see comments)

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -84,10 +84,9 @@ public final class OpenTelemetryAgent {
     System.out.println("Could not get bootstrap jar from code source, using -javaagent arg");
 
     // ManagementFactory indirectly references java.util.logging.LogManager
-    // - On Oracle-based JDKs after 1.8
-    // - On IBM-based JDKs since at least 1.7
-    // This prevents custom log managers from working correctly
-    // Use reflection to bypass the loading of the class
+    // on IBM-based JDKs since at least 1.7.
+    // This prevents custom log managers from working correctly.
+    // Use reflection to bypass the loading of the class.
     List<String> arguments = getVmArgumentsThroughReflection();
 
     String agentArgument = null;


### PR DESCRIPTION
I tried the following code

```java


public class DummyLogManagerMain {
	public static void main(String[] args) {
		System.out.println(ManagementFactory.getRuntimeMXBean().getInputArguments());
		System.setProperty("java.util.logging.manager", DummyLogManager.class.getCanonicalName());
		java.util.logging.Logger.getLogger(DummyLogManager.class.getName()).severe("Hello");
		System.out.println("Done.");
	}
}
```
```java
import java.util.logging.LogManager;

public class DummyLogManager extends LogManager {
	public DummyLogManager() {
		System.out.println("DummyLogManager is used.");
	}
}
```
And the "DummyLogManager is used." output appeared on Oracle 8, Oracle 11, Adopt Hotspot 8, Adopt Hotspot 9, Adopt Hotspot 11, Adopt J9 11.
It did however actually fail to use the custom log manager on IBM J9 7 and Adopt J9 9.

If we can find out where the wrong(?) assumption that it also fails on Oracle > 8 comes from, we might want to remove the non-J9-specific reflection code too.