### PR TITLE
Fix smoke tests on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,8 +192,7 @@ jobs:
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        # using --no-daemon because windows builds have been sporadically running out of virtual memory
-        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }} --no-daemon
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}
 
   setup-muzzle-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-no-cache.yml
+++ b/.github/workflows/nightly-no-cache.yml
@@ -151,8 +151,7 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Test
-        # using --no-daemon because windows builds have been sporadically running out of virtual memory
-        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }} --no-build-cache --no-daemon
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }} --no-build-cache
 
   # muzzle is intentionally not included in the nightly-no-cache build because
   # it doesn't use gradle cache anyways and so is already covered by the normal nightly build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -192,8 +192,7 @@ jobs:
         env:
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.S3_BUILD_CACHE_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.S3_BUILD_CACHE_SECRET_KEY }}
-        # using --no-daemon because windows builds have been sporadically running out of virtual memory
-        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }} --no-daemon
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}
 
   setup-muzzle-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -162,8 +162,7 @@ jobs:
           git cherry-pick ${{ github.event.inputs.commits }}
 
       - name: Test
-        # using --no-daemon because windows builds have been sporadically running out of virtual memory
-        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }} --no-daemon
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}
 
   # muzzle is intentionally not included in the release workflows
   # because any time a new library version is released to maven central it can fail,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -191,8 +191,7 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Test
-        # using --no-daemon because windows builds have been sporadically running out of virtual memory
-        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }} --no-daemon
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}
 
   setup-muzzle-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -97,8 +97,7 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Test
-        # using --no-daemon because windows builds have been sporadically running out of virtual memory
-        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }} --no-daemon
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}
 
   # muzzle is intentionally not included in the release workflows
   # because any time a new library version is released to maven central it can fail,

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -44,7 +44,6 @@ dependencies {
 tasks {
   test {
     inputs.files(project(":javaagent").tasks.getByName("fullJavaagentJar").outputs.files)
-    maxParallelForks = 2
 
     testLogging.showStandardStreams = true
 


### PR DESCRIPTION
#4000 didn't work, see https://github.com/open-telemetry/opentelemetry-java-instrumentation/runs/3451879973?check_suite_focus=true.

Noticed that there were two liberty tests running in parallel.

Removed parallelism from the smoke tests, guessing this is from before the smoke tests were parallelized across multiple workflow jobs.

Btw, this makes sense why liberty was the one that kept failing, because that has two tests, which made this parallelism possible:
* LibertySmokeTest
* LibertyServletOnlySmokeTest

(I went ahead and reverted #4000 in this PR as well)