### PR TITLE
Fix kafka Stream instrumentation for library in version 2.6+

### DIFF
--- a/instrumentation/kafka-streams-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/StreamTaskStopInstrumentation.java
+++ b/instrumentation/kafka-streams-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/StreamTaskStopInstrumentation.java
@@ -10,7 +10,6 @@ import static io.opentelemetry.javaagent.instrumentation.kafkastreams.KafkaStrea
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
@@ -29,7 +28,7 @@ public class StreamTaskStopInstrumentation implements TypeInstrumentation {
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        isMethod().and(isPublic()).and(named("process")).and(takesArguments(0)),
+        isMethod().and(isPublic()).and(named("process")),
         StreamTaskStopInstrumentation.class.getName() + "$StopSpanAdvice");
   }
 


### PR DESCRIPTION
This PR fixes the instrumentation of kafka stream when the library version is above 2.6 #3436

It takes into account the change in the method signature of _org.apache.kafka.streams.processor.internals.StreamTask._

* 2.5 and below : public boolean process() 
* 2.6 and above : public boolean process(final long wallClockTime)
