### PR TITLE
support logs in the fake test backend

### DIFF
--- a/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
+++ b/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
@@ -69,7 +69,6 @@ public class FakeBackendMain {
             marshaller.writeValue(value, gen);
           }
         });
-    module.setSerializers(serializers);
     serializers.addSerializer(
         new StdSerializer<>(ExportLogsServiceRequest.class) {
           @Override

--- a/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeLogsCollectorService.java
+++ b/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeLogsCollectorService.java
@@ -1,0 +1,31 @@
+package io.opentelemetry.smoketest.fakebackend;
+
+import com.google.common.collect.ImmutableList;
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse;
+import io.opentelemetry.proto.collector.logs.v1.LogsServiceGrpc;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+public class FakeLogsCollectorService extends LogsServiceGrpc.LogsServiceImplBase{
+
+  private BlockingQueue<ExportLogsServiceRequest> exportRequests = new LinkedBlockingDeque<>();
+
+  List<ExportLogsServiceRequest> getRequests() {
+    return ImmutableList.copyOf(exportRequests);
+  }
+
+  void clearRequests() {
+    exportRequests.clear();
+  }
+
+  @Override
+  public void export(ExportLogsServiceRequest request,
+      StreamObserver<ExportLogsServiceResponse> responseObserver) {
+    exportRequests.add(request);
+    responseObserver.onNext(ExportLogsServiceResponse.getDefaultInstance());
+    responseObserver.onCompleted();
+  }
+}


### PR DESCRIPTION
Interest in logs is heating up. I think we might find it helpful to have this wired up.

I just followed the pattern that existed for logs and metrics.