### PR TITLE
Fix dubbo trace/span cross-process propagation 

### DIFF
--- a/instrumentation/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboInjectAdapter.java
+++ b/instrumentation/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboInjectAdapter.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.instrumentation.apachedubbo.v2_7;
 
 import io.opentelemetry.context.propagation.TextMapSetter;
-import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.RpcContext;
 
-class DubboInjectAdapter implements TextMapSetter<RpcInvocation> {
+class DubboInjectAdapter implements TextMapSetter<RpcContext> {
 
   static final DubboInjectAdapter SETTER = new DubboInjectAdapter();
 

--- a/instrumentation/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboInjectAdapter.java
+++ b/instrumentation/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboInjectAdapter.java
@@ -13,7 +13,7 @@ class DubboInjectAdapter implements TextMapSetter<RpcInvocation> {
   static final DubboInjectAdapter SETTER = new DubboInjectAdapter();
 
   @Override
-  public void set(RpcInvocation rpcInvocation, String key, String value) {
-    rpcInvocation.setAttachment(key, value);
+  public void set(RpcContext rpcContext, String key, String value) {
+    rpcContext.setAttachment(key, value);
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/OpenTelemetryFilter.java
+++ b/instrumentation/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/OpenTelemetryFilter.java
@@ -40,7 +40,7 @@ public class OpenTelemetryFilter implements Filter {
     final Context context;
     if (kind.equals(CLIENT)) {
       context = tracer.startClientSpan(interfaceName, methodName);
-      tracer.inject(context, (RpcInvocation) invocation, DubboInjectAdapter.SETTER);
+      tracer.inject(context, rpcContext, DubboInjectAdapter.SETTER);
     } else {
       context = tracer.startServerSpan(interfaceName, methodName, (RpcInvocation) invocation);
     }


### PR DESCRIPTION
It is inappropriate to use the Invocation for cross-process propagation. When the Dubbo Client makes an RPC call, No matter how to set up the invocation's attachement  in Filter, ``AbstractInvoker`` will eventually get the attachement from the RPCContext and backfill it to the invocation.

[OpenTelemetryFilter](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/OpenTelemetryFilter.java)

```java
if (kind.equals(CLIENT)) {
      context = tracer.startClientSpan(interfaceName, methodName);
      tracer.inject(context, (RpcInvocation) invocation, DubboInjectAdapter.SETTER);
    } else {
      context = tracer.startServerSpan(interfaceName, methodName, (RpcInvocation) invocation);
    }
```

``DubboInjectAdapter``
```java
@Override
  public void set(RpcInvocation rpcInvocation, String key, String value) {
    rpcInvocation.setAttachment(key, value);
  }
```


[AbstractInvoker](https://github.com/apache/dubbo/blob/dubbo-2.7.12/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/protocol/AbstractInvoker.java)

```java
RpcInvocation invocation = (RpcInvocation) inv;
        invocation.setInvoker(this);
        if (attachment != null && attachment.size() > 0) {
            invocation.addAttachmentsIfAbsent(attachment);
        }
        Map<String, String> contextAttachments = RpcContext.getContext().getAttachments();
        if (contextAttachments != null && contextAttachments.size() != 0) {
            /**
             * invocation.addAttachmentsIfAbsent(context){@link RpcInvocation#addAttachmentsIfAbsent(Map)}should not be used here,
             * because the {@link RpcContext#setAttachment(String, String)} is passed in the Filter when the call is triggered
             * by the built-in retry mechanism of the Dubbo. The attachment to update RpcContext will no longer work, which is
             * a mistake in most cases (for example, through Filter to RpcContext output traceId and spanId and other information).
             */
            invocation.addAttachments(contextAttachments);
        }
```


As a Dubbo server, the attachements of the ``RpcContext`` are set in the ``ContextFilter``, which is derived from the invocation. ,and this Filter is a high priority.

[ContextFilter](https://github.com/apache/dubbo/blob/dubbo-2.7.12/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/filter/ContextFilter.java)

```java
RpcContext.getContext()
                .setInvoker(invoker)
                .setInvocation(invocation)
//                .setAttachments(attachments)  // merged from dubbox
                .setLocalAddress(invoker.getUrl().getHost(),
                        invoker.getUrl().getPort());

        // merged from dubbox
        // we may already added some attachments into RpcContext before this filter (e.g. in rest protocol)
        if (attachments != null) {
            if (RpcContext.getContext().getAttachments() != null) {
                RpcContext.getContext().getAttachments().putAll(attachments);
            } else {
                RpcContext.getContext().setAttachments(attachments);
            }
        }
```


About this issue see #3427 