### PR TITLE
Hide Config#create() method and use builder everywhere

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
@@ -176,6 +176,12 @@ public abstract class Config {
     return anyEnabled;
   }
 
+  /**
+   * Converts this config instance to Java {@link Properties}.
+   *
+   * @deprecated Use {@link #getAllProperties()} instead.
+   */
+  @Deprecated
   public Properties asJavaProperties() {
     Properties properties = new Properties();
     properties.putAll(getAllProperties());

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
@@ -25,7 +25,12 @@ public abstract class Config {
   // read system properties
   @Nullable private static volatile Config instance = null;
 
-  public static Config create(Map<String, String> allProperties) {
+  /** Start building a new {@link Config} instance. */
+  public static ConfigBuilder newBuilder() {
+    return new ConfigBuilder();
+  }
+
+  static Config create(Map<String, String> allProperties) {
     return new AutoValue_Config(allProperties);
   }
 
@@ -47,12 +52,13 @@ public abstract class Config {
       // this should only happen in library instrumentation
       //
       // no need to synchronize because worst case is creating INSTANCE more than once
-      instance = new ConfigBuilder().readEnvironmentVariables().readSystemProperties().build();
+      instance = newBuilder().readEnvironmentVariables().readSystemProperties().build();
     }
     return instance;
   }
 
-  abstract Map<String, String> getAllProperties();
+  /** Returns all properties stored in this instance. The returned map is unmodifiable. */
+  public abstract Map<String, String> getAllProperties();
 
   /**
    * Returns a string property value or null if a property with name {@code name} did not exist.
@@ -90,6 +96,18 @@ public abstract class Config {
    */
   public boolean getBooleanProperty(String name, boolean defaultValue) {
     return getTypedProperty(name, Boolean::parseBoolean, defaultValue);
+  }
+
+  /**
+   * Returns a long property value or {@code defaultValue} if a property with name {@code name} did
+   * not exist.
+   *
+   * <p>This property may be used by vendor distributions to get numerical values.
+   *
+   * @see #getProperty(String, String)
+   */
+  public long getLongProperty(String name, long defaultValue) {
+    return getTypedProperty(name, Long::parseLong, defaultValue);
   }
 
   /**

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/ConfigBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/ConfigBuilder.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.instrumentation.api.config;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-public class ConfigBuilder {
+public final class ConfigBuilder {
 
   private final Map<String, String> allProperties = new HashMap<>();
 
@@ -43,6 +44,6 @@ public class ConfigBuilder {
   }
 
   public Config build() {
-    return Config.create(allProperties);
+    return Config.create(Collections.unmodifiableMap(new HashMap<>(allProperties)));
   }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SupportabilityMetricsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SupportabilityMetricsTest.java
@@ -19,8 +19,7 @@ class SupportabilityMetricsTest {
   void disabled() {
     List<String> reports = new ArrayList<>();
     SupportabilityMetrics metrics =
-        new SupportabilityMetrics(
-            Config.create(Collections.singletonMap("otel.javaagent.debug", "false")), reports::add);
+        new SupportabilityMetrics(configWithJavaagentDebug(false), reports::add);
 
     metrics.recordSuppressedSpan(SpanKind.CLIENT, "favoriteInstrumentation");
     metrics.recordSuppressedSpan(SpanKind.SERVER, "favoriteInstrumentation");
@@ -39,8 +38,7 @@ class SupportabilityMetricsTest {
   void reportsMetrics() {
     List<String> reports = new ArrayList<>();
     SupportabilityMetrics metrics =
-        new SupportabilityMetrics(
-            Config.create(Collections.singletonMap("otel.javaagent.debug", "true")), reports::add);
+        new SupportabilityMetrics(configWithJavaagentDebug(true), reports::add);
 
     metrics.recordSuppressedSpan(SpanKind.CLIENT, "favoriteInstrumentation");
     metrics.recordSuppressedSpan(SpanKind.SERVER, "favoriteInstrumentation");
@@ -65,8 +63,7 @@ class SupportabilityMetricsTest {
   void resetsCountsEachReport() {
     List<String> reports = new ArrayList<>();
     SupportabilityMetrics metrics =
-        new SupportabilityMetrics(
-            Config.create(Collections.singletonMap("otel.javaagent.debug", "true")), reports::add);
+        new SupportabilityMetrics(configWithJavaagentDebug(true), reports::add);
 
     metrics.recordSuppressedSpan(SpanKind.CLIENT, "favoriteInstrumentation");
     metrics.incrementCounter("some counter");
@@ -78,5 +75,11 @@ class SupportabilityMetricsTest {
         .containsExactlyInAnyOrder(
             "Suppressed Spans by 'favoriteInstrumentation' (CLIENT) : 1",
             "Counter 'some counter' : 1");
+  }
+
+  private static Config configWithJavaagentDebug(boolean enabled) {
+    return Config.newBuilder()
+        .readProperties(Collections.singletonMap("otel.javaagent.debug", Boolean.toString(enabled)))
+        .build();
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -7,11 +7,11 @@ package io.opentelemetry.javaagent.tooling;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.instrumentation.api.config.Config;
-import io.opentelemetry.instrumentation.api.config.ConfigBuilder;
 import io.opentelemetry.javaagent.extension.AgentListener;
 import io.opentelemetry.javaagent.instrumentation.api.OpenTelemetrySdkAccess;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
+import java.util.Map;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,12 +50,12 @@ public class OpenTelemetryInstaller implements AgentListener {
   // TODO(anuraaga): Make this less hacky
   private static void copySystemProperties(Config config) {
     Properties allProperties = config.asJavaProperties();
-    Properties environmentProperties =
-        new ConfigBuilder()
+    Map<String, String> environmentProperties =
+        Config.newBuilder()
             .readEnvironmentVariables()
             .readSystemProperties()
             .build()
-            .asJavaProperties();
+            .getAllProperties();
 
     allProperties.forEach(
         (key, value) -> {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -12,7 +12,6 @@ import io.opentelemetry.javaagent.instrumentation.api.OpenTelemetrySdkAccess;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
 import java.util.Map;
-import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +48,7 @@ public class OpenTelemetryInstaller implements AgentListener {
   // massage any properties we have that aren't in the environment to system properties.
   // TODO(anuraaga): Make this less hacky
   private static void copySystemProperties(Config config) {
-    Properties allProperties = config.asJavaProperties();
+    Map<String, String> allProperties = config.getAllProperties();
     Map<String, String> environmentProperties =
         Config.newBuilder()
             .readEnvironmentVariables()
@@ -59,11 +58,10 @@ public class OpenTelemetryInstaller implements AgentListener {
 
     allProperties.forEach(
         (key, value) -> {
-          String keyStr = (String) key;
           if (!environmentProperties.containsKey(key)
-              && keyStr.startsWith("otel.")
-              && !keyStr.startsWith("otel.instrumentation")) {
-            System.setProperty(keyStr, (String) value);
+              && key.startsWith("otel.")
+              && !key.startsWith("otel.instrumentation")) {
+            System.setProperty(key, value);
           }
         });
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigInitializer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigInitializer.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.tooling.config;
 
 import io.opentelemetry.instrumentation.api.config.Config;
-import io.opentelemetry.instrumentation.api.config.ConfigBuilder;
 import io.opentelemetry.javaagent.spi.config.PropertySource;
 import io.opentelemetry.javaagent.tooling.SafeServiceLoader;
 import java.io.File;
@@ -31,7 +30,7 @@ public final class ConfigInitializer {
 
   // visible for testing
   static Config create(Properties spiConfiguration, Properties configurationFile) {
-    return new ConfigBuilder()
+    return Config.newBuilder()
         .readProperties(spiConfiguration)
         .readProperties(configurationFile)
         .readEnvironmentVariables()

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/ignore/UserExcludedClassesConfigurerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/ignore/UserExcludedClassesConfigurerTest.java
@@ -6,13 +6,11 @@
 package io.opentelemetry.javaagent.tooling.ignore;
 
 import static io.opentelemetry.javaagent.tooling.ignore.UserExcludedClassesConfigurer.EXCLUDED_CLASSES_CONFIG;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.opentelemetry.instrumentation.api.config.Config;
-import io.opentelemetry.instrumentation.api.config.ConfigBuilder;
 import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesBuilder;
 import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
 import org.junit.jupiter.api.Test;
@@ -29,7 +27,7 @@ class UserExcludedClassesConfigurerTest {
   @Test
   void shouldAddNothingToBuilderWhenPropertyIsEmpty() {
     // when
-    underTest.configure(Config.create(emptyMap()), builder);
+    underTest.configure(Config.newBuilder().build(), builder);
 
     // then
     verifyNoInteractions(builder);
@@ -39,7 +37,7 @@ class UserExcludedClassesConfigurerTest {
   void shouldIgnoreClassesAndPackages() {
     // given
     Config config =
-        new ConfigBuilder()
+        Config.newBuilder()
             .readProperties(
                 singletonMap(
                     EXCLUDED_CLASSES_CONFIG,


### PR DESCRIPTION
`Config#create()` does not normalize property names, which could cause some confusion when writing tests. Now it was made private and `ConfigBuilder` is used everywhere to create `Config` instances.

Also added a `Config#getLongProperty()` that might be useful for vendor distros.