### PR TITLE
Extract some muzzle checking logic from plugin util into standalone class

### DIFF
--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ClassLoaderMatcher.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ClassLoaderMatcher.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.muzzle;
+
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * This class verifies that a given {@link ClassLoader} satisfies all expectations of a given {@link
+ * InstrumentationModule}. It is used to make sure than module's transformations can be safely
+ * applied to a given class loader.
+ *
+ * @see InstrumentationModule
+ * @see ReferenceMatcher
+ */
+public class ClassLoaderMatcher {
+
+  /**
+   * For all {@link InstrumentationModule}s found in the current thread's context classloader calls
+   * {@link #matches(InstrumentationModule, ClassLoader)} and returns the aggregated result.
+   *
+   * <p>The returned map will be empty if and only if no instrumentation modules were found.
+   */
+  public static Map<String, List<Mismatch>> matchesAll(ClassLoader classLoader) {
+    Map<String, List<Mismatch>> result = new HashMap<>();
+    ServiceLoader.load(InstrumentationModule.class)
+        .forEach(
+            module -> {
+              result.put(module.getClass().getName(), matches(module, classLoader));
+            });
+    return result;
+  }
+
+  /**
+   * Returns a list of {@link Mismatch}s between expectations of the given {@link
+   * InstrumentationModule} and what the given ClassLoader can provide.
+   */
+  public static List<Mismatch> matches(
+      InstrumentationModule instrumentationModule, ClassLoader classLoader) {
+    ReferenceMatcher muzzle =
+        new ReferenceMatcher(
+            instrumentationModule.getMuzzleHelperClassNames(),
+            instrumentationModule.getMuzzleReferences(),
+            instrumentationModule::isHelperClass);
+    List<Mismatch> mismatches = muzzle.getMismatchedReferenceSources(classLoader);
+
+    if (!instrumentationModule.classLoaderMatcher().matches(classLoader)) {
+      mismatches =
+          ReferenceMatcher.lazyAdd(
+              mismatches, new Mismatch.InstrumentationModuleClassLoaderMismatch());
+    }
+
+    return mismatches;
+  }
+
+  private ClassLoaderMatcher() {}
+}

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ClassLoaderMatcher.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ClassLoaderMatcher.java
@@ -13,7 +13,7 @@ import java.util.ServiceLoader;
 
 /**
  * This class verifies that a given {@link ClassLoader} satisfies all expectations of a given {@link
- * InstrumentationModule}. It is used to make sure than module's transformations can be safely
+ * InstrumentationModule}. It is used to make sure than a module's transformations can be safely
  * applied to a given class loader.
  *
  * @see InstrumentationModule
@@ -52,8 +52,7 @@ public class ClassLoaderMatcher {
 
     if (!instrumentationModule.classLoaderMatcher().matches(classLoader)) {
       mismatches =
-          ReferenceMatcher.lazyAdd(
-              mismatches, new Mismatch.InstrumentationModuleClassLoaderMismatch());
+          ReferenceMatcher.add(mismatches, new Mismatch.InstrumentationModuleClassLoaderMismatch());
     }
 
     return mismatches;

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ClassLoaderMatcher.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ClassLoaderMatcher.java
@@ -41,7 +41,7 @@ public class ClassLoaderMatcher {
    * Returns a list of {@link Mismatch}s between expectations of the given {@link
    * InstrumentationModule} and what the given ClassLoader can provide.
    */
