### PR TITLE
Fix tomcat 9.0.52

### DIFF
--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
@@ -87,6 +87,7 @@ public abstract class AbstractExecutorInstrumentation implements TypeInstrumenta
         "java.util.concurrent.ForkJoinPool",
         "java.util.concurrent.ScheduledThreadPoolExecutor",
         "java.util.concurrent.ThreadPoolExecutor",
+        "org.apache.tomcat.util.threads.ThreadPoolExecutor",
         "org.eclipse.jetty.util.thread.QueuedThreadPool", // dispatch() is covered in the jetty
         // module
         "org.eclipse.jetty.util.thread.ReservedThreadExecutor",

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/build.gradle.kts
@@ -13,15 +13,15 @@ muzzle {
 }
 
 dependencies {
-  library("org.apache.tomcat.embed:tomcat-embed-core:7.0.4")
+  compileOnly("org.apache.tomcat.embed:tomcat-embed-core:7.0.4")
   implementation(project(":instrumentation:tomcat:tomcat-common:javaagent"))
   implementation(project(":instrumentation:servlet:servlet-3.0:javaagent"))
   testInstrumentation(project(":instrumentation:servlet:servlet-javax-common:javaagent"))
   // Make sure nothing breaks due to both 7.0 and 10.0 modules being present together
   testInstrumentation(project(":instrumentation:tomcat:tomcat-10.0:javaagent"))
 
-  // Tests need at least version 9 to have necessary classes to configure the embedded tomcat...
-  // ... but not newer that version 10, because its servlet 5.
-  testLibrary("org.apache.tomcat.embed:tomcat-embed-core:[9.+, 10)")
+  testLibrary("org.apache.tomcat.embed:tomcat-embed-core:8.0.41")
+  testLibrary("org.apache.tomcat.embed:tomcat-embed-jasper:8.0.41")
   latestDepTestLibrary("org.apache.tomcat.embed:tomcat-embed-core:[9.+, 10)")
+  latestDepTestLibrary("org.apache.tomcat.embed:tomcat-embed-jasper:[9.+, 10)")
 }


### PR DESCRIPTION
In tomcat 9.0.52 async servlet tests don't pass without instrumenting `org.apache.tomcat.util.threads.ThreadPoolExecutor`