### PR TITLE
Limit rocketmq version for lib instrumentation too

### DIFF
--- a/instrumentation/rocketmq-client-4.8/library/build.gradle.kts
+++ b/instrumentation/rocketmq-client-4.8/library/build.gradle.kts
@@ -10,4 +10,8 @@ dependencies {
 
   testLibrary("org.apache.rocketmq:rocketmq-test:4.8.0")
   testImplementation(project(":instrumentation:rocketmq-client-4.8:testing"))
+
+  // 4.9.1 seems to have a bug which makes on of our tests fail
+  latestDepTestLibrary("org.apache.rocketmq:rocketmq-client:4.9.0")
+  latestDepTestLibrary("org.apache.rocketmq:rocketmq-test:4.9.0")
 }


### PR DESCRIPTION
Same as #3909 but for library instrumentation
Closes #3914