### PR TITLE
Use unsafe to inject classes to boot loader

### DIFF
--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -222,6 +222,10 @@ public class HelperInjector implements Transformer {
 
   private Map<String, Class<?>> injectBootstrapClassLoader(Map<String, byte[]> classnameToBytes)
       throws IOException {
+    if (ClassInjector.UsingUnsafe.isAvailable()) {
+      return ClassInjector.UsingUnsafe.ofBootLoader().injectRaw(classnameToBytes);
+    }
+
     // Mar 2020: Since we're proactively cleaning up tempDirs, we cannot share dirs per thread.
     // If this proves expensive, we could do a per-process tempDir with
     // a reference count -- but for now, starting simple.


### PR DESCRIPTION
`ClassInjector.UsingInstrumentation` packages new classes in a temporary jar and calls `Instrumentation.appendToBootstrapClassLoaderSearch`. This seems a bit excessive for just defining a few classes. If `Unsafe` is available then use it instead. I kept the original code as fallback, though this might not be necessary as with `jvmArgs("-Dnet.bytebuddy.safe=true")` which disables unsafe tests fail with
```
[otel.javaagent 2021-08-30 17:48:13:942 +0300] [Time-limited test] ERROR io.opentelemetry.javaagent.testing.bytebuddy.TestAgentListener - Unexpected instrumentation error when instrumenting io.opentelemetry.context.ContextStorageWrappers on jdk.internal.loader.ClassLoaders$AppClassLoader@512ddf17
[otel.javaagent 2021-08-30 17:48:13:942 +0300] [otel-javaagent-transform-safe-logger] WARN io.opentelemetry.javaagent.tooling.HelperInjector - level ERROR not implemented yet in TransformSafeLogger
java.lang.IllegalStateException: java.lang.UnsupportedOperationException: Cannot get defined package using reflection: Use of Unsafe was disabled by system property
	at io.opentelemetry.javaagent.tooling.HelperInjector.lambda$injectHelperClasses$1(HelperInjector.java:214)
	at io.opentelemetry.javaagent.shaded.instrumentation.api.caching.WeakLockFreeCache.computeIfAbsent(WeakLockFreeCache.java:35)
	at io.opentelemetry.javaagent.tooling.HelperInjector.injectHelperClasses(HelperInjector.java:184)
	at io.opentelemetry.javaagent.tooling.HelperInjector.transform(HelperInjector.java:150)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:10889)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10827)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1600(AgentBuilder.java:10569)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:11292)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:11231)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10769)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$ByteBuddy$ModuleSupport.transform(Unknown Source)
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:563)
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:800)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:698)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:621)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:579)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at io.opentelemetry.context.LazyStorage.<clinit>(LazyStorage.java:85)
	at io.opentelemetry.context.ContextStorage.get(ContextStorage.java:72)
	at io.opentelemetry.context.Context.current(Context.java:86)
	at io.opentelemetry.api.trace.Span.current(Span.java:35)
	at io.opentelemetry.api.trace.Span$current.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:119)
	at io.opentelemetry.instrumentation.test.InstrumentationSpecification.setup(InstrumentationSpecification.groovy:43)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
```
I believe there is a good chance that this resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3896