### PR TITLE
Skeleton for overhead testing subproject.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "testing-overhead/spring-petclinic-rest"]
-	path = testing-overhead/spring-petclinic-rest
-	url = https://github.com/spring-petclinic/spring-petclinic-rest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "testing-overhead/spring-petclinic-rest"]
+	path = testing-overhead/spring-petclinic-rest
+	url = https://github.com/spring-petclinic/spring-petclinic-rest.git

--- a/testing-overhead/.dockerignore
+++ b/testing-overhead/.dockerignore
@@ -1,0 +1,5 @@
+*.hprof
+*.jfr
+*.class
+logs/
+.idea/

--- a/testing-overhead/Dockerfile-petclinic-base
+++ b/testing-overhead/Dockerfile-petclinic-base
@@ -11,25 +11,9 @@ WORKDIR /app/spring-petclinic-rest
 RUN ./mvnw package -Dmaven.test.skip=true
 RUN cp target/spring-petclinic-rest*.jar /app/spring-petclinic-rest.jar
 
-
 FROM adoptopenjdk:11-jdk
-
-# Allow the test runner to ssh into our container to start and control
-# the application under test.
-
-RUN apt update && \
-    apt install -y openssh-server sudo && \
-    mkdir /run/sshd && \
-    sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
-    sed -i 's/^#PermitUserEnvironment.*/PermitUserEnvironment yes/' /etc/ssh/sshd_config && \
-    sed -i 's/^#PermitEmptyPasswords.*/PermitEmptyPasswords yes/' /etc/ssh/sshd_config && \
-    sed -i 's/secure_path="/secure_path="\/opt\/java\/openjdk\/bin:/' /etc/sudoers && \
-    sed -i 's/PATH="/PATH="\/opt\/java\/openjdk\/bin:/' /etc/environment && \
-    useradd -m -d /app -s /bin/bash -u 5001 remote && \
-    passwd -d remote && \
-    mkdir -p /app/.ssh && chmod 700 /app/.ssh && \
-    ln -s /etc/environment /app/.ssh/environment && \
-    echo "%remote ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 COPY --from=app-build /app/spring-petclinic-rest.jar /app/spring-petclinic-rest.jar
 WORKDIR /app
+EXPOSE 9966
+CMD ["java", "-jar", "spring-petclinic-rest.jar"]

--- a/testing-overhead/Dockerfile-petclinic-base
+++ b/testing-overhead/Dockerfile-petclinic-base
@@ -11,7 +11,7 @@ WORKDIR /app/spring-petclinic-rest
 RUN ./mvnw package -Dmaven.test.skip=true
 RUN cp target/spring-petclinic-rest*.jar /app/spring-petclinic-rest.jar
 
-FROM adoptopenjdk:11-jdk
+FROM adoptopenjdk:11-jre
 
 COPY --from=app-build /app/spring-petclinic-rest.jar /app/spring-petclinic-rest.jar
 WORKDIR /app

--- a/testing-overhead/Dockerfile-petclinic-base
+++ b/testing-overhead/Dockerfile-petclinic-base
@@ -1,14 +1,24 @@
-FROM adoptopenjdk:11-jdk
+FROM adoptopenjdk:11-jdk as app-build
 
 # This is the base image that will contain a built version of the spring-petclinic-rest
 # application. Installing the dependencies and maven compiling the application is time
 # consuming, so we do it in a base image to save time nightly.
 
+RUN apt update && apt install -y git
+WORKDIR /app
+RUN git clone http://github.com/spring-petclinic/spring-petclinic-rest.git
+WORKDIR /app/spring-petclinic-rest
+RUN ./mvnw package -Dmaven.test.skip=true
+RUN cp target/spring-petclinic-rest*.jar /app/spring-petclinic-rest.jar
+
+
+FROM adoptopenjdk:11-jdk
+
 # Allow the test runner to ssh into our container to start and control
 # the application under test.
 
 RUN apt update && \
-    apt install -y openssh-server sudo git && \
+    apt install -y openssh-server sudo && \
     mkdir /run/sshd && \
     sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
     sed -i 's/^#PermitUserEnvironment.*/PermitUserEnvironment yes/' /etc/ssh/sshd_config && \
@@ -21,9 +31,5 @@ RUN apt update && \
     ln -s /etc/environment /app/.ssh/environment && \
     echo "%remote ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
+COPY --from=app-build /app/spring-petclinic-rest.jar /app/spring-petclinic-rest.jar
 WORKDIR /app
-RUN git clone http://github.com/spring-petclinic/spring-petclinic-rest.git
-WORKDIR /app/spring-petclinic-rest
-
-RUN ./mvnw package -Dmaven.test.skip=true
-

