### PR TITLE
Exclude duplicates from -all.jar

### DIFF
--- a/javaagent/build.gradle
+++ b/javaagent/build.gradle
@@ -59,6 +59,7 @@ shadowJar {
     dependsOn("${it.path}:shadowJar")
   }
   with isolateSpec(projectsWithShadowJar)
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 //Includes instrumentations, but not exporters


### PR DESCRIPTION
Fixes #3405

I tried excluding duplicate dependencies from the javaagent-exporters project but found it quite complicated - in particular, while it's easy to exclude the declared dependencies (opentelemetry-sdk), excluding transitives (opentelemetry-sdk-trace) requires resolving configurations and adding lots of hairyness. This one line seems fine instead, since we apply dependency management I think it's unlikely we'd attempt to package different versions and smoke tests should catch anything fishy that could result from ignoring dupes.