### PR TITLE
Draft: suppress instrumentation flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix incorrect dependency in published BOM (#3376)
 - Fix UnsupportedOperationException with reactor-rabbitmq (#3381)
 - Fix Spring JMS not being instrumented (#3359)
+- Allow suppressing  
 
 ## Version 1.3.0 - 2021-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Fix incorrect dependency in published BOM (#3376)
 - Fix UnsupportedOperationException with reactor-rabbitmq (#3381)
 - Fix Spring JMS not being instrumented (#3359)
-- Allow suppressing  
 
 ## Version 1.3.0 - 2021-06-17
 

--- a/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/BaseTracerTest.groovy
+++ b/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/BaseTracerTest.groovy
@@ -8,11 +8,15 @@ package io.opentelemetry.instrumentation.api.tracer
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
 import spock.lang.Shared
 import spock.lang.Specification
 
+import static org.junit.Assume.assumeTrue
+
 // TODO add tests for BaseTracer
 class BaseTracerTest extends Specification {
+
   @Shared
   def tracer = newTracer()
 
@@ -20,6 +24,10 @@ class BaseTracerTest extends Specification {
 
   @Shared
   def root = Context.root()
+
+  @Shared
+  def ContextKey<Boolean> suppressContextKey = ContextKey.named("otel.suppress_instrumentation")
+
 
   @Shared
   def existingSpan = Span.getInvalid()
@@ -59,6 +67,26 @@ class BaseTracerTest extends Specification {
     SpanKind.CLIENT   | tracer.withServerSpan(root, existingSpan) | true
   }
 
+  def "test shouldStartSpan is false when instrumentation is suppressed"() {
+    when:
+    boolean result = tracer.shouldStartSpan(context, kind)
+
+    then:
+    result == expected
+
+    where:
+    kind              | context                                                   | expected
+    SpanKind.CLIENT   | root.with(BaseTracer.SUPPRESS_INSTRUMENTATION_KEY, false) | true
+    SpanKind.SERVER   | root.with(BaseTracer.SUPPRESS_INSTRUMENTATION_KEY, false) | true
+    SpanKind.INTERNAL | root.with(BaseTracer.SUPPRESS_INSTRUMENTATION_KEY, false) | true
+    SpanKind.CONSUMER | root.with(BaseTracer.SUPPRESS_INSTRUMENTATION_KEY, false) | true
+    SpanKind.PRODUCER | root.with(BaseTracer.SUPPRESS_INSTRUMENTATION_KEY, false) | true
+    SpanKind.CLIENT   | root.with(BaseTracer.SUPPRESS_INSTRUMENTATION_KEY, true)  | false
+    SpanKind.SERVER   | root.with(BaseTracer.SUPPRESS_INSTRUMENTATION_KEY, true)  | false
+    SpanKind.INTERNAL | root.with(BaseTracer.SUPPRESS_INSTRUMENTATION_KEY, true)  | false
+    SpanKind.CONSUMER | root.with(BaseTracer.SUPPRESS_INSTRUMENTATION_KEY, true)  | false
+    SpanKind.PRODUCER | root.with(BaseTracer.SUPPRESS_INSTRUMENTATION_KEY, true)  | false
+  }
 
   class SomeInnerClass implements Runnable {
     void run() {


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-specification/issues/1767

> #### Suppressing instrumentation implementations in OTel
>  **Please note that context suppression is not really possible in client libraries as it requires dependency on instrumentation packages (to export suppress key)**.

>  - [pyhton](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/63e7561931cd2d5e8edca9281c5156b9852eb348/instrumentation/opentelemetry-instrumentation-requests/src/opentelemetry/instrumentation/requests/__init__.py#L60)
>  - [.net](https://github.com/open-telemetry/opentelemetry-dotnet/blob/6b7f2dd77cf9d37260a853fcc95f7b77e296065d/src/OpenTelemetry/SuppressInstrumentationScope.cs) 
>  - [js](https://github.com/open-telemetry/opentelemetry-js/blob/c85fbe6682b9a8fd52e4b99bdbb079833b04e845/packages/opentelemetry-core/src/trace/suppress-tracing.ts)
>  - [java suppresses nested client spans by default](https://github.com/trask/opentelemetry-java-instrumentation/blob/9c1083b5410d2a1f2ece899bbcd0c933ac7f6bbd/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java#L109)
>  - [seems ruby does it](https://github.com/open-telemetry/opentelemetry-specification/issues/530#issuecomment-605462917)


