### PR TITLE
Bump gradle-plugins version

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.opentelemetry.instrumentation"
-version = "0.7.0-SNAPSHOT"
+version = "0.7.0"
 
 repositories {
   mavenCentral()


### PR DESCRIPTION
~I think this is why the `Publish Gradle plugin snapshots` job keeps opening staging repositories on `oss.sonatype.org`~

The above was written when this PR was bumping the version from `0.6.0` to `0.7.0-SNAPSHOT`.

But I'd like to make a new gradle-plugins release already to be able to use #3980, so hijacking this PR and bumping straight to `0.7.0` for release.