### PR TITLE
Register logs marshaller

### DIFF
--- a/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
+++ b/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
@@ -46,6 +46,7 @@ public class FakeBackendMain {
         MessageMarshaller.builder()
             .register(ExportTraceServiceRequest.getDefaultInstance())
             .register(ExportMetricsServiceRequest.getDefaultInstance())
+            .register(ExportLogsServiceRequest.getDefaultInstance())
             .build();
 
     var mapper = JsonMapper.builder();

--- a/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeLogsCollectorService.java
+++ b/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeLogsCollectorService.java
@@ -11,7 +11,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 
 public class FakeLogsCollectorService extends LogsServiceGrpc.LogsServiceImplBase{
 
-  private BlockingQueue<ExportLogsServiceRequest> exportRequests = new LinkedBlockingDeque<>();
+  private final BlockingQueue<ExportLogsServiceRequest> exportRequests = new LinkedBlockingDeque<>();
 
   List<ExportLogsServiceRequest> getRequests() {
     return ImmutableList.copyOf(exportRequests);


### PR DESCRIPTION
I overlooked this critical part in the prior logs wiring. Without it, `/get-logs` returns a 500.