### PR TITLE
Add junit test timeout

### DIFF
--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/InstrumentationSpecification.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/InstrumentationSpecification.groovy
@@ -16,7 +16,11 @@ import io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil
 import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier
 import io.opentelemetry.sdk.metrics.data.MetricData
 import io.opentelemetry.sdk.trace.data.SpanData
+import java.util.concurrent.TimeUnit
+import org.junit.Rule
+import org.junit.rules.Timeout
 import spock.lang.Specification
+
 /**
  * Base class for test specifications that are shared between instrumentation libraries and agent.
  * The methods in this class are implemented by {@link AgentTestTrait} and
@@ -24,6 +28,9 @@ import spock.lang.Specification
  */
 abstract class InstrumentationSpecification extends Specification {
   abstract InstrumentationTestRunner testRunner()
+
+  @Rule
+  public Timeout testTimeout = new Timeout(10, TimeUnit.MINUTES)
 
   def setupSpec() {
     testRunner().beforeTestClass()


### PR DESCRIPTION
Currently we rely on gradle stopping hung tests after 15 minutest. As can be seen from https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3845 and https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3844 this doesn't yield any information about the cause of hang. Adding junit timeout also in the hope that this will reveal something useful when test times out.
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3845
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3844
Marking these as resolved as I don't see anything that could be done based on the info available.