### PR TITLE
[overhead] ignore temp results files

### DIFF
--- a/benchmark-overhead/.gitignore
+++ b/benchmark-overhead/.gitignore
@@ -1,0 +1,2 @@
+results
+!results/README.md


### PR DESCRIPTION
So in the latest [failure mode](https://github.com/open-telemetry/opentelemetry-java-instrumentation/runs/3458373282?check_suite_focus=true), we couldn't switch to the `gh-pages` branch to commit our results because they would have been overwritten.

So this sets up a `.gitignore` that will allow the results to be safely ignored when the action switches to the target commit branch.  🤞🏻 