### PR TITLE
Cherry-pick for 1.5.1 patch release: Fix javaagent publishing

### DIFF
--- a/benchmark-e2e/build.gradle.kts
+++ b/benchmark-e2e/build.gradle.kts
@@ -14,11 +14,11 @@ dependencies {
 
 tasks {
   test {
-    dependsOn(":javaagent:shadowJar")
+    dependsOn(":javaagent:fullJavaagentJar")
     maxParallelForks = 2
 
     doFirst {
-      jvmArgs("-Dio.opentelemetry.smoketest.agent.shadowJar.path=${project(":javaagent").tasks.getByName<ShadowJar>("shadowJar").archivePath}")
+      jvmArgs("-Dio.opentelemetry.smoketest.agent.shadowJar.path=${project(":javaagent").tasks.getByName<ShadowJar>("fullJavaagentJar").archivePath}")
     }
   }
 }

--- a/benchmark-overhead-jmh/build.gradle.kts
+++ b/benchmark-overhead-jmh/build.gradle.kts
@@ -39,7 +39,7 @@ tasks {
   val jmhStartFlightRecording = gradle.startParameter.projectProperties.get("jmh.startFlightRecording")
 
   named<JMHTask>("jmh") {
-    val shadowTask = project(":javaagent").tasks.named<ShadowJar>("shadowJar").get()
+    val shadowTask = project(":javaagent").tasks.named<ShadowJar>("fullJavaagentJar").get()
     inputs.files(layout.files(shadowTask))
 
     // note: without an exporter, toSpanData() won't even be called

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -54,7 +54,7 @@ tasks {
   }
 
   named("jmh") {
-    dependsOn(":javaagent:shadowJar")
+    dependsOn(":javaagent:fullJavaagentJar")
   }
 }
 

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -100,11 +100,6 @@ tasks {
     }
   }
 
-  // lightShadow is the default classifier we publish so disable the default jar.
-  jar {
-    enabled = false
-  }
-
   val relocateJavaagentLibs by registering(ShadowJar::class) {
     configurations = listOf(javaagentLibs)
 
@@ -128,7 +123,7 @@ tasks {
   }
 
   //Includes instrumentations, but not exporters
-  val lightShadow by registering(ShadowJar::class) {
+  val shadowJar by existing(ShadowJar::class) {
     configurations = listOf(bootstrapLibs)
 
     dependsOn(relocateJavaagentLibs)
@@ -137,6 +132,7 @@ tasks {
     archiveClassifier.set("")
 
     manifest {
+      attributes(jar.get().manifest.attributes)
       attributes(
         "Main-Class" to "io.opentelemetry.javaagent.OpenTelemetryAgent",
         "Agent-Class" to "io.opentelemetry.javaagent.OpenTelemetryAgent",
@@ -148,7 +144,7 @@ tasks {
   }
 
   //Includes everything needed for OOTB experience
-  val shadowJar by existing(ShadowJar::class) {
+  val fullJavaagentJar by registering(ShadowJar::class) {
     configurations = listOf(bootstrapLibs)
 
     dependsOn(relocateJavaagentLibs, relocateExporterLibs)
@@ -160,23 +156,23 @@ tasks {
     archiveClassifier.set("all")
 
     manifest {
-      attributes(lightShadow.get().manifest.attributes)
+      attributes(shadowJar.get().manifest.attributes)
     }
   }
 
   assemble {
-    dependsOn(lightShadow, shadowJar)
+    dependsOn(shadowJar, fullJavaagentJar)
   }
 
   withType<Test>().configureEach {
-    dependsOn(shadowJar)
-    inputs.file(shadowJar.get().archiveFile)
+    dependsOn(fullJavaagentJar)
+    inputs.file(fullJavaagentJar.get().archiveFile)
 
     jvmArgs("-Dotel.javaagent.debug=true")
 
     doFirst {
       // Defining here to allow jacoco to be first on the command line.
-      jvmArgs("-javaagent:${shadowJar.get().archiveFile.get().asFile}")
+      jvmArgs("-javaagent:${fullJavaagentJar.get().archiveFile.get().asFile}")
     }
 
     testLogging {
@@ -195,7 +191,7 @@ tasks {
   publishing {
     publications {
       named<MavenPublication>("maven") {
-        artifact(lightShadow)
+        artifact(fullJavaagentJar)
       }
     }
   }

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 
 tasks {
   test {
-    inputs.files(project(":javaagent").tasks.getByName("shadowJar").outputs.files)
+    inputs.files(project(":javaagent").tasks.getByName("fullJavaagentJar").outputs.files)
     maxParallelForks = 2
 
     testLogging.showStandardStreams = true
@@ -79,7 +79,7 @@ tasks {
       }
     }
 
-    val shadowTask = project(":javaagent").tasks.named<ShadowJar>("shadowJar").get()
+    val shadowTask = project(":javaagent").tasks.named<ShadowJar>("fullJavaagentJar").get()
     inputs.files(layout.files(shadowTask))
 
     doFirst {


### PR DESCRIPTION
This was thought to be fixed in 1.5.0, so treating it as a regression.