### PR TITLE
Fix printMuzzleReferences gradle task

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.opentelemetry.instrumentation"
-version = "0.3.0"
+version = "0.4.0"
 
 repositories {
   mavenCentral()

--- a/gradle-plugins/src/main/java/io/opentelemetry/javaagent/muzzle/matcher/MuzzleGradlePluginUtil.java
+++ b/gradle-plugins/src/main/java/io/opentelemetry/javaagent/muzzle/matcher/MuzzleGradlePluginUtil.java
@@ -108,45 +108,13 @@ public final class MuzzleGradlePluginUtil {
    *
    * <p>Called by the {@code printMuzzleReferences} gradle task.
    */
-  public static void printMuzzleReferences(ClassLoader instrumentationClassLoader) {
-    for (InstrumentationModule instrumentationModule :
-        ServiceLoader.load(InstrumentationModule.class, instrumentationClassLoader)) {
-      try {
-        System.out.println(instrumentationModule.getClass().getName());
-        for (ClassRef ref : instrumentationModule.getMuzzleReferences().values()) {
-          System.out.print(prettyPrint(ref));
-        }
-      } catch (RuntimeException e) {
-        String message =
-            "Unexpected exception printing references for "
-                + instrumentationModule.getClass().getName();
-        System.out.println(message);
-        throw new IllegalStateException(message, e);
-      }
-    }
-  }
-
-  private static String prettyPrint(ClassRef ref) {
-    StringBuilder builder = new StringBuilder(INDENT).append(ref).append(lineSeparator());
-    if (!ref.getSources().isEmpty()) {
-      builder.append(INDENT).append(INDENT).append("Sources:").append(lineSeparator());
-      for (Source source : ref.getSources()) {
-        builder
-            .append(INDENT)
-            .append(INDENT)
-            .append(INDENT)
-            .append("at: ")
-            .append(source)
-            .append(lineSeparator());
-      }
-    }
-    for (FieldRef field : ref.getFields()) {
-      builder.append(INDENT).append(INDENT).append(field).append(lineSeparator());
-    }
-    for (MethodRef method : ref.getMethods()) {
-      builder.append(INDENT).append(INDENT).append(method).append(lineSeparator());
-    }
-    return builder.toString();
+  public static void printMuzzleReferences(ClassLoader instrumentationClassLoader)
+      throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException,
+          IllegalAccessException {
+    Class<?> matcherClass =
+        instrumentationClassLoader.loadClass(
+            "io.opentelemetry.javaagent.tooling.muzzle.ReferencesPrinter");
+    matcherClass.getMethod("printMuzzleReferences").invoke(null);
   }
 
   private MuzzleGradlePluginUtil() {}

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferencesPrinter.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferencesPrinter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.muzzle;
+
+import static java.lang.System.lineSeparator;
+
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.muzzle.ClassRef;
+import io.opentelemetry.javaagent.extension.muzzle.FieldRef;
+import io.opentelemetry.javaagent.extension.muzzle.MethodRef;
+import io.opentelemetry.javaagent.extension.muzzle.Source;
+import java.util.ServiceLoader;
+
+public final class ReferencesPrinter {
+
+  private static final String INDENT = "  ";
+
+  /**
+   * For all {@link InstrumentationModule}s found in the current thread's context classloader this
+   * method prints references returned by the {@link InstrumentationModule#getMuzzleReferences()}
+   * method to the standard output.
+   */
+  public static void printMuzzleReferences() {
+    for (InstrumentationModule instrumentationModule :
+        ServiceLoader.load(InstrumentationModule.class)) {
+      try {
+        System.out.println(instrumentationModule.getClass().getName());
+        for (ClassRef ref : instrumentationModule.getMuzzleReferences().values()) {
+          System.out.print(prettyPrint(ref));
+        }
+      } catch (RuntimeException e) {
+        String message =
+            "Unexpected exception printing references for "
+                + instrumentationModule.getClass().getName();
+        System.out.println(message);
+        throw new IllegalStateException(message, e);
+      }
+    }
+  }
+
+  private static String prettyPrint(ClassRef ref) {
+    StringBuilder builder = new StringBuilder(INDENT).append(ref).append(lineSeparator());
+    if (!ref.getSources().isEmpty()) {
+      builder.append(INDENT).append(INDENT).append("Sources:").append(lineSeparator());
+      for (Source source : ref.getSources()) {
+        builder
+            .append(INDENT)
+            .append(INDENT)
+            .append(INDENT)
+            .append("at: ")
+            .append(source)
+            .append(lineSeparator());
+      }
+    }
+    for (FieldRef field : ref.getFields()) {
+      builder.append(INDENT).append(INDENT).append(field).append(lineSeparator());
+    }
+    for (MethodRef method : ref.getMethods()) {
+      builder.append(INDENT).append(INDENT).append(method).append(lineSeparator());
+    }
+    return builder.toString();
+  }
+
+  private ReferencesPrinter() {}
+}

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferencesPrinter.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferencesPrinter.java
@@ -14,6 +14,7 @@ import io.opentelemetry.javaagent.extension.muzzle.MethodRef;
 import io.opentelemetry.javaagent.extension.muzzle.Source;
 import java.util.ServiceLoader;
 
+@SuppressWarnings("SystemOut")
 public final class ReferencesPrinter {
 
   private static final String INDENT = "  ";


### PR DESCRIPTION
Currently when you try to run the `printMuzzleReferences` task it fails with the following exception:

```
* What went wrong:
Execution failed for task ':printMuzzleReferences'.
> io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule: com.example.javaagent.instrumentation.DemoServlet3InstrumentationModule not a subtype

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':printMuzzleReferences'.
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:188)
// ...
Caused by: java.util.ServiceConfigurationError: io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule: com.example.javaagent.instrumentation.DemoServlet3InstrumentationModule not a subtype
        at io.opentelemetry.javaagent.muzzle.matcher.MuzzleGradlePluginUtil.printMuzzleReferences(MuzzleGradlePluginUtil.java:113)
```

I suppose that's because we're trying to load `InstrumentationModule` with the gradle classloader, not the instrumentation classloader.