### PR TITLE
Remove jetty-server exclude

### DIFF
--- a/instrumentation/grails-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/grails-3.0/javaagent/build.gradle.kts
@@ -42,10 +42,6 @@ dependencies {
   testLibrary("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
   testLibrary("org.springframework.boot:spring-boot-starter-tomcat:$springBootVersion")
 
-  testImplementation(project(":testing-common")) {
-    exclude("org.eclipse.jetty", "jetty-server")
-  }
-
   latestDepTestLibrary("org.grails:grails-plugin-url-mappings:4.0.+")
   latestDepTestLibrary("org.springframework.boot:spring-boot-autoconfigure:2.1.17.RELEASE")
   latestDepTestLibrary("org.springframework.boot:spring-boot-starter-tomcat:2.1.17.RELEASE")

--- a/instrumentation/gwt-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/gwt-2.0/javaagent/build.gradle.kts
@@ -44,9 +44,6 @@ dependencies {
   testImplementation("org.testcontainers:selenium:${versions["org.testcontainers"]}")
   testImplementation("org.seleniumhq.selenium:selenium-java:3.141.59")
 
-  testImplementation(project(":testing-common")) {
-    exclude("org.eclipse.jetty", "jetty-server")
-  }
   testImplementation("org.eclipse.jetty:jetty-webapp:9.4.35.v20201120")
 }
 

--- a/instrumentation/jetty/jetty-11.0/javaagent/build.gradle.kts
+++ b/instrumentation/jetty/jetty-11.0/javaagent/build.gradle.kts
@@ -15,11 +15,6 @@ dependencies {
   implementation(project(":instrumentation:servlet:servlet-5.0:javaagent"))
   implementation(project(":instrumentation:jetty:jetty-common:javaagent"))
 
-  // Don't want to conflict with jetty from the test server.
-  testImplementation(project(":testing-common")) {
-    exclude("org.eclipse.jetty", "jetty-server")
-  }
-
   testLibrary("org.eclipse.jetty:jetty-servlet:11.0.0")
 }
 

--- a/instrumentation/jetty/jetty-8.0/javaagent/build.gradle.kts
+++ b/instrumentation/jetty/jetty-8.0/javaagent/build.gradle.kts
@@ -18,11 +18,6 @@ dependencies {
   implementation(project(":instrumentation:jetty:jetty-common:javaagent"))
   testInstrumentation(project(":instrumentation:servlet:servlet-javax-common:javaagent"))
 
-  // Don't want to conflict with jetty from the test server.
-  testImplementation(project(":testing-common")) {
-    exclude("org.eclipse.jetty", "jetty-server")
-  }
-
   testLibrary("org.eclipse.jetty:jetty-servlet:8.0.0.v20110901")
   testLibrary("org.eclipse.jetty:jetty-continuation:8.0.0.v20110901")
 

--- a/instrumentation/jsf/jsf-testing-common/build.gradle.kts
+++ b/instrumentation/jsf/jsf-testing-common/build.gradle.kts
@@ -11,9 +11,7 @@ dependencies {
   compileOnly("jakarta.faces:jakarta.faces-api:2.3.2")
   compileOnly("jakarta.el:jakarta.el-api:3.0.3")
 
-  implementation(project(":testing-common")) {
-    exclude("org.eclipse.jetty", "jetty-server")
-  }
+  implementation(project(":testing-common"))
   implementation("org.jsoup:jsoup:1.13.1")
 
   val jettyVersion = "9.4.35.v20201120"

--- a/instrumentation/servlet/servlet-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/servlet/servlet-2.2/javaagent/build.gradle.kts
@@ -24,9 +24,6 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:servlet:servlet-javax-common:javaagent"))
 
-  testImplementation(project(":testing-common")) {
-    exclude("org.eclipse.jetty", "jetty-server")
-  }
   testLibrary("org.eclipse.jetty:jetty-server:7.0.0.v20091005")
   testLibrary("org.eclipse.jetty:jetty-servlet:7.0.0.v20091005")
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/servlet/servlet-3.0/javaagent/build.gradle.kts
@@ -23,9 +23,6 @@ dependencies {
   testInstrumentation(project(":instrumentation:jetty:jetty-8.0:javaagent"))
   testInstrumentation(project(":instrumentation:servlet:servlet-javax-common:javaagent"))
 
-  testImplementation(project(":testing-common")) {
-    exclude("org.eclipse.jetty", "jetty-server")
-  }
   testLibrary("org.eclipse.jetty:jetty-server:8.0.0.v20110901")
   testLibrary("org.eclipse.jetty:jetty-servlet:8.0.0.v20110901")
   testLibrary("org.apache.tomcat.embed:tomcat-embed-core:8.0.41")

--- a/instrumentation/servlet/servlet-javax-common/javaagent/build.gradle.kts
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/build.gradle.kts
@@ -22,10 +22,6 @@ dependencies {
 
   compileOnly("javax.servlet:servlet-api:2.3")
 
-  testImplementation(project(":testing-common")) {
-    exclude("org.eclipse.jetty", "jetty-server")
-  }
-
   // We don't check testLatestDeps for this module since we have coverage in others like servlet-3.0
   testImplementation("org.eclipse.jetty:jetty-server:7.0.0.v20091005")
   testImplementation("org.eclipse.jetty:jetty-servlet:7.0.0.v20091005")

--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -57,7 +57,6 @@ dependencies {
   add("vaadin142TestImplementation", "com.vaadin:vaadin-spring-boot-starter:14.2.0")
 
   testImplementation(project(":instrumentation:vaadin-14.2:testing"))
-  testImplementation(project(":testing-common"))
 
   testInstrumentation(project(":instrumentation:servlet:servlet-3.0:javaagent"))
   testInstrumentation(project(":instrumentation:servlet:servlet-javax-common:javaagent"))

--- a/instrumentation/vaadin-14.2/testing/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/testing/build.gradle.kts
@@ -8,8 +8,6 @@ dependencies {
   compileOnly("com.vaadin:vaadin-spring-boot-starter:14.2.0")
 
   api("org.testcontainers:selenium:${versions["org.testcontainers"]}")
-  implementation(project(":testing-common")) {
-    exclude(module = "jetty-server")
-  }
+  implementation(project(":testing-common"))
   implementation("org.seleniumhq.selenium:selenium-java:3.141.59")
 }


### PR DESCRIPTION
As `testing-common` doesn't depend on `jetty-server` any more this exclude isn't needed.