### PR TITLE
Use valid Java identifiers for message keys

### DIFF
--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/TracingChannelInterceptor.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/TracingChannelInterceptor.java
@@ -22,8 +22,11 @@ import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 import org.springframework.util.LinkedMultiValueMap;
 
 final class TracingChannelInterceptor implements ExecutorChannelInterceptor {
-  private static final String CONTEXT_AND_SCOPE_KEY = ContextAndScope.class.getName();
-  private static final String SCOPE_KEY = TracingChannelInterceptor.class.getName() + ".scope";
+  // some messaging products (e.g. IBM MQ) require message keys to be valid Java identifiers
+  private static final String CONTEXT_AND_SCOPE_KEY =
+      ContextAndScope.class.getName().replace('.', '_');
+  private static final String SCOPE_KEY =
+      TracingChannelInterceptor.class.getName().replace('.', '_') + "_scope";
 
   private final ContextPropagators propagators;
   private final Instrumenter<MessageWithChannel, Void> instrumenter;


### PR DESCRIPTION
This is causing error on IBM MQ:

```
Error Setting JMS Property io.opentelemetry.javaagent.shaded.instrumentation.spring.integration.ContextAndScope with value ContextAndScope{context=null, scope=INSTANCE}
com.ibm.msg.client.jms.DetailedMessageFormatException: JMSCC0049: The property name 'io.opentelemetry.javaagent.shaded.instrumentation.spring.integration.ContextAndScope' is not a valid Java(tm) identifier.
```

Probably could rename to "valid" header name, but seems better not to use message header for local propagation.