### PR TITLE
Add error parameter to EndTimeExtractor and AttributesExtractor#onEnd()

### DIFF
--- a/instrumentation-api-annotation-support/src/main/java/io/opentelemetry/instrumentation/api/annotation/support/MethodSpanAttributesExtractor.java
+++ b/instrumentation-api-annotation-support/src/main/java/io/opentelemetry/instrumentation/api/annotation/support/MethodSpanAttributesExtractor.java
@@ -57,7 +57,10 @@ public final class MethodSpanAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {}
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {}
 
   /**
    * Creates a binding of the parameters of the traced method to span attributes.

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/AttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/AttributesExtractor.java
@@ -15,10 +15,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /**
  * Extractor of {@link io.opentelemetry.api.common.Attributes} for a given request and response.
  * Will be called {@linkplain #onStart(AttributesBuilder, Object) on start} with just the {@link
- * REQUEST} and again {@linkplain #onEnd(AttributesBuilder, Object, Object) on end} with both {@link
- * REQUEST} and {@link RESPONSE} to allow populating attributes at each stage of a request's
- * lifecycle. It is best to populate as much as possible in {@link #onStart(AttributesBuilder,
- * Object)} to have it available during sampling.
+ * REQUEST} and again {@linkplain #onEnd(AttributesBuilder, Object, Object, Throwable) on end} with
+ * both {@link REQUEST} and {@link RESPONSE} to allow populating attributes at each stage of a
+ * request's lifecycle. It is best to populate as much as possible in {@link
+ * #onStart(AttributesBuilder, Object)} to have it available during sampling.
  *
  * @see DbAttributesExtractor
  * @see HttpAttributesExtractor
@@ -32,11 +32,14 @@ public abstract class AttributesExtractor<REQUEST, RESPONSE> {
   protected abstract void onStart(AttributesBuilder attributes, REQUEST request);
 
   /**
-   * Extracts attributes from the {@link REQUEST} and {@link RESPONSE} into the {@link
-   * AttributesBuilder} at the end of a request.
+   * Extracts attributes from the {@link REQUEST} and either {@link RESPONSE} or {@code error} into
+   * the {@link AttributesBuilder} at the end of a request.
    */
   protected abstract void onEnd(
-      AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response);
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error);
 
   /**
    * Sets the {@code value} with the given {@code key} to the {@link AttributesBuilder} if {@code

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/EndTimeExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/EndTimeExtractor.java
@@ -17,5 +17,5 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public interface EndTimeExtractor<REQUEST, RESPONSE> {
 
   /** Returns the timestamp marking the end of the response processing. */
