### PR TITLE
[overhead] - Remove local gh-pages dir after rsync

### DIFF
--- a/.github/workflows/nightly-benchmark-overhead.yml
+++ b/.github/workflows/nightly-benchmark-overhead.yml
@@ -18,7 +18,7 @@ jobs:
           path: gh-pages
       - name: copy results from gh-pages branch
         run: |
-          rsync -avv gh-pages/benchmark-overhead/results/ benchmark-overhead/results/
+          rsync -avv gh-pages/benchmark-overhead/results/ benchmark-overhead/results/ && rm -rf gh-pages
       - name: run tests
         run: ./gradlew test
         working-directory: benchmark-overhead


### PR DESCRIPTION
The action failed when attempting to commit the results back to the `gh-pages` branch:

```
fatal: 'gh-pages' could be both a local file and a tracking branch.
Please use -- (and optionally --no-guess) to disambiguate
```

That's because we checked out that branch to a dir called `gh-pages`, which makes the commit ambiguous. So this PR removes the dir after we rsync the content that we care about.

