### PR TITLE
Bump gradle-plugins version to SNAPSHOT

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.opentelemetry.instrumentation"
-version = "0.7.0"
+version = "0.8.0-SNAPSHOT"
 
 repositories {
   mavenCentral()


### PR DESCRIPTION
This is needed to avoid the snapshot build from opening and publishing to staging repositories.