### PR TITLE
 Fixed potential NullPointerException if AMQP.Properties::getHeaders returns null

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -191,7 +191,7 @@ jobs:
         with:
           job-id: jdk11
           remote-build-cache-proxy-enabled: false
-          arguments: build final closeAndReleaseRepository --stacktrace -x :smoke-tests:test -Prelease.version=${{ github.event.inputs.version }}
+          arguments: build final closeAndReleaseSonatypeStagingRepository --stacktrace -x :smoke-tests:test -Prelease.version=${{ github.event.inputs.version }}
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}

--- a/bom-alpha/bom-alpha.gradle
+++ b/bom-alpha/bom-alpha.gradle
@@ -18,9 +18,11 @@ javaPlatform {
   allowDependencies()
 }
 
+def otelVersion = findProperty("otelVersion")
+
 dependencies {
-  api(platform("io.opentelemetry:opentelemetry-bom:${versions["io.opentelemetry"]}"))
-  api(platform("io.opentelemetry:opentelemetry-bom-alpha:${versions["io.opentelemetry"]}"))
+  api(platform("io.opentelemetry:opentelemetry-bom:${otelVersion}"))
+  api(platform("io.opentelemetry:opentelemetry-bom-alpha:${otelVersion}-alpha"))
 }
 
 afterEvaluate {

--- a/dependencyManagement/dependencyManagement.gradle.kts
+++ b/dependencyManagement/dependencyManagement.gradle.kts
@@ -11,6 +11,9 @@ data class DependencySet(val group: String, val version: String, val modules: Li
 val dependencyVersions = hashMapOf<String, String>()
 rootProject.extra["versions"] = dependencyVersions
 
+val otelVersion = "1.3.0"
+rootProject.extra["otelVersion"] = otelVersion
+
 // Need both BOM and -all
 val groovyVersion = "2.5.11"
 
@@ -30,8 +33,8 @@ val DEPENDENCY_BOMS = listOf(
   "com.fasterxml.jackson:jackson-bom:2.12.3",
   "com.google.guava:guava-bom:30.1.1-jre",
   "org.codehaus.groovy:groovy-bom:${groovyVersion}",
-  "io.opentelemetry:opentelemetry-bom:1.3.0",
-  "io.opentelemetry:opentelemetry-bom-alpha:1.3.0-alpha",
+  "io.opentelemetry:opentelemetry-bom:${otelVersion}",
+  "io.opentelemetry:opentelemetry-bom-alpha:${otelVersion}-alpha",
   "org.junit:junit-bom:5.7.2"
 )
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-arquillian-testing/jaxrs-2.0-arquillian-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-arquillian-testing/jaxrs-2.0-arquillian-testing.gradle
@@ -6,7 +6,7 @@ apply plugin: "otel.java-conventions"
 // add repo for org.gradle:gradle-tooling-api which org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-gradle-depchain depends on
 repositories {
   mavenCentral()
-  maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+  maven { url 'https://repo.gradle.org/artifactory/libs-releases-local' }
   mavenLocal()
 }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-payara-testing/jaxrs-2.0-payara-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-payara-testing/jaxrs-2.0-payara-testing.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/instrumentation.gradle"
 // which is used by jaxrs-2.0-arquillian-testing depends on
 repositories {
   mavenCentral()
-  maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+  maven { url 'https://repo.gradle.org/artifactory/libs-releases-local' }
   mavenLocal()
 }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-tomee-testing/jaxrs-2.0-tomee-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-tomee-testing/jaxrs-2.0-tomee-testing.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/instrumentation.gradle"
 // which is used by jaxrs-2.0-arquillian-testing depends on
 repositories {
   mavenCentral()
-  maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+  maven { url 'https://repo.gradle.org/artifactory/libs-releases-local' }
   mavenLocal()
 }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-wildfly-testing/jaxrs-2.0-wildfly-testing.gradle
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-wildfly-testing/jaxrs-2.0-wildfly-testing.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/instrumentation.gradle"
 // which is used by jaxrs-2.0-arquillian-testing depends on
 repositories {
   mavenCentral()
-  maven { url 'https://repo.gradle.org/gradle/libs-releases' }
+  maven { url 'https://repo.gradle.org/artifactory/libs-releases-local' }
   mavenLocal()
 }
 

--- a/instrumentation/rabbitmq-2.7/javaagent/rabbitmq-2.7-javaagent.gradle
+++ b/instrumentation/rabbitmq-2.7/javaagent/rabbitmq-2.7-javaagent.gradle
@@ -15,6 +15,10 @@ dependencies {
   testLibrary ("org.springframework.amqp:spring-rabbit:1.1.0.RELEASE") {
     exclude group: 'com.rabbitmq', module: 'amqp-client'
   }
+
+  testInstrumentation project(':instrumentation:reactor-3.1:javaagent')
+
+  testLibrary 'io.projectreactor.rabbitmq:reactor-rabbitmq:1.0.0.RELEASE'
 }
 
 tasks.withType(Test).configureEach {

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelInstrumentation.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelInstrumentation.java
@@ -50,7 +50,9 @@ public class RabbitChannelInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return implementsInterface(named("com.rabbitmq.client.Channel"));
+    return implementsInterface(named("com.rabbitmq.client.Channel"))
+        // broken implementation that throws UnsupportedOperationException on getConnection() calls
+        .and(not(named("reactor.rabbitmq.ChannelProxy")));
   }
 
   @Override

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TextMapExtractAdapter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TextMapExtractAdapter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
 import io.opentelemetry.context.propagation.TextMapGetter;
+import java.util.Collections;
 import java.util.Map;
 
 public class TextMapExtractAdapter implements TextMapGetter<Map<String, Object>> {
@@ -14,12 +15,12 @@ public class TextMapExtractAdapter implements TextMapGetter<Map<String, Object>>
 
   @Override
   public Iterable<String> keys(Map<String, Object> carrier) {
-    return carrier.keySet();
+    return carrier != null ? carrier.keySet() : Collections.emptyList();
   }
 
   @Override
   public String get(Map<String, Object> carrier, String key) {
-    Object obj = carrier.get(key);
+    Object obj = carrier != null? carrier.get(key) : null;
     return obj == null ? null : obj.toString();
   }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TextMapExtractAdapter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TextMapExtractAdapter.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
-import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Collections;
 import java.util.Map;
+
+import io.opentelemetry.context.propagation.TextMapGetter;
 
 public class TextMapExtractAdapter implements TextMapGetter<Map<String, Object>> {
 
@@ -20,7 +21,11 @@ public class TextMapExtractAdapter implements TextMapGetter<Map<String, Object>>
 
   @Override
   public String get(Map<String, Object> carrier, String key) {
-    Object obj = carrier != null? carrier.get(key) : null;
-    return obj == null ? null : obj.toString();
+    if (carrier != null) {
+      Object obj = carrier.get(key);
+      return obj == null ? null : obj.toString();
+    } else {
+      return null;
+    }
   }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/ReactorRabbitMqTest.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/ReactorRabbitMqTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import reactor.rabbitmq.ExchangeSpecification
+import reactor.rabbitmq.RabbitFlux
+import reactor.rabbitmq.SenderOptions
+
+class ReactorRabbitMqTest extends AgentInstrumentationSpecification implements WithRabbitMqTrait {
+
+  def setupSpec() {
+    startRabbit()
+  }
+
+  def cleanupSpec() {
+    stopRabbit()
+  }
+
+  def "should not fail declaring exchange"() {
+    given:
+    def sender = RabbitFlux.createSender(new SenderOptions().connectionFactory(connectionFactory))
+
+    when:
+    sender.declareExchange(ExchangeSpecification.exchange("testExchange"))
+      .block()
+
+    then:
+    noExceptionThrown()
+
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name 'exchange.declare'
+          kind SpanKind.CLIENT
+          attributes {
+            "${SemanticAttributes.NET_PEER_NAME.key}" { it == null || it instanceof String }
+            "${SemanticAttributes.NET_PEER_IP.key}" String
+            "${SemanticAttributes.NET_PEER_PORT.key}" { it == null || it instanceof Long }
+            "${SemanticAttributes.MESSAGING_SYSTEM.key}" "rabbitmq"
+            "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "queue"
+            "rabbitmq.command" "exchange.declare"
+          }
+        }
+      }
+    }
+
+    cleanup:
+    sender?.close()
+  }
+}

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/WithRabbitMqTrait.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/WithRabbitMqTrait.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import com.rabbitmq.client.ConnectionFactory
+import java.time.Duration
+import org.testcontainers.containers.GenericContainer
+
+trait WithRabbitMqTrait {
+
+  static GenericContainer rabbitMqContainer
+  static ConnectionFactory connectionFactory
+
+  def startRabbit() {
+    rabbitMqContainer = new GenericContainer('rabbitmq:latest')
+      .withExposedPorts(5672)
+      .withStartupTimeout(Duration.ofSeconds(120))
+    rabbitMqContainer.start()
+
+    connectionFactory = new ConnectionFactory(
+      host: rabbitMqContainer.containerIpAddress,
+      port: rabbitMqContainer.getMappedPort(5672)
+    )
+  }
+
+  def stopRabbit() {
+    rabbitMqContainer?.stop()
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
@@ -29,10 +29,13 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
 
   @Override
   public void configure(Config config, IgnoredTypesBuilder builder) {
-    if (!config.getBooleanProperty(ADDITIONAL_LIBRARY_IGNORES_ENABLED, true)) {
-      return;
+    if (config.getBooleanProperty(ADDITIONAL_LIBRARY_IGNORES_ENABLED, true)) {
+      configure(builder);
     }
+  }
 
+  // only used by tests (to bypass the ignores check)
+  public void configure(IgnoredTypesBuilder builder) {
     builder
         .ignoreClass("com.beust.jcommander.")
         .ignoreClass("com.fasterxml.classmate.")
@@ -76,7 +79,14 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
 
     builder
         .ignoreClass("org.springframework.amqp.")
-        .allowClass("org.springframework.amqp.rabbit.connection.");
+        .allowClass("org.springframework.amqp.rabbit.connection.")
+        .allowClass("org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer")
+        // these implement Runnable, so tests currently force these allows
+        // though not sure if it's important or not that they get instrumented
+        .allowClass(
+            "org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer$AsyncMessageProcessingConsumer")
+        .allowClass(
+            "org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry$AggregatingCallback");
 
     builder
         .ignoreClass("org.springframework.beans.")
@@ -146,8 +156,8 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
 
     builder
         .ignoreClass("org.springframework.jms.")
-        .ignoreClass("org.springframework.jms.listener.")
-        .ignoreClass(
+        .allowClass("org.springframework.jms.listener.")
+        .allowClass(
             "org.springframework.jms.config.JmsListenerEndpointRegistry$AggregatingCallback");
 
     builder

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/AgentTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/AgentTestRunner.java
@@ -46,6 +46,11 @@ public final class AgentTestRunner implements InstrumentationTestRunner {
     assert TestAgentListenerAccess.getInstrumentationErrorCount() == 0
         : TestAgentListenerAccess.getInstrumentationErrorCount()
             + " Instrumentation errors during test";
+    // additional library ignores are ignored during tests, because they can make it really
+    // confusing for contributors wondering why their instrumentation is not applied
+    //
+    // but we then need to make sure that the additional library ignores won't then silently prevent
+    // the instrumentation from being applied in real life outside of these tests
     assert TestAgentListenerAccess.getIgnoredButTransformedClassNames().isEmpty()
         : "Transformed classes match global libraries ignore matcher: "
             + TestAgentListenerAccess.getIgnoredButTransformedClassNames();

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.testing.bytebuddy;
 
-import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.tooling.ignore.AdditionalLibraryIgnoredTypesConfigurer;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoreAllow;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesBuilderImpl;
@@ -33,7 +32,7 @@ public class TestAgentListener implements AgentBuilder.Listener {
 
   static {
     IgnoredTypesBuilderImpl builder = new IgnoredTypesBuilderImpl();
-    new AdditionalLibraryIgnoredTypesConfigurer().configure(Config.get(), builder);
+    new AdditionalLibraryIgnoredTypesConfigurer().configure(builder);
     ADDITIONAL_LIBRARIES_TRIE = builder.buildIgnoredTypesTrie();
   }
 


### PR DESCRIPTION
In some applications we are not providing headers at the AMQP.Properties, which results in the following exception:
java.lang.NullPointerException\n at io.opentelemetry.javaagent.instrumentation.rabbitmq.TextMapExtractAdapter.get(TextMapExtractAdapter.java:22)\n at io.opentelemetry.javaagent.instrumentation.rabbitmq.TextMapExtractAdapter.get(TextMapExtractAdapter.java:11)\n 
.... 

After the error RabbitMQ stopped working, these fix prevents the NullPointerException