### PR TITLE
Stub benchmark-overhead results dir

### DIFF
--- a/benchmark-overhead/results/README.md
+++ b/benchmark-overhead/results/README.md
@@ -1,0 +1,1 @@
+This directory contains the results data.


### PR DESCRIPTION
Note that this is going into `gh-pages` branch. The stub dir needs to be required for the rsync to work.