### PR TITLE
Support multiple subscriptions for Reactor spans

### DIFF
--- a/instrumentation/reactor-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/reactor-3.1/javaagent/build.gradle.kts
@@ -13,7 +13,7 @@ muzzle {
 
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
-  jvmArgs("-Dotel.instrumentation.reactor.experimental-span-attributes=true")
+  jvmArgs("-Dotel.instrumentation.reactor.experimental-span-attributes=true", "-Dotel.instrumentation.reactor.trace-multiple-subscribers=true", "-Dotel.instrumentation.reactor.emit-checkpoints=true")
 }
 
 dependencies {

--- a/instrumentation/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/HooksInstrumentation.java
+++ b/instrumentation/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/HooksInstrumentation.java
@@ -37,13 +37,11 @@ public class HooksInstrumentation implements TypeInstrumentation {
       Config config = Config.get();
       TracingOperator.newBuilder()
           .setCaptureExperimentalSpanAttributes(
-              config.getBoolean(
-                  "otel.instrumentation.reactor.experimental-span-attributes", false))
+              config.getBoolean("otel.instrumentation.reactor.experimental-span-attributes", false))
           .setEmitCheckpoints(
               config.getBoolean("otel.instrumentation.reactor.emit-checkpoints", false))
           .setTraceMultipleSubscribers(
-              config.getBoolean(
-                  "otel.instrumentation.reactor.trace-multiple-subscribers", false))
+              config.getBoolean("otel.instrumentation.reactor.trace-multiple-subscribers", false))
           .build()
           .registerOnEachOperator();
     }

--- a/instrumentation/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/HooksInstrumentation.java
+++ b/instrumentation/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/HooksInstrumentation.java
@@ -34,10 +34,16 @@ public class HooksInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void postStaticInitializer() {
+      Config config = Config.get();
       TracingOperator.newBuilder()
           .setCaptureExperimentalSpanAttributes(
-              Config.get()
-                  .getBoolean("otel.instrumentation.reactor.experimental-span-attributes", false))
+              config.getBoolean(
+                  "otel.instrumentation.reactor.experimental-span-attributes", false))
+          .setEmitCheckpoints(
+              config.getBoolean("otel.instrumentation.reactor.emit-checkpoints", false))
+          .setTraceMultipleSubscribers(
+              config.getBoolean(
+                  "otel.instrumentation.reactor.trace-multiple-subscribers", false))
           .build()
           .registerOnEachOperator();
     }

--- a/instrumentation/reactor-3.1/javaagent/src/test/groovy/ReactorWithSpanInstrumentationTest.groovy
+++ b/instrumentation/reactor-3.1/javaagent/src/test/groovy/ReactorWithSpanInstrumentationTest.groovy
@@ -9,6 +9,7 @@ import io.opentelemetry.instrumentation.reactor.TracedWithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.publisher.ReplayProcessor
 import reactor.core.publisher.UnicastProcessor
 import reactor.test.StepVerifier
 
