### PR TITLE
Simplify shouldStart() check for SERVER & CONSUMER spans

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -103,8 +103,10 @@ public class Instrumenter<REQUEST, RESPONSE> {
     SpanKind spanKind = spanKindExtractor.extract(request);
     switch (spanKind) {
       case SERVER:
+        suppressed = ServerSpan.exists(parentContext);
+        break;
       case CONSUMER:
-        suppressed = ServerSpan.exists(parentContext) || ConsumerSpan.exists(parentContext);
+        suppressed = ConsumerSpan.exists(parentContext);
         break;
       case CLIENT:
         suppressed = ClientSpan.exists(parentContext);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/tracer/BaseTracer.java
@@ -107,8 +107,10 @@ public abstract class BaseTracer {
         suppressed = ClientSpan.exists(context);
         break;
       case SERVER:
+        suppressed = ServerSpan.exists(context);
+        break;
       case CONSUMER:
-        suppressed = ServerSpan.exists(context) || ConsumerSpan.exists(context);
+        suppressed = ConsumerSpan.exists(context);
         break;
       default:
         break;

--- a/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/BaseTracerTest.groovy
+++ b/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/BaseTracerTest.groovy
@@ -41,22 +41,27 @@ class BaseTracerTest extends Specification {
     result == expected
 
     where:
-    kind              | context                                   | expected
-    SpanKind.CLIENT   | root                                      | true
-    SpanKind.SERVER   | root                                      | true
-    SpanKind.INTERNAL | root                                      | true
-    SpanKind.PRODUCER | root                                      | true
-    SpanKind.CONSUMER | root                                      | true
-    SpanKind.CLIENT   | tracer.withClientSpan(root, existingSpan) | false
-    SpanKind.SERVER   | tracer.withClientSpan(root, existingSpan) | true
-    SpanKind.INTERNAL | tracer.withClientSpan(root, existingSpan) | true
-    SpanKind.CONSUMER | tracer.withClientSpan(root, existingSpan) | true
-    SpanKind.PRODUCER | tracer.withClientSpan(root, existingSpan) | true
-    SpanKind.SERVER   | tracer.withServerSpan(root, existingSpan) | false
-    SpanKind.INTERNAL | tracer.withServerSpan(root, existingSpan) | true
-    SpanKind.CONSUMER | tracer.withServerSpan(root, existingSpan) | false
-    SpanKind.PRODUCER | tracer.withServerSpan(root, existingSpan) | true
-    SpanKind.CLIENT   | tracer.withServerSpan(root, existingSpan) | true
+    kind              | context                                     | expected
+    SpanKind.CLIENT   | root                                        | true
+    SpanKind.SERVER   | root                                        | true
+    SpanKind.INTERNAL | root                                        | true
+    SpanKind.PRODUCER | root                                        | true
+    SpanKind.CONSUMER | root                                        | true
+    SpanKind.CLIENT   | tracer.withClientSpan(root, existingSpan)   | false
+    SpanKind.SERVER   | tracer.withClientSpan(root, existingSpan)   | true
+    SpanKind.INTERNAL | tracer.withClientSpan(root, existingSpan)   | true
+    SpanKind.CONSUMER | tracer.withClientSpan(root, existingSpan)   | true
+    SpanKind.PRODUCER | tracer.withClientSpan(root, existingSpan)   | true
+    SpanKind.SERVER   | tracer.withServerSpan(root, existingSpan)   | false
+    SpanKind.INTERNAL | tracer.withServerSpan(root, existingSpan)   | true
+    SpanKind.CONSUMER | tracer.withServerSpan(root, existingSpan)   | true
+    SpanKind.PRODUCER | tracer.withServerSpan(root, existingSpan)   | true
+    SpanKind.CLIENT   | tracer.withServerSpan(root, existingSpan)   | true
+    SpanKind.SERVER   | tracer.withConsumerSpan(root, existingSpan) | true
+    SpanKind.INTERNAL | tracer.withConsumerSpan(root, existingSpan) | true
+    SpanKind.CONSUMER | tracer.withConsumerSpan(root, existingSpan) | false
+    SpanKind.PRODUCER | tracer.withConsumerSpan(root, existingSpan) | true
+    SpanKind.CLIENT   | tracer.withConsumerSpan(root, existingSpan) | true
   }
 
 

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/AbstractSpringCloudStreamRabbitTest.groovy
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/AbstractSpringCloudStreamRabbitTest.groovy
@@ -25,23 +25,18 @@ abstract class AbstractSpringCloudStreamRabbitTest extends InstrumentationSpecif
 
     then:
     assertTraces(1) {
-      trace(0, 4) {
+      trace(0, 3) {
         span(0) {
           name "producer"
         }
         span(1) {
-          name "testProducer.output process"
+          name "testConsumer.input process"
           childOf span(0)
           kind CONSUMER
         }
         span(2) {
-          name "testConsumer.input process"
-          childOf span(1)
-          kind CONSUMER
-        }
-        span(3) {
           name "consumer"
-          childOf span(2)
+          childOf span(1)
         }
       }
     }

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/AbstractSpringIntegrationTracingTest.groovy
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/AbstractSpringIntegrationTracingTest.groovy
@@ -57,30 +57,24 @@ abstract class AbstractSpringIntegrationTracingTest extends InstrumentationSpeci
     channel.subscribe(messageHandler)
 
     when:
-    runWithSpan("parent") {
       channel.send(MessageBuilder.withPayload("test")
         .build())
-    }
 
     then:
     def capturedMessage = messageHandler.join()
 
     assertTraces(1) {
-      trace(0, 3) {
+      trace(0, 2) {
         span(0) {
-          name "parent"
-        }
-        span(1) {
           name interceptorSpanName
-          childOf span(0)
           kind CONSUMER
         }
-        span(2) {
+        span(1) {
           name "handler"
-          childOf span(1)
+          childOf span(0)
         }
 
-        def interceptorSpan = span(1)
+        def interceptorSpan = span(0)
         verifyCorrectSpanWasPropagated(capturedMessage, interceptorSpan)
       }
     }
@@ -94,6 +88,38 @@ abstract class AbstractSpringIntegrationTracingTest extends InstrumentationSpeci
     "executorChannel" | "executorChannel process"
   }
 
+  def "should not create a span when there is already a span in the context"() {
+    given:
+    def channel = applicationContext.getBean("directChannel", SubscribableChannel)
+
+    def messageHandler = new CapturingMessageHandler()
+    channel.subscribe(messageHandler)
+
+    when:
+    runWithSpan("parent") {
+      channel.send(MessageBuilder.withPayload("test")
+        .build())
+    }
+
+    then:
+    messageHandler.join()
+
+    assertTraces(1) {
+      trace(0, 2) {
+        span(0) {
+          name "parent"
+        }
+        span(1) {
+          name "handler"
+          childOf span(0)
+        }
+      }
+    }
+
+    cleanup:
+    channel.unsubscribe(messageHandler)
+  }
+
   def "should handle multiple message channels in a chain"() {
     given:
     def channel1 = applicationContext.getBean("linkedChannel1", SubscribableChannel)
@@ -103,30 +129,24 @@ abstract class AbstractSpringIntegrationTracingTest extends InstrumentationSpeci
     channel2.subscribe(messageHandler)
 
     when:
-    runWithSpan("parent") {
-      channel1.send(MessageBuilder.withPayload("test")
-        .build())
-    }
+    channel1.send(MessageBuilder.withPayload("test")
+      .build())
 
     then:
     def capturedMessage = messageHandler.join()
 
     assertTraces(1) {
-      trace(0, 3) {
+      trace(0, 2) {
         span(0) {
-          name "parent"
-        }
-        span(1) {
           name "application.linkedChannel1 process"
-          childOf span(0)
           kind CONSUMER
         }
-        span(2) {
+        span(1) {
           name "handler"
-          childOf span(1)
+          childOf span(0)
         }
 
-        def lastChannelSpan = span(1)
+        def lastChannelSpan = span(0)
         verifyCorrectSpanWasPropagated(capturedMessage, lastChannelSpan)
       }
     }


### PR DESCRIPTION
After our last discussion on Tuesday I wanted to check whether this `ServerSpan.exists(parentContext) || ConsumerSpan.exists(parentContext)` check is really needed after all. It turns out the only instrumentation that made use of it was the spring-integration one, and there's an alternate solution for this one: do not create a span if there's ANY span in the current context - please see the comment in the `TracingChannelInterceptor` class for a detailed explanation on that.

If SERVER & CONSUMER spans don't get any special treatment then we'll be able to handle them with `InstrumentationType` proposed in another PR.