### PR TITLE
Pin latest tested vaadin version to 19

### DIFF
--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -64,5 +64,9 @@ dependencies {
   testInstrumentation(project(":instrumentation:tomcat:tomcat-7.0:javaagent"))
 
   add("vaadin14LatestTestImplementation", "com.vaadin:vaadin-spring-boot-starter:14.+")
-  add("latestDepTestImplementation", "com.vaadin:vaadin-spring-boot-starter:+")
+  // Pin latest tested vaadin version to 19
+  // https://github.com/vaadin/flow/issues/11524
+  // Update to workbox-build node module broke building javascript, remove this restriction after
+  // new version of vaadin is released.
+  add("latestDepTestImplementation", "com.vaadin:vaadin-spring-boot-starter:19.+")
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3782
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3781 (this one has one more failure, but it seems like a one time occurrence)