### PR TITLE
Deprecate CallDepth.reset() and get()

### DIFF
--- a/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcServerBuilderInstrumentation.java
+++ b/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcServerBuilderInstrumentation.java
@@ -47,7 +47,7 @@ public class GrpcServerBuilderInstrumentation implements TypeInstrumentation {
         @Advice.This ServerBuilder<?> serverBuilder,
         @Advice.Local("otelCallDepth") CallDepth callDepth) {
       callDepth = CallDepth.forClass(ServerBuilder.class);
-      if (callDepth.getAndIncrement() == 0) {
+      if (callDepth.getAndIncrement() > 0) {
         serverBuilder.intercept(GrpcSingletons.SERVER_INTERCEPTOR);
       }
     }

--- a/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcServerBuilderInstrumentation.java
+++ b/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcServerBuilderInstrumentation.java
@@ -47,7 +47,7 @@ public class GrpcServerBuilderInstrumentation implements TypeInstrumentation {
         @Advice.This ServerBuilder<?> serverBuilder,
         @Advice.Local("otelCallDepth") CallDepth callDepth) {
       callDepth = CallDepth.forClass(ServerBuilder.class);
-      if (callDepth.getAndIncrement() > 0) {
+      if (callDepth.getAndIncrement() == 0) {
         serverBuilder.intercept(GrpcSingletons.SERVER_INTERCEPTOR);
       }
     }

--- a/instrumentation/internal/internal-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/ClassLoaderInstrumentation.java
+++ b/instrumentation/internal/internal-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/ClassLoaderInstrumentation.java
@@ -128,7 +128,7 @@ public class ClassLoaderInstrumentation implements TypeInstrumentation {
         // ends up calling a ClassFileTransformer which ends up calling loadClass() further down the
         // stack on one of our bootstrap packages (since the call depth check would then suppress
         // the nested loadClass instrumentation)
-        callDepth.reset();
+        callDepth.decrementAndGet();
       }
       return null;
     }

--- a/instrumentation/internal/internal-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/ClassLoaderInstrumentation.java
+++ b/instrumentation/internal/internal-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/ClassLoaderInstrumentation.java
@@ -109,6 +109,7 @@ public class ClassLoaderInstrumentation implements TypeInstrumentation {
       // back to this instrumentation over and over, causing a StackOverflowError
       CallDepth callDepth = CallDepth.forClass(ClassLoader.class);
       if (callDepth.getAndIncrement() > 0) {
+        callDepth.decrementAndGet();
         return null;
       }
 

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotationsInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxRsAnnotationsInstrumentation.java
@@ -82,10 +82,9 @@ public class JaxRsAnnotationsInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelCallDepth") CallDepth callDepth,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      if (scope == null) {
+      if (callDepth.decrementAndGet() > 0) {
         return;
       }
-      callDepth.reset();
 
       scope.close();
       if (throwable == null) {

--- a/instrumentation/jaxws/jaxws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/v2_0/WebServiceProviderInstrumentation.java
+++ b/instrumentation/jaxws/jaxws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/v2_0/WebServiceProviderInstrumentation.java
@@ -68,10 +68,9 @@ public class WebServiceProviderInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelCallDepth") CallDepth callDepth,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      if (scope == null) {
+      if (callDepth.decrementAndGet() > 0) {
         return;
       }
-      callDepth.reset();
 
       scope.close();
       if (throwable == null) {

--- a/instrumentation/jaxws/jws-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/jws/v1_1/JwsAnnotationsInstrumentation.java
+++ b/instrumentation/jaxws/jws-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/jws/v1_1/JwsAnnotationsInstrumentation.java
@@ -79,10 +79,9 @@ public class JwsAnnotationsInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelCallDepth") CallDepth callDepth,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      if (scope == null) {
+      if (callDepth.decrementAndGet() > 0) {
         return;
       }
-      callDepth.reset();
 
       scope.close();
       if (throwable == null) {

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -85,13 +85,14 @@ public class PreparedStatementInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelRequest") DbRequest request,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      if (scope == null) {
+      if (callDepth.decrementAndGet() > 0) {
         return;
       }
-      callDepth.reset();
 
-      scope.close();
-      instrumenter().end(context, request, null, throwable);
+      if (scope != null) {
+        scope.close();
+        instrumenter().end(context, request, null, throwable);
+      }
     }
   }
 }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
@@ -85,13 +85,14 @@ public class StatementInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelRequest") DbRequest request,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      if (scope == null) {
+      if (callDepth.decrementAndGet() > 0) {
         return;
       }
-      callDepth.reset();
 
-      scope.close();
-      instrumenter().end(context, request, null, throwable);
+      if (scope != null) {
+        scope.close();
+        instrumenter().end(context, request, null, throwable);
+      }
     }
   }
 }

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageProducerInstrumentation.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageProducerInstrumentation.java
@@ -92,13 +92,14 @@ public class JmsMessageProducerInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope,
         @Advice.Thrown Throwable throwable) {
-      if (scope == null) {
+      if (callDepth.decrementAndGet() > 0) {
         return;
       }
-      callDepth.reset();
 
-      scope.close();
-      producerInstrumenter().end(context, request, null, throwable);
+      if (scope != null) {
+        scope.close();
+        producerInstrumenter().end(context, request, null, throwable);
+      }
     }
   }
 
