### PR TITLE
AsyncHttpClient: extract net attributes from InetSocketAddress

### DIFF
--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesExtractor.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesExtractor.java
@@ -5,14 +5,15 @@
 
 package io.opentelemetry.javaagent.instrumentation.asynchttpclient.v2_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.net.InetSocketAddress;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.Response;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class AsyncHttpClientNetAttributesExtractor
-    extends NetAttributesExtractor<Request, Response> {
+    extends InetSocketAddressNetAttributesExtractor<Request, Response> {
 
   @Override
   public String transport(Request request) {
@@ -20,18 +21,10 @@ final class AsyncHttpClientNetAttributesExtractor
   }
 
   @Override
-  public String peerName(Request request, @Nullable Response response) {
-    return request.getUri().getHost();
-  }
-
-  @Override
-  public Integer peerPort(Request request, @Nullable Response response) {
-    return request.getUri().getPort();
-  }
-
-  @Override
-  @Nullable
-  public String peerIp(Request request, @Nullable Response response) {
+  public @Nullable InetSocketAddress getAddress(Request request, @Nullable Response response) {
+    if (response != null && response.getRemoteAddress() instanceof InetSocketAddress) {
+      return (InetSocketAddress) response.getRemoteAddress();
+    }
     return null;
   }
 }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/ca8a119e01a2e56c9094d23577838b6e9fccda00/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java#L888 suggests that filling net attributes from request url isn't ideal.