### PR TITLE
Run smoke tests with Java 16

### DIFF
--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -44,7 +44,7 @@ abstract class AppServerTest extends SmokeTest {
   @Override
   protected String getTargetImage(String jdk, String serverVersion, boolean windows) {
     String platformSuffix = windows ? "-windows" : ""
-    String extraTag = "20210703.996596033"
+    String extraTag = "20210704.998730666"
     String fullSuffix = "-${serverVersion}-jdk$jdk$platformSuffix-$extraTag"
     return getTargetImagePrefix() + fullSuffix
   }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -44,7 +44,7 @@ abstract class AppServerTest extends SmokeTest {
   @Override
   protected String getTargetImage(String jdk, String serverVersion, boolean windows) {
     String platformSuffix = windows ? "-windows" : ""
-    String extraTag = "20210428.792292726"
+    String extraTag = "20210703.996596033"
     String fullSuffix = "-${serverVersion}-jdk$jdk$platformSuffix-$extraTag"
     return getTargetImagePrefix() + fullSuffix
   }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JettySmokeTest.groovy
@@ -9,14 +9,16 @@ package io.opentelemetry.smoketest
 @AppServer(version = "9.4.35", jdk = "8-openj9")
 @AppServer(version = "9.4.35", jdk = "11")
 @AppServer(version = "9.4.35", jdk = "11-openj9")
+@AppServer(version = "9.4.35", jdk = "16")
+@AppServer(version = "9.4.35", jdk = "16-openj9")
 @AppServer(version = "10.0.0", jdk = "11")
 @AppServer(version = "10.0.0", jdk = "11-openj9")
-@AppServer(version = "10.0.0", jdk = "15")
-@AppServer(version = "10.0.0", jdk = "15-openj9")
+@AppServer(version = "10.0.0", jdk = "16")
+@AppServer(version = "10.0.0", jdk = "16-openj9")
 @AppServer(version = "11.0.1", jdk = "11")
 @AppServer(version = "11.0.1", jdk = "11-openj9")
-@AppServer(version = "11.0.1", jdk = "15")
-@AppServer(version = "11.0.1", jdk = "15-openj9")
+@AppServer(version = "11.0.1", jdk = "16")
+@AppServer(version = "11.0.1", jdk = "16-openj9")
 class JettySmokeTest extends AppServerTest {
 
   protected String getTargetImagePrefix() {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/LibertySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/LibertySmokeTest.groovy
@@ -11,6 +11,8 @@ import java.time.Duration
 @AppServer(version = "20.0.0.12", jdk = "8-openj9")
 @AppServer(version = "20.0.0.12", jdk = "11")
 @AppServer(version = "20.0.0.12", jdk = "11-openj9")
+@AppServer(version = "20.0.0.12", jdk = "16")
+@AppServer(version = "20.0.0.12", jdk = "16-openj9")
 class LibertySmokeTest extends AppServerTest {
 
   protected String getTargetImagePrefix() {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
@@ -10,8 +10,12 @@ import spock.lang.Unroll
 
 @AppServer(version = "13.0.0.Final", jdk = "8")
 @AppServer(version = "13.0.0.Final", jdk = "8-openj9")
+@AppServer(version = "17.0.1.Final", jdk = "8")
+@AppServer(version = "17.0.1.Final", jdk = "8-openj9")
 @AppServer(version = "17.0.1.Final", jdk = "11")
 @AppServer(version = "17.0.1.Final", jdk = "11-openj9")
+@AppServer(version = "21.0.0.Final", jdk = "8")
+@AppServer(version = "21.0.0.Final", jdk = "8-openj9")
 @AppServer(version = "21.0.0.Final", jdk = "11")
 @AppServer(version = "21.0.0.Final", jdk = "11-openj9")
 class WildflySmokeTest extends AppServerTest {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
@@ -14,10 +14,14 @@ import spock.lang.Unroll
 @AppServer(version = "17.0.1.Final", jdk = "8-openj9")
 @AppServer(version = "17.0.1.Final", jdk = "11")
 @AppServer(version = "17.0.1.Final", jdk = "11-openj9")
+@AppServer(version = "17.0.1.Final", jdk = "16")
+@AppServer(version = "17.0.1.Final", jdk = "16-openj9")
 @AppServer(version = "21.0.0.Final", jdk = "8")
 @AppServer(version = "21.0.0.Final", jdk = "8-openj9")
 @AppServer(version = "21.0.0.Final", jdk = "11")
 @AppServer(version = "21.0.0.Final", jdk = "11-openj9")
+@AppServer(version = "21.0.0.Final", jdk = "16")
+@AppServer(version = "21.0.0.Final", jdk = "16-openj9")
 class WildflySmokeTest extends AppServerTest {
 
   protected String getTargetImagePrefix() {


### PR DESCRIPTION
Also added a couple of missing `@AppServer` annotations that we are building smoke test images for already.