### PR TITLE
Fixed Semantic conventions in RabbitMQ

### DIFF
--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitTracer.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitTracer.java
@@ -65,11 +65,9 @@ public class RabbitTracer extends BaseTracer {
       spanBuilder.setAttribute(
           SemanticAttributes.MESSAGING_DESTINATION,
           normalizeExchangeName(response.getEnvelope().getExchange()));
-      if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
-        spanBuilder.setAttribute(
-            SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY,
-            response.getEnvelope().getRoutingKey());
-      }
+      spanBuilder.setAttribute(
+          SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY,
+          response.getEnvelope().getRoutingKey());
       spanBuilder.setAttribute(
           SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES,
           (long) response.getBody().length);
@@ -116,11 +114,11 @@ public class RabbitTracer extends BaseTracer {
     String exchangeName = normalizeExchangeName(exchange);
     span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION, exchangeName);
     span.updateName(exchangeName + " send");
+    if (routingKey != null && !routingKey.isEmpty()) {
+      span.setAttribute(SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY, routingKey);
+    }
     if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
       span.setAttribute("rabbitmq.command", "basic.publish");
-      if (routingKey != null && !routingKey.isEmpty()) {
-        span.setAttribute(SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY, routingKey);
-      }
     }
   }
 
@@ -162,11 +160,9 @@ public class RabbitTracer extends BaseTracer {
     if (envelope != null) {
       String exchange = envelope.getExchange();
       span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION, normalizeExchangeName(exchange));
-      if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
-        String routingKey = envelope.getRoutingKey();
-        if (routingKey != null && !routingKey.isEmpty()) {
-          span.setAttribute(SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY, routingKey);
-        }
+      String routingKey = envelope.getRoutingKey();
+      if (routingKey != null && !routingKey.isEmpty()) {
+        span.setAttribute(SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY, routingKey);
       }
     }
   }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitTracer.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitTracer.java
@@ -66,7 +66,9 @@ public class RabbitTracer extends BaseTracer {
           SemanticAttributes.MESSAGING_DESTINATION,
           normalizeExchangeName(response.getEnvelope().getExchange()));
       if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
-        spanBuilder.setAttribute("rabbitmq.routing_key", response.getEnvelope().getRoutingKey());
+        spanBuilder.setAttribute(
+            SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY,
+            response.getEnvelope().getRoutingKey());
       }
       spanBuilder.setAttribute(
           SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES,
@@ -113,15 +115,11 @@ public class RabbitTracer extends BaseTracer {
   public void onPublish(Span span, String exchange, String routingKey) {
     String exchangeName = normalizeExchangeName(exchange);
     span.setAttribute(SemanticAttributes.MESSAGING_DESTINATION, exchangeName);
-    String routing =
-        routingKey == null || routingKey.isEmpty()
-            ? "<all>"
-            : routingKey.startsWith("amq.gen-") ? "<generated>" : routingKey;
-    span.updateName(exchangeName + " -> " + routing + " send");
+    span.updateName(exchangeName + " send");
     if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
       span.setAttribute("rabbitmq.command", "basic.publish");
       if (routingKey != null && !routingKey.isEmpty()) {
-        span.setAttribute("rabbitmq.routing_key", routingKey);
+        span.setAttribute(SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY, routingKey);
       }
     }
   }
@@ -167,7 +165,7 @@ public class RabbitTracer extends BaseTracer {
       if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
         String routingKey = envelope.getRoutingKey();
         if (routingKey != null && !routingKey.isEmpty()) {
-          span.setAttribute("rabbitmq.routing_key", routingKey);
+          span.setAttribute(SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY, routingKey);
         }
       }
     }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMqTest.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMqTest.groovy
@@ -74,7 +74,7 @@ class RabbitMqTest extends AgentInstrumentationSpecification implements WithRabb
         rabbitSpan(it, 1, null, null, null, "exchange.declare", span(0))
         rabbitSpan(it, 2, null, null, null, "queue.declare", span(0))
         rabbitSpan(it, 3, null, null, null, "queue.bind", span(0))
-        rabbitSpan(it, 4, exchangeName, routingKey, "send", "$exchangeName -> $routingKey", span(0))
+        rabbitSpan(it, 4, exchangeName, routingKey, "send", "$exchangeName", span(0))
         rabbitSpan(it, 5, exchangeName, routingKey, "receive", "<generated>", span(0))
       }
     }
@@ -100,7 +100,7 @@ class RabbitMqTest extends AgentInstrumentationSpecification implements WithRabb
         rabbitSpan(it, 0, null, null, null, "queue.declare")
       }
       trace(1, 1) {
-        rabbitSpan(it, 0, "<default>", null, "send", "<default> -> <generated>")
+        rabbitSpan(it, 0, "<default>", null, "send", "<default>")
       }
       trace(2, 1) {
         rabbitSpan(it, 0, "<default>", null, "receive", "<generated>", null)
@@ -154,7 +154,7 @@ class RabbitMqTest extends AgentInstrumentationSpecification implements WithRabb
       }
       (1..messageCount).each {
         trace(3 + it, 2) {
-          rabbitSpan(it, 0, exchangeName, null, "send", "$exchangeName -> <all>")
+          rabbitSpan(it, 0, exchangeName, null, "send", "$exchangeName")
           rabbitSpan(it, 1, exchangeName, null, "process", resource, span(0), null, null, null, setTimestamp)
         }
       }
