### PR TITLE
Remove redundant dependency

### DIFF
--- a/instrumentation/finatra-2.9/javaagent/build.gradle.kts
+++ b/instrumentation/finatra-2.9/javaagent/build.gradle.kts
@@ -33,8 +33,6 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
 
-  testImplementation("org.awaitility:awaitility")
-
   if (!(findProperty("testLatestDeps") as Boolean)) {
     // Requires old version of Jackson
     testImplementation(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.9.10"))


### PR DESCRIPTION
now that testing commons has `api("org.awaitility:awaitility")` there is no need to declare it here