### PR TITLE
Don't use daemon for muzzle tasks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -206,7 +206,7 @@ jobs:
           # timing out has not been a problem, these jobs typically finish in 2-3 minutes
           timeout_minutes: 15
           max_attempts: 3
-          command: ./gradlew ${{ matrix.module }}:muzzle
+          command: ./gradlew ${{ matrix.module }}:muzzle --no-daemon
 
   example-distro:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There are almost a minute long pause between gradle logs of starting the daemon and the next line:

```
Tue, 20 Jul 2021 08:11:52 GMT
Starting a Gradle Daemon (subsequent builds will be faster)
22
Tue, 20 Jul 2021 08:12:52 GMT
> Task :buildSrc:extractPrecompiledScriptPluginPlugins FROM-CACHE
```

Let's see if this change makes any difference

