### PR TITLE
Use transform safe logger in HelperInjector

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -204,14 +204,12 @@ public class HelperInjector implements Transformer {
               helperModules.add(new WeakReference<>(javaModule.unwrap()));
             }
           } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-              logger.error(
-                  "Error preparing helpers while processing {} for {}. Failed to inject helper classes into instance {}",
-                  typeDescription,
-                  requestingName,
-                  cl,
-                  e);
-            }
+            logger.error(
+                "Error preparing helpers while processing {} for {}. Failed to inject helper classes into instance {}",
+                typeDescription,
+                requestingName,
+                cl,
+                e);
             throw new IllegalStateException(e);
           }
           return true;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -30,8 +30,6 @@ import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassInjector;
 import net.bytebuddy.utility.JavaModule;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Injects instrumentation helper classes into the user's classloader.
@@ -47,7 +45,8 @@ import org.slf4j.LoggerFactory;
  */
 public class HelperInjector implements Transformer {
 
-  private static final Logger logger = LoggerFactory.getLogger(HelperInjector.class);
+  private static final TransformSafeLogger logger =
+      TransformSafeLogger.getLogger(HelperInjector.class);
 
   // Need this because we can't put null into the injectedClassLoaders map.
   private static final ClassLoader BOOTSTRAP_CLASSLOADER_PLACEHOLDER =

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TransformSafeLogger.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TransformSafeLogger.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.tooling;
 
 import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.ERROR;
 import static org.slf4j.event.Level.TRACE;
 import static org.slf4j.event.Level.WARN;
 
@@ -105,6 +106,14 @@ public final class TransformSafeLogger {
     }
   }
 
+  public void warn(String format) {
+    if (logMessageQueue != null) {
+      logMessageQueue.offer(new LogMessage(WARN, logger, format));
+    } else {
+      logger.warn(format);
+    }
+  }
+
   public void warn(String format, Object arg) {
     if (logMessageQueue != null) {
       logMessageQueue.offer(new LogMessage(WARN, logger, format, arg));
@@ -126,6 +135,38 @@ public final class TransformSafeLogger {
       logMessageQueue.offer(new LogMessage(WARN, logger, format, arguments));
     } else {
       logger.warn(format, arguments);
+    }
+  }
+
+  public void error(String format) {
+    if (logMessageQueue != null) {
+      logMessageQueue.offer(new LogMessage(ERROR, logger, format));
+    } else {
+      logger.error(format);
+    }
+  }
+
+  public void error(String format, Object arg) {
+    if (logMessageQueue != null) {
+      logMessageQueue.offer(new LogMessage(ERROR, logger, format, arg));
+    } else {
+      logger.error(format, arg);
+    }
+  }
+
+  public void error(String format, Object arg1, Object arg2) {
+    if (logMessageQueue != null) {
+      logMessageQueue.offer(new LogMessage(ERROR, logger, format, arg1, arg2));
+    } else {
+      logger.error(format, arg1, arg2);
+    }
+  }
+
+  public void error(String format, Object... arguments) {
+    if (logMessageQueue != null) {
+      logMessageQueue.offer(new LogMessage(ERROR, logger, format, arguments));
+    } else {
+      logger.error(format, arguments);
     }
   }
 


### PR DESCRIPTION
I grabbed the build scan url, but forgot to check for "deadlock detector" files before re-running what looks like a stuck build: https://scans.gradle.com/s/ri43j4qegmvwy/console-log?task=:instrumentation:lettuce:lettuce-5.0:javaagent:test

This PR is just a guess to fix it, but I think a good change anyways.

I stopped short of using TransformSafeLogger in executor-instrumentation where we also do some logging under transform, since really don't want to pollute the public API with TransformSafeLogger.