### PR TITLE
Refactor agent-for-testing build

### DIFF
--- a/testing/agent-exporter/build.gradle.kts
+++ b/testing/agent-exporter/build.gradle.kts
@@ -1,47 +1,19 @@
 plugins {
-  id("io.opentelemetry.instrumentation.javaagent-shadowing")
-
   id("otel.java-conventions")
 }
 
 dependencies {
-  compileOnly("net.bytebuddy:byte-buddy")
-  compileOnly("io.opentelemetry:opentelemetry-sdk")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  compileOnly("org.slf4j:slf4j-api")
-
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service")
 
-  implementation(project(":instrumentation-api"))
-  implementation(project(":javaagent-instrumentation-api"))
   implementation(project(":javaagent-extension-api"))
+  implementation(project(":javaagent-instrumentation-api"))
   implementation(project(":javaagent-tooling"))
-  implementation("io.opentelemetry:opentelemetry-proto")
+
+  implementation("io.grpc:grpc-core:1.33.1")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp-metrics")
-  implementation("io.grpc:grpc-testing:1.33.1")
-
-  // Include instrumentations instrumenting core JDK classes tp ensure interoperability with other instrumentation
-  implementation(project(":instrumentation:executors:javaagent"))
-  // FIXME: we should enable this, but currently this fails tests for google http client
-  //testImplementation project(":instrumentation:http-url-connection:javaagent")
-  implementation(project(":instrumentation:internal:internal-class-loader:javaagent"))
-  implementation(project(":instrumentation:internal:internal-eclipse-osgi-3.6:javaagent"))
-  implementation(project(":instrumentation:internal:internal-proxy:javaagent"))
-  implementation(project(":instrumentation:internal:internal-url-class-loader:javaagent"))
-
-  // Many tests use OpenTelemetry API calls, e.g., via ServerTraceUtils.runUnderServerTrace
-  implementation(project(":instrumentation:opentelemetry-annotations-1.0:javaagent"))
-  // TODO (trask) is full OTel API interop needed, or is @WithSpan enough?
-  implementation(project(":instrumentation:opentelemetry-api-1.0:javaagent"))
-}
-
-tasks {
-  jar {
-    enabled = false
-  }
-  shadowJar {
-    archiveFileName.set("testing-agent-classloader.jar")
-  }
+  implementation("io.opentelemetry:opentelemetry-proto")
+  implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  implementation("org.slf4j:slf4j-api")
 }


### PR DESCRIPTION
This PR removes  the shadowing logic from the `agent-exporter` project; it's now a "normal" library. All shadowing/relocation code is moved to `agent-for-testing`.
The test agent build script has two configurations that are used to assemble the javaagent:
* `bootstrapLibs` for dependencies/modules that are to be placed in the final jar directly (i.e. loadable by the bootstrap CL)
* `javaagentLibs` for dependencies/modules that are to be placed in the `inst/` dir (loadable by the agent CL)

The testing agent had some duplications too, I've removed them all by excluding bootstrap libs from the `javaagentLibs` configuration. 