### PR TITLE
Conform to google style guide checkstyle

### DIFF
--- a/benchmark-e2e/src/main/java/io/opentelemetry/e2ebenchmark/AgentBenchmark.java
+++ b/benchmark-e2e/src/main/java/io/opentelemetry/e2ebenchmark/AgentBenchmark.java
@@ -24,7 +24,7 @@ import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-public class E2EAgentBenchmark {
+public class AgentBenchmark {
   private static final String APP_NAME =
       System.getenv()
           .getOrDefault(
@@ -32,7 +32,7 @@ public class E2EAgentBenchmark {
               "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk8-20201204.400701583");
 
   private List<GenericContainer<?>> containers;
-  private static final Logger LOG = LoggerFactory.getLogger(E2EAgentBenchmark.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AgentBenchmark.class);
 
   // docker images
   private static final DockerImageName APP_IMAGE = DockerImageName.parse(APP_NAME);

--- a/gradle/enforcement/checkstyle.xml
+++ b/gradle/enforcement/checkstyle.xml
@@ -261,8 +261,7 @@
     -->
     <module name="AbbreviationAsWordInName">
       <property name="ignoreFinal" value="false"/>
-      <!-- modified from default to support KHttp -->
-      <property name="allowedAbbreviationLength" value="1"/>
+      <property name="allowedAbbreviationLength" value="0"/>
       <property name="tokens"
         value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/HttpServerTracer.java
@@ -156,7 +156,7 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
 
   protected void onConnection(SpanBuilder spanBuilder, CONNECTION connection) {
     // TODO: use NetPeerAttributes here
-    spanBuilder.setAttribute(SemanticAttributes.NET_PEER_IP, peerHostIP(connection));
+    spanBuilder.setAttribute(SemanticAttributes.NET_PEER_IP, peerHostIp(connection));
     Integer port = peerPort(connection);
     // Negative or Zero ports might represent an unset/null value for an int type.  Skip setting.
     if (port != null && port > 0) {
@@ -199,10 +199,10 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
       }
       spanBuilder.setAttribute(SemanticAttributes.HTTP_FLAVOR, flavor);
     }
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_CLIENT_IP, clientIP(connection, request));
+    spanBuilder.setAttribute(SemanticAttributes.HTTP_CLIENT_IP, clientIp(connection, request));
   }
 
-  private String clientIP(CONNECTION connection, REQUEST request) {
+  private String clientIp(CONNECTION connection, REQUEST request) {
     // try Forwarded
     String forwarded = requestHeader(request, "Forwarded");
     if (forwarded != null) {
@@ -226,7 +226,7 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
     }
 
     // fallback to peer IP if there are no proxy headers
-    return peerHostIP(connection);
+    return peerHostIp(connection);
   }
 
   // VisibleForTesting
@@ -263,7 +263,7 @@ public abstract class HttpServerTracer<REQUEST, RESPONSE, CONNECTION, STORAGE> e
   protected abstract Integer peerPort(CONNECTION connection);
 
   @Nullable
-  protected abstract String peerHostIP(CONNECTION connection);
+  protected abstract String peerHostIp(CONNECTION connection);
 
   protected abstract String flavor(CONNECTION connection, REQUEST request);
 

--- a/instrumentation/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerTracer.java
+++ b/instrumentation/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerTracer.java
@@ -49,7 +49,7 @@ public class AkkaHttpServerTracer
   }
 
   @Override
-  protected String peerHostIP(HttpRequest httpRequest) {
+  protected String peerHostIp(HttpRequest httpRequest) {
     return null;
   }
 

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaMessageTracer.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaMessageTracer.java
@@ -71,7 +71,7 @@ public class AwsLambdaMessageTracer extends BaseTracer {
     String parentHeader = message.getAttributes().get(AWS_TRACE_HEADER_SQS_ATTRIBUTE_KEY);
     if (parentHeader != null) {
       SpanContext parentCtx =
-          Span.fromContext(ParentContextExtractor.fromXRayHeader(parentHeader)).getSpanContext();
+          Span.fromContext(ParentContextExtractor.fromXrayHeader(parentHeader)).getSpanContext();
       if (parentCtx.isValid()) {
         span.addLink(parentCtx);
       }

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractor.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/ParentContextExtractor.java
@@ -25,7 +25,7 @@ public final class ParentContextExtractor {
     Context parentContext = null;
     String parentTraceHeader = System.getenv(AWS_TRACE_HEADER_ENV_KEY);
     if (parentTraceHeader != null) {
-      parentContext = fromXRayHeader(parentTraceHeader);
+      parentContext = fromXrayHeader(parentTraceHeader);
     }
     if (!isValidAndSampled(parentContext)) {
       // try http
@@ -50,7 +50,7 @@ public final class ParentContextExtractor {
   // lower-case map getter used for extraction
   static final String AWS_TRACE_HEADER_PROPAGATOR_KEY = "x-amzn-trace-id";
 
-  static Context fromXRayHeader(String parentHeader) {
+  static Context fromXrayHeader(String parentHeader) {
     return AwsXrayPropagator.getInstance()
         .extract(
             // see BaseTracer#extract() on why we're using root() here

--- a/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/ApiGatewayProxyRequestTest.java
+++ b/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/ApiGatewayProxyRequestTest.java
@@ -44,7 +44,7 @@ class ApiGatewayProxyRequestTest {
   }
 
   @Test
-  public void shouldCreateNoopRequestIfXRayPropagatorsSet() throws IOException {
+  public void shouldCreateNoopRequestIfXrayPropagatorsSet() throws IOException {
     // given
     InputStream mock = mock(InputStream.class);
     GlobalOpenTelemetry.set(

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpServerTracer.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpServerTracer.java
@@ -74,7 +74,7 @@ public class GrizzlyHttpServerTracer
   }
 
   @Override
-  protected String peerHostIP(HttpRequestPacket httpRequest) {
+  protected String peerHostIp(HttpRequestPacket httpRequest) {
     return httpRequest.getRemoteAddress();
   }
 

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyConnectionWrapper.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyConnectionWrapper.java
@@ -22,7 +22,7 @@ public class LibertyConnectionWrapper {
     return httpDispatcherLink.getRemotePort();
   }
 
-  public String peerHostIP() {
+  public String peerHostIp() {
     return httpDispatcherLink.getRemoteHostAddress();
   }
 

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherTracer.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherTracer.java
@@ -37,8 +37,8 @@ public class LibertyDispatcherTracer
 
   @Override
   @Nullable
-  protected String peerHostIP(LibertyConnectionWrapper libertyConnectionWrapper) {
-    return libertyConnectionWrapper.peerHostIP();
+  protected String peerHostIp(LibertyConnectionWrapper libertyConnectionWrapper) {
+    return libertyConnectionWrapper.peerHostIp();
   }
 
   @Override

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerTracer.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerTracer.java
@@ -61,7 +61,7 @@ public class NettyHttpServerTracer
   }
 
   @Override
-  protected String peerHostIP(Channel channel) {
+  protected String peerHostIp(Channel channel) {
     SocketAddress socketAddress = channel.getRemoteAddress();
     if (socketAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) socketAddress).getAddress().getHostAddress();

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/NettyHttpServerTracer.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/NettyHttpServerTracer.java
@@ -72,7 +72,7 @@ public class NettyHttpServerTracer
   }
 
   @Override
-  protected String peerHostIP(Channel channel) {
+  protected String peerHostIp(Channel channel) {
     SocketAddress socketAddress = channel.remoteAddress();
     if (socketAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) socketAddress).getAddress().getHostAddress();

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/NettyHttpServerTracer.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/server/NettyHttpServerTracer.java
@@ -72,7 +72,7 @@ public class NettyHttpServerTracer
   }
 
   @Override
-  protected String peerHostIP(Channel channel) {
+  protected String peerHostIp(Channel channel) {
     SocketAddress socketAddress = channel.remoteAddress();
     if (socketAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) socketAddress).getAddress().getHostAddress();

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -66,13 +66,13 @@ class WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
 
   def "should take span kind from annotation"() {
     setup:
-    new TracedWithSpan().oneOfAKind()
+    new TracedWithSpan().someKind()
 
     expect:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          name "TracedWithSpan.oneOfAKind"
+          name "TracedWithSpan.someKind"
           kind PRODUCER
           hasNoParent()
           attributes {

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/TracedWithSpan.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/java/io/opentelemetry/test/annotation/TracedWithSpan.java
@@ -28,7 +28,7 @@ public class TracedWithSpan {
   }
 
   @WithSpan(kind = SpanKind.PRODUCER)
-  public String oneOfAKind() {
+  public String someKind() {
     return "hello!";
   }
 

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/ServletHttpServerTracer.java
@@ -127,7 +127,7 @@ public abstract class ServletHttpServerTracer<REQUEST, RESPONSE>
   }
 
   @Override
-  protected String peerHostIP(REQUEST connection) {
+  protected String peerHostIp(REQUEST connection) {
     return accessor.getRequestRemoteAddr(connection);
   }
 

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcServerTracer.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcServerTracer.java
@@ -27,7 +27,7 @@ class SpringWebMvcServerTracer
   }
 
   @Override
-  protected String peerHostIP(HttpServletRequest request) {
+  protected String peerHostIp(HttpServletRequest request) {
     return request.getRemoteAddr();
   }
 

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatTracer.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatTracer.java
@@ -63,7 +63,7 @@ public abstract class TomcatTracer extends HttpServerTracer<Request, Response, R
   }
 
   @Override
-  protected String peerHostIP(Request connection) {
+  protected String peerHostIp(Request connection) {
     connection.action(ActionCode.REQ_HOST_ADDR_ATTRIBUTE, connection);
     return connection.remoteAddr().toString();
   }
@@ -80,8 +80,8 @@ public abstract class TomcatTracer extends HttpServerTracer<Request, Response, R
 
   @Override
   protected String url(Request request) {
-    MessageBytes schemeMB = request.scheme();
-    String scheme = schemeMB.isNull() ? "http" : schemeMB.toString();
+    MessageBytes schemeMessageBytes = request.scheme();
+    String scheme = schemeMessageBytes.isNull() ? "http" : schemeMessageBytes.toString();
     String host = request.serverName().toString();
     int serverPort = request.getServerPort();
     String path = request.requestURI().toString();

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpServerTracer.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpServerTracer.java
@@ -103,7 +103,7 @@ public class UndertowHttpServerTracer
 
   @Override
   @Nullable
-  protected String peerHostIP(HttpServerExchange exchange) {
+  protected String peerHostIp(HttpServerExchange exchange) {
     InetSocketAddress peerAddress =
         exchange.getConnection().getPeerAddress(InetSocketAddress.class);
     return peerAddress.getHostString();


### PR DESCRIPTION
I had previously modified the google style guide `checkstyle.xml` in order to handle `KHttp` abbreviation, but we don't need that anymore, and also I realized we can handle one-off things like this in the future using `@SuppressWarnings("checkstyle:AbbreviationAsWordInName")`.