### PR TITLE
Disable S3 build cache when environment variable isn't set.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,11 +40,13 @@ gradleEnterprise {
 
 val awsAccessKey = System.getenv("S3_BUILD_CACHE_ACCESS_KEY_ID") ?: ""
 
-buildCache {
-  remote<com.github.burrunan.s3cache.AwsS3BuildCache> {
-    region = "us-west-2"
-    bucket = "opentelemetry-java-instrumentation-gradle-cache"
-    isPush = isCI && !awsAccessKey.isEmpty()
+if (!awsAccessKey.isEmpty()) {
+  buildCache {
+    remote<com.github.burrunan.s3cache.AwsS3BuildCache> {
+      region = "us-west-2"
+      bucket = "opentelemetry-java-instrumentation-gradle-cache"
+      isPush = isCI
+    }
   }
 }
 


### PR DESCRIPTION
Anyone with AWS credentials set up on their machine (e.g via `aws configure` with the CLI) will have builds made quite a bit slower by trying to request from remote cache, which can't work since we don't make the artifacts public. Unless we will do so, we may as well make sure the remote cache is completely disabled when the environment variable is not provided.

We always set the environment variable on CI, and it will still be possible to specify it locally if needed for debugging.