--- a/testing-overhead/Dockerfile-petclinic-base
+++ b/testing-overhead/Dockerfile-petclinic-base
@@ -1,0 +1,29 @@
+FROM adoptopenjdk:11-jdk
+
+# This is the base image that will contain a built version of the spring-petclinic-rest
+# application. Installing the dependencies and maven compiling the application is time
+# consuming, so we do it in a base image to save time nightly.
+
+# Allow the test runner to ssh into our container to start and control
+# the application under test.
+
+RUN apt update && \
+    apt install -y openssh-server sudo && \
+    mkdir /run/sshd && \
+    sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
+    sed -i 's/^#PermitUserEnvironment.*/PermitUserEnvironment yes/' /etc/ssh/sshd_config && \
+    sed -i 's/^#PermitEmptyPasswords.*/PermitEmptyPasswords yes/' /etc/ssh/sshd_config && \
+    sed -i 's/secure_path="/secure_path="\/opt\/java\/openjdk\/bin:/' /etc/sudoers && \
+    sed -i 's/PATH="/PATH="\/opt\/java\/openjdk\/bin:/' /etc/environment && \
+    useradd -m -d /app -s /bin/bash -u 5001 remote && \
+    passwd -d remote && \
+    mkdir -p /app/.ssh && chmod 700 /app/.ssh && \
+    ln -s /etc/environment /app/.ssh/environment && \
+    echo "%remote ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+COPY spring-petclinic-rest/ /app/spring-petclinic-rest/
+
+WORKDIR /app/spring-petclinic-rest
+
+RUN ./mvnw package -Dmaven.test.skip=true
+

--- a/testing-overhead/Dockerfile-petclinic-base
+++ b/testing-overhead/Dockerfile-petclinic-base
@@ -8,7 +8,7 @@ FROM adoptopenjdk:11-jdk
 # the application under test.
 
 RUN apt update && \
-    apt install -y openssh-server sudo && \
+    apt install -y openssh-server sudo git && \
     mkdir /run/sshd && \
     sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
     sed -i 's/^#PermitUserEnvironment.*/PermitUserEnvironment yes/' /etc/ssh/sshd_config && \
@@ -21,8 +21,8 @@ RUN apt update && \
     ln -s /etc/environment /app/.ssh/environment && \
     echo "%remote ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-COPY spring-petclinic-rest/ /app/spring-petclinic-rest/
-
+WORKDIR /app
+RUN git clone http://github.com/spring-petclinic/spring-petclinic-rest.git
 WORKDIR /app/spring-petclinic-rest
 
 RUN ./mvnw package -Dmaven.test.skip=true

--- a/testing-overhead/README.md
+++ b/testing-overhead/README.md
@@ -1,0 +1,31 @@
+
+# Overhead tests
+
+This is a work in progress. 
+
+This directory will contain tools and utilities
+that help us to measure the performance overhead introduced by 
+the agent and to measure how this overhead changes over time.
+
+## Contents
+
+`spring-petclinic-rest` - This is the sample app that we instrument and test against. It is included as 
+a git submodule (see below).
+
+## Config
+
+tbd
+
+## Setup and Usage
+
+First, init update the submodules in order to pick up the `spring-petclinic-rest` app.
+Once we have an established base image published for `spring-petclinic-rest`, this step
+can be avoided by most users.
+
+```
+$ git submodule init
+$ git submodule update
+$ docker build -f Dockerfile-petclinic-base .
+```
+
+Remaining usage TBD.

--- a/testing-overhead/README.md
+++ b/testing-overhead/README.md
@@ -9,8 +9,7 @@ the agent and to measure how this overhead changes over time.
 
 ## Contents
 
-`spring-petclinic-rest` - This is the sample app that we instrument and test against. It is included as 
-a git submodule (see below).
+tbd
 
 ## Config
 
@@ -18,13 +17,10 @@ tbd
 
 ## Setup and Usage
 
-First, init update the submodules in order to pick up the `spring-petclinic-rest` app.
 Once we have an established base image published for `spring-petclinic-rest`, this step
-can be avoided by most users.
+can be avoided by most users. For now, there is just a spring petclinic base image.
 
 ```
-$ git submodule init
-$ git submodule update
 $ docker build -f Dockerfile-petclinic-base .
 ```
 


### PR DESCRIPTION
Starting the ball rolling on a series of contributions around overhead testing of the agent.  There will be a series of follow-up PRs that continue adding in functionality.

This first one just sets up the directory and README along with a dockerfile for building a `spring-petclinic-rest` base image that also supports ssh.  Ideally we wouldn't have to build petclinic and we could just layer on top of the existing docker image -- but it seems that it hasn't been updated in > 2 years.