### PR TITLE
Add gh action to publish base image for overhead testing

### DIFF
--- a/.github/workflows/build-petclinic-overhead-base.yml
+++ b/.github/workflows/build-petclinic-overhead-base.yml
@@ -1,0 +1,25 @@
+name: publish-petclinic-base-image
+on: workflow_dispatch
+jobs:
+  push_to_registry:
+    name: make spring-petclinic-rest base image for overhead testing
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: check out the repo
+        uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: push to gh packages
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: testing-overhead/Dockerfile-petclinic-base
+          tags: ghcr.io/open-telemetry/opentelemetry-java-instrumentation/petclinic-rest-base:latest

--- a/.github/workflows/build-petclinic-overhead-base.yml
+++ b/.github/workflows/build-petclinic-overhead-base.yml
@@ -1,5 +1,10 @@
 name: publish-petclinic-base-image
-on: workflow_dispatch
+on:
+  push:
+    paths:
+      - 'testing-overhead/Dockerfile-petclinic-base'
+    branches: [ 'main' ]
+  workflow_dispatch:
 jobs:
   push_to_registry:
     name: make spring-petclinic-rest base image for overhead testing


### PR DESCRIPTION
In support of overhead testing, we want to have this petclinic-rest base image handy, so this creates an action to build it and publish to ghcr.

I don't expect needing to change this very often, so it's just left as a manual trigger for now.