### PR TITLE
Revert "Publish shaded OpenTelemetry API and annotations for muzzle"

### DIFF
--- a/buildSrc/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -268,15 +268,10 @@ fun inverseOf(muzzleDirective: MuzzleDirective, system: RepositorySystem, sessio
   val inverseDirectives = mutableSetOf<MuzzleDirective>()
 
   val allVersionsArtifact = DefaultArtifact(
-    muzzleDirective.group.get(),
-    muzzleDirective.module.get(),
-    muzzleDirective.classifier.get(),
-    "jar",
-    "[,)")
+    muzzleDirective.group.get(), muzzleDirective.module.get(), "jar", "[,)")
   val directiveArtifact = DefaultArtifact(
     muzzleDirective.group.get(),
     muzzleDirective.module.get(),
-    muzzleDirective.classifier.get(),
     "jar",
     muzzleDirective.versions.get())
 
@@ -299,7 +294,6 @@ fun inverseOf(muzzleDirective: MuzzleDirective, system: RepositorySystem, sessio
     val inverseDirective = objects.newInstance(MuzzleDirective::class).apply {
       group.set(muzzleDirective.group)
       module.set(muzzleDirective.module)
-      classifier.set(muzzleDirective.classifier)
       versions.set(version)
       assertPass.set(!muzzleDirective.assertPass.get())
       excludedDependencies.set(muzzleDirective.excludedDependencies)
@@ -331,7 +325,6 @@ fun muzzleDirectiveToArtifacts(muzzleDirective: MuzzleDirective, system: Reposit
   val directiveArtifact: Artifact = DefaultArtifact(
     muzzleDirective.group.get(),
     muzzleDirective.module.get(),
-    muzzleDirective.classifier.get(),
     "jar",
     muzzleDirective.versions.get())
 
@@ -346,7 +339,6 @@ fun muzzleDirectiveToArtifacts(muzzleDirective: MuzzleDirective, system: Reposit
       DefaultArtifact(
         muzzleDirective.group.get(),
         muzzleDirective.module.get(),
-        muzzleDirective.classifier.get(),
         "jar",
         it)
     }

--- a/buildSrc/src/main/kotlin/io/opentelemetry/instrumentation/gradle/muzzle/MuzzleDirective.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/instrumentation/gradle/muzzle/MuzzleDirective.kt
@@ -15,7 +15,6 @@ abstract class MuzzleDirective {
   abstract val name: Property<String>
   abstract val group: Property<String>
   abstract val module: Property<String>
-  abstract val classifier: Property<String>
   abstract val versions: Property<String>
   abstract val skipVersions: SetProperty<String>
   abstract val additionalDependencies: ListProperty<String>
@@ -26,7 +25,6 @@ abstract class MuzzleDirective {
 
   init {
     name.convention("")
-    classifier.convention("")
     skipVersions.convention(emptySet())
     additionalDependencies.convention(listOf())
     excludedDependencies.convention(listOf())
@@ -90,9 +88,6 @@ abstract class MuzzleDirective {
         .append(module.get())
         .append(':')
         .append(versions.get())
-      if (classifier.isPresent) {
-        sb.append(':').append(classifier.get())
-      }
     }
     return sb.toString()
   }

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -18,11 +18,10 @@ plugins {
 val otelJava = extensions.create<OtelJavaExtension>("otelJava")
 
 afterEvaluate {
-  val previousBaseArchiveName = base.archivesName.get()
   if (findProperty("mavenGroupId") == "io.opentelemetry.javaagent.instrumentation") {
-    base.archivesName.set("opentelemetry-javaagent-$previousBaseArchiveName")
-  } else if (!previousBaseArchiveName.startsWith("opentelemetry-")) {
-    base.archivesName.set("opentelemetry-$previousBaseArchiveName")
+    base.archivesName.set("opentelemetry-javaagent-${base.archivesName.get()}")
+  } else {
+    base.archivesName.set("opentelemetry-${base.archivesName.get()}")
   }
 }
 

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/build.gradle.kts
@@ -2,8 +2,6 @@ plugins {
   id("otel.javaagent-instrumentation")
 }
 
-// TODO: add muzzle once 1.4.0 is released
-
 val versions: Map<String, String> by project
 
 dependencies {

--- a/instrumentation/opentelemetry-api-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/build.gradle.kts
@@ -2,8 +2,6 @@ plugins {
   id("otel.javaagent-instrumentation")
 }
 
-// TODO: add muzzle once 1.4.0 is released
-
 dependencies {
   // this instrumentation needs to be able to reference both the OpenTelemetry API
   // that is shaded in the bootstrap class loader (for sending telemetry to the agent),

--- a/opentelemetry-api-shaded-for-instrumenting/build.gradle.kts
+++ b/opentelemetry-api-shaded-for-instrumenting/build.gradle.kts
@@ -2,11 +2,7 @@ plugins {
   id("com.github.johnrengelman.shadow")
 
   id("otel.java-conventions")
-  id("otel.publish-conventions")
 }
-
-description = "opentelemetry-api shaded for internal javaagent usage"
-group = "io.opentelemetry.javaagent"
 
 dependencies {
   implementation("io.opentelemetry:opentelemetry-api")

--- a/opentelemetry-ext-annotations-shaded-for-instrumenting/build.gradle.kts
+++ b/opentelemetry-ext-annotations-shaded-for-instrumenting/build.gradle.kts
@@ -2,11 +2,7 @@ plugins {
   id("com.github.johnrengelman.shadow")
 
   id("otel.java-conventions")
-  id("otel.publish-conventions")
 }
-
-description = "opentelemetry-extension-annotations shaded for internal javaagent usage"
-group = "io.opentelemetry.javaagent"
 
 dependencies {
   implementation("io.opentelemetry:opentelemetry-extension-annotations")


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-java-instrumentation#3555

Based on discussions in last Thu and Fri SIG meetings, it sounds like we probably want a different solution (location) for publishing these artifacts, so let's hold off on publishing these to maven central.