### PR TITLE
Fix maven publishing of agent-for-testing module

### DIFF
--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -9,10 +9,8 @@ publishing {
       plugins.withId("java-platform") {
         from(components["javaPlatform"])
       }
-      if(project.name != "agent-for-testing") {
-        plugins.withId("java-library") {
-          from(components["java"])
-        }
+      plugins.withId("java-library") {
+        from(components["java"])
       }
 
       versionMapping {


### PR DESCRIPTION
Publishing 1.5.0 to maven central failed because `agent-for-testing` was missing javadoc and sources jars.

This fix removes a condition that was put into place to also fix maven publishing of agent-for-testing (#3675), but I'm hoping that fix was invalidated by the slightly more recent #3682, and hopefully this is all good now.