### PR TITLE
Use http 1.1 for okhttp3 tests

### DIFF
--- a/instrumentation/okhttp/okhttp-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/okhttp/v3_0/AbstractOkHttp3Test.groovy
+++ b/instrumentation/okhttp/okhttp-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/okhttp/v3_0/AbstractOkHttp3Test.groovy
@@ -14,6 +14,7 @@ import okhttp3.Callback
 import okhttp3.Headers
 import okhttp3.MediaType
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
@@ -28,6 +29,7 @@ abstract class AbstractOkHttp3Test extends HttpClientTest<Request> {
   def client = configureClient(
     new OkHttpClient.Builder()
       .connectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+      .protocols(Arrays.asList(Protocol.HTTP_1_1))
       .retryOnConnectionFailure(false))
     .build()
 


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3563
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3561