### PR TITLE
Limit number of concurrently running docker tests

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -180,7 +180,7 @@ class TestcontainersBuildService : BuildService<BuildServiceParameters.None?> {
 // To limit number of concurrently running resource intensive tests add
 // tasks {
 //   named<Test>("test") {
-//     usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+//     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
 //   }
 // }
 gradle.sharedServices.registerIfAbsent("testcontainersBuildService", TestcontainersBuildService::class.java) {

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -172,6 +172,21 @@ fun isJavaVersionAllowed(version: JavaVersion): Boolean {
   return true
 }
 
+class HeavyTaskBuildService : BuildService<BuildServiceParameters.None?> {
+  override fun getParameters(): BuildServiceParameters.None? {
+    return null
+  }
+}
+// To limit number of concurrently running resource intensive tests add
+// tasks {
+//   named<Test>("test") {
+//     usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+//   }
+// }
+val heavyTaskService: Provider<HeavyTaskBuildService> = gradle.sharedServices.registerIfAbsent("heavyTaskService", HeavyTaskBuildService::class.java) {
+  maxParallelUsages.convention(2)
+}
+
 val testJavaVersion = gradle.startParameter.projectProperties.get("testJavaVersion")?.let(JavaVersion::toVersion)
 val resourceClassesCsv = listOf("Host", "Os", "Process", "ProcessRuntime").map { "io.opentelemetry.sdk.extension.resources.${it}ResourceProvider" }.joinToString(",")
 tasks.withType<Test>().configureEach {

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -172,7 +172,7 @@ fun isJavaVersionAllowed(version: JavaVersion): Boolean {
   return true
 }
 
-class HeavyTaskBuildService : BuildService<BuildServiceParameters.None?> {
+class TestcontainersBuildService : BuildService<BuildServiceParameters.None?> {
   override fun getParameters(): BuildServiceParameters.None? {
     return null
   }
@@ -180,10 +180,10 @@ class HeavyTaskBuildService : BuildService<BuildServiceParameters.None?> {
 // To limit number of concurrently running resource intensive tests add
 // tasks {
 //   named<Test>("test") {
-//     usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+//     usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
 //   }
 // }
-val heavyTaskService: Provider<HeavyTaskBuildService> = gradle.sharedServices.registerIfAbsent("heavyTaskService", HeavyTaskBuildService::class.java) {
+gradle.sharedServices.registerIfAbsent("testcontainersBuildService", TestcontainersBuildService::class.java) {
   maxParallelUsages.convention(2)
 }
 

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
@@ -42,6 +42,6 @@ configurations.testRuntimeClasspath.resolutionStrategy.force("com.google.guava:g
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
@@ -39,3 +39,9 @@ dependencies {
 
 // Requires old Guava. Can't use enforcedPlatform since predates BOM
 configurations.testRuntimeClasspath.resolutionStrategy.force("com.google.guava:guava:19.0")
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
@@ -42,6 +42,6 @@ configurations.testRuntimeClasspath.resolutionStrategy.force("com.google.guava:g
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
@@ -22,6 +22,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
@@ -19,3 +19,9 @@ dependencies {
 
   latestDepTestLibrary("com.datastax.oss:java-driver-core:4.+")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
@@ -22,6 +22,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/couchbase/couchbase-3.1.6/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.1.6/javaagent/build.gradle.kts
@@ -30,6 +30,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/couchbase/couchbase-3.1.6/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.1.6/javaagent/build.gradle.kts
@@ -30,6 +30,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/couchbase/couchbase-3.1.6/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.1.6/javaagent/build.gradle.kts
@@ -27,3 +27,9 @@ dependencies {
   latestDepTestLibrary("com.couchbase.client:java-client:3.1.6")
   latestDepTestLibrary("com.couchbase.client:core-io:2.1.6")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/build.gradle.kts
@@ -30,6 +30,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/build.gradle.kts
@@ -30,6 +30,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/build.gradle.kts
@@ -27,3 +27,9 @@ dependencies {
   latestDepTestLibrary("com.couchbase.client:java-client:3.1.5")
   latestDepTestLibrary("com.couchbase.client:core-io:2.1.5")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/couchbase/couchbase-3.2/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.2/javaagent/build.gradle.kts
@@ -27,6 +27,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/couchbase/couchbase-3.2/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.2/javaagent/build.gradle.kts
@@ -24,3 +24,9 @@ dependencies {
 
   testImplementation("org.testcontainers:couchbase:${versions["org.testcontainers"]}")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/couchbase/couchbase-3.2/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.2/javaagent/build.gradle.kts
@@ -27,6 +27,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/build.gradle.kts
@@ -40,5 +40,6 @@ dependencies {
 tasks {
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/build.gradle.kts
@@ -40,6 +40,6 @@ dependencies {
 tasks {
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/build.gradle.kts
@@ -40,6 +40,6 @@ dependencies {
 tasks {
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
@@ -41,6 +41,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
@@ -38,3 +38,9 @@ dependencies {
 
   latestDepTestLibrary("org.elasticsearch.client:elasticsearch-rest-client:6.+")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
@@ -41,6 +41,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
@@ -38,6 +38,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
@@ -38,6 +38,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
@@ -35,3 +35,9 @@ dependencies {
 
   testImplementation("org.testcontainers:elasticsearch:${versions["org.testcontainers"]}")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/gwt-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/gwt-2.0/javaagent/build.gradle.kts
@@ -97,6 +97,6 @@ tasks {
     // add test app classes to classpath
     classpath = sourceSets.test.get().runtimeClasspath.plus(files("$buildDir/testapp/classes"))
 
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/gwt-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/gwt-2.0/javaagent/build.gradle.kts
@@ -97,6 +97,6 @@ tasks {
     // add test app classes to classpath
     classpath = sourceSets.test.get().runtimeClasspath.plus(files("$buildDir/testapp/classes"))
 
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/gwt-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/gwt-2.0/javaagent/build.gradle.kts
@@ -96,5 +96,7 @@ tasks {
 
     // add test app classes to classpath
     classpath = sourceSets.test.get().runtimeClasspath.plus(files("$buildDir/testapp/classes"))
+
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
   }
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
@@ -20,3 +20,9 @@ dependencies {
   // Jedis 3.0 has API changes that prevent instrumentation from applying
   latestDepTestLibrary("redis.clients:jedis:2.+")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
@@ -33,6 +33,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
@@ -30,3 +30,9 @@ dependencies {
 
   testLibrary("redis.clients:jedis:3.+")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
@@ -33,6 +33,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms-1.1/javaagent/build.gradle.kts
@@ -31,6 +31,7 @@ tasks {
 
   named<Test>("test") {
     dependsOn(jms2Test)
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
   }
 }
 

--- a/instrumentation/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms-1.1/javaagent/build.gradle.kts
@@ -31,7 +31,7 @@ tasks {
 
   named<Test>("test") {
     dependsOn(jms2Test)
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }
 

--- a/instrumentation/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms-1.1/javaagent/build.gradle.kts
@@ -31,7 +31,7 @@ tasks {
 
   named<Test>("test") {
     dependsOn(jms2Test)
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }
 

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/build.gradle.kts
@@ -21,5 +21,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.lettuce.experimental-span-attributes=true")
-  usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/build.gradle.kts
@@ -21,4 +21,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.lettuce.experimental-span-attributes=true")
+  usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/build.gradle.kts
@@ -21,5 +21,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.lettuce.experimental-span-attributes=true")
-  usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+  usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/build.gradle.kts
@@ -23,4 +23,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.lettuce.experimental-span-attributes=true")
+  usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/build.gradle.kts
@@ -23,5 +23,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.lettuce.experimental-span-attributes=true")
-  usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/build.gradle.kts
@@ -23,5 +23,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.lettuce.experimental-span-attributes=true")
-  usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+  usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
 }

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
@@ -26,6 +26,6 @@ dependencies {
 tasks {
   named<Test>("test") {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
@@ -26,6 +26,6 @@ dependencies {
 tasks {
   named<Test>("test") {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
@@ -26,5 +26,6 @@ dependencies {
 tasks {
   named<Test>("test") {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
@@ -15,6 +15,6 @@ dependencies {
 tasks {
   named<Test>("test") {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
@@ -15,6 +15,6 @@ dependencies {
 tasks {
   named<Test>("test") {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
@@ -15,5 +15,6 @@ dependencies {
 tasks {
   named<Test>("test") {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
   }
 }

--- a/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
@@ -21,6 +21,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
@@ -18,3 +18,9 @@ dependencies {
 
   testImplementation(project(":instrumentation:mongo:mongo-3.1:testing"))
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
@@ -21,6 +21,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/mongo/mongo-3.1/library/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/library/build.gradle.kts
@@ -11,6 +11,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/mongo/mongo-3.1/library/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/library/build.gradle.kts
@@ -11,6 +11,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/mongo/mongo-3.1/library/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/library/build.gradle.kts
@@ -8,3 +8,9 @@ dependencies {
 
   testImplementation(project(":instrumentation:mongo:mongo-3.1:testing"))
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
@@ -28,3 +28,9 @@ dependencies {
 
   testImplementation(project(":instrumentation:mongo:mongo-testing"))
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
@@ -31,6 +31,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
@@ -31,6 +31,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
@@ -25,6 +25,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
@@ -25,6 +25,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
@@ -22,3 +22,9 @@ dependencies {
   testImplementation(project(":instrumentation:mongo:mongo-testing"))
   testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.5")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
@@ -21,3 +21,9 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:mongo:mongo-3.7:javaagent"))
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
@@ -24,6 +24,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
@@ -24,6 +24,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
@@ -26,5 +26,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.rabbitmq.experimental-span-attributes=true")
-  usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+  usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
@@ -26,5 +26,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.rabbitmq.experimental-span-attributes=true")
-  usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
@@ -26,4 +26,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.rabbitmq.experimental-span-attributes=true")
+  usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
 }

--- a/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
+++ b/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
@@ -52,6 +52,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
+++ b/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
@@ -49,3 +49,9 @@ muzzle {
 dependencies {
   library("com.github.etaty:rediscala_2.11:1.8.0")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
+++ b/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
@@ -52,6 +52,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/redisson-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/redisson-3.0/javaagent/build.gradle.kts
@@ -19,5 +19,5 @@ dependencies {
 
 tasks.named<Test>("test") {
   systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-  usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
 }

--- a/instrumentation/redisson-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/redisson-3.0/javaagent/build.gradle.kts
@@ -19,5 +19,5 @@ dependencies {
 
 tasks.named<Test>("test") {
   systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-  usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+  usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
 }

--- a/instrumentation/redisson-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/redisson-3.0/javaagent/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
 
 tasks.named<Test>("test") {
   systemProperty("testLatestDeps", findProperty("testLatestDeps"))
+  usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
 }

--- a/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
@@ -56,6 +56,6 @@ tasks {
 
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
@@ -56,6 +56,6 @@ tasks {
 
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
@@ -56,5 +56,6 @@ tasks {
 
   withType<Test>().configureEach {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
@@ -19,5 +19,6 @@ dependencies {
 tasks {
   named<Test>("test") {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
@@ -19,6 +19,6 @@ dependencies {
 tasks {
   named<Test>("test") {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
@@ -19,6 +19,6 @@ dependencies {
 tasks {
   named<Test>("test") {
     systemProperty("testLatestDeps", findProperty("testLatestDeps"))
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
@@ -25,6 +25,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
@@ -25,6 +25,6 @@ dependencies {
 
 tasks {
   named<Test>("test") {
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
@@ -22,3 +22,9 @@ dependencies {
   testLibrary("org.springframework.boot:spring-boot-starter-test:1.5.22.RELEASE")
   testLibrary("org.springframework.boot:spring-boot-starter:1.5.22.RELEASE")
 }
+
+tasks {
+  named<Test>("test") {
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  }
+}

--- a/instrumentation/spymemcached-2.12/javaagent/build.gradle.kts
+++ b/instrumentation/spymemcached-2.12/javaagent/build.gradle.kts
@@ -20,5 +20,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.spymemcached.experimental-span-attributes=true")
-  usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+  usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
 }

--- a/instrumentation/spymemcached-2.12/javaagent/build.gradle.kts
+++ b/instrumentation/spymemcached-2.12/javaagent/build.gradle.kts
@@ -20,4 +20,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.spymemcached.experimental-span-attributes=true")
+  usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
 }

--- a/instrumentation/spymemcached-2.12/javaagent/build.gradle.kts
+++ b/instrumentation/spymemcached-2.12/javaagent/build.gradle.kts
@@ -20,5 +20,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.spymemcached.experimental-span-attributes=true")
-  usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+  usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
 }

--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -47,7 +47,7 @@ tasks {
     if (findProperty("testLatestDeps") as Boolean) {
       dependsOn(vaadin14LatestTest)
     }
-    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
+    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
   }
 }
 

--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -47,7 +47,7 @@ tasks {
     if (findProperty("testLatestDeps") as Boolean) {
       dependsOn(vaadin14LatestTest)
     }
-    usesService(gradle.sharedServices.registrations.getByName("testcontainersBuildService").getService())
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }
 

--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -47,6 +47,7 @@ tasks {
     if (findProperty("testLatestDeps") as Boolean) {
       dependsOn(vaadin14LatestTest)
     }
+    usesService(gradle.sharedServices.registrations.getByName("heavyTaskService").getService())
   }
 }
 


### PR DESCRIPTION
Mark tests using docker as "heavy" and allow only 2 (there is no deep reasoning behind choosing 2) of them run concurrently. This is done in hope that it will reduce failures during local builds which often fail because testcontainers failed to start.