### PR TITLE
Make AgentContextWrapper class private

### DIFF
--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/ContextInstrumentation.java
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/ContextInstrumentation.java
@@ -43,9 +43,7 @@ public class ContextInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void methodExit(@Advice.Return(readOnly = false) Context root) {
-      root =
-          new AgentContextStorage.AgentContextWrapper(
-              io.opentelemetry.context.Context.root(), root);
+      root = AgentContextStorage.newContextWrapper(io.opentelemetry.context.Context.root(), root);
     }
   }
 }

--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/AgentContextStorage.java
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/AgentContextStorage.java
@@ -51,6 +51,11 @@ public class AgentContextStorage implements ContextStorage, AutoCloseable {
     return io.opentelemetry.context.Context.root();
   }
 
+  public static Context newContextWrapper(
+      io.opentelemetry.context.Context agentContext, Context applicationContext) {
+    return new AgentContextWrapper(agentContext, applicationContext);
+  }
+
   static final io.opentelemetry.context.ContextKey<Context> APPLICATION_CONTEXT =
       io.opentelemetry.context.ContextKey.named("otel-context");
 
@@ -157,12 +162,11 @@ public class AgentContextStorage implements ContextStorage, AutoCloseable {
     }
   }
 
-  public static class AgentContextWrapper implements Context {
+  private static class AgentContextWrapper implements Context {
     private final io.opentelemetry.context.Context agentContext;
     private final Context applicationContext;
 
-    public AgentContextWrapper(
-        io.opentelemetry.context.Context agentContext, Context applicationContext) {
+    AgentContextWrapper(io.opentelemetry.context.Context agentContext, Context applicationContext) {
       this.agentContext = agentContext;
       this.applicationContext = applicationContext;
     }

--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/propagation/ApplicationTextMapPropagator.java
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/propagation/ApplicationTextMapPropagator.java
@@ -36,7 +36,7 @@ class ApplicationTextMapPropagator implements TextMapPropagator {
     if (agentUpdatedContext == agentContext) {
       return applicationContext;
     }
-    return new AgentContextStorage.AgentContextWrapper(agentUpdatedContext, applicationContext);
+    return AgentContextStorage.newContextWrapper(agentUpdatedContext, applicationContext);
   }
 
   @Override


### PR DESCRIPTION
While the API surface doesn't matter that much for this instrumentation, we'd still generally not expose the private implementation when not needed.