### PR TITLE
Enable smoke-tests iff specified on command line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        run: ./gradlew build --stacktrace -x :smoke-tests:test
+        run: ./gradlew build --stacktrace
 
   test:
     runs-on: ubuntu-latest
@@ -78,7 +78,7 @@ jobs:
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -x :smoke-tests:test -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
+        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
 
   testLatestDeps:
     runs-on: ubuntu-latest
@@ -108,7 +108,7 @@ jobs:
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        run: ./gradlew test -x :smoke-tests:test -PtestLatestDeps=true --stacktrace
+        run: ./gradlew test -PtestLatestDeps=true --stacktrace
 
   smoke-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nightly-no-cache.yml
+++ b/.github/workflows/nightly-no-cache.yml
@@ -27,7 +27,7 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Build
-        run: ./gradlew build --stacktrace -x :smoke-tests:test --no-build-cache
+        run: ./gradlew build --stacktrace --no-build-cache
 
   test:
     runs-on: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Test
-        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -x :smoke-tests:test -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false --no-build-cache
+        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false --no-build-cache
 
   testLatestDeps:
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Test
-        run: ./gradlew test -x :smoke-tests:test -PtestLatestDeps=true --stacktrace --no-build-cache
+        run: ./gradlew test -PtestLatestDeps=true --stacktrace --no-build-cache
 
   smoke-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        run: ./gradlew build --stacktrace -x :smoke-tests:test
+        run: ./gradlew build --stacktrace
 
   test:
     runs-on: ubuntu-latest
@@ -78,7 +78,7 @@ jobs:
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -x :smoke-tests:test -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
+        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
 
   testLatestDeps:
     runs-on: ubuntu-latest
@@ -108,7 +108,7 @@ jobs:
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        run: ./gradlew test -x :smoke-tests:test -PtestLatestDeps=true --stacktrace
+        run: ./gradlew test -PtestLatestDeps=true --stacktrace
 
   smoke-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -87,7 +87,7 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Test
-        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -x :smoke-tests:test -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
+        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
 
   # testLatestDeps is intentionally not included in the release workflow
   # because any time a new library version is released to maven central
@@ -203,7 +203,7 @@ jobs:
         with:
           job-id: jdk11
           remote-build-cache-proxy-enabled: false
-          arguments: build final closeAndReleaseSonatypeStagingRepository --stacktrace -x :smoke-tests:test -Prelease.version=${{ github.event.inputs.version }}
+          arguments: build final closeAndReleaseSonatypeStagingRepository --stacktrace -Prelease.version=${{ github.event.inputs.version }}
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
         run: .github/scripts/deadlock-detector.sh
 
       - name: Build
-        run: ./gradlew build --stacktrace -x :smoke-tests:test
+        run: ./gradlew build --stacktrace
 
       - name: Upload deadlock detector artifacts
         if: always()
@@ -86,7 +86,7 @@ jobs:
         run: .github/scripts/deadlock-detector.sh
 
       - name: Test
-        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -x :smoke-tests:test -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
+        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
 
       - name: Upload deadlock detector artifacts
         if: always()

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,7 +46,7 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Test
-        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -x :smoke-tests:test -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
+        run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} --stacktrace -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
 
   # testLatestDeps is intentionally not included in the release workflow
   # because any time a new library version is released to maven central

--- a/docs/contributing/running-tests.md
+++ b/docs/contributing/running-tests.md
@@ -40,16 +40,17 @@ Executing `./gradlew :instrumentation:<INSTRUMENTATION_NAME>:test --tests <GROOV
 
 ### Smoke tests
 
-The smoke tests are not run by default since they take a long time and are not relevant for most
-contributions.
-If you need to run a specific smoke test:
+The smoke tests are not run as part of a global `test` task run since they take a long time and are
+not relevant for most contributions. Explicitly specify `:smoke-tests:test` to run them.
+
+If you need to run a specific smoke test suite:
 
 ```
-./gradlew :smoke-tests:test -PsmokeTestSuite=glassfish -PrunSmokeTests=true
+./gradlew :smoke-tests:test -PsmokeTestSuite=glassfish
 ```
 
 If you are on Windows and you want to run the tests using linux containers:
 
 ```
-USE_LINUX_CONTAINERS=1 ./gradlew :smoke-tests:test -PsmokeTestSuite=glassfish -PrunSmokeTests=true
+USE_LINUX_CONTAINERS=1 ./gradlew :smoke-tests:test -PsmokeTestSuite=glassfish
 ```

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -47,9 +47,9 @@ tasks {
     //  this needs to be long enough so that smoke tests that are just running slow don"t time out
     timeout.set(Duration.ofMinutes(45))
 
-    //We enable/disable smoke tests based on the java version requests
-    //In addition to that we disable them by default on local machines
-    enabled = enabled && (System.getenv("CI") != null || findProperty("runSmokeTests") != null)
+    // We enable/disable smoke tests based on the java version requests
+    // In addition to that we disable them on normal test task to only run when explicitly requested.
+    enabled = enabled && gradle.startParameter.taskNames.any { it.startsWith(":smoke-tests:") }
 
     val suites = mapOf(
       "glassfish" to listOf("**/GlassFishSmokeTest.*"),


### PR DESCRIPTION
After splitting out smoke-tests a while ago we actually stopped getting any benefit from the runSmokeTests property as we never run smoke-tests as part of the normal `test` task. May as well just check the task names.