### PR TITLE
Sync windows and linux wildfly smoke test images

### DIFF
--- a/smoke-tests/matrix/build.gradle
+++ b/smoke-tests/matrix/build.gradle
@@ -81,7 +81,7 @@ def windowsTargets = [
   ],
   "wildfly" : [
     [version: ["13.0.0.Final"], vm: ["hotspot", "openj9"], jdk: ["8"]],
-    [version: ["17.0.1.Final", "21.0.0.Final"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]]
+    [version: ["17.0.1.Final", "21.0.0.Final"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "15", "16"]]
   ],
   "liberty" : [
     [version: ["20.0.0.12"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "15", "16"], args: [release: "2020-11-11_0736"]]


### PR DESCRIPTION
Windows wildfly images for Java 15 (and now Java 16) were missing. Will add the missing matrix items to `WildflySmokeTest` once this is merged.