### PR TITLE
Exclude bytebuddy generated helper class from redefinition

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -435,6 +435,10 @@ public class AgentInstaller {
       if (cl instanceof AgentClassLoader || cl instanceof ExtensionClassLoader) {
         return true;
       }
+      // ignore generate byte buddy helper class
+      if (c.getName().startsWith("java.lang.ClassLoader$ByteBuddyAccessor$")) {
+        return true;
+      }
 
       return HelperInjector.isInjectedClass(c);
     }


### PR DESCRIPTION
Gets rid of the following error
```
[otel.javaagent 2021-06-21 11:28:14:334 +0300] [main] ERROR io.opentelemetry.javaagent.testing.bytebuddy.TestAgentListener - Unexpected instrumentation error when instrumenting java.lang.ClassLoader$ByteBuddyAccessor$KohQX7Yc on null
java.lang.IllegalStateException: Cannot resolve type description for java.lang.ClassLoader$ByteBuddyAccessor$KohQX7Yc
        at net.bytebuddy.pool.TypePool$Resolution$Illegal.resolve(TypePool.java:161)
        at io.opentelemetry.javaagent.tooling.bytebuddy.AgentCachingPoolStrategy$CachingResolution.resolve(AgentCachingPoolStrategy.java:262)
        at net.bytebuddy.pool.TypePool$Default$WithLazyResolution$LazyTypeDescription.delegate(TypePool.java:1038)
        at net.bytebuddy.description.type.TypeDescription$AbstractBase$OfSimpleType$WithDelegation.getModifiers(TypeDescription.java:8206)
        at net.bytebuddy.matcher.ModifierMatcher.matches(ModifierMatcher.java:60)
        at net.bytebuddy.matcher.ModifierMatcher.matches(ModifierMatcher.java:27)
        at net.bytebuddy.matcher.NegatingMatcher.matches(NegatingMatcher.java:46)
        at net.bytebuddy.matcher.ElementMatcher$Junction$Conjunction.matches(ElementMatcher.java:144)
        at net.bytebuddy.agent.builder.AgentBuilder$RawMatcher$ForElementMatchers.matches(AgentBuilder.java:1790)
        at net.bytebuddy.agent.builder.AgentBuilder$RawMatcher$Conjunction.matches(AgentBuilder.java:1625)
        at net.bytebuddy.agent.builder.AgentBuilder$Default$Transformation$SimpleMatcher.matches(AgentBuilder.java:10393)
        at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy$Collector.doConsider(AgentBuilder.java:7582)
        at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy$Collector.consider(AgentBuilder.java:7527)
        at net.bytebuddy.agent.builder.AgentBuilder$RedefinitionStrategy.apply(AgentBuilder.java:5439)
        at net.bytebuddy.agent.builder.AgentBuilder$Default.doInstall(AgentBuilder.java:10134)
        at net.bytebuddy.agent.builder.AgentBuilder$Default.installOn(AgentBuilder.java:10047)
        at net.bytebuddy.agent.builder.AgentBuilder$Default$Delegator.installOn(AgentBuilder.java:11553)
        at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:163)
        at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:97)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at io.opentelemetry.javaagent.bootstrap.AgentInitializer.initialize(AgentInitializer.java:40)
        at io.opentelemetry.javaagent.OpenTelemetryAgent.agentmain(OpenTelemetryAgent.java:56)
        at io.opentelemetry.javaagent.OpenTelemetryAgent.premain(OpenTelemetryAgent.java:50)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
```