### PR TITLE
Improve ignored but instrumented types assertion in javaagent tests

### DIFF
--- a/instrumentation/spring/spring-integration-4.1/javaagent/spring-integration-4.1-javaagent.gradle
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/spring-integration-4.1-javaagent.gradle
@@ -22,6 +22,7 @@ dependencies {
   library 'org.springframework.integration:spring-integration-core:4.1.0.RELEASE'
 
   testInstrumentation project(':instrumentation:rabbitmq-2.7:javaagent')
+  testInstrumentation project(':instrumentation:spring:spring-rabbit-1.0:javaagent')
 
   testImplementation project(':instrumentation:spring:spring-integration-4.1:testing')
 
@@ -38,12 +39,14 @@ test {
     excludeTestsMatching 'SpringIntegrationAndRabbitTest'
   }
   jvmArgs "-Dotel.instrumentation.rabbitmq.enabled=false"
+  jvmArgs "-Dotel.instrumentation.spring-rabbit.enabled=false"
 }
 test.finalizedBy(tasks.register("testWithRabbitInstrumentation", Test) {
   filter {
     includeTestsMatching 'SpringIntegrationAndRabbitTest'
   }
   jvmArgs "-Dotel.instrumentation.rabbitmq.enabled=true"
+  jvmArgs "-Dotel.instrumentation.spring-rabbit.enabled=true"
 })
 
 tasks.withType(Test).configureEach {

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/SpringIntegrationIgnoredTypesConfigurer.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/SpringIntegrationIgnoredTypesConfigurer.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.integration;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesBuilder;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
+
+@AutoService(IgnoredTypesConfigurer.class)
+public class SpringIntegrationIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
+  @Override
+  public void configure(Config config, IgnoredTypesBuilder builder) {
+    // we don't instrument any messaging classes
+    builder.ignoreClass("org.springframework.messaging");
+  }
+}

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/SpringIntegrationIgnoredTypesConfigurer.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/SpringIntegrationIgnoredTypesConfigurer.java
@@ -16,5 +16,8 @@ public class SpringIntegrationIgnoredTypesConfigurer implements IgnoredTypesConf
   public void configure(Config config, IgnoredTypesBuilder builder) {
     // we don't instrument any messaging classes
     builder.ignoreClass("org.springframework.messaging");
+
+    // TODO: move to spring-rabbit and include it in tests:
+    builder.ignoreClass("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer");
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/SpringIntegrationIgnoredTypesConfigurer.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/SpringIntegrationIgnoredTypesConfigurer.java
@@ -16,8 +16,5 @@ public class SpringIntegrationIgnoredTypesConfigurer implements IgnoredTypesConf
   public void configure(Config config, IgnoredTypesBuilder builder) {
     // we don't instrument any messaging classes
     builder.ignoreClass("org.springframework.messaging");
-
-    // TODO: move to spring-rabbit and include it in tests:
-    builder.ignoreClass("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer");
   }
 }

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/SpringRabbitIgnoredTypesConfigurer.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/SpringRabbitIgnoredTypesConfigurer.java
@@ -1,0 +1,19 @@
+package io.opentelemetry.javaagent.instrumentation.spring.rabbit;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesBuilder;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
+
+@AutoService(IgnoredTypesConfigurer.class)
+public class SpringRabbitIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
+  @Override
+  public void configure(Config config, IgnoredTypesBuilder builder) {
+    // contains a Runnable that servers as a worker that continuously reads messages from queue
+    builder
+        .ignoreClass("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer")
+        // a Runnable callback called only on shutdown
+        .ignoreClass(
+            "org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry$AggregatingCallback");
+  }
+}

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/SpringRabbitIgnoredTypesConfigurer.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/SpringRabbitIgnoredTypesConfigurer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.instrumentation.spring.rabbit;
 
 import com.google.auto.service.AutoService;

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
@@ -91,6 +91,8 @@ class ContextPropagationTest extends AgentInstrumentationSpecification {
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
           }
         }
