### PR TITLE
Netty4: handle read timeout

### DIFF
--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AbstractChannelHandlerContextInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AbstractChannelHandlerContextInstrumentation.java
@@ -5,15 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v4_0;
 
-import static io.opentelemetry.javaagent.instrumentation.netty.v4_0.server.NettyHttpServerTracer.tracer;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.Attribute;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
+import io.opentelemetry.javaagent.instrumentation.netty.v4_0.client.NettyHttpClientTracer;
+import io.opentelemetry.javaagent.instrumentation.netty.v4_0.server.NettyHttpServerTracer;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -32,19 +36,25 @@ public class AbstractChannelHandlerContextInstrumentation implements TypeInstrum
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
         isMethod()
-            .and(named("notifyHandlerException"))
+            .and(named("invokeExceptionCaught"))
             .and(takesArgument(0, named(Throwable.class.getName()))),
         AbstractChannelHandlerContextInstrumentation.class.getName()
-            + "$NotifyHandlerExceptionAdvice");
+            + "$InvokeExceptionCaughtAdvice");
   }
 
   @SuppressWarnings("unused")
-  public static class NotifyHandlerExceptionAdvice {
+  public static class InvokeExceptionCaughtAdvice {
 
     @Advice.OnMethodEnter
-    public static void onEnter(@Advice.Argument(0) Throwable throwable) {
+    public static void onEnter(@Advice.This ChannelHandlerContext channelContext, @Advice.Argument(0) Throwable throwable) {
       if (throwable != null) {
-        tracer().onException(Java8BytecodeBridge.currentContext(), throwable);
+        Attribute<Context> clientContextAttr = channelContext.channel().attr(AttributeKeys.CLIENT_CONTEXT);
+        Context context = clientContextAttr.get();
+        if (context != null) {
+          NettyHttpClientTracer.tracer().endExceptionally(context, throwable);
+        } else {
+          NettyHttpServerTracer.tracer().onException(Java8BytecodeBridge.currentContext(), throwable);
+        }
       }
     }
   }

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AbstractChannelHandlerContextInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/AbstractChannelHandlerContextInstrumentation.java
@@ -46,14 +46,18 @@ public class AbstractChannelHandlerContextInstrumentation implements TypeInstrum
   public static class InvokeExceptionCaughtAdvice {
 
     @Advice.OnMethodEnter
-    public static void onEnter(@Advice.This ChannelHandlerContext channelContext, @Advice.Argument(0) Throwable throwable) {
+    public static void onEnter(
+        @Advice.This ChannelHandlerContext channelContext,
+        @Advice.Argument(0) Throwable throwable) {
       if (throwable != null) {
-        Attribute<Context> clientContextAttr = channelContext.channel().attr(AttributeKeys.CLIENT_CONTEXT);
+        Attribute<Context> clientContextAttr =
+            channelContext.channel().attr(AttributeKeys.CLIENT_CONTEXT);
         Context context = clientContextAttr.get();
         if (context != null) {
           NettyHttpClientTracer.tracer().endExceptionally(context, throwable);
         } else {
-          NettyHttpServerTracer.tracer().onException(Java8BytecodeBridge.currentContext(), throwable);
+          NettyHttpServerTracer.tracer()
+              .onException(Java8BytecodeBridge.currentContext(), throwable);
         }
       }
     }

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AbstractChannelHandlerContextInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AbstractChannelHandlerContextInstrumentation.java
@@ -5,14 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 
-import static io.opentelemetry.javaagent.instrumentation.netty.v4_1.server.NettyHttpServerTracer.tracer;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.Attribute;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.netty.v4_1.AttributeKeys;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
+import io.opentelemetry.javaagent.instrumentation.netty.v4_1.client.NettyHttpClientTracer;
+import io.opentelemetry.javaagent.instrumentation.netty.v4_1.server.NettyHttpServerTracer;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -38,9 +43,14 @@ public class AbstractChannelHandlerContextInstrumentation implements TypeInstrum
   public static class InvokeExceptionCaughtAdvice {
 
     @Advice.OnMethodEnter
-    public static void onEnter(@Advice.Argument(0) Throwable throwable) {
+    public static void onEnter(@Advice.This ChannelHandlerContext channelContext, @Advice.Argument(0) Throwable throwable) {
       if (throwable != null) {
-        tracer().onException(Java8BytecodeBridge.currentContext(), throwable);
+        if (channelContext.channel().hasAttr(AttributeKeys.CLIENT_CONTEXT)) {
+          Attribute<Context> clientContextAttr = channelContext.channel().attr(AttributeKeys.CLIENT_CONTEXT);
+          NettyHttpClientTracer.tracer().endExceptionally(clientContextAttr.get(), throwable);
+        } else {
+          NettyHttpServerTracer.tracer().onException(Java8BytecodeBridge.currentContext(), throwable);
+        }
       }
     }
   }

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AbstractChannelHandlerContextInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AbstractChannelHandlerContextInstrumentation.java
@@ -43,13 +43,17 @@ public class AbstractChannelHandlerContextInstrumentation implements TypeInstrum
   public static class InvokeExceptionCaughtAdvice {
 
     @Advice.OnMethodEnter
-    public static void onEnter(@Advice.This ChannelHandlerContext channelContext, @Advice.Argument(0) Throwable throwable) {
+    public static void onEnter(
+        @Advice.This ChannelHandlerContext channelContext,
+        @Advice.Argument(0) Throwable throwable) {
       if (throwable != null) {
         if (channelContext.channel().hasAttr(AttributeKeys.CLIENT_CONTEXT)) {
-          Attribute<Context> clientContextAttr = channelContext.channel().attr(AttributeKeys.CLIENT_CONTEXT);
+          Attribute<Context> clientContextAttr =
+              channelContext.channel().attr(AttributeKeys.CLIENT_CONTEXT);
           NettyHttpClientTracer.tracer().endExceptionally(clientContextAttr.get(), throwable);
         } else {
-          NettyHttpServerTracer.tracer().onException(Java8BytecodeBridge.currentContext(), throwable);
+          NettyHttpServerTracer.tracer()
+              .onException(Java8BytecodeBridge.currentContext(), throwable);
         }
       }
     }

--- a/instrumentation/ratpack-1.4/javaagent/src/test/groovy/client/RatpackForkedHttpClientTest.groovy
+++ b/instrumentation/ratpack-1.4/javaagent/src/test/groovy/client/RatpackForkedHttpClientTest.groovy
@@ -16,6 +16,9 @@ class RatpackForkedHttpClientTest extends RatpackHttpClientTest {
     def resp = client.request(uri) { spec ->
       // Connect timeout for the whole client was added in 1.5 so we need to add timeout for each request
       spec.connectTimeout(Duration.ofSeconds(2))
+      if (uri.getPath() == "/read-timeout") {
+        spec.readTimeout(Duration.ofMillis(READ_TIMEOUT_MS))
+      }
       spec.method(method)
       spec.headers { headersSpec ->
         headers.entrySet().each {

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -60,6 +60,7 @@ import spock.lang.Unroll
 abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
   protected static final BODY_METHODS = ["POST", "PUT"]
   protected static final CONNECT_TIMEOUT_MS = 5000
+  protected static final READ_TIMEOUT_MS = 2000
   protected static final BASIC_AUTH_KEY = "custom-authorization-header"
   protected static final BASIC_AUTH_VAL = "plain text auth token"
 
@@ -109,6 +110,11 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
         }
         .service("/to-secured") {ctx, req ->
           HttpResponse.ofRedirect(HttpStatus.FOUND, "/secured")
+        }
+        .service("/read-timeout") {ctx, req ->
+          Thread.sleep(READ_TIMEOUT_MS * 5)
+          ResponseHeadersBuilder headers = ResponseHeaders.builder(HttpStatus.OK)
+          HttpResponse.of(headers.build(), HttpData.ofAscii("Should have timed out."))
         }
         .decorator(new DecoratingHttpServiceFunction() {
           @Override
@@ -719,6 +725,31 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     method = "HEAD"
   }
 
+  def "read timeout"() {
+    given:
+    assumeTrue(testReadTimeout())
+    def uri = resolveAddress("/read-timeout")
+
+    when:
+    runWithSpan("parent") {
+      doRequest(method, uri)
+    }
+
+    then:
+    def ex = thrown(Exception)
+    def thrownException = ex instanceof ExecutionException ? ex.cause : ex
+    assertTraces(1) {
+      trace(0, 3) {
+        basicSpan(it, 0, "parent", null, thrownException)
+        clientSpan(it, 1, span(0), method, uri, null, thrownException)
+        serverSpan(it, 2, span(1))
+      }
+    }
+
+    where:
+    method = "GET"
+  }
+
   // IBM JVM has different protocol support for TLS
   @Requires({ !System.getProperty("java.vm.name").contains("IBM J9 VM") })
   def "test https request"() {
@@ -1020,6 +1051,10 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
 
   boolean testConnectionFailure() {
     true
+  }
+
+  boolean testReadTimeout() {
+    false
   }
 
   boolean testRemoteConnection() {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3558
Netty `ReadTimeoutHandler` triggers exception handling when timeout is reached. When there is an exception on client channel end span with exception as otherwise the span is leaked because code flow doesn't reach to where span is normally ended.