### PR TITLE
[overhead] add in some additional verbosity for debugging.

### DIFF
--- a/benchmark-overhead/build.gradle.kts
+++ b/benchmark-overhead/build.gradle.kts
@@ -20,5 +20,9 @@ dependencies {
 tasks {
   test {
     useJUnitPlatform()
+    testLogging {
+      outputs.upToDateWhen {false}
+      showStandardStreams = true
+    }
   }
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/OverheadTests.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/OverheadTests.java
@@ -66,8 +66,13 @@ public class OverheadTests {
         fail("Unhandled exception in " + config.getName(), e);
       }
     });
-    List<AppPerfResults> results = new ResultsCollector(namingConventions.local).collect(config);
-    new MainResultsPersister(config).write(results);
+    try {
+      List<AppPerfResults> results = new ResultsCollector(namingConventions.local).collect(config);
+      new MainResultsPersister(config).write(results);
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw e;
+    }
   }
 
   void runAppOnce(TestConfig config, Agent agent) throws Exception {


### PR DESCRIPTION
The [build failed](https://github.com/open-telemetry/opentelemetry-java-instrumentation/runs/3378798745?check_suite_focus=true) with a file not found, but it's unclear which file was missing. Probably one of the result output files (jfr or k6 or startup time file) but without a filename it is hard to continue troubleshooting.