### PR TITLE
Remove testLatestDeps from release build.

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -80,29 +80,6 @@ jobs:
       - name: Test
         run: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -x :smoke-tests:test -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
 
-  testLatestDeps:
-    runs-on: ubuntu-latest
-    needs: prepare-release-branch
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          ref: ${{ needs.prepare-release-branch.outputs.release-branch-name }}
-          fetch-depth: 0
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 11
-
-      - name: Restore cache
-        uses: burrunan/gradle-cache-action@v1.10
-        with:
-          job-id: latestDepTest
-
-      - name: Test
-        run: ./gradlew test -x :smoke-tests:test -PtestLatestDeps=true --stacktrace
-
   smoke-test:
     runs-on: ${{ matrix.os }}
     needs: prepare-release-branch

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -39,27 +39,6 @@ jobs:
       - name: Test
         run: ./gradlew test -PtestJavaVersion=${{ matrix.java }} --stacktrace -x :smoke-tests:test -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
 
-  testLatestDeps:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 11
-
-      - name: Restore cache
-        uses: burrunan/gradle-cache-action@v1.10
-        with:
-          job-id: latestDepTest
-
-      - name: Test
-        run: ./gradlew test -x :smoke-tests:test -PtestLatestDeps=true --stacktrace
-
   smoke-test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -112,7 +91,7 @@ jobs:
         working-directory: examples/distro
 
   release:
-    needs: [ test, testLatestDeps, smoke-test, example-distro ]
+    needs: [ test, smoke-test, example-distro ]
     name: Build and release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I noticed that testLatestDeps took forever in the release build probably for sporadic reasons. But while this may be ok in general, we actually wouldn't want a release to be blocked because of a latest deps failure that showed up on the release day.