### PR TITLE
Fix aws-sdk latest dep tests

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
 
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core")
+
+  latestDepTestLibrary("software.amazon.awssdk:kinesis:+")
 }
 
 tasks {


### PR DESCRIPTION
When running latest dep tests all dependencies from `instrumentation/aws-sdk/aws-sdk-2.2/testing/build.gradle.kts` are not automatically update to latest which means test runs with a mix of old and new dependencies. Currently the problematic dependency is `software.amazon.awssdk:aws-cbor-protocol` which is a dependency of `software.amazon.awssdk:kinesis`.