### PR TITLE
Remove evaluation dependencies for bom project.

### DIFF
--- a/bom-alpha/build.gradle.kts
+++ b/bom-alpha/build.gradle.kts
@@ -8,12 +8,6 @@ description = "OpenTelemetry Instrumentation Bill of Materials (Alpha)"
 group = "io.opentelemetry.instrumentation"
 base.archivesName.set("opentelemetry-instrumentation-bom-alpha")
 
-for (subproject in rootProject.subprojects) {
-  if (!subproject.name.startsWith("bom")) {
-    evaluationDependsOn(subproject.path)
-  }
-}
-
 javaPlatform {
   allowDependencies()
 }
@@ -25,16 +19,15 @@ dependencies {
   api(platform("io.opentelemetry:opentelemetry-bom-alpha:${otelVersion}-alpha"))
 }
 
-afterEvaluate {
-  dependencies {
-    constraints {
-      rootProject.subprojects
-        .filter { it.name != project.name && it.name != "javaagent" }
-        .forEach { proj ->
-          proj.plugins.withId("maven-publish") {
-            api(proj)
-          }
+dependencies {
+  constraints {
+    rootProject.subprojects {
+      val proj = this
+      if (!proj.name.startsWith("bom") && proj.name != "javaagent") {
+        proj.plugins.withId("maven-publish") {
+          api(proj)
         }
+      }
     }
   }
 }


### PR DESCRIPTION
Less evaluation order dependencies means less build fragility. Originally had the dependency to sort but removed the sorting previously as it didn't change much vs Gradle's default breadth-first-ordering. 