### PR TITLE
Allow disabling thread details and disable for most tests.

### DIFF
--- a/buildSrc/src/main/kotlin/otel.javaagent-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.javaagent-testing.gradle.kts
@@ -71,6 +71,10 @@ afterEvaluate {
     // prevent sporadic gradle deadlocks, see SafeLogger for more details
     jvmArgs("-Dotel.javaagent.testing.transform-safe-logging.enabled=true")
 
+    // Reduce noise in assertion messages since we don't need to verify this in most tests. We check
+    // in smoke tests instead.
+    jvmArgs("-Dotel.javaagent.add-thread-details=false")
+
     // We do fine-grained filtering of the classpath of this codebase's sources since Gradle's
     // configurations will include transitive dependencies as well, which tests do often need.
     classpath = classpath.filter {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTracerProviderConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTracerProviderConfigurer.java
@@ -35,6 +35,8 @@ public class AgentTracerProviderConfigurer implements SdkTracerProviderConfigure
 
   static final String EXPORTER_JAR_CONFIG = "otel.javaagent.experimental.exporter.jar";
 
+  private static final String ADD_THREAD_DETAILS = "otel.javaagent.add-thread-details";
+
   @Override
   public void configure(SdkTracerProviderBuilder sdkTracerProviderBuilder) {
     if (!Config.get().getBooleanProperty(OpenTelemetryInstaller.JAVAAGENT_ENABLED_CONFIG, true)) {
@@ -42,7 +44,9 @@ public class AgentTracerProviderConfigurer implements SdkTracerProviderConfigure
     }
 
     // Register additional thread details logging span processor
-    sdkTracerProviderBuilder.addSpanProcessor(new AddThreadDetailsSpanProcessor());
+    if (Config.get().getBooleanProperty(ADD_THREAD_DETAILS, true)) {
+      sdkTracerProviderBuilder.addSpanProcessor(new AddThreadDetailsSpanProcessor());
+    }
 
     maybeConfigureExporterJar(sdkTracerProviderBuilder);
     maybeEnableLoggingExporter(sdkTracerProviderBuilder);

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -37,6 +37,10 @@ class SpringBootSmokeTest extends SmokeTest {
     countSpansByName(traces, 'WebController.greeting') == 1
     countSpansByName(traces, 'WebController.withSpan') == 1
 
+    then: "thread details are recorded"
+    getSpanStream(traces)
+      .allMatch { it.attributesList.stream().map { it.key }.collect(toSet()).containsAll(["thread.id", "thread.name"]) }
+
     then: "correct agent version is captured in the resource"
     [currentAgentVersion] as Set == findResourceAttribute(traces, "telemetry.auto.version")
       .map { it.stringValue }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/AttributesAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/AttributesAssert.groovy
@@ -58,12 +58,6 @@ class AttributesAssert {
     Set<String> unverifiedAttributes = new TreeSet(allAttributes)
     unverifiedAttributes.removeAll(assertedAttributes)
 
-    // Don't need to verify thread details.
-    assertedAttributes.add("thread.id")
-    unverifiedAttributes.remove("thread.id")
-    assertedAttributes.add("thread.name")
-    unverifiedAttributes.remove("thread.name")
-
     // The first and second condition in the assert are exactly the same
     // but both are included in order to provide better context in the error message.
     // containsAll because tests may assert more attributes than span actually has


### PR DESCRIPTION
I think there is always a use case for disabling a global procesor that adds data, similar to how we support disabling ResourceProvider, so tried adding here. We have a use case here in that the thread details add noise to assertion messages and it's nicer if we don't have to worry.