### PR TITLE
Don't clobber user decorators in Armeria client instrumentation

### DIFF
--- a/instrumentation/armeria-1.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaWebClientBuilderInstrumentation.java
+++ b/instrumentation/armeria-1.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/armeria/v1_3/ArmeriaWebClientBuilderInstrumentation.java
@@ -8,12 +8,10 @@ package io.opentelemetry.javaagent.instrumentation.armeria.v1_3;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.linecorp.armeria.client.WebClientBuilder;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import java.util.function.Function;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -28,34 +26,8 @@ public class ArmeriaWebClientBuilderInstrumentation implements TypeInstrumentati
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        isMethod().and(isPublic()).and(named("decorator").and(takesArgument(0, Function.class))),
-        ArmeriaWebClientBuilderInstrumentation.class.getName() + "$SuppressDecoratorAdvice");
-    transformer.applyAdviceToMethod(
         isMethod().and(isPublic()).and(named("build")),
         ArmeriaWebClientBuilderInstrumentation.class.getName() + "$BuildAdvice");
-  }
-
-  // Intercept calls from app to register decorator and suppress them to avoid registering
-  // multiple decorators, one from user app and one from our auto instrumentation. Otherwise, we
-  // will end up with double telemetry.
-  // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/903
-  @SuppressWarnings("unused")
-  public static class SuppressDecoratorAdvice {
-
-    @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class)
-    public static boolean suppressDecorator(@Advice.Argument(0) Function<?, ?> decorator) {
-      return decorator != ArmeriaSingletons.CLIENT_DECORATOR;
-    }
-
-    @Advice.OnMethodExit
-    public static void handleSuppression(
-        @Advice.This WebClientBuilder builder,
-        @Advice.Enter boolean suppressed,
-        @Advice.Return(readOnly = false) WebClientBuilder returned) {
-      if (suppressed) {
-        returned = builder;
-      }
-    }
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpClientTest.java
+++ b/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpClientTest.java
@@ -41,10 +41,11 @@ public abstract class AbstractArmeriaHttpClientTest extends AbstractHttpClientTe
     client =
         configureClient(
                 WebClient.builder()
-                    .decorator((delegate, ctx, req) -> {
-                      decoratorCalled.set(true);
-                      return delegate.execute(ctx, req);
-                    })
+                    .decorator(
+                        (delegate, ctx, req) -> {
+                          decoratorCalled.set(true);
+                          return delegate.execute(ctx, req);
+                        })
                     .factory(ClientFactory.builder().connectTimeout(connectTimeout()).build()))
             .build();
   }


### PR DESCRIPTION
I remember this being pointed out a while ago but apparently forgot to fix it. This removes the dedupe logic that is currently deduping away all decorators, in favor of not doing anything for now same as all our other instrumentation.