### PR TITLE
Nightly build examples against locally published agent snapshots

### DIFF
--- a/.github/scripts/prepare-extension-snapshot.sh
+++ b/.github/scripts/prepare-extension-snapshot.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+sed -i -e 's/opentelemetryJavaagent[ ]*: "1.3.0"/opentelemetryJavaagent:"1.4.0-SNAPSHOT"/' build.gradle
+sed -i -e 's/opentelemetryJavaagentAlpha[ ]*: "1.3.0-alpha"/opentelemetryJavaagentAlpha:"1.4.0-alpha-SNAPSHOT"/' build.gradle
+echo 'dependencyResolutionManagement {repositories{mavenLocal()}}' >> settings.gradle

--- a/.github/scripts/prepare-extension-snapshot.sh
+++ b/.github/scripts/prepare-extension-snapshot.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env sh
 sed -i -e 's/opentelemetryJavaagent[ ]*: "1.3.0"/opentelemetryJavaagent:"1.4.0-SNAPSHOT"/' build.gradle
 sed -i -e 's/opentelemetryJavaagentAlpha[ ]*: "1.3.0-alpha"/opentelemetryJavaagentAlpha:"1.4.0-alpha-SNAPSHOT"/' build.gradle
-echo 'dependencyResolutionManagement {repositories{mavenLocal()}}' >> settings.gradle

--- a/.github/workflows/nightly-no-cache.yml
+++ b/.github/workflows/nightly-no-cache.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Test
         run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.suite }} --no-build-cache
 
-  example-distro:
+  examples:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
@@ -134,13 +134,47 @@ jobs:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('examples/distro/gradle/wrapper/gradle-wrapper.properties') }}
 
-      - name: Build
+      - name: Build distro
         run: ./gradlew build --stacktrace --no-build-cache
         working-directory: examples/distro
 
+      - name: Build extension
+        run: ./gradlew build --stacktrace --no-build-cache
+        working-directory: examples/extension
+
+  examples-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11 for running checks
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+      - name: Cache Gradle Wrapper
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('examples/distro/gradle/wrapper/gradle-wrapper.properties') }}
+
+      - name: Local publish
+        run: ./gradlew publishToMavenLocal --no-build-cache
+
+      - name: Point extensions to local snapshot
+        run: ../../.github/scripts/prepare-extension-snapshot.sh
+        working-directory: examples/extension
+
+      - name: Build
+        run: ./gradlew build --no-build-cache
+        working-directory: examples/extension
+
   issue:
     name: Open issue on failure
-    needs: [ build, test, testLatestDeps, smoke-test, example-distro ]
+    needs: [ build, test, testLatestDeps, smoke-test, examples, examples-snapshot ]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -147,7 +147,7 @@ jobs:
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
         run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.suite }}
 
-  example-distro:
+  examples:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
@@ -171,13 +171,17 @@ jobs:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('examples/distro/gradle/wrapper/gradle-wrapper.properties') }}
 
-      - name: Build
+      - name: Build distro
         run: ./gradlew build --stacktrace
         working-directory: examples/distro
 
+      - name: Build extension
+        run: ./gradlew build --stacktrace
+        working-directory: examples/extension
+
   issue:
     name: Open issue on failure
-    needs: [ build, test, testLatestDeps, smoke-test, example-distro ]
+    needs: [ build, test, testLatestDeps, smoke-test, examples ]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -89,11 +89,11 @@ rootProject.tasks.named("release").configure {
   finalizedBy(tasks["publishToSonatype"])
 }
 
-// Stub out entire signing block off of CI since Gradle provides no way of lazy configuration of
-// signing tasks.
-if (System.getenv("CI") != null) {
+// Sign only if have a key to do so
+val signingKey: String? = System.getenv("GPG_PRIVATE_KEY")
+if (signingKey != null) {
   signing {
-    useInMemoryPgpKeys(System.getenv("GPG_PRIVATE_KEY"), System.getenv("GPG_PASSWORD"))
+    useInMemoryPgpKeys(signingKey, System.getenv("GPG_PASSWORD"))
     sign(publishing.publications["maven"])
   }
 }

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -89,7 +89,7 @@ rootProject.tasks.named("release").configure {
   finalizedBy(tasks["publishToSonatype"])
 }
 
-// Sign only if have a key to do so
+// Sign only if we have a key to do so
 val signingKey: String? = System.getenv("GPG_PRIVATE_KEY")
 if (signingKey != null) {
   signing {

--- a/examples/extension/build.gradle
+++ b/examples/extension/build.gradle
@@ -31,9 +31,7 @@ ext {
 
 repositories {
   mavenCentral()
-  maven {
-    url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-  }
+  mavenLocal()
 }
 
 configurations {

--- a/examples/extension/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/extension/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Part of #3503.

As examples serve as, well, examples, I chose not to spoil their build scripts with this conditional "let us choose snapshot" logic. Instead I did a small shell script that makes required changes in extensions example build scripts externally.

It does fail currently, because our examples were not yet updated to latest snapshot changes.