### PR TITLE
Allow RMI test to run on Java 16

### DIFF
--- a/instrumentation/rmi/javaagent/build.gradle.kts
+++ b/instrumentation/rmi/javaagent/build.gradle.kts
@@ -46,5 +46,10 @@ tasks {
   }
   withType<Test>().configureEach {
     jvmArgs("-Djava.rmi.server.hostname=127.0.0.1")
+
+    if (JavaVersion.current().isJava9Compatible) {
+      jvmArgs("--add-exports=java.rmi/sun.rmi.server=ALL-UNNAMED")
+      jvmArgs("--add-exports=java.rmi/sun.rmi.transport=ALL-UNNAMED")
+    }
   }
 }

--- a/instrumentation/rmi/javaagent/build.gradle.kts
+++ b/instrumentation/rmi/javaagent/build.gradle.kts
@@ -47,7 +47,9 @@ tasks {
   withType<Test>().configureEach {
     jvmArgs("-Djava.rmi.server.hostname=127.0.0.1")
 
-    if (JavaVersion.current().isJava9Compatible) {
+    // Can only export on Java 9+
+    val testJavaVersion = gradle.startParameter.projectProperties.get("testJavaVersion")?.let(JavaVersion::toVersion) ?: JavaVersion.current()
+    if (testJavaVersion.isJava9Compatible) {
       jvmArgs("--add-exports=java.rmi/sun.rmi.server=ALL-UNNAMED")
       jvmArgs("--add-exports=java.rmi/sun.rmi.transport=ALL-UNNAMED")
     }


### PR DESCRIPTION
Java 16 blocks the exports by default, so export them on JVMs that support defining exports. 