### PR TITLE
Clean up bootstrap dependencies and build scripts

### DIFF
--- a/buildSrc/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-instrumentation.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-instrumentation.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 dependencies {
+  add("muzzleBootstrap", "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-annotation-support")
   add("muzzleBootstrap", "io.opentelemetry.javaagent:opentelemetry-javaagent-instrumentation-api")
   add("muzzleTooling", "io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
   add("muzzleTooling", "io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")

--- a/buildSrc/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-instrumentation.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-instrumentation.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  add("muzzleBootstrap", "io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap")
-  add("muzzleTooling", "io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
+  add("muzzleBootstrap", "io.opentelemetry.javaagent:opentelemetry-javaagent-instrumentation-api")
   add("muzzleTooling", "io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
+  add("muzzleTooling", "io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
 }

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -279,6 +279,7 @@ configurations.configureEach {
     // what modules they add to reference generically.
     dependencySubstitution {
       substitute(module("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")).using(project(":instrumentation-api"))
+      substitute(module("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-annotation-support")).using(project(":instrumentation-api-annotation-support"))
       substitute(module("io.opentelemetry.javaagent:opentelemetry-javaagent-instrumentation-api")).using(project(":javaagent-instrumentation-api"))
       substitute(module("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap")).using(project(":javaagent-bootstrap"))
       substitute(module("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")).using(project(":javaagent-extension-api"))

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -6,8 +6,6 @@ plugins {
   id("otel.java-conventions")
 }
 
-val bootstrap by configurations.creating
-
 val instrumentationProjectTest = tasks.named("test")
 val instrumentationProjectDependencies = dependencies
 
@@ -16,12 +14,6 @@ subprojects {
   plugins.withId("java") {
     instrumentationProjectTest.configure {
       dependsOn(subProj.tasks.named("test"))
-    }
-
-    if (subProj.name == "bootstrap") {
-      instrumentationProjectDependencies.run {
-        add(bootstrap.name, project(subProj.path))
-      }
     }
   }
 

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -49,6 +49,7 @@ tasks {
       //These classes are added to bootstrap classloader by javaagent module
       exclude(project(":javaagent-bootstrap"))
       exclude(project(":instrumentation-api"))
+      exclude(project(":instrumentation-api-annotation-support"))
       exclude(project(":javaagent-instrumentation-api"))
     }
   }

--- a/javaagent-bootstrap/build.gradle.kts
+++ b/javaagent-bootstrap/build.gradle.kts
@@ -6,18 +6,8 @@ plugins {
 group = "io.opentelemetry.javaagent"
 
 dependencies {
-  api("io.opentelemetry:opentelemetry-api")
-  api("io.opentelemetry:opentelemetry-api-metrics")
-
-  compileOnly("io.opentelemetry:opentelemetry-sdk")
-
   implementation(project(":instrumentation-api"))
-  implementation(project(":instrumentation-api-annotation-support"))
-  implementation(project(":javaagent-instrumentation-api"))
-
   implementation("org.slf4j:slf4j-api")
-  implementation("org.slf4j:slf4j-simple")
-  // ^ Generally a bad idea for libraries, but we're shadowing.
 
   testImplementation(project(":testing-common"))
   testImplementation("org.mockito:mockito-core")

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -14,9 +14,53 @@ description = "OpenTelemetry Javaagent"
 
 group = "io.opentelemetry.javaagent"
 
-val shadowInclude by configurations.creating {
+val bootstrapLibs by configurations.creating {
   isCanBeResolved = true
   isCanBeConsumed = false
+}
+
+val licenseReportDependencies by configurations.creating {
+  extendsFrom(bootstrapLibs)
+}
+
+dependencies {
+  bootstrapLibs(project(":instrumentation-api"))
+  bootstrapLibs(project(":instrumentation-api-annotation-support"))
+  bootstrapLibs(project(":javaagent-bootstrap"))
+  bootstrapLibs(project(":javaagent-instrumentation-api"))
+  bootstrapLibs("org.slf4j:slf4j-simple")
+
+  // We only have compileOnly dependencies on these to make sure they don"t leak into POMs.
+  licenseReportDependencies("com.github.ben-manes.caffeine:caffeine") {
+    isTransitive = false
+  }
+  licenseReportDependencies("com.blogspot.mydailyjava:weak-lock-free")
+  // TODO ideally this would be :instrumentation instead of :javaagent-tooling
+  //  in case there are dependencies (accidentally) pulled in by instrumentation modules
+  //  but I couldn"t get that to work
+  licenseReportDependencies(project(":javaagent-tooling"))
+  licenseReportDependencies(project(":javaagent-extension-api"))
+
+  testCompileOnly(project(":javaagent-bootstrap"))
+  testCompileOnly(project(":javaagent-instrumentation-api"))
+
+  testImplementation("com.google.guava:guava")
+  testImplementation("io.opentracing.contrib.dropwizard:dropwizard-opentracing:0.2.2")
+}
+
+val javaagentDependencies = dependencies
+
+// collect all bootstrap instrumentation dependencies
+project(":instrumentation").subprojects {
+  val subProj = this
+
+  plugins.withId("java") {
+    if (subProj.name == "bootstrap") {
+      javaagentDependencies.run {
+        add(bootstrapLibs.name, project(subProj.path))
+      }
+    }
+  }
 }
 
 fun isolateSpec(projectsWithShadowJar: Collection<Project>): CopySpec = copySpec {
@@ -30,7 +74,7 @@ fun isolateSpec(projectsWithShadowJar: Collection<Project>): CopySpec = copySpec
 }
 
 tasks {
-  processResources.configure {
+  processResources {
     from(rootProject.file("licenses")) {
       into("META-INF/licenses")
     }
@@ -55,9 +99,8 @@ tasks {
     with(isolateSpec(projectsWithShadowJar))
   }
 
-  // lightShadow is the default classifier we publish so disable the default jar.
-  jar.configure {
-    enabled = false
+  withType<ShadowJar>().configureEach {
+    configurations = listOf(bootstrapLibs)
 
     manifest {
       attributes(
@@ -70,10 +113,9 @@ tasks {
     }
   }
 
-  withType<ShadowJar>().configureEach {
-    configurations = listOf(shadowInclude)
-
-    manifest.inheritFrom(jar.get().manifest)
+  // lightShadow is the default classifier we publish so disable the default jar.
+  jar {
+    enabled = false
   }
 
   withType<Test>().configureEach {
@@ -115,39 +157,12 @@ tasks {
   }
 }
 
-val licenseReportDependencies by configurations.creating {
-  extendsFrom(shadowInclude)
-}
-
-dependencies {
-  testCompileOnly(project(":javaagent-bootstrap"))
-  testCompileOnly(project(":javaagent-instrumentation-api"))
-
-  testImplementation("com.google.guava:guava")
-
-  testImplementation("io.opentracing.contrib.dropwizard:dropwizard-opentracing:0.2.2")
-
-  shadowInclude(project(":javaagent-bootstrap"))
-  shadowInclude(project(":instrumentation", configuration = "bootstrap"))
-
-  // We only have compileOnly dependencies on these to make sure they don"t leak into POMs.
-  licenseReportDependencies("com.github.ben-manes.caffeine:caffeine") {
-    isTransitive = false
-  }
-  licenseReportDependencies("com.blogspot.mydailyjava:weak-lock-free")
-  // TODO ideally this would be :instrumentation instead of :javaagent-tooling
-  //  in case there are dependencies (accidentally) pulled in by instrumentation modules
-  //  but I couldn"t get that to work
-  licenseReportDependencies(project(":javaagent-tooling"))
-  licenseReportDependencies(project(":javaagent-extension-api"))
-}
-
 licenseReport {
   outputDir = rootProject.file("licenses").absolutePath
 
   renderers = arrayOf(InventoryMarkdownReportRenderer())
 
-  configurations = arrayOf("licenseReportDependencies")
+  configurations = arrayOf(licenseReportDependencies.name)
 
   excludeGroups = arrayOf(
     "io.opentelemetry.instrumentation",

--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -47,9 +47,9 @@ project(":instrumentation").subprojects {
   }
 }
 
-fun isolateAgentClasses (jars: Iterable<File>): CopySpec {
+fun isolateAgentClasses (configuration: Configuration): CopySpec {
   return copySpec {
-    jars.forEach {
+    configuration.files.forEach {
       from(zipTree(it)) {
         // important to keep prefix "inst" short, as it is prefixed to lots of strings in runtime mem
         into("inst")
@@ -72,7 +72,7 @@ tasks {
     dependsOn(":testing:agent-exporter:shadowJar")
 
     configurations = listOf(bootstrapLibs)
-    with(isolateAgentClasses(javaagentLibs.files))
+    with(isolateAgentClasses(javaagentLibs))
 
     archiveClassifier.set("")
 

--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -10,26 +10,69 @@ plugins {
 description = "OpenTelemetry Javaagent for testing"
 group = "io.opentelemetry.javaagent"
 
-fun isolateSpec(shadowJarTasks: Collection<Jar>): CopySpec = copySpec {
-  from(shadowJarTasks.map { zipTree(it.archiveFile) }) {
-    // important to keep prefix "inst" short, as it is prefixed to lots of strings in runtime mem
-    into("inst")
-    rename("""(^.*)\.class$""", "$1.classdata")
-    // Rename LICENSE file since it clashes with license dir on non-case sensitive FSs (i.e. Mac)
-    rename("""^LICENSE$""", "LICENSE.renamed")
-  }
+val bootstrapLibs by configurations.creating {
+  isCanBeResolved = true
+  isCanBeConsumed = false
 }
-
-val shadowInclude by configurations.creating {
+val javaagentLibs by configurations.creating {
   isCanBeResolved = true
   isCanBeConsumed = false
 }
 
-evaluationDependsOn(":testing:agent-exporter")
+dependencies {
+  bootstrapLibs(project(":instrumentation-api"))
+  bootstrapLibs(project(":instrumentation-api-annotation-support"))
+  bootstrapLibs(project(":javaagent-bootstrap"))
+  bootstrapLibs(project(":javaagent-instrumentation-api"))
+  bootstrapLibs("org.slf4j:slf4j-simple")
+
+  javaagentLibs(project(":testing:agent-exporter", configuration = "shadow"))
+
+  testImplementation(project(":testing-common"))
+  testImplementation("io.opentelemetry:opentelemetry-api")
+}
+
+val javaagentDependencies = dependencies
+
+// collect all bootstrap instrumentation dependencies
+project(":instrumentation").subprojects {
+  val subProj = this
+
+  plugins.withId("java") {
+    if (subProj.name == "bootstrap") {
+      javaagentDependencies.run {
+        add(bootstrapLibs.name, project(subProj.path))
+      }
+    }
+  }
+}
+
+fun isolateAgentClasses (jars: Iterable<File>): CopySpec {
+  return copySpec {
+    jars.forEach {
+      from(zipTree(it)) {
+        // important to keep prefix "inst" short, as it is prefixed to lots of strings in runtime mem
+        into("inst")
+        rename("""(^.*)\.class$""", "$1.classdata")
+        // Rename LICENSE file since it clashes with license dir on non-case sensitive FSs (i.e. Mac)
+        rename("""^LICENSE$""", "LICENSE.renamed")
+      }
+    }
+  }
+}
 
 tasks {
-  jar.configure {
+  jar {
     enabled = false
+  }
+
+  val shadowJar by existing(ShadowJar::class) {
+    dependsOn(":testing:agent-exporter:shadowJar")
+
+    configurations = listOf(bootstrapLibs)
+    with(isolateAgentClasses(javaagentLibs.files))
+
+    archiveClassifier.set("")
 
     manifest {
       attributes(
@@ -42,17 +85,6 @@ tasks {
     }
   }
 
-  val shadowJar by existing(ShadowJar::class) {
-    configurations = listOf(shadowInclude)
-
-    archiveClassifier.set("")
-
-    dependsOn(":testing:agent-exporter:shadowJar")
-    with(isolateSpec(listOf(project(":testing:agent-exporter").tasks.getByName<ShadowJar>("shadowJar"))))
-
-    manifest.inheritFrom(jar.get().manifest)
-  }
-
   afterEvaluate {
     withType<Test>().configureEach {
       inputs.file(shadowJar.get().archiveFile)
@@ -63,22 +95,13 @@ tasks {
       dependsOn(shadowJar)
     }
   }
-}
 
-dependencies {
-  // Dependencies to include without obfuscation.
-  shadowInclude(project(":javaagent-bootstrap"))
-  shadowInclude(project(":instrumentation", configuration = "bootstrap"))
-
-  testImplementation(project(":testing-common"))
-  testImplementation("io.opentelemetry:opentelemetry-api")
-}
-
-// Because shadow does not use default configurations
-publishing {
-  publications {
-    named<MavenPublication>("maven") {
-      project.shadow.component(this)
+  // Because shadow does not use default configurations
+  publishing {
+    publications {
+      named<MavenPublication>("maven") {
+        project.shadow.component(this)
+      }
     }
   }
 }

--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -61,6 +61,8 @@ fun isolateAgentClasses (jars: Iterable<File>): CopySpec {
   }
 }
 
+evaluationDependsOn(":testing:agent-exporter")
+
 tasks {
   jar {
     enabled = false


### PR DESCRIPTION
This PR moves the bootstrap projects aggregation to the `javaagent` module (and `agent-for-testing` too); `javaagent-bootstrap` is now a plain, standard library. I also reorganized both javaagent modules a bit to keep configurations/dependencies and tasks together.