@@ -135,13 +136,14 @@ public class JmsMessageProducerInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope,
         @Advice.Thrown Throwable throwable) {
-      if (scope == null) {
+      if (callDepth.decrementAndGet() > 0) {
         return;
       }
-      callDepth.reset();
 
-      scope.close();
-      producerInstrumenter().end(context, request, null, throwable);
+      if (scope != null) {
+        scope.close();
+        producerInstrumenter().end(context, request, null, throwable);
+      }
     }
   }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelInstrumentation.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelInstrumentation.java
@@ -111,11 +111,11 @@ public class RabbitChannelInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelCallDepth") CallDepth callDepth,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      if (scope == null) {
+      if (callDepth.decrementAndGet() > 0) {
         return;
       }
+
       scope.close();
-      callDepth.reset();
 
       CURRENT_RABBIT_CONTEXT.remove();
       if (throwable != null) {

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RemoteServerInstrumentation.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RemoteServerInstrumentation.java
@@ -65,12 +65,11 @@ public class RemoteServerInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelCallDepth") CallDepth callDepth,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      if (scope == null) {
+      if (callDepth.decrementAndGet() > 0) {
         return;
       }
-      scope.close();
-      callDepth.reset();
 
+      scope.close();
       if (throwable != null) {
         RmiServerTracer.tracer().endExceptionally(context, throwable);
       } else {

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Advice.java
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Advice.java
@@ -66,13 +66,13 @@ public class Servlet2Advice {
       @Advice.Local("otelContext") Context context,
       @Advice.Local("otelScope") Scope scope) {
 
-    callDepth.decrementAndGet();
+    int depth = callDepth.decrementAndGet();
 
     if (scope != null) {
       scope.close();
     }
 
-    if (context == null && callDepth.get() == 0) {
+    if (context == null && depth == 0) {
       Context currentContext = Java8BytecodeBridge.currentContext();
       // Something else is managing the context, we're in the outermost level of Servlet
       // instrumentation and we have an uncaught throwable. Let's add it to the current span.

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/AsyncDispatchAdvice.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/AsyncDispatchAdvice.java
@@ -19,13 +19,13 @@ import net.bytebuddy.asm.Advice;
 public class AsyncDispatchAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static boolean enter(
+  public static void enter(
       @Advice.This AsyncContext context,
       @Advice.AllArguments Object[] args,
       @Advice.Local("otelCallDepth") CallDepth callDepth) {
     callDepth = CallDepth.forClass(AsyncContext.class);
     if (callDepth.getAndIncrement() > 0) {
-      return false;
+      return;
     }
 
     ServletRequest request = context.getRequest();
@@ -42,15 +42,10 @@ public class AsyncDispatchAdvice {
       // processing, and nothing can be done with the request anymore after this
       request.setAttribute(CONTEXT_ATTRIBUTE, currentContext);
     }
-
-    return true;
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-  public static void exit(
-      @Advice.Enter boolean topLevel, @Advice.Local("otelCallDepth") CallDepth callDepth) {
-    if (topLevel) {
-      callDepth.reset();
-    }
+  public static void exit(@Advice.Local("otelCallDepth") CallDepth callDepth) {
+    callDepth.decrementAndGet();
   }
 }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Advice.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Advice.java
@@ -36,8 +36,10 @@ public class Servlet3Advice {
       @Advice.Local("otelCallDepth") CallDepth callDepth,
       @Advice.Local("otelContext") Context context,
       @Advice.Local("otelScope") Scope scope) {
+
     callDepth = CallDepth.forClass(AppServerBridge.getCallDepthKey());
     callDepth.getAndIncrement();
+
     if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
       return;
     }
@@ -97,6 +99,8 @@ public class Servlet3Advice {
       @Advice.Local("otelContext") Context context,
       @Advice.Local("otelScope") Scope scope) {
 
+    boolean topLevel = callDepth.decrementAndGet() == 0;
+
     if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
       return;
     }
@@ -106,7 +110,7 @@ public class Servlet3Advice {
         (HttpServletRequest) request,
         (HttpServletResponse) response,
         throwable,
-        callDepth,
+        topLevel,
         context,
         scope);
   }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/async/AsyncDispatchAdvice.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/async/AsyncDispatchAdvice.java
@@ -19,13 +19,13 @@ import net.bytebuddy.asm.Advice;
 public class AsyncDispatchAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static boolean enter(
+  public static void enter(
       @Advice.This AsyncContext context,
       @Advice.AllArguments Object[] args,
       @Advice.Local("otelCallDepth") CallDepth callDepth) {
     callDepth = CallDepth.forClass(AsyncContext.class);
     if (callDepth.getAndIncrement() > 0) {
-      return false;
+      return;
     }
 
     ServletRequest request = context.getRequest();
@@ -42,15 +42,10 @@ public class AsyncDispatchAdvice {
       // processing, and nothing can be done with the request anymore after this
       request.setAttribute(CONTEXT_ATTRIBUTE, currentContext);
     }
-
-    return true;
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-  public static void exit(
-      @Advice.Enter boolean topLevel, @Advice.Local("otelCallDepth") CallDepth callDepth) {
-    if (topLevel) {
-      callDepth.reset();
-    }
+  public static void exit(@Advice.Local("otelCallDepth") CallDepth callDepth) {
+    callDepth.decrementAndGet();
   }
 }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/response/ResponseSendAdvice.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/response/ResponseSendAdvice.java
@@ -26,9 +26,11 @@ public class ResponseSendAdvice {
       @Advice.Local("otelScope") Scope scope,
       @Advice.Local("otelCallDepth") CallDepth callDepth) {
     callDepth = CallDepth.forClass(HttpServletResponse.class);
+    if (callDepth.getAndIncrement() > 0) {
+      return;
+    }
     // Don't want to generate a new top-level span
-    if (callDepth.getAndIncrement() == 0
-        && Java8BytecodeBridge.currentSpan().getSpanContext().isValid()) {
+    if (Java8BytecodeBridge.currentSpan().getSpanContext().isValid()) {
       context = tracer().startSpan(method);
       scope = context.makeCurrent();
     }
@@ -40,6 +42,9 @@ public class ResponseSendAdvice {
       @Advice.Local("otelContext") Context context,
       @Advice.Local("otelScope") Scope scope,
       @Advice.Local("otelCallDepth") CallDepth callDepth) {
-    HttpServletResponseAdviceHelper.stopSpan(tracer(), throwable, context, scope, callDepth);
+    if (callDepth.decrementAndGet() > 0) {
+      return;
+    }
+    HttpServletResponseAdviceHelper.stopSpan(tracer(), throwable, context, scope);
   }
 }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/service/JakartaServletServiceAdvice.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/service/JakartaServletServiceAdvice.java
@@ -39,6 +39,7 @@ public class JakartaServletServiceAdvice {
 
     callDepth = CallDepth.forClass(AppServerBridge.getCallDepthKey());
     callDepth.getAndIncrement();
+
     if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
       return;
     }
@@ -97,6 +98,9 @@ public class JakartaServletServiceAdvice {
       @Advice.Local("otelCallDepth") CallDepth callDepth,
       @Advice.Local("otelContext") Context context,
       @Advice.Local("otelScope") Scope scope) {
+
+    boolean topLevel = callDepth.decrementAndGet() == 0;
+
     if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
       return;
     }
@@ -106,7 +110,7 @@ public class JakartaServletServiceAdvice {
         (HttpServletRequest) request,
         (HttpServletResponse) response,
         throwable,
-        callDepth,
+        topLevel,
         context,
         scope);
   }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/response/HttpServletResponseAdviceHelper.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/response/HttpServletResponseAdviceHelper.java
@@ -8,12 +8,11 @@ package io.opentelemetry.javaagent.instrumentation.servlet.common.response;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
-import io.opentelemetry.javaagent.instrumentation.api.CallDepth;
 
 public class HttpServletResponseAdviceHelper {
   public static void stopSpan(
-      BaseTracer tracer, Throwable throwable, Context context, Scope scope, CallDepth callDepth) {
-    if (callDepth.decrementAndGet() == 0 && context != null) {
+      BaseTracer tracer, Throwable throwable, Context context, Scope scope) {
+    if (context != null) {
       scope.close();
 
       if (throwable != null) {

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/service/ServletAndFilterAdviceHelper.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/service/ServletAndFilterAdviceHelper.java
@@ -8,7 +8,6 @@ package io.opentelemetry.javaagent.instrumentation.servlet.common.service;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.servlet.ServletHttpServerTracer;
-import io.opentelemetry.javaagent.instrumentation.api.CallDepth;
 import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
 
 public class ServletAndFilterAdviceHelper {
@@ -17,16 +16,15 @@ public class ServletAndFilterAdviceHelper {
       REQUEST request,
       RESPONSE response,
       Throwable throwable,
-      CallDepth callDepth,
+      boolean topLevel,
       Context context,
       Scope scope) {
-    int depth = callDepth.decrementAndGet();
 
     if (scope != null) {
       scope.close();
     }
 
-    if (context == null && depth == 0) {
+    if (context == null && topLevel) {
       Context currentContext = Java8BytecodeBridge.currentContext();
       // Something else is managing the context, we're in the outermost level of Servlet
       // instrumentation and we have an uncaught throwable. Let's add it to the current span.

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/service/ServletAndFilterAdviceHelper.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/service/ServletAndFilterAdviceHelper.java
@@ -20,13 +20,13 @@ public class ServletAndFilterAdviceHelper {
       CallDepth callDepth,
       Context context,
       Scope scope) {
-    callDepth.decrementAndGet();
+    int depth = callDepth.decrementAndGet();
 
     if (scope != null) {
       scope.close();
     }
 
-    if (context == null && callDepth.get() == 0) {
+    if (context == null && depth == 0) {
       Context currentContext = Java8BytecodeBridge.currentContext();
       // Something else is managing the context, we're in the outermost level of Servlet
       // instrumentation and we have an uncaught throwable. Let's add it to the current span.

--- a/instrumentation/servlet/servlet-javax-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/javax/response/ResponseSendAdvice.java
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/javax/response/ResponseSendAdvice.java
@@ -26,7 +26,7 @@ public class ResponseSendAdvice {
       @Advice.Local("otelScope") Scope scope,
       @Advice.Local("otelCallDepth") CallDepth callDepth) {
     callDepth = CallDepth.forClass(HttpServletResponse.class);
-    if (callDepth.getAndIncrement() == 0) {
+    if (callDepth.getAndIncrement() > 0) {
       return;
     }
     // Don't want to generate a new top-level span

--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/AnnotatedMethodInstrumentation.java
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/AnnotatedMethodInstrumentation.java
@@ -71,10 +71,9 @@ public class AnnotatedMethodInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelCallDepth") CallDepth callDepth,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      if (scope == null) {
+      if (callDepth.decrementAndGet() > 0) {
         return;
       }
-      callDepth.reset();
 
       scope.close();
       if (throwable == null) {

--- a/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/CallDepth.java
+++ b/javaagent-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/CallDepth.java
@@ -58,11 +58,13 @@ public final class CallDepth {
    * Get current call depth. This method may be used by vendor distributions to extend existing
    * instrumentations.
    */
+  @Deprecated
   public int get() {
     return depth;
   }
 
   /** Reset the call depth to its initial value. */
+  @Deprecated
   public void reset() {
     depth = 0;
   }


### PR DESCRIPTION
Several calls to CallDepth.reset() and get() are removed in #3510. This PR removes the remaining calls and deprecates those methods.

This PR also changes `ServletAndFilterAdviceHelper.stopSpan` and `HttpServletResponseAdviceHelper.stopSpan` to not pass in CallDepth, but instead handle CallDepth at the very beginning of advice methods, where we can guarantee they won't get messed up if some code inside our advice accidentally throws an exception.