@@ -59,6 +60,51 @@ class ReactorWithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
     assertTraces(1) {
       trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.mono"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          attributes {
+          }
+        }
+      }
+    }
+  }
+
+  def "should capture span for eventually completed Mono per subscription"() {
+    setup:
+    def source = ReplayProcessor.<String>create()
+    def mono = source.singleOrEmpty()
+    def result = new TracedWithSpan()
+      .mono(mono)
+    def verifier = StepVerifier.create(result)
+      .expectSubscription()
+
+    expect:
+    Thread.sleep(500) // sleep a bit just to make sure no span is captured
+    assertTraces(0) {}
+
+    source.onNext("Value")
+    source.onComplete()
+
+    verifier.expectNext("Value")
+      .verifyComplete()
+
+    StepVerifier.create(result)
+      .expectNext("Value")
+      .verifyComplete()
+
+    assertTraces(2) {
+      trace(0, 1) {
+        span(0) {
+          name "TracedWithSpan.mono"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+          attributes {
+          }
+        }
+      }
+      trace(1, 1) {
         span(0) {
           name "TracedWithSpan.mono"
           kind SpanKind.INTERNAL

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/InstrumentedOperator.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/InstrumentedOperator.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.reactor;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+
+final class InstrumentedOperator<REQUEST, RESPONSE, T>
+    implements BiFunction<Scannable, CoreSubscriber<? super T>, CoreSubscriber<? super T>> {
+
+  private final Instrumenter<REQUEST, RESPONSE> instrumenter;
+  private final Context context;
+  private final REQUEST request;
+  private final Class<RESPONSE> responseType;
+  private final boolean captureExperimentalSpanAttributes;
+  private final AtomicBoolean firstSubscriber = new AtomicBoolean(true);
+
+  static <REQUEST, RESPONSE, T> Mono<T> transformMono(
+      Mono<T> mono,
+      Instrumenter<REQUEST, RESPONSE> instrumenter,
+      Context context,
+      REQUEST request,
+      Class<RESPONSE> responseType,
+      boolean captureExperimentalSpanAttributes) {
+
+    return mono.transform(
+        InstrumentedOperator.<REQUEST, RESPONSE, T>tracingLift(
+            instrumenter, context, request, responseType, captureExperimentalSpanAttributes));
+  }
+
+  static <REQUEST, RESPONSE, T> Flux<T> transformFlux(
+      Flux<T> flux,
+      Instrumenter<REQUEST, RESPONSE> instrumenter,
+      Context context,
+      REQUEST request,
+      Class<RESPONSE> responseType,
+      boolean captureExperimentalSpanAttributes) {
+
+    return flux.transform(
+        InstrumentedOperator.<REQUEST, RESPONSE, T>tracingLift(
+            instrumenter, context, request, responseType, captureExperimentalSpanAttributes));
+  }
+
+  private static <REQUEST, RESPONSE, T>
+      Function<? super Publisher<T>, ? extends Publisher<T>> tracingLift(
+          Instrumenter<REQUEST, RESPONSE> instrumenter,
+          Context context,
+          REQUEST request,
+          Class<RESPONSE> responseType,
+          boolean captureExperimentalSpanAttributes) {
+
+    return Operators.lift(
+        new InstrumentedOperator<>(
+            instrumenter, context, request, responseType, captureExperimentalSpanAttributes));
+  }
+
+  private InstrumentedOperator(
+      Instrumenter<REQUEST, RESPONSE> instrumenter,
+      Context context,
+      REQUEST request,
+      Class<RESPONSE> responseType,
+      boolean captureExperimentalSpanAttributes) {
+    this.instrumenter = instrumenter;
+    this.context = context;
+    this.request = request;
+    this.responseType = responseType;
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+  }
+
+  @Override
+  public CoreSubscriber<? super T> apply(
+      Scannable scannable, CoreSubscriber<? super T> coreSubscriber) {
+
+    if (isFirstSubscriber()) {
+      return new InstrumentedSubscriber<>(
+          instrumenter,
+          context,
+          request,
+          responseType,
+          captureExperimentalSpanAttributes,
+          coreSubscriber);
+    }
+
+    Context parentContext = Context.current();
+    if (instrumenter.shouldStart(parentContext, request)) {
+      Context context = instrumenter.start(parentContext, request);
+      return new InstrumentedSubscriber<>(
+          instrumenter,
+          context,
+          request,
+          responseType,
+          captureExperimentalSpanAttributes,
+          coreSubscriber);
+    }
+    return coreSubscriber;
+  }
+
+  private boolean isFirstSubscriber() {
+    return firstSubscriber.compareAndSet(true, false);
+  }
+}

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/InstrumentedSubscriber.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/InstrumentedSubscriber.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.reactor;
+
+import static io.opentelemetry.instrumentation.api.annotation.support.async.AsyncOperationEndSupport.tryToGetResponse;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Operators;
+
+final class InstrumentedSubscriber<REQUEST, RESPONSE, T>
+    implements CoreSubscriber<T>, Subscription {
+
+  private static final AttributeKey<Boolean> CANCELED_ATTRIBUTE_KEY =
+      AttributeKey.booleanKey("reactor.canceled");
+
+  private final Instrumenter<REQUEST, RESPONSE> instrumenter;
+  private final Context context;
+  private final REQUEST request;
+  private final Class<RESPONSE> responseType;
+  private final boolean captureExperimentalSpanAttributes;
+  private final CoreSubscriber<T> actual;
+  private Subscription subscription;
+  private T value;
+
+  InstrumentedSubscriber(
+      Instrumenter<REQUEST, RESPONSE> instrumenter,
+      Context context,
+      REQUEST request,
+      Class<RESPONSE> responseType,
+      boolean captureExperimentalSpanAttributes,
+      CoreSubscriber<T> actual) {
+
+    this.instrumenter = instrumenter;
+    this.context = context;
+    this.request = request;
+    this.responseType = responseType;
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    this.actual = actual;
+  }
+
+  @Override
+  public void onSubscribe(Subscription subscription) {
+    if (Operators.validate(this.subscription, subscription)) {
+      this.subscription = subscription;
+      actual.onSubscribe(this);
+    }
+  }
+
+  @Override
+  public void request(long count) {
+    if (subscription != null) {
+      subscription.request(count);
+    }
+  }
+
+  @Override
+  public void cancel() {
+    if (subscription != null) {
+      if (captureExperimentalSpanAttributes) {
+        Span.fromContext(context).setAttribute(CANCELED_ATTRIBUTE_KEY, true);
+      }
+      instrumenter.end(context, request, null, null);
+      subscription.cancel();
+    }
+  }
+
+  @Override
+  public void onNext(T value) {
+    this.value = value;
+    actual.onNext(value);
+  }
+
+  @Override
+  public void onError(Throwable error) {
+    instrumenter.end(context, request, null, error);
+    actual.onError(error);
+  }
+
+  @Override
+  public void onComplete() {
+    instrumenter.end(context, request, tryToGetResponse(responseType, value), null);
+    actual.onComplete();
+  }
+
+  @Override
+  public reactor.util.context.Context currentContext() {
+    return actual.currentContext();
+  }
+}

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/InstrumentedSubscriber.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/InstrumentedSubscriber.java
@@ -25,7 +25,7 @@ final class InstrumentedSubscriber<REQUEST, RESPONSE, T>
   private final Context context;
   private final REQUEST request;
   private final Class<RESPONSE> responseType;
-  private final boolean captureExperimentalSpanAttributes;
+  private final ReactorAsyncOperationOptions options;
   private final CoreSubscriber<T> actual;
   private Subscription subscription;
   private T value;
@@ -35,14 +35,14 @@ final class InstrumentedSubscriber<REQUEST, RESPONSE, T>
       Context context,
       REQUEST request,
       Class<RESPONSE> responseType,
-      boolean captureExperimentalSpanAttributes,
+      ReactorAsyncOperationOptions options,
       CoreSubscriber<T> actual) {
 
     this.instrumenter = instrumenter;
     this.context = context;
     this.request = request;
     this.responseType = responseType;
-    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    this.options = options;
     this.actual = actual;
   }
 
@@ -64,7 +64,7 @@ final class InstrumentedSubscriber<REQUEST, RESPONSE, T>
   @Override
   public void cancel() {
     if (subscription != null) {
-      if (captureExperimentalSpanAttributes) {
+      if (options.captureExperimentalSpanAttributes()) {
         Span.fromContext(context).setAttribute(CANCELED_ATTRIBUTE_KEY, true);
       }
       instrumenter.end(context, request, null, null);

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/ReactorAsyncOperationEndStrategyBuilder.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/ReactorAsyncOperationEndStrategyBuilder.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.reactor;
 
 public final class ReactorAsyncOperationEndStrategyBuilder {
   private boolean captureExperimentalSpanAttributes;
+  private boolean emitCheckpoints;
+  private boolean traceMultipleSubscribers;
 
   ReactorAsyncOperationEndStrategyBuilder() {}
 
@@ -16,7 +18,21 @@ public final class ReactorAsyncOperationEndStrategyBuilder {
     return this;
   }
 
+  public ReactorAsyncOperationEndStrategyBuilder setEmitCheckpoints(boolean emitCheckpoints) {
+    this.emitCheckpoints = emitCheckpoints;
+    return this;
+  }
+
+  public ReactorAsyncOperationEndStrategyBuilder setTraceMultipleSubscribers(
+      boolean traceMultipleSubscribers) {
+    this.traceMultipleSubscribers = traceMultipleSubscribers;
+    return this;
+  }
+
   public ReactorAsyncOperationEndStrategy build() {
-    return new ReactorAsyncOperationEndStrategy(captureExperimentalSpanAttributes);
+    ReactorAsyncOperationOptions options =
+        new ReactorAsyncOperationOptions(
+            captureExperimentalSpanAttributes, emitCheckpoints, traceMultipleSubscribers);
+    return new ReactorAsyncOperationEndStrategy(options);
   }
 }

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/ReactorAsyncOperationOptions.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/ReactorAsyncOperationOptions.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.reactor;
+
+public final class ReactorAsyncOperationOptions {
+  private final boolean captureExperimentalSpanAttributes;
+  private final boolean emitCheckpoints;
+  private final boolean traceMultipleSubscribers;
+
+  ReactorAsyncOperationOptions(
+      boolean captureExperimentalSpanAttributes,
+      boolean emitCheckpoint,
+      boolean traceMultipleSubscribers) {
+    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    this.emitCheckpoints = emitCheckpoint;
+    this.traceMultipleSubscribers = traceMultipleSubscribers;
+  }
+
+  public boolean captureExperimentalSpanAttributes() {
+    return captureExperimentalSpanAttributes;
+  }
+
+  public boolean emitCheckpoints() {
+    return emitCheckpoints;
+  }
+
+  public boolean traceMultipleSubscribers() {
+    return traceMultipleSubscribers;
+  }
+}

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingOperator.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingOperator.java
@@ -46,11 +46,8 @@ public final class TracingOperator {
 
   private final ReactorAsyncOperationEndStrategy asyncOperationEndStrategy;
 
-  TracingOperator(boolean captureExperimentalSpanAttributes) {
-    this.asyncOperationEndStrategy =
-        ReactorAsyncOperationEndStrategy.newBuilder()
-            .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes)
-            .build();
+  TracingOperator(ReactorAsyncOperationEndStrategy asyncOperationEndStrategy) {
+    this.asyncOperationEndStrategy = asyncOperationEndStrategy;
   }
 
   /**

--- a/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingOperatorBuilder.java
+++ b/instrumentation/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/TracingOperatorBuilder.java
@@ -6,17 +6,30 @@
 package io.opentelemetry.instrumentation.reactor;
 
 public final class TracingOperatorBuilder {
-  private boolean captureExperimentalSpanAttributes;
+  private final ReactorAsyncOperationEndStrategyBuilder asyncOperationEndStrategyBuilder;
 
-  TracingOperatorBuilder() {}
+  TracingOperatorBuilder() {
+    asyncOperationEndStrategyBuilder = ReactorAsyncOperationEndStrategy.newBuilder();
+  }
 
   public TracingOperatorBuilder setCaptureExperimentalSpanAttributes(
       boolean captureExperimentalSpanAttributes) {
-    this.captureExperimentalSpanAttributes = captureExperimentalSpanAttributes;
+    asyncOperationEndStrategyBuilder.setCaptureExperimentalSpanAttributes(
+        captureExperimentalSpanAttributes);
+    return this;
+  }
+
+  public TracingOperatorBuilder setEmitCheckpoints(boolean emitCheckpoints) {
+    asyncOperationEndStrategyBuilder.setEmitCheckpoints(emitCheckpoints);
+    return this;
+  }
+
+  public TracingOperatorBuilder setTraceMultipleSubscribers(boolean traceMultipleSubscribers) {
+    asyncOperationEndStrategyBuilder.setTraceMultipleSubscribers(traceMultipleSubscribers);
     return this;
   }
 
   public TracingOperator build() {
-    return new TracingOperator(captureExperimentalSpanAttributes);
+    return new TracingOperator(asyncOperationEndStrategyBuilder.build());
   }
 }

--- a/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorAsyncOperationEndStrategyTest.groovy
+++ b/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorAsyncOperationEndStrategyTest.groovy
@@ -24,9 +24,14 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
 
   Span span
 
-  def underTest = ReactorAsyncOperationEndStrategy.create()
+  def underTest = ReactorAsyncOperationEndStrategy.newBuilder()
+    .setEmitCheckpoints(true)
+    .setTraceMultipleSubscribers(true)
+    .build()
 
   def underTestWithExperimentalAttributes = ReactorAsyncOperationEndStrategy.newBuilder()
+    .setEmitCheckpoints(true)
+    .setTraceMultipleSubscribers(true)
     .setCaptureExperimentalSpanAttributes(true)
     .build()
 


### PR DESCRIPTION
Explores refactoring the Reactor 3.x async strategy to use an operator instead of composing over the various `doOnSignal` methods.  Using an operator provides closer access to the Subscriber/Subscription allowing it to be decorated so that I can intercept each subscription and the signals sent to them.

What this would enable is allowing multiple spans to be started/ended for a Reactor publisher, one for the original method call plus one for each subsequent subscription if the publisher is re-used, which can happen accidentally or can be intentional if treated as a Reader/IO monad.

It looks like RxJava 2/3 also support the same approach although it is a bit more involved as there are separate operator/observer interfaces for each of the reactive types.

Discussion: https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/3753