### PR TITLE
Fix flaky reactor netty test

### DIFF
--- a/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/AbstractReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/AbstractReactorNettyHttpClientTest.groovy
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.sdk.trace.data.SpanData
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
 import reactor.netty.http.client.HttpClient
 
@@ -103,12 +104,16 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
     def afterRequestSpan = new AtomicReference<Span>()
     def onResponseSpan = new AtomicReference<Span>()
     def afterResponseSpan = new AtomicReference<Span>()
+    def latch = new CountDownLatch(1)
 
     def httpClient = createHttpClient()
       .doOnRequest({ rq, con -> onRequestSpan.set(Span.current()) })
       .doAfterRequest({ rq, con -> afterRequestSpan.set(Span.current()) })
       .doOnResponse({ rs, con -> onResponseSpan.set(Span.current()) })
-      .doAfterResponse({ rs, con -> afterResponseSpan.set(Span.current()) })
+      .doAfterResponse({ rs, con ->
+        afterResponseSpan.set(Span.current())
+        latch.countDown()
+      })
 
     when:
     runWithSpan("parent") {
@@ -121,6 +126,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
         }
         .block()
     }
+    latch.await()
 
     then:
     assertTraces(1) {
@@ -188,7 +194,6 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
       }
     }
   }
-
 
   private static void assertSameSpan(SpanData expected, AtomicReference<Span> actual) {
     def expectedSpanContext = expected.spanContext


### PR DESCRIPTION
https://scans.gradle.com/s/ttrxo4km5xflu/tests/:instrumentation:reactor-netty:reactor-netty-0.9:javaagent:test/io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9.ReactorNettyHttpClientTest/should%20expose%20context%20to%20http%20client%20callbacks?top-execution=1
`doAfterResponse` may be called after traces have been received, ensure it is called before the span captured in it is needed