### PR TITLE
Add missing library instrumentation to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@
 
 - Jetty 9 HTTP client instrumentation
   ([#3079](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3079))
+- Jdbc instrumentation
+  ([#3367](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3367))
 
 ### 📈 Enhancements
 


### PR DESCRIPTION
Not sure how I missed this. I updated release notes too.

(I was wondering when the "issue" behind #3987 started)