### PR TITLE
Fix examples build again

### DIFF
--- a/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
+++ b/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
@@ -64,7 +64,7 @@ abstract class SmokeTest {
     backend.start();
 
     collector =
-        new GenericContainer<>("otel/opentelemetry-collector-dev:latest")
+        new GenericContainer<>("otel/opentelemetry-collector-contrib-dev:latest")
             .dependsOn(backend)
             .withNetwork(network)
             .withNetworkAliases("collector")

--- a/examples/extension/src/test/java/com/example/javaagent/smoketest/IntegrationTest.java
+++ b/examples/extension/src/test/java/com/example/javaagent/smoketest/IntegrationTest.java
@@ -69,7 +69,7 @@ abstract class IntegrationTest {
     backend.start();
 
     collector =
-        new GenericContainer<>("otel/opentelemetry-collector-dev:latest")
+        new GenericContainer<>("otel/opentelemetry-collector-contrib-dev:latest")
             .dependsOn(backend)
             .withNetwork(network)
             .withNetworkAliases("collector")


### PR DESCRIPTION
Need to switch examples builds to collector-contrib also now because the `health_check` extension has been removed from collector core (https://github.com/open-telemetry/opentelemetry-collector/pull/3903).