### PR TITLE
Fix Tomcat Java 16 images

### DIFF
--- a/smoke-tests/matrix/build.gradle
+++ b/smoke-tests/matrix/build.gradle
@@ -36,9 +36,10 @@ def linuxTargets = [
     [version: ["11.0.1"], vm: ["hotspot", "openj9"], jdk: ["11", "15", "16"], war: "servlet-5.0"]
   ],
   "tomcat": [
-    [version: ["7.0.107"], vm: ["hotspot", "openj9"], jdk: ["8"]],
-    [version: ["8.5.60", "9.0.40"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]],
-    [version: ["10.0.4"], vm: ["hotspot", "openj9"], jdk: ["11", "15", "16"], war: "servlet-5.0"]
+    [version: ["7.0.107"], vm: ["adoptopenjdk-hotspot", "adoptopenjdk-openj9"], jdk: ["8"]],
+    [version: ["8.5.60", "9.0.40"], vm: ["adoptopenjdk-hotspot", "adoptopenjdk-openj9"], jdk: ["8", "11"]],
+    [version: ["10.0.4"], vm: ["adoptopenjdk-hotspot", "adoptopenjdk-openj9"], jdk: ["11", "15"], war: "servlet-5.0"],
+    [version: ["10.0.4"], vm: ["openjdk"], jdk: ["16"], war: "servlet-5.0"]
   ],
   "tomee": [
     [version: ["7.0.0"], vm: ["hotspot"], jdk: ["8"]],
@@ -67,10 +68,11 @@ def windowsTargets = [
     [version: ["11.0.1"], vm: ["hotspot", "openj9"], jdk: ["11", "15", "16"], dockerfile: "jetty-split", args: [sourceVersion: "11.0.1"], war: "servlet-5.0"]
   ],
   "tomcat" : [
-    [version: ["7.0.107"], vm: ["hotspot", "openj9"], jdk: ["8"], args: [majorVersion: "7"]],
-    [version: ["8.5.60"], vm: ["hotspot", "openj9"], jdk: ["8", "11"], args: [majorVersion: "8"]],
-    [version: ["9.0.40"], vm: ["hotspot", "openj9"], jdk: ["8", "11"], args: [majorVersion: "9"]],
-    [version: ["10.0.4"], vm: ["hotspot", "openj9"], jdk: ["11", "15", "16"], args: [majorVersion: "10"], war: "servlet-5.0"]
+    [version: ["7.0.107"], vm: ["adoptopenjdk-hotspot", "adoptopenjdk-openj9"], jdk: ["8"], args: [majorVersion: "7"]],
+    [version: ["8.5.60"], vm: ["adoptopenjdk-hotspot", "adoptopenjdk-openj9"], jdk: ["8", "11"], args: [majorVersion: "8"]],
+    [version: ["9.0.40"], vm: ["adoptopenjdk-hotspot", "adoptopenjdk-openj9"], jdk: ["8", "11"], args: [majorVersion: "9"]],
+    [version: ["10.0.4"], vm: ["adoptopenjdk-hotspot", "adoptopenjdk-openj9"], jdk: ["11", "15"], args: [majorVersion: "10"], war: "servlet-5.0"],
+    [version: ["10.0.4"], vm: ["openjdk"], jdk: ["16"], args: [majorVersion: "10"], war: "servlet-5.0"]
   ],
   "tomee" : [
     [version: ["7.0.0"], vm: ["hotspot", "openj9"], jdk: ["8"]],

--- a/smoke-tests/matrix/src/tomcat.dockerfile
+++ b/smoke-tests/matrix/src/tomcat.dockerfile
@@ -2,6 +2,6 @@ ARG version
 ARG jdk
 ARG vm
 
-FROM tomcat:${version}-jdk${jdk}-adoptopenjdk-${vm}
+FROM tomcat:${version}-jdk${jdk}-${vm}
 
 COPY app.war /usr/local/tomcat/webapps/


### PR DESCRIPTION
Tomcat Java 16 images don't have `adoptopenjdk` variants.