### PR TITLE
Test nested CLIENT span suppression in library instrumentations

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientHostAbsoluteUriRequestContextTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientHostAbsoluteUriRequestContextTest.groovy
@@ -19,10 +19,4 @@ class ApacheClientHostAbsoluteUriRequestContextTest extends AbstractApacheClient
       .build()
     return builder.build()
   }
-
-  // library instrumentation doesn't have a good way of suppressing nested CLIENT spans yet
-  @Override
-  boolean testWithClientParent() {
-    false
-  }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientHostAbsoluteUriRequestTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientHostAbsoluteUriRequestTest.groovy
@@ -19,10 +19,4 @@ class ApacheClientHostAbsoluteUriRequestTest extends AbstractApacheClientHostAbs
       .build()
     return builder.build()
   }
-
-  // library instrumentation doesn't have a good way of suppressing nested CLIENT spans yet
-  @Override
-  boolean testWithClientParent() {
-    false
-  }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientHostRequestContextTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientHostRequestContextTest.groovy
@@ -19,10 +19,4 @@ class ApacheClientHostRequestContextTest extends AbstractApacheClientHostRequest
       .build()
     return builder.build()
   }
-
-  // library instrumentation doesn't have a good way of suppressing nested CLIENT spans yet
-  @Override
-  boolean testWithClientParent() {
-    false
-  }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientHostRequestTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientHostRequestTest.groovy
@@ -19,10 +19,4 @@ class ApacheClientHostRequestTest extends AbstractApacheClientHostRequestTest im
       .build()
     return builder.build()
   }
-
-  // library instrumentation doesn't have a good way of suppressing nested CLIENT spans yet
-  @Override
-  boolean testWithClientParent() {
-    false
-  }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientUriRequestContextTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientUriRequestContextTest.groovy
@@ -19,10 +19,4 @@ class ApacheClientUriRequestContextTest extends AbstractApacheClientUriRequestCo
       .build()
     return builder.build()
   }
-
-  // library instrumentation doesn't have a good way of suppressing nested CLIENT spans yet
-  @Override
-  boolean testWithClientParent() {
-    false
-  }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientUriRequestTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheClientUriRequestTest.groovy
@@ -19,10 +19,4 @@ class ApacheClientUriRequestTest extends AbstractApacheClientUriRequestTest impl
       .build()
     return builder.build()
   }
-
-  // library instrumentation doesn't have a good way of suppressing nested CLIENT spans yet
-  @Override
-  boolean testWithClientParent() {
-    false
-  }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/groovy/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9LibraryTest.groovy
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/groovy/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9LibraryTest.groovy
@@ -12,13 +12,6 @@ import org.eclipse.jetty.util.ssl.SslContextFactory
 
 class JettyHttpClient9LibraryTest extends AbstractJettyClient9Test implements LibraryTestTrait {
 
-
-  @Override
-  boolean testWithClientParent() {
-    //The client parent test does not work well in the context of library only tests.
-    false
-  }
-
   @Override
   HttpClient createStandardClient() {
     JettyClientTracingBuilder jettyClientTracingBuilder = new JettyClientTracingBuilder(getOpenTelemetry())

--- a/instrumentation/okhttp/okhttp-3.0/library/src/test/groovy/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttp3Test.groovy
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/test/groovy/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttp3Test.groovy
@@ -16,11 +16,4 @@ class OkHttp3Test extends AbstractOkHttp3Test implements LibraryTestTrait {
   Call.Factory createCallFactory(OkHttpClient.Builder clientBuilder) {
     return OkHttpTracing.create(getOpenTelemetry()).newCallFactory(clientBuilder.build())
   }
-
-  // library instrumentation doesn't have a good way of suppressing nested CLIENT spans yet
-  @Override
-  boolean testWithClientParent() {
-    false
-  }
-
 }

--- a/instrumentation/spring/spring-web-3.1/library/src/test/groovy/SpringWebInstrumentationTest.groovy
+++ b/instrumentation/spring/spring-web-3.1/library/src/test/groovy/SpringWebInstrumentationTest.groovy
@@ -63,12 +63,6 @@ class SpringWebInstrumentationTest extends HttpClientTest<HttpEntity<String>> im
     false
   }
 
-  // library instrumentation doesn't have a good way of suppressing nested CLIENT spans yet
-  @Override
-  boolean testWithClientParent() {
-    false
-  }
-
   @Override
   Set<AttributeKey<?>> httpAttributes(URI uri) {
     def attributes = super.httpAttributes(uri)

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.extension.annotations.WithSpan;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.InstrumentationTestRunner;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
@@ -29,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -257,11 +255,13 @@ public abstract class AbstractHttpClientTest<REQUEST> {
 
   @ParameterizedTest
   @ValueSource(strings = {"PUT", "POST"})
-  void shouldSuppressNestedClientSpanIfAlreadyUnderParentClientSpan(String method) {
+  void shouldSuppressNestedClientSpanIfAlreadyUnderParentClientSpan(String method)
+      throws Exception {
     assumeTrue(options.testWithClientParent);
 
     URI uri = resolveAddress("/success");
-    int responseCode = runUnderParentClientSpan(() -> doRequest(method, uri));
+    int responseCode =
+        testing.runWithClientSpan("parent-client-span", () -> doRequest(method, uri));
 
     assertThat(responseCode).isEqualTo(200);
 
@@ -1136,16 +1136,5 @@ public abstract class AbstractHttpClientTest<REQUEST> {
   final void setTesting(InstrumentationTestRunner testing, HttpClientTestServer server) {
     this.testing = testing;
     this.server = server;
-  }
-
-  // Must create span within agent using annotation until
-  // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1726
-  @WithSpan(value = "parent-client-span", kind = SpanKind.CLIENT)
-  private static <T> T runUnderParentClientSpan(Callable<T> r) {
-    try {
-      return r.call();
-    } catch (Throwable t) {
-      throw new AssertionError(t);
-    }
   }
 }


### PR DESCRIPTION
Thanks to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3911 we can finally enable those tests for library instrumentations.