### PR TITLE
Publish muzze plugins to Gradle Plugin Portal only when manually requested

### DIFF
--- a/.github/workflows/gradle-plugins-release.yml
+++ b/.github/workflows/gradle-plugins-release.yml
@@ -1,0 +1,31 @@
+name: Publish Gradle plugins to Gradle Plugin Portal
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11 for running checks
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+      - name: Cache Gradle Wrapper
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
+      - name: Publish plugins
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: ../gradlew build publishPlugins
+        working-directory: gradle-plugins

--- a/.github/workflows/gradle-plugins-snapshot.yml
+++ b/.github/workflows/gradle-plugins-snapshot.yml
@@ -4,13 +4,13 @@ on:
   push:
     paths:
       - 'gradle-plugins/**'
-      - '.github/workflows/gradle-plugins.yml'
+      - '.github/workflows/gradle-plugins-snapshot.yml'
     branches:
       - main
   workflow_dispatch:
 
 jobs:
-  publish:
+  snapshot:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
@@ -29,9 +29,11 @@ jobs:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
-      - name: Publish plugins
+      - name: Publish snapshot
         env:
-          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
-          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-        run: ../gradlew build publishPlugins
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+        run: ../gradlew build publishToSonatype
         working-directory: gradle-plugins

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   `maven-publish`
 
   id("com.gradle.plugin-publish")
+  id("io.github.gradle-nexus.publish-plugin")
 }
 
 group = "io.opentelemetry.instrumentation"
@@ -53,9 +54,31 @@ gradlePlugin {
   plugins {
     get("io.opentelemetry.instrumentation.muzzle-generation").apply {
       displayName = "Muzzle safety net generation"
+      description = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/contributing/muzzle.md"
     }
     get("io.opentelemetry.instrumentation.muzzle-check").apply {
       displayName = "Checks instrumented libraries against muzzle safety net"
+      description = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/contributing/muzzle.md"
     }
+  }
+}
+
+nexusPublishing {
+  packageGroup.set("io.opentelemetry")
+
+  repositories {
+    sonatype {
+      username.set(System.getenv("SONATYPE_USER"))
+      password.set(System.getenv("SONATYPE_KEY"))
+    }
+  }
+
+  connectTimeout.set(Duration.ofMinutes(5))
+  clientTimeout.set(Duration.ofMinutes(5))
+}
+
+tasks {
+  publishPlugins {
+    enabled = !version.toString().contains("SNAPSHOT")
   }
 }

--- a/gradle-plugins/settings.gradle.kts
+++ b/gradle-plugins/settings.gradle.kts
@@ -2,5 +2,6 @@ pluginManagement {
   plugins {
     id("com.gradle.plugin-publish") version "0.15.0"
     id("org.jetbrains.kotlin.jvm") version "1.5.10"
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
   }
 }


### PR DESCRIPTION
Restored publishing to Sonatype OSS repository on every change