### PR TITLE
Remove latest dep version restriction from reactor instrumentation

### DIFF
--- a/instrumentation/reactor-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/reactor-3.1/javaagent/build.gradle.kts
@@ -26,8 +26,6 @@ dependencies {
   testImplementation(project(":instrumentation:reactor-3.1:testing"))
   testImplementation("io.opentelemetry:opentelemetry-extension-annotations")
 
-  latestDepTestLibrary("io.projectreactor:reactor-core:3.+")
-  latestDepTestLibrary("io.projectreactor:reactor-test:3.+")
   // Looks like later versions on reactor need this dependency for some reason even though it is marked as optional.
   latestDepTestLibrary("io.micrometer:micrometer-core:1.+")
 }

--- a/instrumentation/reactor-3.1/library/build.gradle.kts
+++ b/instrumentation/reactor-3.1/library/build.gradle.kts
@@ -8,8 +8,7 @@ dependencies {
   testLibrary("io.projectreactor:reactor-test:3.1.0.RELEASE")
 
   testImplementation(project(":instrumentation:reactor-3.1:testing"))
-  latestDepTestLibrary("io.projectreactor:reactor-core:3.+")
-  latestDepTestLibrary("io.projectreactor:reactor-test:3.+")
+
   // Looks like later versions on reactor need this dependency for some reason even though it is marked as optional.
   latestDepTestLibrary("io.micrometer:micrometer-core:1.+")
 }


### PR DESCRIPTION
As the latest version is 3.x there is no need to explicitly limit it.