### PR TITLE
Fix naming of muzzle tasks

### DIFF
--- a/buildSrc/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -172,7 +172,7 @@ fun addMuzzleTask(muzzleDirective: MuzzleDirective, versionArtifact: Artifact?, 
     "muzzle-Assert${muzzleDirective}"
   } else {
     StringBuilder("muzzle-Assert").apply {
-      if (muzzleDirective.assertPass.isPresent) {
+      if (muzzleDirective.assertPass.get()) {
         append("Pass")
       } else {
         append("Fail")


### PR DESCRIPTION
`assertPass` property is always present because we set to a default value right in the constructor.