### PR TITLE
Limit rocketmq latest dep test version

### DIFF
--- a/instrumentation/rocketmq-client-4.8/javaagent/build.gradle.kts
+++ b/instrumentation/rocketmq-client-4.8/javaagent/build.gradle.kts
@@ -16,6 +16,10 @@ dependencies {
   implementation(project(":instrumentation:rocketmq-client-4.8:library"))
   testImplementation(project(":instrumentation:rocketmq-client-4.8:testing"))
   testLibrary("org.apache.rocketmq:rocketmq-test:4.8.0")
+
+  // 4.9.1 seems to have a bug which makes on of our tests fail
+  latestDepTestLibrary("org.apache.rocketmq:rocketmq-client:4.9.0")
+  latestDepTestLibrary("org.apache.rocketmq:rocketmq-test:4.9.0")
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
Apparently rocketmq 4.9.1 has a bug that causes some of the message properties to be merged when sending a batch of messages which makes `test rocketmq produce and batch consume` fail. @addname would you be willing to report this to rocketmq developers?

Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3905
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3902