### PR TITLE
An alternative idea of how to suppress client spans per instrumentati…

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/BuiltInInstrumentationCategories.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/BuiltInInstrumentationCategories.java
@@ -1,0 +1,173 @@
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+final class BuiltInInstrumentationCategories {
+
+  static final InstrumentationCategory NONE = new InstrumentationCategory() {
+    @Override
+    public @Nullable Span getMatchingSpanOrNull(Context context) {
+      return null;
+    }
+
+    @Override
+    public Context setInContext(Context context, Span clientSpan) {
+      return context;
+    }
+
+    @Override
+    public String toString() {
+      return "none";
+    }
+  };
+
+  private static final String TYPED_CONTEXT_KEY_PREFIX = "opentelemetry-trace-span-key-";
+
+  abstract static class KeyBasedCategory extends InstrumentationCategory {
+
+    private final String name;
+
+    KeyBasedCategory(String name) {
+      this.name = name;
+    }
+
+    /** This method is expected to always return the same instance. */
+    abstract ContextKey<Span> key();
+
+    @Nullable
+    public final Span getMatchingSpanOrNull(Context context) {
+      return context.get(key());
+    }
+
+    public Context setInContext(Context context, Span span) {
+      return context.with(key(), span);
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  static final class CustomCategory extends KeyBasedCategory {
+    private final ContextKey<Span> key;
+
+    CustomCategory(String name) {
+      super(name);
+      key = ContextKey.named(TYPED_CONTEXT_KEY_PREFIX + "custom-" + name);
+    }
+
+    @Override
+    public ContextKey<Span> key() {
+      return key;
+    }
+  }
+
+  static final class LocalRootCategory extends KeyBasedCategory {
+
+    private static final ContextKey<Span> KEY =
+        ContextKey.named(TYPED_CONTEXT_KEY_PREFIX + "local-root");
+
+    static final InstrumentationCategory INSTANCE = new LocalRootCategory();
+
+    private LocalRootCategory() {
+      super("local-root");
+    }
+
+    @Override
+    public ContextKey<Span> key() {
+      return KEY;
+    }
+  }
+
+  static final class ServerCategory extends KeyBasedCategory {
+
+    private static final ContextKey<Span> KEY =
+        ContextKey.named(TYPED_CONTEXT_KEY_PREFIX + "server");
+
+    static final InstrumentationCategory INSTANCE = new ServerCategory();
+
+    private ServerCategory() {
+      super("server");
+    }
+
+    @Override
+    public ContextKey<Span> key() {
+      return KEY;
+    }
+  }
+
+  @Deprecated
+  static final class ClientCategory extends KeyBasedCategory {
+
+    private static final ContextKey<Span> KEY =
+        ContextKey.named(TYPED_CONTEXT_KEY_PREFIX + "client");
+
+    static final InstrumentationCategory INSTANCE = new ClientCategory();
+
+    private ClientCategory() {
+      super("client");
+    }
+
+    @Override
+    public ContextKey<Span> key() {
+      return KEY;
+    }
+  }
+
+  static final class HttpClientCategory extends KeyBasedCategory {
+
+    private static final ContextKey<Span> KEY =
+        ContextKey.named(TYPED_CONTEXT_KEY_PREFIX + "http-client");
+
+    static final InstrumentationCategory INSTANCE = new HttpClientCategory();
+
+    private HttpClientCategory() {
+      super("http-client");
+    }
+
+    @Override
+    public ContextKey<Span> key() {
+      return KEY;
+    }
+  }
+
+  static final class DatabaseClientCategory extends KeyBasedCategory {
+
+    private static final ContextKey<Span> KEY =
+        ContextKey.named(TYPED_CONTEXT_KEY_PREFIX + "db-client");
+
+    static final InstrumentationCategory INSTANCE = new DatabaseClientCategory();
+
+    private DatabaseClientCategory() {
+      super("db-client");
+    }
+
+    @Override
+    public ContextKey<Span> key() {
+      return KEY;
+    }
+  }
+
+  static final class RpcClientCategory extends KeyBasedCategory {
+
+    private static final ContextKey<Span> KEY =
+        ContextKey.named(TYPED_CONTEXT_KEY_PREFIX + "rpc-client");
+
+    static final InstrumentationCategory INSTANCE = new RpcClientCategory();
+
+    private RpcClientCategory() {
+      super("rpc-client");
+    }
+
+    @Override
+    public ContextKey<Span> key() {
+      return KEY;
+    }
+  }
+
+  private BuiltInInstrumentationCategories() {}
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumentationCategory.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumentationCategory.java
@@ -1,0 +1,65 @@
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public abstract class InstrumentationCategory {
+
+  public static InstrumentationCategory none() {
+    return BuiltInInstrumentationCategories.NONE;
+  }
+
+  public static InstrumentationCategory localRoot() {
+    return BuiltInInstrumentationCategories.LocalRootCategory.INSTANCE;
+  }
+
+  // TODO: a server span is always a localRoot span; these two should be connected together; same
+  // for consumer spans
+  // or should we just get rid of server() and just use localRoot() everywhere? that'd simplify some
+  // logic for sure
+
+  // alternatively: local root spans could be marked/checked by the ServerInstrumenter (consider
+  // renaming to sth like UpstreamPropagatingInstrumenter) - it's a good place to apply this
+  // automagically without manual intervention from the instrumentation author
+  public static InstrumentationCategory server() {
+    return BuiltInInstrumentationCategories.ServerCategory.INSTANCE;
+  }
+
+  /** Same as old {@link io.opentelemetry.instrumentation.api.tracer.ClientSpan}, to be removed. */
+  @Deprecated
+  public static InstrumentationCategory client() {
+    return BuiltInInstrumentationCategories.LocalRootCategory.INSTANCE;
+  }
+
+  public static InstrumentationCategory httpClient() {
+    return BuiltInInstrumentationCategories.HttpClientCategory.INSTANCE;
+  }
+
+  public static InstrumentationCategory databaseClient() {
+    return BuiltInInstrumentationCategories.DatabaseClientCategory.INSTANCE;
+  }
+
+  public static InstrumentationCategory rpcClient() {
+    return BuiltInInstrumentationCategories.RpcClientCategory.INSTANCE;
+  }
+
+  // each call to this method creates a unique instrumentation type
+  // name is only used for debugging
+  public static InstrumentationCategory custom(String name) {
+    return new BuiltInInstrumentationCategories.CustomCategory(name);
+  }
+
+  // package private constructor to limit implementations
+  InstrumentationCategory() {}
+
+  public final boolean matches(Context context) {
+    return getMatchingSpanOrNull(context) != null;
+  }
+
+  // TODO: could it be not public?
+  @Nullable
+  public abstract Span getMatchingSpanOrNull(Context context);
+
+  public abstract Context setInContext(Context context, Span clientSpan);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
@@ -36,10 +36,12 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
   final List<SpanLinkExtractor<? super REQUEST>> spanLinkExtractors = new ArrayList<>();
   final List<RequestListener> requestListeners = new ArrayList<>();
 
+  InstrumentationCategory instrumentationCategory = InstrumentationCategory.none();
   SpanKindExtractor<? super REQUEST> spanKindExtractor = SpanKindExtractor.alwaysInternal();
   SpanStatusExtractor<? super REQUEST, ? super RESPONSE> spanStatusExtractor =
       SpanStatusExtractor.getDefault();
   ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.jdk();
+
   @Nullable StartTimeExtractor<REQUEST> startTimeExtractor = null;
   @Nullable EndTimeExtractor<RESPONSE> endTimeExtractor = null;
 
@@ -52,6 +54,13 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
     this.meter = GlobalMeterProvider.get().get(instrumentationName);
     this.instrumentationName = instrumentationName;
     this.spanNameExtractor = spanNameExtractor;
+  }
+
+  // TODO: should it be an InstrumentationCategoryExtractor instead? InstrumentationCategorizer?
+  public InstrumenterBuilder<REQUEST, RESPONSE> setInstrumentationCategory(
+      InstrumentationCategory instrumentationCategory) {
+    this.instrumentationCategory = instrumentationCategory;
+    return this;
   }
 
   /**

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/ClientSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/ClientSpan.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumentationCategory;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -31,11 +32,13 @@ public final class ClientSpan {
    */
   @Nullable
   public static Span fromContextOrNull(Context context) {
-    return context.get(KEY);
+    return InstrumentationCategory.client().getMatchingSpanOrNull(context);
+//    return context.get(KEY);
   }
 
   public static Context with(Context context, Span clientSpan) {
-    return context.with(KEY, clientSpan);
+    return InstrumentationCategory.client().setInContext(context, clientSpan);
+//    return context.with(KEY, clientSpan);
   }
 
   private ClientSpan() {}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/ConsumerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/ConsumerSpan.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumentationCategory;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -33,11 +34,13 @@ public final class ConsumerSpan {
    */
   @Nullable
   public static Span fromContextOrNull(Context context) {
-    return context.get(KEY);
+    return InstrumentationCategory.localRoot().getMatchingSpanOrNull(context);
+//    return context.get(KEY);
   }
 
   public static Context with(Context context, Span consumerSpan) {
-    return context.with(KEY, consumerSpan);
+    return InstrumentationCategory.localRoot().setInContext(context, consumerSpan);
+//    return context.with(KEY, consumerSpan);
   }
 
   private ConsumerSpan() {}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/ServerSpan.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/ServerSpan.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumentationCategory;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -31,11 +32,13 @@ public final class ServerSpan {
    */
   @Nullable
   public static Span fromContextOrNull(Context context) {
-    return context.get(KEY);
+    return InstrumentationCategory.server().getMatchingSpanOrNull(context);
+//    return context.get(KEY);
   }
 
   public static Context with(Context context, Span serverSpan) {
-    return context.with(KEY, serverSpan);
+    return InstrumentationCategory.server().setInContext(context, serverSpan);
+//    return context.with(KEY, serverSpan);
   }
 
   private ServerSpan() {}

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTracingBuilder.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTracingBuilder.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.instrumentation.okhttp.v3_0;
 
+import static io.opentelemetry.instrumentation.api.instrumenter.InstrumentationCategory.httpClient;
 import static io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor.alwaysClient;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumentationCategory;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
@@ -51,6 +53,7 @@ public final class OkHttpTracingBuilder {
                 openTelemetry,
                 INSTRUMENTATION_NAME,
                 HttpSpanNameExtractor.create(httpAttributesExtractor))
+            .setInstrumentationCategory(httpClient())
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesExtractor))
             .addAttributesExtractor(httpAttributesExtractor)
             .addAttributesExtractor(netAttributesExtractor)


### PR DESCRIPTION
…on type

An alternative proposition of https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3691

This PR solves 2 problems that I found in #3691 (and introduces a few new ones... 😅 )
* ease of context key bridging - I've used `static final ContextKey` constants that should make bridging much easier. The resulting implementations is a bit more complex, but on the other hand - most users don't need to care about that.
* duplication of logic between `ServerSpan`/`ClientSpan` and `InstrumentationType` - well it's just a few first steps to remove that duplication, but I guess you can see the idea of how to do that in this PR.

I didn't even touch the configuration part, which is bound to make the whole thing a tad more complex. And I've enclosed a few questions about how we should handle `ServerSpan`/`ConsumerSpan` - maybe it's not really worth it to try to categorize them? Maybe we should just introduce a new "local root span" just for those two. That'd probably leave us with categories just for client/outgoing calls.

Oh, and I used the name `InstrumentationCategory` instead of `InstrumentationType`: my initial idea was to have instrumenters "tagged" with 0+ categories (e.g. `db` and `client`), but it turned out to be very problematic (trying to determine if a span of all given categories is already in the context would be a major pain) so I went back to exactly 1 category.

Anyway, please take a look at it; the main purpose of this PR is the discussion around this topic.
@lmolkova feel free to take any part of this PR that you find useful.