### PR TITLE
Remove latestDepTestLibrary upper bound from jaxrs-2.0-resteasy-3.1

### DIFF
--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/jaxrs-2.0-resteasy-3.1-javaagent.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/jaxrs-2.0-resteasy-3.1-javaagent.gradle
@@ -39,8 +39,7 @@ dependencies {
   testLibrary "org.jboss.resteasy:resteasy-servlet-initializer:3.1.0.Final"
 
   // artifact name changed from 'resteasy-jaxrs' to 'resteasy-core' starting from version 4.0.0
-  // TODO (trask) 4.6.1.Beta3 appears broken, revisit after next release
-  latestDepTestLibrary "org.jboss.resteasy:resteasy-core:4.6.1.Beta2"
+  latestDepTestLibrary "org.jboss.resteasy:resteasy-core:+"
 }
 
 test {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3267