### PR TITLE
fixed potential NullPointerException if AMQP.Properties::getHeaders returns null

### DIFF
--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TextMapExtractAdapter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/TextMapExtractAdapter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
 import io.opentelemetry.context.propagation.TextMapGetter;
+import java.util.Collections;
 import java.util.Map;
 
 public class TextMapExtractAdapter implements TextMapGetter<Map<String, Object>> {
@@ -14,12 +15,16 @@ public class TextMapExtractAdapter implements TextMapGetter<Map<String, Object>>
 
   @Override
   public Iterable<String> keys(Map<String, Object> carrier) {
-    return carrier.keySet();
+    return carrier != null ? carrier.keySet() : Collections.emptyList();
   }
 
   @Override
   public String get(Map<String, Object> carrier, String key) {
-    Object obj = carrier.get(key);
-    return obj == null ? null : obj.toString();
+    if (carrier != null) {
+      Object obj = carrier.get(key);
+      return obj == null ? null : obj.toString();
+    } else {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
In some applications we are not providing headers at the AMQP.Properties, which results in the following exception:
java.lang.NullPointerException\n at io.opentelemetry.javaagent.instrumentation.rabbitmq.TextMapExtractAdapter.get(TextMapExtractAdapter.java:22)\n at io.opentelemetry.javaagent.instrumentation.rabbitmq.TextMapExtractAdapter.get(TextMapExtractAdapter.java:11)\n
....

After the error RabbitMQ stopped working, these fix prevents the NullPointerException