### PR TITLE
Limit lates dep version for rxjava-3.0

### DIFF
--- a/instrumentation/rxjava/rxjava-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
 
   testImplementation("io.opentelemetry:opentelemetry-extension-annotations")
   testImplementation(project(":instrumentation:rxjava:rxjava-3.0:testing"))
+
+  latestDepTestLibrary("io.reactivex.rxjava3:rxjava:3.1.0")
 }
 
 tasks.withType<Test>().configureEach {

--- a/instrumentation/rxjava/rxjava-3.0/library/build.gradle.kts
+++ b/instrumentation/rxjava/rxjava-3.0/library/build.gradle.kts
@@ -7,6 +7,8 @@ dependencies {
   implementation(project(":instrumentation-api-annotation-support"))
 
   testImplementation(project(":instrumentation:rxjava:rxjava-3.0:testing"))
+
+  latestDepTestLibrary("io.reactivex.rxjava3:rxjava:3.1.0")
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
Muzzle version was limited in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4022