### PR TITLE
Use freshly released muzzle plugins

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,8 +29,8 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("io.opentelemetry.instrumentation.muzzle-generation:io.opentelemetry.instrumentation.muzzle-generation.gradle.plugin:0.2.0-SNAPSHOT")
-  implementation("io.opentelemetry.instrumentation.muzzle-check:io.opentelemetry.instrumentation.muzzle-check.gradle.plugin:0.2.0-SNAPSHOT")
+  implementation("io.opentelemetry.instrumentation.muzzle-generation:io.opentelemetry.instrumentation.muzzle-generation.gradle.plugin:0.3.0")
+  implementation("io.opentelemetry.instrumentation.muzzle-check:io.opentelemetry.instrumentation.muzzle-check.gradle.plugin:0.3.0")
 
   implementation("org.eclipse.aether:aether-connector-basic:1.1.0")
   implementation("org.eclipse.aether:aether-transport-http:1.1.0")

--- a/examples/extension/build.gradle
+++ b/examples/extension/build.gradle
@@ -12,8 +12,8 @@ plugins {
    */
   id "com.github.johnrengelman.shadow" version "6.1.0"
 
-  id "io.opentelemetry.instrumentation.muzzle-generation" version "0.2.0-SNAPSHOT"
-  id "io.opentelemetry.instrumentation.muzzle-check" version "0.2.0-SNAPSHOT"
+  id "io.opentelemetry.instrumentation.muzzle-generation" version "0.3.0"
+  id "io.opentelemetry.instrumentation.muzzle-check" version "0.3.0"
 }
 
 group 'io.opentelemetry.example'
@@ -93,6 +93,10 @@ dependencies {
 
   //Otel Java instrumentation that we use and extend during integration tests
   otel("io.opentelemetry.javaagent:opentelemetry-javaagent:${versions.opentelemetryJavaagent}:all")
+
+  //TODO remove when start using io.opentelemetry.instrumentation.javaagent-instrumentation plugin
+  add("muzzleTooling", "io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:${versions.opentelemetryJavaagentAlpha}")
+  add("muzzleTooling", "ch.qos.logback:logback-classic:1.2.3")
 }
 
 //Extracts manifest from OpenTelemetry Java agent to reuse it later

--- a/examples/extension/settings.gradle
+++ b/examples/extension/settings.gradle
@@ -1,7 +1,6 @@
 pluginManagement {
   repositories {
     gradlePluginPortal()
-    mavenLocal()
     maven {
       url = uri("https://oss.sonatype.org/content/repositories/snapshots")
     }


### PR DESCRIPTION
As they still depend on the snapshot versions of our modules, plugin management still has to depend on oss sonatype repo, which is unfortunate.

In addition, it became obvious that we have to release `io.opentelemetry.instrumentation.javaagent-instrumentation` plugin ASAP.