### PR TITLE
Bump smoke test timeout

### DIFF
--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -49,7 +49,7 @@ tasks {
 
     // TODO investigate why smoke tests occasionally hang forever
     //  this needs to be long enough so that smoke tests that are just running slow don"t time out
-    timeout.set(Duration.ofMinutes(45))
+    timeout.set(Duration.ofMinutes(60))
 
     // We enable/disable smoke tests based on the java version requests
     // In addition to that we disable them on normal test task to only run when explicitly requested.


### PR DESCRIPTION
recent failure:

```
2021-08-31T04:20:02.4753195Z Requesting stop of task ':smoke-tests:test' as it has exceeded its configured timeout of 45m 0s.
2021-08-31T04:20:08.1340528Z Timed out task ':smoke-tests:test' has not yet stopped.
2021-08-31T04:20:10.4552206Z Timed out task ':smoke-tests:test' has stopped.
```

https://github.com/open-telemetry/opentelemetry-java-instrumentation/runs/3468765831?check_suite_focus=true

I looked at some of the recent successful runs for smoke-test (windows-latest, wildfly), and they were up near the timeout, so seems like we should bump it.