-  public static List<Mismatch> matches(
+  private static List<Mismatch> matches(
       InstrumentationModule instrumentationModule, ClassLoader classLoader) {
     ReferenceMatcher muzzle =
         new ReferenceMatcher(

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/Mismatch.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/Mismatch.java
@@ -170,7 +170,7 @@ public abstract class Mismatch {
 
   /**
    * Represents failure of some classloader to satisfy {@link
-   * InstrumentationModule#classLoaderMatcher()}
+   * InstrumentationModule#classLoaderMatcher()}.
    */
   public static class InstrumentationModuleClassLoaderMismatch extends Mismatch {
 

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/Mismatch.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/Mismatch.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.tooling.muzzle;
 
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.muzzle.ClassRef;
 import io.opentelemetry.javaagent.extension.muzzle.FieldRef;
 import io.opentelemetry.javaagent.extension.muzzle.Flag;
@@ -164,6 +165,22 @@ public abstract class Mismatch {
       PrintWriter pw = new PrintWriter(sw);
       referenceCheckException.printStackTrace(pw);
       return sw.toString();
+    }
+  }
+
+  /**
+   * Represents failure of some classloader to satisfy {@link
+   * InstrumentationModule#classLoaderMatcher()}
+   */
+  public static class InstrumentationModuleClassLoaderMismatch extends Mismatch {
+
+    public InstrumentationModuleClassLoaderMismatch() {
+      super(Collections.emptyList());
+    }
+
+    @Override
+    String getMismatchDetails() {
+      return "InstrumentationModule classloader check";
     }
   }
 }

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceMatcher.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceMatcher.java
@@ -81,7 +81,7 @@ public final class ReferenceMatcher {
     List<Mismatch> mismatches = emptyList();
 
     for (ClassRef reference : references.values()) {
-      mismatches = lazyAddAll(mismatches, checkMatch(reference, typePool, loader));
+      mismatches = addAll(mismatches, checkMatch(reference, typePool, loader));
     }
 
     return mismatches;
@@ -150,7 +150,7 @@ public final class ReferenceMatcher {
 
       undeclaredFields.removeAll(superClassFields);
       for (HelperReferenceWrapper.Field missingField : undeclaredFields) {
-        mismatches = lazyAdd(mismatches, new Mismatch.MissingField(helperClass, missingField));
+        mismatches = add(mismatches, new Mismatch.MissingField(helperClass, missingField));
       }
     }
 
@@ -167,8 +167,7 @@ public final class ReferenceMatcher {
 
     abstractMethods.removeAll(plainMethods);
     for (HelperReferenceWrapper.Method unimplementedMethod : abstractMethods) {
-      mismatches =
-          lazyAdd(mismatches, new Mismatch.MissingMethod(helperClass, unimplementedMethod));
+      mismatches = add(mismatches, new Mismatch.MissingMethod(helperClass, unimplementedMethod));
     }
 
     return mismatches;
@@ -202,7 +201,7 @@ public final class ReferenceMatcher {
       if (!flag.matches(typeOnClasspath.getActualModifiers(false))) {
         String desc = reference.getClassName();
         mismatches =
-            lazyAdd(
+            add(
                 mismatches,
                 new Mismatch.MissingFlag(
                     reference.getSources(), desc, flag, typeOnClasspath.getActualModifiers(false)));
@@ -212,7 +211,7 @@ public final class ReferenceMatcher {
     for (FieldRef fieldRef : reference.getFields()) {
       FieldDescription.InDefinedShape fieldDescription = findField(fieldRef, typeOnClasspath);
       if (fieldDescription == null) {
-        mismatches = lazyAdd(mismatches, new Mismatch.MissingField(reference, fieldRef));
+        mismatches = add(mismatches, new Mismatch.MissingField(reference, fieldRef));
       } else {
         for (Flag flag : fieldRef.getFlags()) {
           if (!flag.matches(fieldDescription.getModifiers())) {
@@ -222,7 +221,7 @@ public final class ReferenceMatcher {
                     + fieldRef.getName()
                     + Type.getType(fieldRef.getDescriptor()).getInternalName();
             mismatches =
-                lazyAdd(
+                add(
                     mismatches,
                     new Mismatch.MissingFlag(
                         fieldRef.getSources(), desc, flag, fieldDescription.getModifiers()));
@@ -234,14 +233,14 @@ public final class ReferenceMatcher {
     for (MethodRef methodRef : reference.getMethods()) {
       MethodDescription.InDefinedShape methodDescription = findMethod(methodRef, typeOnClasspath);
       if (methodDescription == null) {
-        mismatches = lazyAdd(mismatches, new Mismatch.MissingMethod(reference, methodRef));
+        mismatches = add(mismatches, new Mismatch.MissingMethod(reference, methodRef));
       } else {
         for (Flag flag : methodRef.getFlags()) {
           if (!flag.matches(methodDescription.getModifiers())) {
             String desc =
                 reference.getClassName() + "#" + methodRef.getName() + methodRef.getDescriptor();
             mismatches =
-                lazyAdd(
+                add(
                     mismatches,
                     new Mismatch.MissingFlag(
                         methodRef.getSources(), desc, flag, methodDescription.getModifiers()));
@@ -304,14 +303,14 @@ public final class ReferenceMatcher {
   }
 
   // optimization to avoid ArrayList allocation in the common case when there are no mismatches
-  static List<Mismatch> lazyAdd(List<Mismatch> mismatches, Mismatch mismatch) {
+  static List<Mismatch> add(List<Mismatch> mismatches, Mismatch mismatch) {
     List<Mismatch> result = mismatches.isEmpty() ? new ArrayList<>() : mismatches;
     result.add(mismatch);
     return result;
   }
 
   // optimization to avoid ArrayList allocation in the common case when there are no mismatches
-  static List<Mismatch> lazyAddAll(List<Mismatch> mismatches, List<Mismatch> toAdd) {
+  static List<Mismatch> addAll(List<Mismatch> mismatches, List<Mismatch> toAdd) {
     if (!toAdd.isEmpty()) {
       List<Mismatch> result = mismatches.isEmpty() ? new ArrayList<>() : mismatches;
       result.addAll(toAdd);

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceMatcher.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceMatcher.java
@@ -304,14 +304,14 @@ public final class ReferenceMatcher {
   }
 
   // optimization to avoid ArrayList allocation in the common case when there are no mismatches
-  private static List<Mismatch> lazyAdd(List<Mismatch> mismatches, Mismatch mismatch) {
+  static List<Mismatch> lazyAdd(List<Mismatch> mismatches, Mismatch mismatch) {
     List<Mismatch> result = mismatches.isEmpty() ? new ArrayList<>() : mismatches;
     result.add(mismatch);
     return result;
   }
 
   // optimization to avoid ArrayList allocation in the common case when there are no mismatches
-  private static List<Mismatch> lazyAddAll(List<Mismatch> mismatches, List<Mismatch> toAdd) {
+  static List<Mismatch> lazyAddAll(List<Mismatch> mismatches, List<Mismatch> toAdd) {
     if (!toAdd.isEmpty()) {
       List<Mismatch> result = mismatches.isEmpty() ? new ArrayList<>() : mismatches;
       result.addAll(toAdd);


### PR DESCRIPTION
As it turned out that having `MuzzleGradlePluginUtil` as it is in gradle plugin's classloader does not actually work, I have started a series of PRs to extract all important parts from it into classes in `muzzle` module. In the end this will allow for easier bridge between plugin's and agent's classloaders.

Trying to avoid huge big-bang PR, thus splitting into smaller ones. Hoping for fast reviews and merges :D