### PR TITLE
Extract build plugin for instrumentation testing projects that aren't…

### DIFF
--- a/buildSrc/src/main/kotlin/otel.instrumentation-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.instrumentation-conventions.gradle.kts
@@ -1,5 +1,9 @@
 /** Common setup for manual instrumentation of libraries and javaagent instrumentation. */
 
+plugins {
+  id("otel.java-conventions")
+}
+
 /**
  * We define three dependency configurations to use when adding dependencies to libraries being
  * instrumented.

--- a/buildSrc/src/main/kotlin/otel.javaagent-instrumentation.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.javaagent-instrumentation.gradle.kts
@@ -1,142 +1,23 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import io.opentelemetry.instrumentation.gradle.bytebuddy.ByteBuddyPluginConfigurator
-
 plugins {
-  id("net.bytebuddy.byte-buddy")
-
-  id("otel.java-conventions")
-  id("otel.shadow-conventions")
+  id("otel.javaagent-testing")
+  id("otel.publish-conventions")
 }
+
+// TODO(anuraaga): Migrate MuzzlePlugin to kotlin script since Java plugins don't seem to be usable" +
+// with plugins block. It will be good to add a property for bootstrapRuntime to that plugin at the
+// time instead of defining it here and reading it in a non-obvious way.
+apply(plugin = "muzzle")
 
 extra["mavenGroupId"] = "io.opentelemetry.javaagent.instrumentation"
-// Shadow is only for testing, not publishing.
-extra["noShadowPublish"] = true
 
-val skipPublish: Boolean? by extra
+base.archivesName.set(projectDir.parentFile.name)
 
-if (skipPublish != true) {
-  apply(plugin = "otel.publish-conventions")
-}
-
-apply(plugin = "otel.instrumentation-conventions")
-
-if (projectDir.name == "javaagent") {
-  apply(plugin = "muzzle")
-
-  base.archivesBaseName = projectDir.parentFile.name
-}
-
-val toolingRuntime by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-}
-
+// Used by muzzle
 val bootstrapRuntime by configurations.creating {
   isCanBeConsumed = false
   isCanBeResolved = true
 }
 
-afterEvaluate {
-  // TODO(anuraaga): There is no obvious reason this needs to be in afterEvaluate but it breaks
-  // Finatra tests. Fix it.
-  dependencies {
-    compileOnly(project(":instrumentation-api"))
-    compileOnly(project(":javaagent-api"))
-    compileOnly(project(":javaagent-bootstrap"))
-    // Apply common dependencies for instrumentation.
-    compileOnly(project(":javaagent-extension-api")) {
-      // OpenTelemetry SDK is not needed for compilation
-      exclude(group = "io.opentelemetry", module = "opentelemetry-sdk")
-      exclude(group = "io.opentelemetry", module = "opentelemetry-sdk-metrics")
-    }
-    compileOnly(project(":javaagent-tooling")) {
-      // OpenTelemetry SDK is not needed for compilation
-      exclude(group = "io.opentelemetry", module = "opentelemetry-sdk")
-      exclude(group = "io.opentelemetry", module = "opentelemetry-sdk-metrics")
-    }
-    compileOnly("net.bytebuddy:byte-buddy")
-    annotationProcessor("com.google.auto.service:auto-service")
-    compileOnly("com.google.auto.service:auto-service")
-    compileOnly("org.slf4j:slf4j-api")
-
-    testImplementation("io.opentelemetry:opentelemetry-api")
-
-    testImplementation(project(":testing-common"))
-    testAnnotationProcessor("net.bytebuddy:byte-buddy")
-    testCompileOnly("net.bytebuddy:byte-buddy")
-
-    testImplementation("org.testcontainers:testcontainers")
-
-    toolingRuntime(project(path = ":javaagent-tooling", configuration = "instrumentationMuzzle"))
-    toolingRuntime(project(path = ":javaagent-extension-api", configuration = "instrumentationMuzzle"))
-
-    bootstrapRuntime(project(path = ":javaagent-bootstrap", configuration = "instrumentationMuzzle"))
-  }
-
-  val pluginName = "io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin"
-  ByteBuddyPluginConfigurator(project, sourceSets.main.get(), pluginName,
-    toolingRuntime.plus(configurations.runtimeClasspath.get()))
-    .configure()
-}
-
-val testInstrumentation by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-}
-
-tasks.named<ShadowJar>("shadowJar").configure {
-  configurations = listOf(project.configurations.runtimeClasspath.get(), testInstrumentation)
-
-  archiveFileName.set("agent-testing.jar")
-}
-
-evaluationDependsOn(":testing:agent-for-testing")
-
-// need to run this after evaluate because testSets plugin adds new test tasks
-afterEvaluate {
-  tasks.withType<Test>().configureEach {
-    val shadowJar = tasks.shadowJar.get()
-    val agentShadowJar = project(":testing:agent-for-testing").tasks.shadowJar.get()
-
-    inputs.file(shadowJar.archiveFile)
-
-    dependsOn(shadowJar)
-    dependsOn(agentShadowJar)
-
-    jvmArgs("-Dotel.javaagent.debug=true")
-    jvmArgs("-javaagent:${agentShadowJar.archiveFile.get().asFile.absolutePath}")
-    jvmArgs("-Dotel.javaagent.experimental.initializer.jar=${shadowJar.archiveFile.get().asFile.absolutePath}")
-    jvmArgs("-Dotel.javaagent.testing.additional-library-ignores.enabled=false")
-    val failOnContextLeak = findProperty("failOnContextLeak")
-    jvmArgs("-Dotel.javaagent.testing.fail-on-context-leak=${failOnContextLeak != false}")
-    // prevent sporadic gradle deadlocks, see SafeLogger for more details
-    jvmArgs("-Dotel.javaagent.testing.transform-safe-logging.enabled=true")
-
-    // We do fine-grained filtering of the classpath of this codebase's sources since Gradle's
-    // configurations will include transitive dependencies as well, which tests do often need.
-    classpath = classpath.filter {
-      // The sources are packaged into the testing jar so we need to make sure to exclude from the test
-      // classpath, which automatically inherits them, to ensure our shaded versions are used.
-      if (file("${buildDir}/resources/main").equals(it) || file("${buildDir}/classes/java/main").equals(it)) {
-        return@filter false
-      }
-      // If agent depends on some shared instrumentation module that is not a testing module, it will
-      // be packaged into the testing jar so we need to make sure to exclude from the test classpath.
-      val libPath = it.absolutePath
-      val instrumentationPath = file("${rootDir}/instrumentation/").absolutePath
-      if (libPath.startsWith(instrumentationPath) &&
-        libPath.endsWith(".jar") &&
-        !libPath.substring(instrumentationPath.length).contains("testing")) {
-        return@filter false
-      }
-      return@filter true
-    }
-  }
-}
-
-configurations.configureEach {
-  if (name.toLowerCase().endsWith("testruntimeclasspath")) {
-    // Added by agent, don't let Gradle bring it in when running tests.
-    exclude(module = "javaagent-bootstrap")
-  }
+dependencies {
+  bootstrapRuntime(project(path = ":javaagent-bootstrap", configuration = "instrumentationMuzzle"))
 }

--- a/buildSrc/src/main/kotlin/otel.javaagent-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.javaagent-testing.gradle.kts
@@ -1,0 +1,111 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import io.opentelemetry.instrumentation.gradle.bytebuddy.ByteBuddyPluginConfigurator
+
+plugins {
+  id("net.bytebuddy.byte-buddy")
+
+  id("otel.instrumentation-conventions")
+  id("otel.shadow-conventions")
+}
+
+val toolingRuntime by configurations.creating {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+}
+
+dependencies {
+  // Integration tests may need to define custom instrumentation modules so we include the standard
+  // instrumentation infrastructure for testing too.
+  compileOnly(project(":instrumentation-api"))
+  compileOnly(project(":javaagent-api"))
+  compileOnly(project(":javaagent-bootstrap"))
+  // Apply common dependencies for instrumentation.
+  compileOnly(project(":javaagent-extension-api")) {
+    // OpenTelemetry SDK is not needed for compilation
+    exclude(group = "io.opentelemetry", module = "opentelemetry-sdk")
+    exclude(group = "io.opentelemetry", module = "opentelemetry-sdk-metrics")
+  }
+  compileOnly(project(":javaagent-tooling")) {
+    // OpenTelemetry SDK is not needed for compilation
+    exclude(group = "io.opentelemetry", module = "opentelemetry-sdk")
+    exclude(group = "io.opentelemetry", module = "opentelemetry-sdk-metrics")
+  }
+  compileOnly("net.bytebuddy:byte-buddy")
+  annotationProcessor("com.google.auto.service:auto-service")
+  compileOnly("com.google.auto.service:auto-service")
+  compileOnly("org.slf4j:slf4j-api")
+
+  testImplementation(project(":testing-common"))
+
+  testImplementation("org.testcontainers:testcontainers")
+
+  toolingRuntime(project(path = ":javaagent-tooling", configuration = "instrumentationMuzzle"))
+  toolingRuntime(project(path = ":javaagent-extension-api", configuration = "instrumentationMuzzle"))
+}
+
+val pluginName = "io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin"
+ByteBuddyPluginConfigurator(project, sourceSets.main.get(), pluginName,
+  toolingRuntime.plus(configurations.runtimeClasspath.get()))
+  .configure()
+
+val testInstrumentation by configurations.creating {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+}
+
+tasks.named<ShadowJar>("shadowJar").configure {
+  configurations = listOf(project.configurations.runtimeClasspath.get(), testInstrumentation)
+
+  archiveFileName.set("agent-testing.jar")
+}
+
+evaluationDependsOn(":testing:agent-for-testing")
+
+// need to run this after evaluate because testSets plugin adds new test tasks
+afterEvaluate {
+  tasks.withType<Test>().configureEach {
+    val shadowJar = tasks.shadowJar.get()
+    val agentShadowJar = project(":testing:agent-for-testing").tasks.shadowJar.get()
+
+    inputs.file(shadowJar.archiveFile)
+
+    dependsOn(shadowJar)
+    dependsOn(agentShadowJar)
+
+    jvmArgs("-Dotel.javaagent.debug=true")
+    jvmArgs("-javaagent:${agentShadowJar.archiveFile.get().asFile.absolutePath}")
+    jvmArgs("-Dotel.javaagent.experimental.initializer.jar=${shadowJar.archiveFile.get().asFile.absolutePath}")
+    jvmArgs("-Dotel.javaagent.testing.additional-library-ignores.enabled=false")
+    val failOnContextLeak = findProperty("failOnContextLeak")
+    jvmArgs("-Dotel.javaagent.testing.fail-on-context-leak=${failOnContextLeak != false}")
+    // prevent sporadic gradle deadlocks, see SafeLogger for more details
+    jvmArgs("-Dotel.javaagent.testing.transform-safe-logging.enabled=true")
+
+    // We do fine-grained filtering of the classpath of this codebase's sources since Gradle's
+    // configurations will include transitive dependencies as well, which tests do often need.
+    classpath = classpath.filter {
+      // The sources are packaged into the testing jar so we need to make sure to exclude from the test
+      // classpath, which automatically inherits them, to ensure our shaded versions are used.
+      if (file("${buildDir}/resources/main").equals(it) || file("${buildDir}/classes/java/main").equals(it)) {
+        return@filter false
+      }
+      // If agent depends on some shared instrumentation module that is not a testing module, it will
+      // be packaged into the testing jar so we need to make sure to exclude from the test classpath.
+      val libPath = it.absolutePath
+      val instrumentationPath = file("${rootDir}/instrumentation/").absolutePath
+      if (libPath.startsWith(instrumentationPath) &&
+        libPath.endsWith(".jar") &&
+        !libPath.substring(instrumentationPath.length).contains("testing")) {
+        return@filter false
+      }
+      return@filter true
+    }
+  }
+}
+
+configurations.configureEach {
+  if (name.toLowerCase().endsWith("testruntimeclasspath")) {
+    // Added by agent, don't let Gradle bring it in when running tests.
+    exclude(module = "javaagent-bootstrap")
+  }
+}

--- a/buildSrc/src/main/kotlin/otel.library-instrumentation.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.library-instrumentation.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-  id("otel.java-conventions")
+  id("otel.instrumentation-conventions")
   id("otel.jacoco-conventions")
   id("otel.publish-conventions")
-  id("otel.instrumentation-conventions")
 }
 
 extra["mavenGroupId"] = "io.opentelemetry.instrumentation"

--- a/instrumentation/cdi-testing/cdi-testing.gradle
+++ b/instrumentation/cdi-testing/cdi-testing.gradle
@@ -1,7 +1,6 @@
-ext {
-  skipPublish = true
+plugins {
+  id("otel.javaagent-testing")
 }
-apply plugin: "otel.javaagent-instrumentation"
 
 dependencies {
   testLibrary "org.jboss.weld:weld-core:2.3.0.Final"

--- a/instrumentation/dropwizard-testing/dropwizard-testing.gradle
+++ b/instrumentation/dropwizard-testing/dropwizard-testing.gradle
@@ -1,7 +1,6 @@
-ext {
-  skipPublish = true
+plugins {
+  id("otel.javaagent-testing")
 }
-apply plugin: "otel.javaagent-instrumentation"
 
 dependencies {
   testInstrumentation project(':instrumentation:jaxrs:jaxrs-2.0:jaxrs-2.0-jersey-2.0:javaagent')

--- a/instrumentation/internal/internal-class-loader/javaagent-integration-tests/internal-class-loader-javaagent-integration-tests.gradle
+++ b/instrumentation/internal/internal-class-loader/javaagent-integration-tests/internal-class-loader-javaagent-integration-tests.gradle
@@ -1,6 +1,6 @@
-ext.skipPublish = true
-
-apply plugin: "otel.javaagent-instrumentation"
+plugins {
+  id("otel.javaagent-testing")
+}
 
 dependencies {
   testImplementation "org.apache.commons:commons-lang3:3.12.0"

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-arquillian-testing/jaxrs-2.0-arquillian-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-arquillian-testing/jaxrs-2.0-arquillian-testing.gradle
@@ -1,7 +1,6 @@
-ext {
-  skipPublish = true
+plugins {
+  id("otel.javaagent-testing")
 }
-apply plugin: "otel.java-conventions"
 
 // add repo for org.gradle:gradle-tooling-api which org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-gradle-depchain depends on
 repositories {

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-payara-testing/jaxrs-2.0-payara-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-payara-testing/jaxrs-2.0-payara-testing.gradle
@@ -1,7 +1,6 @@
-ext {
-  skipPublish = true
+plugins {
+  id("otel.javaagent-testing")
 }
-apply plugin: "otel.javaagent-instrumentation"
 
 // add repo for org.gradle:gradle-tooling-api which org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-gradle-depchain
 // which is used by jaxrs-2.0-arquillian-testing depends on

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-tomee-testing/jaxrs-2.0-tomee-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-tomee-testing/jaxrs-2.0-tomee-testing.gradle
@@ -1,7 +1,6 @@
-ext {
-  skipPublish = true
+plugins {
+  id("otel.javaagent-testing")
 }
-apply plugin: "otel.javaagent-instrumentation"
 
 // add repo for org.gradle:gradle-tooling-api which org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-gradle-depchain
 // which is used by jaxrs-2.0-arquillian-testing depends on

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-wildfly-testing/jaxrs-2.0-wildfly-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-wildfly-testing/jaxrs-2.0-wildfly-testing.gradle
@@ -1,7 +1,6 @@
-ext {
-  skipPublish = true
+plugins {
+  id("otel.javaagent-testing")
 }
-apply plugin: "otel.javaagent-instrumentation"
 
 // add repo for org.gradle:gradle-tooling-api which org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-gradle-depchain
 // which is used by jaxrs-2.0-arquillian-testing depends on

--- a/instrumentation/vaadin-14.2/testing/vaadin-14.2-testing.gradle
+++ b/instrumentation/vaadin-14.2/testing/vaadin-14.2-testing.gradle
@@ -1,8 +1,6 @@
-ext {
-  skipPublish = true
+plugins {
+  id("otel.javaagent-testing")
 }
-
-apply plugin: "otel.java-conventions"
 
 dependencies {
   compileOnly 'com.vaadin:vaadin-spring-boot-starter:14.2.0'

--- a/testing-common/integration-tests/integration-tests.gradle
+++ b/testing-common/integration-tests/integration-tests.gradle
@@ -1,6 +1,6 @@
-ext.skipPublish = true
-
-apply plugin: "otel.javaagent-instrumentation"
+plugins {
+  id("otel.javaagent-testing")
+}
 
 dependencies {
   implementation project(':testing-common:library-for-integration-tests')

--- a/testing/armeria-shaded-for-testing/armeria-shaded-for-testing.gradle
+++ b/testing/armeria-shaded-for-testing/armeria-shaded-for-testing.gradle
@@ -8,7 +8,11 @@ apply plugin: "otel.java-conventions"
 apply plugin: "otel.publish-conventions"
 
 dependencies {
-  implementation "com.linecorp.armeria:armeria-junit5:1.8.0"
+  implementation("com.linecorp.armeria:armeria-junit5:1.8.0") {
+    // We don't use JSON features of Armeria but shading it in can cause version conflicts with
+    // instrumentation tests that do.
+    exclude group: "com.fasterxml.jackson.core"
+  }
 }
 
 shadowJar {


### PR DESCRIPTION
… muzzled / published.

Removes the `skipPublish` property, making testing projects a bit less verbose and reduces the amount of conditionals needed in the build logic.