### PR TITLE
Revert save-gradle-dependencies-cache and try setting cache key for smoke tests

### DIFF
--- a/.github/workflows/build-grpc-smoke-dist.yml
+++ b/.github/workflows/build-grpc-smoke-dist.yml
@@ -27,7 +27,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: grpc-smoke
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/build-play-smoke-dist.yml
+++ b/.github/workflows/build-play-smoke-dist.yml
@@ -27,7 +27,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: play-smoke
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/build-smoke-dist-fakebackend.yml
+++ b/.github/workflows/build-smoke-dist-fakebackend.yml
@@ -26,7 +26,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: fakebackend-smoke
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/build-springboot-smoke-dist.yml
+++ b/.github/workflows/build-springboot-smoke-dist.yml
@@ -27,7 +27,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: springboot-smoke
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/build-test-matrix.yml
+++ b/.github/workflows/build-test-matrix.yml
@@ -26,7 +26,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: matrix-smoke
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: jdk${{ matrix.test-java-version }}
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2
@@ -153,7 +152,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: smokeTests
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2
@@ -208,7 +206,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: jdk11
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,10 +148,17 @@ jobs:
           distribution: adopt
           java-version: 11
 
+      # Workaround https://github.com/burrunan/gradle-cache-action/issues/46
+      - name: Set dependencies cache key
+        shell: bash
+        run: echo "smokeTests" > gradle/otel-gradle-dependencies-key
+
       - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: smokeTests
+          gradle-dependencies-cache-key: |
+            gradle/otel-gradle-dependencies-key
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -148,10 +148,17 @@ jobs:
           distribution: adopt
           java-version: 11
 
+      # Workaround https://github.com/burrunan/gradle-cache-action/issues/46
+      - name: Set dependencies cache key
+        shell: bash
+        run: echo "smokeTests" > gradle/otel-gradle-dependencies-key
+
       - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: smokeTests
+          gradle-dependencies-cache-key: |
+            gradle/otel-gradle-dependencies-key
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: jdk${{ matrix.test-java-version }}
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2
@@ -153,7 +152,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: smokeTests
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -126,10 +126,17 @@ jobs:
           distribution: adopt
           java-version: 11
 
+      # Workaround https://github.com/burrunan/gradle-cache-action/issues/46
+      - name: Set dependencies cache key
+        shell: bash
+        run: echo "smokeTests" > gradle/otel-gradle-dependencies-key
+
       - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: smokeTests
+          gradle-dependencies-cache-key: |
+            gradle/otel-gradle-dependencies-key
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -79,7 +79,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: jdk${{ matrix.test-java-version }}
-          read-only: true
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2
@@ -131,7 +130,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: smokeTests
-          read-only: true
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,7 +75,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: jdk${{ matrix.test-java-version }}
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2
@@ -139,7 +138,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: smokeTests
-          save-gradle-dependencies-cache: false
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -134,10 +134,17 @@ jobs:
           distribution: adopt
           java-version: 11
 
+      # Workaround https://github.com/burrunan/gradle-cache-action/issues/46
+      - name: Set dependencies cache key
+        shell: bash
+        run: echo "smokeTests" > gradle/otel-gradle-dependencies-key
+
       - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: smokeTests
+          gradle-dependencies-cache-key: |
+            gradle/otel-gradle-dependencies-key
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -83,10 +83,17 @@ jobs:
           distribution: adopt
           java-version: 11
 
+      # Workaround https://github.com/burrunan/gradle-cache-action/issues/46
+      - name: Set dependencies cache key
+        shell: bash
+        run: echo "smokeTests" > gradle/otel-gradle-dependencies-key
+
       - name: Restore cache
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: smokeTests
+          gradle-dependencies-cache-key: |
+            gradle/otel-gradle-dependencies-key
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -38,7 +38,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: jdk${{ matrix.test-java-version }}
-          read-only: true
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2
@@ -88,7 +87,6 @@ jobs:
         uses: burrunan/gradle-cache-action@v1.10
         with:
           job-id: smokeTests
-          read-only: true
 
       - name: Cache Gradle Wrapper
         uses: actions/cache@v2


### PR DESCRIPTION
Not sure if a bug or confusingly named property, but it seems like we now don't even download gradle dependencies cache at all for these jobs

![image](https://user-images.githubusercontent.com/198344/126109464-f023737d-5970-434a-a0b4-3938c84fb09c.png)