+        // spring-cloud-stream-binder-rabbit listener puts all messages into a BlockingQueue immediately after receiving
+        // that's why the rabbitmq CONSUMER span will never have any child span (and propagate context, actually)
         span(2) {
           // created by rabbitmq instrumentation
           name "testQueue process"
@@ -105,7 +107,7 @@ class ContextPropagationTest extends AgentInstrumentationSpecification {
           }
         }
         span(3) {
-          // created by spring-amqp instrumentation
+          // created by spring-rabbit instrumentation
           name "testQueue process"
           kind CONSUMER
           childOf span(1)

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
@@ -62,6 +62,7 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
         .ignoreClass("org.springframework.jmx.")
         .ignoreClass("org.springframework.jndi.")
         .ignoreClass("org.springframework.lang.")
+        .ignoreClass("org.springframework.messaging.")
         .ignoreClass("org.springframework.objenesis.")
         .ignoreClass("org.springframework.orm.")
         .ignoreClass("org.springframework.remoting.")
@@ -81,10 +82,8 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
         .ignoreClass("org.springframework.amqp.")
         .allowClass("org.springframework.amqp.rabbit.connection.")
         .allowClass("org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer")
-        // these implement Runnable, so tests currently force these allows
+        // this one implements Runnable, so tests currently force these allows
         // though not sure if it's important or not that they get instrumented
-        .allowClass(
-            "org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer$AsyncMessageProcessingConsumer")
         .allowClass(
             "org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry$AggregatingCallback");
 
@@ -159,11 +158,6 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
         .allowClass("org.springframework.jms.listener.")
         .allowClass(
             "org.springframework.jms.config.JmsListenerEndpointRegistry$AggregatingCallback");
-
-    builder
-        .ignoreClass("org.springframework.messaging.")
-        .allowClass("org.springframework.messaging.support.ExecutorSubscribableChannel$SendTask")
-        .allowClass("org.springframework.messaging.support.MessageHandlingRunnable");
 
     builder
         .ignoreClass("org.springframework.util.")

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
@@ -81,11 +81,7 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
     builder
         .ignoreClass("org.springframework.amqp.")
         .allowClass("org.springframework.amqp.rabbit.connection.")
-        .allowClass("org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer")
-        // this one implements Runnable, so tests currently force these allows
-        // though not sure if it's important or not that they get instrumented
-        .allowClass(
-            "org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry$AggregatingCallback");
+        .allowClass("org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer");
 
     builder
         .ignoreClass("org.springframework.beans.")

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
@@ -5,7 +5,11 @@
 
 package io.opentelemetry.javaagent.testing.bytebuddy;
 
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
+import io.opentelemetry.javaagent.tooling.SafeServiceLoader;
 import io.opentelemetry.javaagent.tooling.ignore.AdditionalLibraryIgnoredTypesConfigurer;
+import io.opentelemetry.javaagent.tooling.ignore.GlobalIgnoredTypesConfigurer;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoreAllow;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesBuilderImpl;
 import io.opentelemetry.javaagent.tooling.ignore.trie.Trie;
@@ -29,11 +33,32 @@ public class TestAgentListener implements AgentBuilder.Listener {
   private static final Logger logger = LoggerFactory.getLogger(TestAgentListener.class);
 
   private static final Trie<IgnoreAllow> ADDITIONAL_LIBRARIES_TRIE;
+  private static final Trie<IgnoreAllow> OTHER_IGNORES_TRIE;
 
   static {
+    ADDITIONAL_LIBRARIES_TRIE = buildAdditionalLibraryIgnores();
+    OTHER_IGNORES_TRIE = buildOtherConfiguredIgnores();
+  }
+
+  private static Trie<IgnoreAllow> buildAdditionalLibraryIgnores() {
     IgnoredTypesBuilderImpl builder = new IgnoredTypesBuilderImpl();
     new AdditionalLibraryIgnoredTypesConfigurer().configure(builder);
-    ADDITIONAL_LIBRARIES_TRIE = builder.buildIgnoredTypesTrie();
+    return builder.buildIgnoredTypesTrie();
+  }
+
+  private static Trie<IgnoreAllow> buildOtherConfiguredIgnores() {
+    Config config = Config.newBuilder().build();
+    IgnoredTypesBuilderImpl builder = new IgnoredTypesBuilderImpl();
+    for (IgnoredTypesConfigurer configurer :
+        SafeServiceLoader.loadOrdered(IgnoredTypesConfigurer.class)) {
+      // skip built-in agent ignores
+      if (configurer instanceof AdditionalLibraryIgnoredTypesConfigurer
+          || configurer instanceof GlobalIgnoredTypesConfigurer) {
+        continue;
+      }
+      configurer.configure(config, builder);
+    }
+    return builder.buildIgnoredTypesTrie();
   }
 
   public static void reset() {
@@ -50,7 +75,10 @@ public class TestAgentListener implements AgentBuilder.Listener {
   public static List<String> getIgnoredButTransformedClassNames() {
     List<String> names = new ArrayList<>();
     for (String name : INSTANCE.transformedClassesNames) {
-      if (ADDITIONAL_LIBRARIES_TRIE.getOrNull(name) == IgnoreAllow.IGNORE) {
+      // only record those types that weren't explicitly marked as either ignored or allowed by the
+      // instrumentation authors
+      if (ADDITIONAL_LIBRARIES_TRIE.getOrNull(name) == IgnoreAllow.IGNORE
+          && OTHER_IGNORES_TRIE.getOrNull(name) == null) {
         names.add(name);
       }
     }


### PR DESCRIPTION
Instrumentations can now choose whether types ignored by default in `AdditionalLibraryIgnoredTypesConfigurer` should be ignored or not (previously the only way to silence this assertion was to allow instrumenting all types detected by it).