### PR TITLE
Don't publish per-instrumentation testing -all jar.

### DIFF
--- a/buildSrc/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-testing.gradle.kts
@@ -40,7 +40,7 @@ val testInstrumentation by configurations.creating {
   isCanBeResolved = true
 }
 
-tasks.named<ShadowJar>("shadowJar").configure {
+tasks.shadowJar {
   configurations = listOf(project.configurations.runtimeClasspath.get(), testInstrumentation)
 
   archiveFileName.set("agent-testing.jar")
@@ -104,6 +104,19 @@ afterEvaluate {
         return@filter false
       }
       return@filter true
+    }
+  }
+}
+
+// shadowJar is only used for creating a jar for testing, but the shadow plugin automatically adds
+// it to a project's published Java component. Skip it if publishing is configured for this
+// project.
+plugins.withId("maven-publish") {
+  configure<PublishingExtension> {
+    (components["java"] as AdhocComponentWithVariants).run {
+      withVariantsFromConfiguration(configurations["shadowRuntimeElements"]) {
+        skip()
+      }
     }
   }
 }


### PR DESCRIPTION
Found that shadow plugin automatically adds its elements to the java component

https://github.com/johnrengelman/shadow/blob/master/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/ShadowJavaPlugin.groovy#L54

And found an example of how to skip publishing of an element added by a plugin

https://docs.gradle.org/current/userguide/publishing_customization.html#sec:adding-variants-to-existing-components