### PR TITLE
Check scope for null before closing it

### DIFF
--- a/instrumentation/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedisConnectionInstrumentation.java
+++ b/instrumentation/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedisConnectionInstrumentation.java
@@ -59,6 +59,10 @@ public class RedisConnectionInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelRedissonRequest") RedissonRequest request,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
+      if (scope == null) {
+        return;
+      }
+
       scope.close();
       instrumenter().end(context, request, null, throwable);
     }

--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/AnnotatedMethodInstrumentation.java
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/AnnotatedMethodInstrumentation.java
@@ -81,7 +81,7 @@ public class AnnotatedMethodInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelRequest") SpringWsRequest request,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      if (callDepth.decrementAndGet() > 0) {
+      if (callDepth.decrementAndGet() > 0 || scope == null) {
         return;
       }
 


### PR DESCRIPTION
Conversion to instrumenter api introduced `if (!instrumenter().shouldStart(...` check which made null scope possible where it previously wasn't.