### PR TITLE
Limit RxJava3 muzzle check version range

### DIFF
--- a/instrumentation/rxjava/rxjava-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/build.gradle.kts
@@ -6,14 +6,9 @@ muzzle {
   pass {
     group.set("io.reactivex.rxjava3")
     module.set("rxjava")
-    versions.set("[3.0.0,)")
+    versions.set("[3.0.0,3.1.0]")
     assertInverse.set(true)
   }
-}
-
-tasks.withType<Test>().configureEach {
-  // TODO run tests both with and without experimental span attributes
-  jvmArgs("-Dotel.instrumentation.rxjava.experimental-span-attributes=true")
 }
 
 dependencies {
@@ -27,5 +22,8 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
+  // TODO run tests both with and without experimental span attributes
+  jvmArgs("-Dotel.instrumentation.rxjava.experimental-span-attributes=true")
+
   jvmArgs("-Dio.opentelemetry.javaagent.shaded.io.opentelemetry.context.enableStrictContext=false")
 }


### PR DESCRIPTION
It looks like in RxJava 3.1.1 some internal classes were moved to non-internal packages:

```
FAILED MUZZLE VALIDATION: io.opentelemetry.javaagent.instrumentation.rxjava3.RxJava3InstrumentationModule mismatches:
-- io.opentelemetry.instrumentation.rxjava3.TracingAssembly:193 Missing field io.reactivex.rxjava3.internal.fuseable.QueueSubscription qs in class io.opentelemetry.instrumentation.rxjava3.TracingConditionalSubscriber
-- io.opentelemetry.instrumentation.rxjava3.TracingAssembly:193 Missing field io.reactivex.rxjava3.internal.fuseable.ConditionalSubscriber downstream in class io.opentelemetry.instrumentation.rxjava3.TracingConditionalSubscriber
-- io.opentelemetry.instrumentation.rxjava3.TracingAssembly:196 Missing field io.reactivex.rxjava3.internal.fuseable.QueueSubscription qs in class io.opentelemetry.instrumentation.rxjava3.TracingSubscriber
-- io.opentelemetry.instrumentation.rxjava3.TracingConditionalSubscriber:70 Missing class io.reactivex.rxjava3.internal.fuseable.QueueSubscription
-- io.opentelemetry.instrumentation.rxjava3.TracingAssembly:192 Missing class io.reactivex.rxjava3.internal.fuseable.ConditionalSubscriber
-- io.opentelemetry.instrumentation.rxjava3.TracingObserver:63 Missing class io.reactivex.rxjava3.internal.fuseable.QueueDisposable
-- io.opentelemetry.instrumentation.rxjava3.TracingConditionalSubscriber:36 Missing method io.reactivex.rxjava3.internal.subscribers.BasicFuseableConditionalSubscriber#<init>(Lio/reactivex/rxjava3/internal/fuseable/ConditionalSubscriber;)V
-- io.opentelemetry.instrumentation.rxjava3.TracingAssembly:211 Missing field io.reactivex.rxjava3.internal.fuseable.QueueDisposable qd in class io.opentelemetry.instrumentation.rxjava3.TracingObserver
```

Before (3-3.1):
```java
import io.reactivex.rxjava3.internal.fuseable.ConditionalSubscriber;
import io.reactivex.rxjava3.internal.fuseable.QueueSubscription;
```

After (3.1.1+):
```java
import io.reactivex.rxjava3.operators.ConditionalSubscriber;
import io.reactivex.rxjava3.operators.QueueSubscription;
```