### PR TITLE
Update gradle plugin artifact groupId

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -8,7 +8,9 @@ plugins {
   id("io.github.gradle-nexus.publish-plugin")
 }
 
-group = "io.opentelemetry.javaagent"
+// this is the groupId for the gradle plugin artifact (the groupId for each gradle plugin is
+// determined by the gradle plugin file name)
+group = "io.opentelemetry.instrumentation"
 version = "0.1.0-SNAPSHOT"
 
 repositories {


### PR DESCRIPTION
An alternative to this PR would be to publish two separate gradle plugin artifacts:
* `io.opentelemetry.instrumentation:gradle-plugins` for library instrumentation gradle plugins
* `io.opentelemetry.javaagent:gradle-plugins` for javaagent instrumentation gradle plugins
