### PR TITLE
Skip bad spring-rabbit version

### DIFF
--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
@@ -8,7 +8,7 @@ muzzle {
     module.set("spring-rabbit")
     versions.set("(,)")
     // Problematic release depending on snapshots
-    skip("2.1.1.RELEASE")
+    skip("1.6.4.RELEASE", "2.1.1.RELEASE")
   }
 }
 


### PR DESCRIPTION
https://search.maven.org/artifact/org.springframework.amqp/spring-rabbit/1.6.4.RELEASE/jar has snapshot dependencies