### PR TITLE
Fix shadow publishing of javaagent instrumentation

### DIFF
--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 publishing {
   publications {
     register<MavenPublication>("maven") {
-      if (tasks.names.contains("shadowJar") && findProperty("noShadowPublish") != "true") {
+      if (tasks.names.contains("shadowJar") && findProperty("noShadowPublish") != true) {
         the<ShadowExtension>().component(this)
       } else {
         plugins.withId("java-platform") {


### PR DESCRIPTION
Previously only the `-all` artifact was being published:

```
  10456 Jun 16 11:45 opentelemetry-javaagent-google-http-client-1.19-1.3.0-alpha-SNAPSHOT-all.jar
   1497 Jun 16 11:45 opentelemetry-javaagent-google-http-client-1.19-1.3.0-alpha-SNAPSHOT.pom
```

I don't completely understand it, but after a bunch of trial and error this change seems to be working.