### PR TITLE
Hibernate: set span name only on method entry

### DIFF
--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/CriteriaInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/CriteriaInstrumentation.java
@@ -21,9 +21,9 @@ import io.opentelemetry.javaagent.instrumentation.api.InstrumentationContext;
 import io.opentelemetry.javaagent.instrumentation.hibernate.SessionMethodUtils;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.Criteria;
+import org.hibernate.impl.CriteriaImpl;
 
 public class CriteriaInstrumentation implements TypeInstrumentation {
 
@@ -63,7 +63,13 @@ public class CriteriaInstrumentation implements TypeInstrumentation {
       ContextStore<Criteria, Context> contextStore =
           InstrumentationContext.get(Criteria.class, Context.class);
 
-      context = SessionMethodUtils.startSpanFrom(contextStore, criteria, "Criteria." + name, null);
+      String entityName = null;
+      if (criteria instanceof CriteriaImpl) {
+        entityName = ((CriteriaImpl) criteria).getEntityOrClassName();
+      }
+
+      context =
+          SessionMethodUtils.startSpanFrom(contextStore, criteria, "Criteria." + name, entityName);
       if (context != null) {
         scope = context.makeCurrent();
       }
@@ -72,7 +78,6 @@ public class CriteriaInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void endMethod(
         @Advice.Thrown Throwable throwable,
-        @Advice.Return(typing = Assigner.Typing.DYNAMIC) Object entity,
         @Advice.Origin("#m") String name,
         @Advice.Local("otelCallDepth") CallDepth callDepth,
         @Advice.Local("otelContext") Context context,
@@ -84,7 +89,7 @@ public class CriteriaInstrumentation implements TypeInstrumentation {
 
       if (scope != null) {
         scope.close();
-        SessionMethodUtils.end(context, throwable, "Criteria." + name, entity);
+        SessionMethodUtils.end(context, throwable);
       }
     }
   }

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/EntityNameUtil.java
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/EntityNameUtil.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.hibernate.v3_3;
+
+import java.util.function.Function;
+import org.hibernate.impl.AbstractSessionImpl;
+
+public final class EntityNameUtil {
+
+  private EntityNameUtil() {}
+
+  private static String bestGuessEntityName(Object session, Object entity) {
+    if (entity == null) {
+      return null;
+    }
+
+    if (session instanceof AbstractSessionImpl) {
+      return ((AbstractSessionImpl) session).bestGuessEntityName(entity);
+    }
+
+    return null;
+  }
+
+  public static Function<Object, String> bestGuessEntityName(Object session) {
+    return (entity) -> bestGuessEntityName(session, entity);
+  }
+}

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/QueryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/QueryInstrumentation.java
@@ -80,7 +80,7 @@ public class QueryInstrumentation implements TypeInstrumentation {
 
       if (scope != null) {
         scope.close();
-        SessionMethodUtils.end(context, throwable, null, null);
+        SessionMethodUtils.end(context, throwable);
       }
     }
   }

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/TransactionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/TransactionInstrumentation.java
@@ -81,7 +81,7 @@ public class TransactionInstrumentation implements TypeInstrumentation {
 
       if (scope != null) {
         scope.close();
-        SessionMethodUtils.end(context, throwable, null, null);
+        SessionMethodUtils.end(context, throwable);
       }
     }
   }

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/CriteriaTest.groovy
@@ -36,7 +36,7 @@ class CriteriaTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          name "Criteria.$methodName"
+          name "Criteria.$methodName Value"
           kind INTERNAL
           childOf span(0)
           attributes {

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/SessionTest.groovy
@@ -283,7 +283,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          name "Session.replicate"
+          name "Session.replicate java.lang.Long"
           kind INTERNAL
           childOf span(0)
           status ERROR

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/EntityNameUtil.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/EntityNameUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.hibernate.v4_0;
+
+import java.util.function.Function;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.internal.SessionImpl;
+import org.hibernate.internal.StatelessSessionImpl;
+
+public final class EntityNameUtil {
+
+  private EntityNameUtil() {}
+
+  private static String bestGuessEntityName(SharedSessionContract session, Object entity) {
+    if (entity == null) {
+      return null;
+    }
+
+    if (session instanceof SessionImpl) {
+      return ((SessionImpl) session).bestGuessEntityName(entity);
+    } else if (session instanceof StatelessSessionImpl) {
+      return ((StatelessSessionImpl) session).bestGuessEntityName(entity);
+    }
+
+    return null;
+  }
+
+  public static Function<Object, String> bestGuessEntityName(SharedSessionContract session) {
+    return (entity) -> bestGuessEntityName(session, entity);
+  }
+}

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/QueryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/QueryInstrumentation.java
@@ -80,7 +80,7 @@ public class QueryInstrumentation implements TypeInstrumentation {
 
       if (scope != null) {
         scope.close();
-        SessionMethodUtils.end(context, throwable, null, null);
+        SessionMethodUtils.end(context, throwable);
       }
     }
   }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionInstrumentation.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
 import static io.opentelemetry.javaagent.instrumentation.hibernate.HibernateTracer.tracer;
 import static io.opentelemetry.javaagent.instrumentation.hibernate.SessionMethodUtils.SCOPE_ONLY_METHODS;
+import static io.opentelemetry.javaagent.instrumentation.hibernate.SessionMethodUtils.getEntityName;
 import static io.opentelemetry.javaagent.instrumentation.hibernate.SessionMethodUtils.getSessionMethodSpanName;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -27,7 +28,6 @@ import io.opentelemetry.javaagent.instrumentation.api.InstrumentationContext;
 import io.opentelemetry.javaagent.instrumentation.hibernate.SessionMethodUtils;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
