### PR TITLE
Increase metrics tests timeout

### DIFF
--- a/instrumentation/oshi/library/src/test/java/io/opentelemetry/instrumentation/oshi/AbstractMetricsTest.java
+++ b/instrumentation/oshi/library/src/test/java/io/opentelemetry/instrumentation/oshi/AbstractMetricsTest.java
@@ -111,7 +111,7 @@ class AbstractMetricsTest {
     }
 
     public void waitForData() throws InterruptedException {
-      latch.await(1, TimeUnit.SECONDS);
+      latch.await(20, TimeUnit.SECONDS);
     }
   }
 }


### PR DESCRIPTION
`SystemMetricsTest` occasionally fails locally with `org.opentest4j.AssertionFailedError: No metric for system.memory.usage` Increasing timeout in the hope of making it pass with greater certainty.