### PR TITLE
Disable strict context check for elasticsearch 6 tests

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
@@ -43,4 +43,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.elasticsearch.experimental-span-attributes=true")
+  jvmArgs("-Dio.opentelemetry.javaagent.shaded.io.opentelemetry.context.enableStrictContext=false")
 }

--- a/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
@@ -28,3 +28,7 @@ tasks {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }
+
+tasks.withType<Test>().configureEach {
+  jvmArgs("-Dio.opentelemetry.javaagent.shaded.io.opentelemetry.context.enableStrictContext=false")
+}


### PR DESCRIPTION
Seen in https://scans.gradle.com/s/6vj5drk2cdyce/console-log?task=:instrumentation:elasticsearch:elasticsearch-transport-6.0:javaagent:test

Added to list in #3916