### PR TITLE
Add prepare-release-branch to release needs since output is used.

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -160,7 +160,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [ test, smoke-test, example-distro ]
+    needs: [ prepare-release-branch, test, smoke-test, example-distro ]
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
We reference `needs.prepare-release-branch`