### PR TITLE
Fix running tests from intellij

### DIFF
--- a/instrumentation/external-annotations/javaagent/build.gradle.kts
+++ b/instrumentation/external-annotations/javaagent/build.gradle.kts
@@ -32,22 +32,28 @@ tasks {
   val testIncludeProperty by registering(Test::class) {
     filter {
       includeTestsMatching("ConfiguredTraceAnnotationsTest")
+      isFailOnNoMatchingTests = false
     }
+    include("**/ConfiguredTraceAnnotationsTest.*")
     jvmArgs("-Dotel.instrumentation.external-annotations.include=package.Class\$Name;OuterClass\$InterestingMethod")
   }
 
   val testExcludeMethodsProperty by registering(Test::class) {
     filter {
       includeTestsMatching("TracedMethodsExclusionTest")
+      isFailOnNoMatchingTests = false
     }
+    include("**/TracedMethodsExclusionTest.*")
     jvmArgs("-Dotel.instrumentation.external-annotations.exclude-methods=TracedMethodsExclusionTest\$TestClass[excluded,annotatedButExcluded]")
   }
 
   named<Test>("test") {
     dependsOn(testIncludeProperty)
+    dependsOn(testExcludeMethodsProperty)
     filter {
       excludeTestsMatching("ConfiguredTraceAnnotationsTest")
       excludeTestsMatching("TracedMethodsExclusionTest")
+      isFailOnNoMatchingTests = false
     }
   }
 }

--- a/instrumentation/kafka-clients-0.11/javaagent/build.gradle.kts
+++ b/instrumentation/kafka-clients-0.11/javaagent/build.gradle.kts
@@ -41,7 +41,9 @@ tasks {
   val testPropagationDisabled by registering(Test::class) {
     filter {
       includeTestsMatching("KafkaClientPropagationDisabledTest")
+      isFailOnNoMatchingTests = false
     }
+    include("**/KafkaClientPropagationDisabledTest.*")
     jvmArgs("-Dotel.instrumentation.kafka.client-propagation.enabled=false")
   }
 
@@ -49,6 +51,7 @@ tasks {
     dependsOn(testPropagationDisabled)
     filter {
       excludeTestsMatching("KafkaClientPropagationDisabledTest")
+      isFailOnNoMatchingTests = false
     }
   }
 }

--- a/instrumentation/spring/spring-batch-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/build.gradle.kts
@@ -23,14 +23,18 @@ tasks {
   val testChunkRootSpan by registering(Test::class) {
     filter {
       includeTestsMatching("*ChunkRootSpanTest")
+      isFailOnNoMatchingTests = false
     }
+    include("**/*ChunkRootSpanTest.*")
     jvmArgs("-Dotel.instrumentation.spring-batch.experimental.chunk.new-trace=true")
   }
   
   val testItemLevelSpan by registering(Test::class) {
     filter {
       includeTestsMatching("*ItemLevelSpanTest")
+      isFailOnNoMatchingTests = false
     }
+    include("**/*ItemLevelSpanTest.*")
     jvmArgs("-Dotel.instrumentation.spring-batch.item.enabled=true")
   }
   
@@ -40,6 +44,7 @@ tasks {
     filter {
       excludeTestsMatching("*ChunkRootSpanTest")
       excludeTestsMatching("*ItemLevelSpanTest")
+      isFailOnNoMatchingTests = false
     }
   }
 

--- a/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
@@ -39,7 +39,9 @@ tasks {
   val testWithRabbitInstrumentation by registering(Test::class) {
     filter {
       includeTestsMatching("SpringIntegrationAndRabbitTest")
+      isFailOnNoMatchingTests = false
     }
+    include("**/SpringIntegrationAndRabbitTest.*")
     jvmArgs("-Dotel.instrumentation.rabbitmq.enabled=true")
     jvmArgs("-Dotel.instrumentation.spring-rabbit.enabled=true")
   }
@@ -49,6 +51,7 @@ tasks {
 
     filter {
       excludeTestsMatching("SpringIntegrationAndRabbitTest")
+      isFailOnNoMatchingTests = false
     }
     jvmArgs("-Dotel.instrumentation.rabbitmq.enabled=false")
     jvmArgs("-Dotel.instrumentation.spring-rabbit.enabled=false")


### PR DESCRIPTION
Intellij gets confused when running tests from modules like `kafka-clients-0.11` that have an extra test task with different jvm arguments. For example `KafkaClientPropagationEnabledTest` will run with jvm arguments designated for `KafkaClientPropagationDisabledTest` and thus fail. 