### PR TITLE
Remove usages of agent runtime specific code from reusable classes

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -134,7 +134,7 @@ public class AgentInstaller {
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
             .with(AgentTooling.poolStrategy())
             .with(new ClassLoadListener())
-            .with(AgentTooling.locationStrategy());
+            .with(AgentTooling.locationStrategy(Utils.getBootstrapProxy()));
     // FIXME: we cannot enable it yet due to BB/JVM bug, see
     // https://github.com/raphw/byte-buddy/issues/558
     // .with(AgentBuilder.LambdaInstrumentationStrategy.ENABLED)

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTooling.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTooling.java
@@ -17,7 +17,7 @@ public final class AgentTooling {
 
   private static final AgentCachingPoolStrategy POOL_STRATEGY = new AgentCachingPoolStrategy();
 
-  public static AgentLocationStrategy locationStrategy(){
+  public static AgentLocationStrategy locationStrategy() {
     return locationStrategy(null);
   }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTooling.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentTooling.java
@@ -15,11 +15,14 @@ import io.opentelemetry.javaagent.tooling.bytebuddy.AgentLocationStrategy;
  */
 public final class AgentTooling {
 
-  private static final AgentLocationStrategy LOCATION_STRATEGY = new AgentLocationStrategy();
   private static final AgentCachingPoolStrategy POOL_STRATEGY = new AgentCachingPoolStrategy();
 
-  public static AgentLocationStrategy locationStrategy() {
-    return LOCATION_STRATEGY;
+  public static AgentLocationStrategy locationStrategy(){
+    return locationStrategy(null);
+  }
+
+  public static AgentLocationStrategy locationStrategy(ClassLoader bootstrapProxy) {
+    return new AgentLocationStrategy(bootstrapProxy);
   }
 
   public static AgentCachingPoolStrategy poolStrategy() {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bytebuddy/AgentLocationStrategy.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bytebuddy/AgentLocationStrategy.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.tooling.bytebuddy;
 
-import io.opentelemetry.javaagent.tooling.Utils;
 import java.util.ArrayList;
 import java.util.List;
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -19,6 +18,12 @@ import net.bytebuddy.utility.JavaModule;
  */
 public class AgentLocationStrategy implements AgentBuilder.LocationStrategy {
 
+  private final ClassLoader bootstrapProxy;
+
+  public AgentLocationStrategy(ClassLoader bootstrapProxy) {
+    this.bootstrapProxy = bootstrapProxy;
+  }
+
   public ClassFileLocator classFileLocator(ClassLoader classLoader) {
     return classFileLocator(classLoader, null);
   }
@@ -26,7 +31,9 @@ public class AgentLocationStrategy implements AgentBuilder.LocationStrategy {
   @Override
   public ClassFileLocator classFileLocator(ClassLoader classLoader, JavaModule javaModule) {
     List<ClassFileLocator> locators = new ArrayList<>();
-    locators.add(ClassFileLocator.ForClassLoader.of(Utils.getBootstrapProxy()));
+    if (bootstrapProxy != null) {
+      locators.add(ClassFileLocator.ForClassLoader.of(bootstrapProxy));
+    }
     while (classLoader != null) {
       locators.add(ClassFileLocator.ForClassLoader.WeaklyReferenced.of(classLoader));
       classLoader = classLoader.getParent();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.tooling.instrumentation;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.failSafe;
+import static net.bytebuddy.dynamic.loading.ClassLoadingStrategy.BOOTSTRAP_LOADER;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -136,6 +137,9 @@ public final class InstrumentationModuleInstaller {
         Class<?> classBeingRedefined,
         ProtectionDomain protectionDomain) {
       ReferenceMatcher muzzle = getReferenceMatcher();
+      if (classLoader == BOOTSTRAP_LOADER) {
+        classLoader = Utils.getBootstrapProxy();
+      }
       boolean isMatch = muzzle.matches(classLoader);
 
       if (!isMatch) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.ServiceLoader;
 import net.bytebuddy.dynamic.ClassFileLocator;
 
@@ -52,9 +51,6 @@ public final class MuzzleGradlePluginUtil {
   public static void assertInstrumentationMuzzled(
       ClassLoader agentClassLoader, ClassLoader userClassLoader, boolean assertPass)
       throws Exception {
-    Objects.requireNonNull(agentClassLoader);
-    Objects.requireNonNull(userClassLoader);
-
     // muzzle validate all instrumenters
     int validatedModulesCount = 0;
     for (InstrumentationModule instrumentationModule :

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/MuzzleGradlePluginUtil.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import net.bytebuddy.dynamic.ClassFileLocator;
 
@@ -51,6 +52,9 @@ public final class MuzzleGradlePluginUtil {
   public static void assertInstrumentationMuzzled(
       ClassLoader agentClassLoader, ClassLoader userClassLoader, boolean assertPass)
       throws Exception {
+    Objects.requireNonNull(agentClassLoader);
+    Objects.requireNonNull(userClassLoader);
+
     // muzzle validate all instrumenters
     int validatedModulesCount = 0;
     for (InstrumentationModule instrumentationModule :

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
@@ -7,7 +7,6 @@ package io.opentelemetry.javaagent.tooling.muzzle.matcher;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static net.bytebuddy.dynamic.loading.ClassLoadingStrategy.BOOTSTRAP_LOADER;
 
 import io.opentelemetry.instrumentation.api.caching.Cache;
 import io.opentelemetry.javaagent.extension.muzzle.ClassRef;
@@ -15,7 +14,6 @@ import io.opentelemetry.javaagent.extension.muzzle.FieldRef;
 import io.opentelemetry.javaagent.extension.muzzle.Flag;
 import io.opentelemetry.javaagent.extension.muzzle.MethodRef;
 import io.opentelemetry.javaagent.tooling.AgentTooling;
-import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.javaagent.tooling.muzzle.InstrumentationClassPredicate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,9 +55,6 @@ public final class ReferenceMatcher {
    * @return true if all references match the classpath of loader
    */
   public boolean matches(ClassLoader userClassLoader) {
-    if (userClassLoader == BOOTSTRAP_LOADER) {
-      userClassLoader = Utils.getBootstrapProxy();
-    }
     return mismatchCache.computeIfAbsent(userClassLoader, this::doesMatch);
   }
 
@@ -80,9 +75,6 @@ public final class ReferenceMatcher {
    * @return A list of all mismatches between this ReferenceMatcher and loader's classpath.
    */
   public List<Mismatch> getMismatchedReferenceSources(ClassLoader loader) {
-    if (loader == BOOTSTRAP_LOADER) {
-      loader = Utils.getBootstrapProxy();
-    }
     TypePool typePool = createTypePool(loader);
 
     List<Mismatch> mismatches = emptyList();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -52,18 +51,16 @@ public final class ReferenceMatcher {
   /**
    * Matcher used by ByteBuddy. Fails fast and only caches empty results, or complete results
    *
-   * @param userClassLoader Classloader to validate against (or "bootstrap proxy" for bootstrap)
+   * @param userClassLoader Classloader to validate against (cannot be {@code null}, must pass
+   *     "bootstrap proxy" instead of bootstrap class loader)
    * @return true if all references match the classpath of loader
    */
   public boolean matches(ClassLoader userClassLoader) {
-    Objects.requireNonNull(userClassLoader); // "proxy bootstrap" must be passed instead of null
-
     return mismatchCache.computeIfAbsent(userClassLoader, this::doesMatch);
   }
 
+  // loader cannot be null, must pass "bootstrap proxy" instead of bootstrap class loader
   private boolean doesMatch(ClassLoader loader) {
-    Objects.requireNonNull(loader); // "proxy bootstrap" must be passed instead of null
-
     TypePool typePool = createTypePool(loader);
     for (ClassRef reference : references.values()) {
       if (!checkMatch(reference, typePool, loader).isEmpty()) {
@@ -76,12 +73,11 @@ public final class ReferenceMatcher {
   /**
    * Loads the full list of mismatches. Used in debug contexts only
    *
-   * @param loader Classloader to validate against (or null for bootstrap)
+   * @param loader Classloader to validate against (cannot be {@code null}, must pass "bootstrap *
+   *     proxy" instead of bootstrap class loader)
    * @return A list of all mismatches between this ReferenceMatcher and loader's classpath.
    */
   public List<Mismatch> getMismatchedReferenceSources(ClassLoader loader) {
-    Objects.requireNonNull(loader); // "proxy bootstrap" must be passed instead of null
-
     TypePool typePool = createTypePool(loader);
 
     List<Mismatch> mismatches = emptyList();
@@ -93,11 +89,9 @@ public final class ReferenceMatcher {
     return mismatches;
   }
 
+  // loader cannot be null, must pass "bootstrap proxy" instead of bootstrap class loader
   private static TypePool createTypePool(ClassLoader loader) {
-    Objects.requireNonNull(loader); // "proxy bootstrap" must be passed instead of null
-
-    // it's ok to use locationStrategy() without fallback bootstrap proxy here since the class
-    // loader cannot be null
+    // ok to use locationStrategy() without fallback bootstrap proxy here since loader is non-null
     return AgentTooling.poolStrategy()
         .typePool(AgentTooling.locationStrategy().classFileLocator(loader), loader);
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/matcher/ReferenceMatcher.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -51,14 +52,18 @@ public final class ReferenceMatcher {
   /**
    * Matcher used by ByteBuddy. Fails fast and only caches empty results, or complete results
    *
-   * @param userClassLoader Classloader to validate against (or null for bootstrap)
+   * @param userClassLoader Classloader to validate against (or "bootstrap proxy" for bootstrap)
    * @return true if all references match the classpath of loader
    */
   public boolean matches(ClassLoader userClassLoader) {
+    Objects.requireNonNull(userClassLoader); // "proxy bootstrap" must be passed instead of null
+
     return mismatchCache.computeIfAbsent(userClassLoader, this::doesMatch);
   }
 
   private boolean doesMatch(ClassLoader loader) {
+    Objects.requireNonNull(loader); // "proxy bootstrap" must be passed instead of null
+
     TypePool typePool = createTypePool(loader);
     for (ClassRef reference : references.values()) {
       if (!checkMatch(reference, typePool, loader).isEmpty()) {
@@ -75,6 +80,8 @@ public final class ReferenceMatcher {
    * @return A list of all mismatches between this ReferenceMatcher and loader's classpath.
    */
   public List<Mismatch> getMismatchedReferenceSources(ClassLoader loader) {
+    Objects.requireNonNull(loader); // "proxy bootstrap" must be passed instead of null
+
     TypePool typePool = createTypePool(loader);
 
     List<Mismatch> mismatches = emptyList();
@@ -87,6 +94,10 @@ public final class ReferenceMatcher {
   }
 
   private static TypePool createTypePool(ClassLoader loader) {
+    Objects.requireNonNull(loader); // "proxy bootstrap" must be passed instead of null
+
+    // it's ok to use locationStrategy() without fallback bootstrap proxy here since the class
+    // loader cannot be null
     return AgentTooling.poolStrategy()
         .typePool(AgentTooling.locationStrategy().classFileLocator(loader), loader);
   }


### PR DESCRIPTION
I am not so sure in these changes, but reusable `ReferenceMatcher` cannot depend on agent runtime specific `Utils.getBootstrapProxy()`