-  Instant extract(REQUEST request, @Nullable RESPONSE response);
+  Instant extract(REQUEST request, @Nullable RESPONSE response, @Nullable Throwable error);
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/RequestListener.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/RequestListener.java
@@ -21,8 +21,8 @@ public interface RequestListener {
    * the start and end of the request, e.g., an in-progress span, it should be added to the passed
    * in {@link Context} and returned.
    */
-  Context start(Context context, Attributes requestAttributes);
+  Context start(Context context, Attributes startAttributes);
 
   /** Listener method that is called at the end of a request. */
-  void end(Context context, Attributes responseAttributes);
+  void end(Context context, Attributes endAttributes);
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/ServerInstrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/ServerInstrumenter.java
@@ -73,7 +73,10 @@ final class ServerInstrumenter<REQUEST, RESPONSE> extends Instrumenter<REQUEST, 
 
     @Override
     protected void onEnd(
-        AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {
+        AttributesBuilder attributes,
+        REQUEST request,
+        @Nullable RESPONSE response,
+        @Nullable Throwable error) {
       String clientIp = getForwardedClientIp(request);
       if (clientIp == null && netAttributesExtractor != null) {
         clientIp = netAttributesExtractor.peerIp(request, response);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractor.java
@@ -31,7 +31,10 @@ public abstract class CodeAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   protected final void onEnd(
-      AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {}
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {}
 
   @Nullable
   protected abstract Class<?> codeClass(REQUEST request);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbAttributesExtractor.java
@@ -33,7 +33,10 @@ public abstract class DbAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   protected final void onEnd(
-      AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {}
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {}
 
   @Nullable
   protected abstract String system(REQUEST request);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpAttributesExtractor.java
@@ -37,7 +37,10 @@ public abstract class HttpAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   protected final void onEnd(
-      AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
     set(
         attributes,
         SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH,

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
@@ -60,16 +60,16 @@ public final class HttpClientMetrics implements RequestListener {
   }
 
   @Override
-  public Context start(Context context, Attributes requestAttributes) {
+  public Context start(Context context, Attributes startAttributes) {
     long startTimeNanos = System.nanoTime();
 
     return context.with(
         HTTP_CLIENT_REQUEST_METRICS_STATE,
-        new AutoValue_HttpClientMetrics_State(requestAttributes, startTimeNanos));
+        new AutoValue_HttpClientMetrics_State(startAttributes, startTimeNanos));
   }
 
   @Override
-  public void end(Context context, Attributes responseAttributes) {
+  public void end(Context context, Attributes endAttributes) {
     State state = context.get(HTTP_CLIENT_REQUEST_METRICS_STATE);
     if (state == null) {
       logger.debug(

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
@@ -70,17 +70,17 @@ public final class HttpServerMetrics implements RequestListener {
   }
 
   @Override
-  public Context start(Context context, Attributes requestAttributes) {
+  public Context start(Context context, Attributes startAttributes) {
     long startTimeNanos = System.nanoTime();
-    activeRequests.add(1, applyActiveRequestsView(requestAttributes));
+    activeRequests.add(1, applyActiveRequestsView(startAttributes));
 
     return context.with(
         HTTP_SERVER_REQUEST_METRICS_STATE,
-        new AutoValue_HttpServerMetrics_State(requestAttributes, startTimeNanos));
+        new AutoValue_HttpServerMetrics_State(startAttributes, startTimeNanos));
   }
 
   @Override
-  public void end(Context context, Attributes responseAttributes) {
+  public void end(Context context, Attributes endAttributes) {
     State state = context.get(HTTP_SERVER_REQUEST_METRICS_STATE);
     if (state == null) {
       logger.debug(

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractor.java
@@ -54,7 +54,10 @@ public abstract class MessagingAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   protected final void onEnd(
-      AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
     set(attributes, SemanticAttributes.MESSAGING_MESSAGE_ID, messageId(request, response));
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetAttributesExtractor.java
@@ -32,7 +32,10 @@ public abstract class NetAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   protected final void onEnd(
-      AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
     set(attributes, SemanticAttributes.NET_PEER_IP, peerIp(request, response));
     set(attributes, SemanticAttributes.NET_PEER_NAME, peerName(request, response));
     Integer peerPort = peerPort(request, response);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcAttributesExtractor.java
@@ -31,7 +31,10 @@ public abstract class RpcAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   protected final void onEnd(
-      AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
     // No response attributes
   }
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/AttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/AttributesExtractorTest.java
@@ -13,6 +13,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 class AttributesExtractorTest {
@@ -28,23 +29,39 @@ class AttributesExtractorTest {
 
     @Override
     protected void onEnd(
-        AttributesBuilder attributes, Map<String, String> request, Map<String, String> response) {
-      set(attributes, AttributeKey.stringKey("food"), response.get("food"));
-      set(attributes, AttributeKey.stringKey("number"), request.get("number"));
+        AttributesBuilder attributes,
+        Map<String, String> request,
+        @Nullable Map<String, String> response,
+        @Nullable Throwable error) {
+      if (response != null) {
+        set(attributes, AttributeKey.stringKey("food"), response.get("food"));
+        set(attributes, AttributeKey.stringKey("number"), request.get("number"));
+      }
+      if (error != null) {
+        set(attributes, AttributeKey.stringKey("full_error_class"), error.getClass().getName());
+      }
     }
   }
 
   @Test
   void normal() {
     TestAttributesExtractor extractor = new TestAttributesExtractor();
+
     Map<String, String> request = new HashMap<>();
     request.put("animal", "cat");
     Map<String, String> response = new HashMap<>();
     response.put("food", "pizza");
+    Exception error = new RuntimeException();
+
     AttributesBuilder attributesBuilder = Attributes.builder();
     extractor.onStart(attributesBuilder, request);
-    extractor.onEnd(attributesBuilder, request, response);
+    extractor.onEnd(attributesBuilder, request, response, null);
+    extractor.onEnd(attributesBuilder, request, null, error);
+
     assertThat(attributesBuilder.build())
-        .containsOnly(attributeEntry("animal", "cat"), attributeEntry("food", "pizza"));
+        .containsOnly(
+            attributeEntry("animal", "cat"),
+            attributeEntry("food", "pizza"),
+            attributeEntry("full_error_class", "java.lang.RuntimeException"));
   }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -80,7 +81,10 @@ class InstrumenterTest {
 
     @Override
     protected void onEnd(
-        AttributesBuilder attributes, Map<String, String> request, Map<String, String> response) {
+        AttributesBuilder attributes,
+        Map<String, String> request,
+        Map<String, String> response,
+        @Nullable Throwable error) {
       attributes.put("resp1", response.get("resp1"));
       attributes.put("resp2", response.get("resp2"));
     }
@@ -97,7 +101,10 @@ class InstrumenterTest {
 
     @Override
     protected void onEnd(
-        AttributesBuilder attributes, Map<String, String> request, Map<String, String> response) {
+        AttributesBuilder attributes,
+        Map<String, String> request,
+        Map<String, String> response,
+        @Nullable Throwable error) {
       attributes.put("resp3", response.get("resp3"));
       attributes.put("resp2", response.get("resp2_2"));
     }
@@ -490,7 +497,7 @@ class InstrumenterTest {
     Instrumenter<Instant, Instant> instrumenter =
         Instrumenter.<Instant, Instant>newBuilder(
                 otelTesting.getOpenTelemetry(), "test", request -> "test span")
-            .setTimeExtractors(request -> request, (request, response) -> response)
+            .setTimeExtractors(request -> request, (request, response, error) -> response)
             .newInstrumenter();
 
     Instant startTime = Instant.ofEpochSecond(100);

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractorTest.java
@@ -61,7 +61,7 @@ class CodeAttributesExtractorTest {
     underTest.onStart(startAttributes, request);
 
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, request, null);
+    underTest.onEnd(endAttributes, request, null, null);
 
     // then
     assertThat(startAttributes.build())

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbAttributesExtractorTest.java
@@ -66,7 +66,7 @@ class DbAttributesExtractorTest {
     underTest.onStart(startAttributes, request);
 
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, request, null);
+    underTest.onEnd(endAttributes, request, null, null);
 
     // then
     assertThat(startAttributes.build())

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlAttributesExtractorTest.java
@@ -70,7 +70,7 @@ class SqlAttributesExtractorTest {
     underTest.onStart(startAttributes, request);
 
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, request, null);
+    underTest.onEnd(endAttributes, request, null, null);
 
     // then
     assertThat(startAttributes.build())

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpAttributesExtractorTest.java
@@ -127,7 +127,7 @@ class HttpAttributesExtractorTest {
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
             entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"));
 
-    extractor.onEnd(attributes, request, response);
+    extractor.onEnd(attributes, request, response, null);
     assertThat(attributes.build())
         .containsOnly(
             entry(SemanticAttributes.HTTP_METHOD, "POST"),

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractorTest.java
@@ -120,7 +120,7 @@ class MessagingAttributesExtractorTest {
     underTest.onStart(startAttributes, request);
 
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, request, "42");
+    underTest.onEnd(endAttributes, request, "42", null);
 
     // then
     List<MapEntry<AttributeKey<?>, Object>> expectedEntries = new ArrayList<>();
@@ -168,7 +168,7 @@ class MessagingAttributesExtractorTest {
     underTest.onStart(startAttributes, Collections.emptyMap());
 
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, Collections.emptyMap(), null);
+    underTest.onEnd(endAttributes, Collections.emptyMap(), null, null);
 
     // then
     assertThat(startAttributes.build().isEmpty()).isTrue();

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetAttributesExtractorTest.java
@@ -38,7 +38,7 @@ class InetSocketAddressNetAttributesExtractorTest {
   void noInetSocketAddress() {
     AttributesBuilder attributes = Attributes.builder();
     extractor.onStart(attributes, null);
-    extractor.onEnd(attributes, null, null);
+    extractor.onEnd(attributes, null, null, null);
     assertThat(attributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_TRANSPORT, SemanticAttributes.NetTransportValues.IP_TCP));
@@ -55,7 +55,7 @@ class InetSocketAddressNetAttributesExtractorTest {
     extractor.onStart(startAttributes, address);
 
     AttributesBuilder endAttributes = Attributes.builder();
-    extractor.onEnd(endAttributes, null, address);
+    extractor.onEnd(endAttributes, null, address, null);
 
     // then
     assertThat(startAttributes.build())
@@ -83,7 +83,7 @@ class InetSocketAddressNetAttributesExtractorTest {
     extractor.onStart(startAttributes, address);
 
     AttributesBuilder endAttributes = Attributes.builder();
-    extractor.onEnd(endAttributes, null, address);
+    extractor.onEnd(endAttributes, null, address, null);
 
     // then
     assertThat(startAttributes.build())

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetAttributesExtractorTest.java
@@ -71,7 +71,7 @@ class NetAttributesExtractorTest {
     extractor.onStart(startAttributes, request);
 
     AttributesBuilder endAttributes = Attributes.builder();
-    extractor.onEnd(endAttributes, request, response);
+    extractor.onEnd(endAttributes, request, response, null);
 
     // then
     assertThat(startAttributes.build())

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcAttributesExtractorTest.java
@@ -49,7 +49,7 @@ class RpcAttributesExtractorTest {
             entry(SemanticAttributes.RPC_SYSTEM, "test"),
             entry(SemanticAttributes.RPC_SERVICE, "my.Service"),
             entry(SemanticAttributes.RPC_METHOD, "Method"));
-    extractor.onEnd(attributes, request, null);
+    extractor.onEnd(attributes, request, null, null);
     assertThat(attributes.build())
         .containsOnly(
             entry(SemanticAttributes.RPC_SYSTEM, "test"),

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientAdditionalAttributesExtractor.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientAdditionalAttributesExtractor.java
@@ -20,7 +20,10 @@ public class AsyncHttpClientAdditionalAttributesExtractor
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, RequestContext requestContext, @Nullable Response response) {
+      AttributesBuilder attributes,
+      RequestContext requestContext,
+      @Nullable Response response,
+      @Nullable Throwable error) {
     NettyRequest nettyRequest = requestContext.getNettyRequest();
     if (nettyRequest != null) {
       set(

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraKeyspaceExtractor.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraKeyspaceExtractor.java
@@ -9,6 +9,7 @@ import com.datastax.driver.core.ExecutionInfo;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class CassandraKeyspaceExtractor
     extends AttributesExtractor<CassandraRequest, ExecutionInfo> {
@@ -21,5 +22,8 @@ final class CassandraKeyspaceExtractor
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, CassandraRequest request, ExecutionInfo executionInfo) {}
+      AttributesBuilder attributes,
+      CassandraRequest request,
+      ExecutionInfo executionInfo,
+      @Nullable Throwable error) {}
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraAttributesExtractor.java
@@ -31,7 +31,8 @@ final class CassandraAttributesExtractor
   protected void onEnd(
       AttributesBuilder attributes,
       CassandraRequest request,
-      @Nullable ExecutionInfo executionInfo) {
+      @Nullable ExecutionInfo executionInfo,
+      @Nullable Throwable error) {
     if (executionInfo == null) {
       return;
     }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcAttributesExtractor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcAttributesExtractor.java
@@ -18,7 +18,11 @@ final class GrpcAttributesExtractor extends AttributesExtractor<GrpcRequest, Sta
   }
 
   @Override
-  protected void onEnd(AttributesBuilder attributes, GrpcRequest request, @Nullable Status status) {
+  protected void onEnd(
+      AttributesBuilder attributes,
+      GrpcRequest request,
+      @Nullable Status status,
+      @Nullable Throwable error) {
     if (status != null) {
       attributes.put(SemanticAttributes.RPC_GRPC_STATUS_CODE, status.getCode().value());
     }

--- a/instrumentation/hystrix-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/ExperimentalAttributesExtractor.java
+++ b/instrumentation/hystrix-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/ExperimentalAttributesExtractor.java
@@ -32,5 +32,8 @@ final class ExperimentalAttributesExtractor extends AttributesExtractor<HystrixR
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, HystrixRequest hystrixRequest, @Nullable Void unused) {}
+      AttributesBuilder attributes,
+      HystrixRequest hystrixRequest,
+      @Nullable Void unused,
+      @Nullable Throwable error) {}
 }

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
@@ -36,7 +36,8 @@ public final class JmsSingletons {
                 otel, INSTRUMENTATION_NAME, spanNameExtractor)
             .addAttributesExtractor(attributesExtractor)
             .setTimeExtractors(
-                MessageWithDestination::startTime, (request, response) -> request.endTime())
+                MessageWithDestination::getStartTime,
+                (request, response, error) -> request.endTime())
             .newInstrumenter(SpanKindExtractor.alwaysConsumer());
     LISTENER_INSTRUMENTER =
         Instrumenter.<MessageWithDestination, Void>newBuilder(

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
@@ -36,8 +36,7 @@ public final class JmsSingletons {
                 otel, INSTRUMENTATION_NAME, spanNameExtractor)
             .addAttributesExtractor(attributesExtractor)
             .setTimeExtractors(
-                MessageWithDestination::startTime,
-                (request, response, error) -> request.endTime())
+                MessageWithDestination::startTime, (request, response, error) -> request.endTime())
             .newInstrumenter(SpanKindExtractor.alwaysConsumer());
     LISTENER_INSTRUMENTER =
         Instrumenter.<MessageWithDestination, Void>newBuilder(

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
@@ -36,7 +36,7 @@ public final class JmsSingletons {
                 otel, INSTRUMENTATION_NAME, spanNameExtractor)
             .addAttributesExtractor(attributesExtractor)
             .setTimeExtractors(
-                MessageWithDestination::getStartTime,
+                MessageWithDestination::startTime,
                 (request, response, error) -> request.endTime())
             .newInstrumenter(SpanKindExtractor.alwaysConsumer());
     LISTENER_INSTRUMENTER =

--- a/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerAdditionalAttributesExtractor.java
+++ b/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaProducerAdditionalAttributesExtractor.java
@@ -26,5 +26,8 @@ public final class KafkaProducerAdditionalAttributesExtractor
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, ProducerRecord<?, ?> producerRecord, @Nullable Void unused) {}
+      AttributesBuilder attributes,
+      ProducerRecord<?, ?> producerRecord,
+      @Nullable Void unused,
+      @Nullable Throwable error) {}
 }

--- a/instrumentation/kafka-clients/kafka-clients-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafka/KafkaConsumerAdditionalAttributesExtractor.java
+++ b/instrumentation/kafka-clients/kafka-clients-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafka/KafkaConsumerAdditionalAttributesExtractor.java
@@ -26,5 +26,8 @@ public final class KafkaConsumerAdditionalAttributesExtractor
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, ConsumerRecord<?, ?> consumerRecord, @Nullable Void unused) {}
+      AttributesBuilder attributes,
+      ConsumerRecord<?, ?> consumerRecord,
+      @Nullable Void unused,
+      @Nullable Throwable error) {}
 }

--- a/instrumentation/kafka-clients/kafka-clients-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafka/KafkaConsumerExperimentalAttributesExtractor.java
+++ b/instrumentation/kafka-clients/kafka-clients-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafka/KafkaConsumerExperimentalAttributesExtractor.java
@@ -47,5 +47,8 @@ public final class KafkaConsumerExperimentalAttributesExtractor
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, ConsumerRecord<?, ?> consumerRecord, @Nullable Void unused) {}
+      AttributesBuilder attributes,
+      ConsumerRecord<?, ?> consumerRecord,
+      @Nullable Void unused,
+      @Nullable Throwable error) {}
 }

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesExperimentalAttributesExtractor.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesExperimentalAttributesExtractor.java
@@ -23,5 +23,8 @@ class KubernetesExperimentalAttributesExtractor
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, Request request, @Nullable ApiResponse<?> apiResponse) {}
+      AttributesBuilder attributes,
+      Request request,
+      @Nullable ApiResponse<?> apiResponse,
+      @Nullable Throwable error) {}
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectAttributesExtractor.java
@@ -9,6 +9,7 @@ import com.lambdaworks.redis.RedisURI;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class LettuceConnectAttributesExtractor extends AttributesExtractor<RedisURI, Void> {
 
@@ -23,5 +24,6 @@ final class LettuceConnectAttributesExtractor extends AttributesExtractor<RedisU
   }
 
   @Override
-  protected void onEnd(AttributesBuilder attributes, RedisURI redisUri, Void unused) {}
+  protected void onEnd(
+      AttributesBuilder attributes, RedisURI redisUri, Void unused, @Nullable Throwable error) {}
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectAttributesExtractor.java
@@ -9,6 +9,7 @@ import io.lettuce.core.RedisURI;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class LettuceConnectAttributesExtractor extends AttributesExtractor<RedisURI, Void> {
 
@@ -23,5 +24,6 @@ final class LettuceConnectAttributesExtractor extends AttributesExtractor<RedisU
   }
 
   @Override
-  protected void onEnd(AttributesBuilder attributes, RedisURI redisUri, Void unused) {}
+  protected void onEnd(
+      AttributesBuilder attributes, RedisURI redisUri, Void unused, @Nullable Throwable error) {}
 }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/ExperimentalAttributesExtractor.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/ExperimentalAttributesExtractor.java
@@ -22,7 +22,11 @@ public class ExperimentalAttributesExtractor extends AttributesExtractor<Object,
   }
 
   @Override
-  protected void onEnd(AttributesBuilder attributes, Object handler, @Nullable Void unused) {}
+  protected void onEnd(
+      AttributesBuilder attributes,
+      Object handler,
+      @Nullable Void unused,
+      @Nullable Throwable error) {}
 
   private static String getHandlerType(Object handler) {
     if (handler instanceof HandlerMethod) {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/ModelAndViewAttributesExtractor.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/ModelAndViewAttributesExtractor.java
@@ -32,5 +32,8 @@ public class ModelAndViewAttributesExtractor extends AttributesExtractor<ModelAn
 
   @Override
   protected void onEnd(
-      AttributesBuilder attributes, ModelAndView modelAndView, @Nullable Void unused) {}
+      AttributesBuilder attributes,
+      ModelAndView modelAndView,
+      @Nullable Void unused,
+      @Nullable Throwable error) {}
 }

--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/instrumenter/PeerServiceAttributesExtractor.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/instrumenter/PeerServiceAttributesExtractor.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Extractor of the {@code peer.service} span attribute, described in <a
@@ -49,11 +50,15 @@ public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   protected void onStart(AttributesBuilder attributes, REQUEST request) {
-    onEnd(attributes, request, null);
+    onEnd(attributes, request, null, null);
   }
 
   @Override
-  protected void onEnd(AttributesBuilder attributes, REQUEST request, RESPONSE response) {
+  protected void onEnd(
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
     String peerName = netAttributesExtractor.peerName(request, response);
     String peerService = mapToPeerService(peerName);
     if (peerService == null) {

--- a/javaagent-instrumentation-api/src/test/java/io/opentelemetry/javaagent/instrumentation/api/instrumenter/PeerServiceAttributesExtractorTest.java
+++ b/javaagent-instrumentation-api/src/test/java/io/opentelemetry/javaagent/instrumentation/api/instrumenter/PeerServiceAttributesExtractorTest.java
@@ -38,7 +38,7 @@ class PeerServiceAttributesExtractorTest {
     // when
     AttributesBuilder attributes = Attributes.builder();
     underTest.onStart(attributes, "request");
-    underTest.onEnd(attributes, "request", "response");
+    underTest.onEnd(attributes, "request", "response", null);
 
     // then
     assertTrue(attributes.build().isEmpty());
@@ -58,7 +58,7 @@ class PeerServiceAttributesExtractorTest {
     AttributesBuilder startAttributes = Attributes.builder();
     underTest.onStart(startAttributes, "request");
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, "request", "response");
+    underTest.onEnd(endAttributes, "request", "response", null);
 
     // then
     assertTrue(startAttributes.build().isEmpty());
@@ -79,7 +79,7 @@ class PeerServiceAttributesExtractorTest {
     AttributesBuilder startAttributes = Attributes.builder();
     underTest.onStart(startAttributes, "request");
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, "request", "response");
+    underTest.onEnd(endAttributes, "request", "response", null);
 
     // then
     assertTrue(startAttributes.build().isEmpty());
@@ -102,7 +102,7 @@ class PeerServiceAttributesExtractorTest {
     AttributesBuilder startAttributes = Attributes.builder();
     underTest.onStart(startAttributes, "request");
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, "request", "response");
+    underTest.onEnd(endAttributes, "request", "response", null);
 
     // then
     assertThat(startAttributes.build())
@@ -128,7 +128,7 @@ class PeerServiceAttributesExtractorTest {
     AttributesBuilder startAttributes = Attributes.builder();
     underTest.onStart(startAttributes, "request");
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, "request", "response");
+    underTest.onEnd(endAttributes, "request", "response", null);
 
     // then
     assertThat(startAttributes.build())


### PR DESCRIPTION
I've added a `@Nullable Throwable error` parameter to `EndTimeExtractor` and `AttributesExtractor#onEnd()`. Now, along with the `SpanStatusExtractor`, every method in the Instrumenter API that accepts a `RESPONSE` also accepts a `Throwable`. The operation can end with either a `RESPONSE` or an `error` being passed to the instrumenter so I thought it makes sense to always pass both of these to have a complete view of how it ended.

This PR resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3730. It is now possible to extract custom attributes in an `AttributesExtractor` and they'll be passed along to the `RequestListener`, thus making it possible to use those attributes in custom metrics.