@@ -208,7 +208,7 @@ class RabbitMqTest extends AgentInstrumentationSpecification implements WithRabb
         rabbitSpan(it, null, null, null, "basic.consume")
       }
       trace(4, 2) {
-        rabbitSpan(it, 0, exchangeName, null, "send", "$exchangeName -> <all>")
+        rabbitSpan(it, 0, exchangeName, null, "send", "$exchangeName")
         rabbitSpan(it, 1, exchangeName, null, "process", "<generated>", span(0), null, error, error.message)
       }
     }
@@ -265,7 +265,7 @@ class RabbitMqTest extends AgentInstrumentationSpecification implements WithRabb
         rabbitSpan(it, null, null, null, "queue.declare")
       }
       trace(1, 1) {
-        rabbitSpan(it, 0, "<default>", "some-routing-queue", "send", "<default> -> some-routing-queue")
+        rabbitSpan(it, 0, "<default>", "some-routing-queue", "send", "<default>")
       }
       trace(2, 1) {
         rabbitSpan(it, 0, "<default>", "some-routing-queue", "receive", queue.name, null)
@@ -347,8 +347,8 @@ class RabbitMqTest extends AgentInstrumentationSpecification implements WithRabb
         "${SemanticAttributes.MESSAGING_SYSTEM.key}" "rabbitmq"
         "${SemanticAttributes.MESSAGING_DESTINATION.key}" exchange
         "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "queue"
-        //TODO add to SemanticAttributes
-        "rabbitmq.routing_key" { it == null || it == routingKey || it.startsWith("amq.gen-") }
+
+        "${SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY}" { it == null || it == routingKey || it.startsWith("amq.gen-") }
         if (operation != null && operation != "send") {
           "${SemanticAttributes.MESSAGING_OPERATION.key}" operation
         }
@@ -359,7 +359,7 @@ class RabbitMqTest extends AgentInstrumentationSpecification implements WithRabb
         switch (trace.span(index).attributes.get(AttributeKey.stringKey("rabbitmq.command"))) {
           case "basic.publish":
             "rabbitmq.command" "basic.publish"
-            "rabbitmq.routing_key" {
+            "${SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY}" {
               it == null || it == "some-routing-key" || it == "some-routing-queue" || it.startsWith("amq.gen-")
             }
             "rabbitmq.delivery_mode" { it == null || it == 2 }

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/test/groovy/SpringIntegrationAndRabbitTest.groovy
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/test/groovy/SpringIntegrationAndRabbitTest.groovy
@@ -56,7 +56,7 @@ class SpringIntegrationAndRabbitTest extends AgentInstrumentationSpecification i
         }
         span(3) {
           // span created by rabbitmq instrumentation
-          name "testTopic -> testTopic send"
+          name "testTopic send"
           childOf span(1)
           kind PRODUCER
           attributes {

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/test/groovy/SpringIntegrationAndRabbitTest.groovy
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/test/groovy/SpringIntegrationAndRabbitTest.groovy
@@ -67,6 +67,7 @@ class SpringIntegrationAndRabbitTest extends AgentInstrumentationSpecification i
             "${SemanticAttributes.MESSAGING_DESTINATION.key}" "testTopic"
             "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "queue"
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
+            "${SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY.key}" String
           }
         }
         // spring-cloud-stream-binder-rabbit listener puts all messages into a BlockingQueue immediately after receiving
@@ -82,6 +83,7 @@ class SpringIntegrationAndRabbitTest extends AgentInstrumentationSpecification i
             "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "queue"
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
+            "${SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY.key}" String
           }
         }
         // spring-integration will detect that spring-rabbit has already created a consumer span and back off

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
@@ -78,7 +78,7 @@ class ContextPropagationTest extends AgentInstrumentationSpecification {
         }
         span(1) {
           // created by rabbitmq instrumentation
-          name "<default> -> testQueue send"
+          name "<default> send"
           kind PRODUCER
           childOf span(0)
           attributes {

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
@@ -89,6 +89,7 @@ class ContextPropagationTest extends AgentInstrumentationSpecification {
             "${SemanticAttributes.MESSAGING_DESTINATION.key}" "<default>"
             "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "queue"
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
+            "${SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY.key}" String
           }
         }
         // spring-cloud-stream-binder-rabbit listener puts all messages into a BlockingQueue immediately after receiving
@@ -104,6 +105,7 @@ class ContextPropagationTest extends AgentInstrumentationSpecification {
             "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "queue"
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
             "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
+            "${SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY.key}" String
           }
         }
         span(3) {


### PR DESCRIPTION
1. Constructed producer span name according to spec rule. (Removed routing key as part of span name)
2. Renamed routing key attribute(part of experiment span attributes feature) according to semantic convention

Fixes #3337