### PR TITLE
Remove noShadowPublish

### DIFF
--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.ShadowExtension
-
 plugins {
   `maven-publish`
   signing
@@ -8,18 +6,11 @@ plugins {
 publishing {
   publications {
     register<MavenPublication>("maven") {
-      if (tasks.names.contains("shadowJar") && findProperty("noShadowPublish") != true) {
-        the<ShadowExtension>().component(this)
-        // These two are here just to satisfy Maven Central
-        artifact(tasks["sourcesJar"])
-        artifact(tasks["javadocJar"])
-      } else {
-        plugins.withId("java-platform") {
-          from(components["javaPlatform"])
-        }
-        plugins.withId("java-library") {
-          from(components["java"])
-        }
+      plugins.withId("java-platform") {
+        from(components["javaPlatform"])
+      }
+      plugins.withId("java-library") {
+        from(components["java"])
       }
 
       versionMapping {

--- a/instrumentation-api-caching/build.gradle
+++ b/instrumentation-api-caching/build.gradle
@@ -41,3 +41,12 @@ jar {
 
   dependsOn shadowJar
 }
+
+// Because shadow does not use default configurations
+publishing {
+  publications {
+    maven {
+      project.shadow.component(it)
+    }
+  }
+}

--- a/javaagent/build.gradle
+++ b/javaagent/build.gradle
@@ -53,6 +53,7 @@ CopySpec isolateSpec(Collection<Project> projectsWithShadowJar) {
 
 //Includes everything needed for OOTB experience
 shadowJar {
+  archiveClassifier.set("all")
   def projectsWithShadowJar = [project(':instrumentation'), project(":javaagent-exporters")]
   projectsWithShadowJar.each {
     dependsOn("${it.path}:shadowJar")
@@ -62,10 +63,14 @@ shadowJar {
 
 //Includes instrumentations, but not exporters
 task lightShadow(type: ShadowJar) {
+  archiveClassifier.set("")
   dependsOn ':instrumentation:shadowJar'
   def projectsWithShadowJar = [project(':instrumentation')]
   with isolateSpec(projectsWithShadowJar)
 }
+
+// lightShadow is the default classifier we publish so disable the default jar.
+jar.enabled = false
 
 publishing {
   publications {

--- a/testing/agent-for-testing/build.gradle
+++ b/testing/agent-for-testing/build.gradle
@@ -76,3 +76,12 @@ afterEvaluate {
     dependsOn shadowJar
   }
 }
+
+// Because shadow does not use default configurations
+publishing {
+  publications {
+    maven {
+      project.shadow.component(it)
+    }
+  }
+}


### PR DESCRIPTION
`noShadowPublish` wasn't being set. Actually, I realized that shadowJar with the default seems to be part of `components["java"]` anyways, I didn't know that. So there wasn't a huge point in having the branch. This brings the publishing back to where instrumentation libraries publish both `all` and not all, which is better than now. I'll try to see how to get rid of the `all`, it's not obvious from the documentation but I'm guessing any shadowJar with a configuration including `runtimeClasspath` ends up in there strangely enough.

Checked armeria-javaagent, javaagent, instrumentation-api-caching, armeria-for-testing and all seemed to publish what we expect