### PR TITLE
Disable vaadin test unless requested.

### DIFF
--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -41,6 +41,12 @@ tasks {
   val vaadin16Test by existing
   val vaadin14LatestTest by existing
 
+  withType<Test>().configureEach {
+    // TODO(anuraaga): Reenable after fixing
+    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3724
+    enabled = gradle.startParameter.taskNames.any { it.contains(":vaadin-14.2") }
+  }
+
   named<Test>("test") {
     dependsOn(vaadin142Test)
     dependsOn(vaadin16Test)


### PR DESCRIPTION
Had another test that uses selenium. Though interesting #3725 build passed so while it seems to fail a ton, not all the time.