### PR TITLE
Build Java 16 smoke test images

### DIFF
--- a/.github/workflows/build-grpc-smoke-dist.yml
+++ b/.github/workflows/build-grpc-smoke-dist.yml
@@ -47,5 +47,7 @@ jobs:
           echo "Pushing to tag $TAG"
           ./gradlew jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain --stacktrace -Ptag=$TAG
           ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain --stacktrace -Ptag=$TAG
+          # TODO (trask) drop JDK 15 after JDK 16 is passing
           ./gradlew jib -PtargetJDK=15 -Djib.httpTimeout=120000 -Djib.console=plain --stacktrace -Ptag=$TAG
+          ./gradlew jib -PtargetJDK=16 -Djib.httpTimeout=120000 -Djib.console=plain --stacktrace -Ptag=$TAG
         working-directory: smoke-tests/grpc

--- a/.github/workflows/build-play-smoke-dist.yml
+++ b/.github/workflows/build-play-smoke-dist.yml
@@ -47,5 +47,7 @@ jobs:
           echo "Pushing to tag $TAG"
           ./gradlew jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
           ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          # TODO (trask) drop JDK 15 after JDK 16 is passing
           ./gradlew jib -PtargetJDK=15 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          ./gradlew jib -PtargetJDK=16 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
         working-directory: smoke-tests/play

--- a/.github/workflows/build-springboot-smoke-dist.yml
+++ b/.github/workflows/build-springboot-smoke-dist.yml
@@ -47,5 +47,7 @@ jobs:
           echo "Pushing to tag $TAG"
           ./gradlew jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain --stacktrace -Ptag=$TAG
           ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain --stacktrace -Ptag=$TAG
+          # TODO (trask) drop JDK 15 after JDK 16 is passing
           ./gradlew jib -PtargetJDK=15 -Djib.httpTimeout=120000 -Djib.console=plain --stacktrace -Ptag=$TAG
+          ./gradlew jib -PtargetJDK=16 -Djib.httpTimeout=120000 -Djib.console=plain --stacktrace -Ptag=$TAG
         working-directory: smoke-tests/springboot


### PR DESCRIPTION
I'm not sure how this is going to work out, so leaving the Java 15 image generation in place for now.