@@ -125,7 +125,9 @@ public class SessionInstrumentation implements TypeInstrumentation {
     public static void startMethod(
         @Advice.This SharedSessionContract session,
         @Advice.Origin("#m") String name,
-        @Advice.Argument(0) Object entity,
+        @Advice.Origin("#d") String descriptor,
+        @Advice.Argument(0) Object arg0,
+        @Advice.Argument(value = 1, optional = true) Object arg1,
         @Advice.Local("otelCallDepth") CallDepth callDepth,
         @Advice.Local("otelContext") Context spanContext,
         @Advice.Local("otelScope") Scope scope) {
@@ -144,7 +146,10 @@ public class SessionInstrumentation implements TypeInstrumentation {
       }
 
       if (!SCOPE_ONLY_METHODS.contains(name)) {
-        spanContext = tracer().startSpan(sessionContext, getSessionMethodSpanName(name), entity);
+        String entityName =
+            getEntityName(descriptor, arg0, arg1, EntityNameUtil.bestGuessEntityName(session));
+        spanContext =
+            tracer().startSpan(sessionContext, getSessionMethodSpanName(name), entityName);
         scope = spanContext.makeCurrent();
       } else {
         scope = sessionContext.makeCurrent();
@@ -154,8 +159,6 @@ public class SessionInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void endMethod(
         @Advice.Thrown Throwable throwable,
-        @Advice.Return(typing = Assigner.Typing.DYNAMIC) Object returned,
-        @Advice.Origin("#m") String name,
         @Advice.Local("otelCallDepth") CallDepth callDepth,
         @Advice.Local("otelContext") Context spanContext,
         @Advice.Local("otelScope") Scope scope) {
@@ -166,7 +169,7 @@ public class SessionInstrumentation implements TypeInstrumentation {
 
       if (scope != null) {
         scope.close();
-        SessionMethodUtils.end(spanContext, throwable, getSessionMethodSpanName(name), returned);
+        SessionMethodUtils.end(spanContext, throwable);
       }
     }
   }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/TransactionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/TransactionInstrumentation.java
@@ -81,7 +81,7 @@ public class TransactionInstrumentation implements TypeInstrumentation {
 
       if (scope != null) {
         scope.close();
-        SessionMethodUtils.end(context, throwable, null, null);
+        SessionMethodUtils.end(context, throwable);
       }
     }
   }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/AbstractHibernateTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/AbstractHibernateTest.groovy
@@ -23,7 +23,7 @@ abstract class AbstractHibernateTest extends AgentInstrumentationSpecification {
     Session writer = sessionFactory.openSession()
     writer.beginTransaction()
     prepopulated = new ArrayList<>()
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < 5; i++) {
       prepopulated.add(new Value("Hello :) " + i))
       writer.save(prepopulated.get(i))
     }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/CriteriaTest.groovy
@@ -36,7 +36,7 @@ class CriteriaTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          name "Criteria.$methodName"
+          name "Criteria.$methodName Value"
           kind INTERNAL
           childOf span(0)
           attributes {

--- a/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/HibernateTracer.java
+++ b/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/HibernateTracer.java
@@ -8,10 +8,6 @@ package io.opentelemetry.javaagent.instrumentation.hibernate;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.tracer.BaseTracer;
-import java.lang.annotation.Annotation;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 public class HibernateTracer extends BaseTracer {
   private static final HibernateTracer TRACER = new HibernateTracer();
@@ -20,46 +16,19 @@ public class HibernateTracer extends BaseTracer {
     return TRACER;
   }
 
-  public Context startSpan(Context parentContext, String operationName, Object entity) {
-    return startSpan(parentContext, spanNameForOperation(operationName, entity));
+  public Context startSpan(Context parentContext, String operationName, String entityName) {
+    return startSpan(parentContext, spanNameForOperation(operationName, entityName));
   }
 
   public Context startSpan(Context parentContext, String spanName) {
     return startSpan(parentContext, spanName, SpanKind.INTERNAL);
   }
 
-  private String spanNameForOperation(String operationName, Object entity) {
-    if (entity != null) {
-      String entityName = entityName(entity);
-      if (entityName != null) {
-        return operationName + " " + entityName;
-      }
+  private static String spanNameForOperation(String operationName, String entityName) {
+    if (entityName != null) {
+      return operationName + " " + entityName;
     }
     return operationName;
-  }
-
-  String entityName(Object entity) {
-    if (entity == null) {
-      return null;
-    }
-    String name = null;
-    Set<String> annotations = new HashSet<>();
-    for (Annotation annotation : entity.getClass().getDeclaredAnnotations()) {
-      annotations.add(annotation.annotationType().getName());
-    }
-
-    if (entity instanceof String) {
-      // We were given an entity name, not the entity itself.
-      name = (String) entity;
-    } else if (annotations.contains("javax.persistence.Entity")) {
-      // We were given an instance of an entity.
-      name = entity.getClass().getName();
-    } else if (entity instanceof List && !((List) entity).isEmpty()) {
-      // We have a list of entities.
-      name = entityName(((List) entity).get(0));
-    }
-
-    return name;
   }
 
   @Override

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/ProcedureCallInstrumentation.java
@@ -82,7 +82,7 @@ public class ProcedureCallInstrumentation implements TypeInstrumentation {
 
       if (scope != null) {
         scope.close();
-        SessionMethodUtils.end(context, throwable, null, null);
+        SessionMethodUtils.end(context, throwable);
       }
     }
   }


### PR DESCRIPTION
This pr removes updating span name on method exit, we don't need to inspect the return value of method to know what entity is being operated on. Also instead of trying to figure out whether the first argument of a method is String representing requested entity name or an Object representing entity make things a bit more explicit by using method descriptor. If we know that the first argument of method is a String use it as entity name, if it is an Object then it must be an entity and ask hibernate what its name is.