### PR TITLE
Add peer.service to grpc javaagent instrumentation

### DIFF
--- a/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
+++ b/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
@@ -8,24 +8,43 @@ package io.opentelemetry.javaagent.instrumentation.grpc.v1_6;
 import io.grpc.ClientInterceptor;
 import io.grpc.Context;
 import io.grpc.ServerInterceptor;
+import io.grpc.Status;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcRequest;
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTracing;
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTracingBuilder;
 import io.opentelemetry.instrumentation.grpc.v1_6.internal.ContextStorageBridge;
+import io.opentelemetry.javaagent.instrumentation.api.instrumenter.PeerServiceAttributesExtractor;
 
 // Holds singleton references.
 public final class GrpcSingletons {
-  private static final GrpcTracing TRACING =
-      GrpcTracing.newBuilder(GlobalOpenTelemetry.get())
-          .setCaptureExperimentalSpanAttributes(
-              Config.get()
-                  .getBooleanProperty(
-                      "otel.instrumentation.grpc.experimental-span-attributes", false))
-          .build();
 
-  public static final ClientInterceptor CLIENT_INTERCEPTOR = TRACING.newClientInterceptor();
+  public static final ClientInterceptor CLIENT_INTERCEPTOR;
 
-  public static final ServerInterceptor SERVER_INTERCEPTOR = TRACING.newServerInterceptor();
+  public static final ServerInterceptor SERVER_INTERCEPTOR;
 
   public static final Context.Storage STORAGE = new ContextStorageBridge();
+
+  static {
+    GrpcTracingBuilder builder =
+        GrpcTracing.newBuilder(GlobalOpenTelemetry.get())
+            .setCaptureExperimentalSpanAttributes(
+                Config.get()
+                    .getBooleanProperty(
+                        "otel.instrumentation.grpc.experimental-span-attributes", false));
+
+    PeerServiceAttributesExtractor<GrpcRequest, Status> peerServiceExtractor =
+        PeerServiceAttributesExtractor.createUsingReflection(
+            "io.opentelemetry.instrumentation.grpc.v1_6.GrpcNetAttributesExtractor");
+    if (peerServiceExtractor != null) {
+      builder.addAttributeExtractor(peerServiceExtractor);
+    }
+
+    GrpcTracing tracing = builder.build();
+    CLIENT_INTERCEPTOR = tracing.newClientInterceptor();
+    SERVER_INTERCEPTOR = tracing.newServerInterceptor();
+  }
+
+  private GrpcSingletons() {}
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRequest.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRequest.java
@@ -10,7 +10,7 @@ import io.grpc.MethodDescriptor;
 import java.net.SocketAddress;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class GrpcRequest {
+public final class GrpcRequest {
 
   private final MethodDescriptor<?, ?> method;
   @Nullable private final Metadata metadata;
@@ -26,15 +26,17 @@ final class GrpcRequest {
     this.remoteAddress = remoteAddress;
   }
 
-  MethodDescriptor<?, ?> getMethod() {
+  public MethodDescriptor<?, ?> getMethod() {
     return method;
   }
 
-  Metadata getMetadata() {
+  @Nullable
+  public Metadata getMetadata() {
     return metadata;
   }
 
-  SocketAddress getRemoteAddress() {
+  @Nullable
+  public SocketAddress getRemoteAddress() {
     return remoteAddress;
   }
 


### PR DESCRIPTION
I must have missed that one instrumentation when I was adding `PeerServiceAttributesExtractor`