### PR TITLE
Support empty values in config maps

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/ConfigValueParsers.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/ConfigValueParsers.java
@@ -55,7 +55,7 @@ final class ConfigValueParsers {
   }
 
   static List<String> parseList(@SuppressWarnings("unused") String propertyName, String value) {
-    return Collections.unmodifiableList(filterBlanksAndNulls(value.split(",")));
+    return Collections.unmodifiableList(filterBlanks(value.split(",")));
   }
 
   static Map<String, String> parseMap(String propertyName, String value) {
@@ -77,7 +77,7 @@ final class ConfigValueParsers {
                 Map.Entry::getKey, Map.Entry::getValue, (first, next) -> next, LinkedHashMap::new));
   }
 
-  private static List<String> filterBlanksAndNulls(String[] values) {
+  private static List<String> filterBlanks(String[] values) {
     return Arrays.stream(values)
         .map(String::trim)
         .filter(s -> !s.isEmpty())

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/ConfigValueParsers.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/ConfigValueParsers.java
@@ -60,10 +60,10 @@ final class ConfigValueParsers {
 
   static Map<String, String> parseMap(String propertyName, String value) {
     return parseList(propertyName, value).stream()
-        .map(keyValuePair -> filterBlanksAndNulls(keyValuePair.split("=", 2)))
+        .map(keyValuePair -> trim(keyValuePair.split("=", 2)))
         .map(
             splitKeyValuePairs -> {
-              if (splitKeyValuePairs.size() != 2) {
+              if (splitKeyValuePairs.size() != 2 || splitKeyValuePairs.get(0).isEmpty()) {
                 throw new ConfigParsingException(
                     "Invalid map property: " + propertyName + "=" + value);
               }
@@ -82,6 +82,10 @@ final class ConfigValueParsers {
         .map(String::trim)
         .filter(s -> !s.isEmpty())
         .collect(Collectors.toList());
+  }
+
+  private static List<String> trim(String[] values) {
+    return Arrays.stream(values).map(String::trim).collect(Collectors.toList());
   }
 
   static Duration parseDuration(String propertyName, String value) {

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigPropertiesAdapterTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigPropertiesAdapterTest.java
@@ -31,6 +31,7 @@ class ConfigPropertiesAdapterTest {
     properties.put("double", "5.4");
     properties.put("list", "cat,dog,bear");
     properties.put("map", "cat=meow,dog=bark,bear=growl");
+    properties.put("mapWithEmptyValue", "cat=meow,dog=,bear=growl");
     properties.put("duration", "1s");
 
     ConfigProperties config = createConfig(properties);
@@ -41,6 +42,8 @@ class ConfigPropertiesAdapterTest {
     assertThat(config.getCommaSeparatedValues("list")).containsExactly("cat", "dog", "bear");
     assertThat(config.getCommaSeparatedMap("map"))
         .containsExactly(entry("cat", "meow"), entry("dog", "bark"), entry("bear", "growl"));
+    assertThat(config.getCommaSeparatedMap("mapWithEmptyValue"))
+        .containsExactly(entry("cat", "meow"), entry("dog", ""), entry("bear", "growl"));
     assertThat(config.getDuration("duration")).isEqualTo(Duration.ofSeconds(1));
   }
 
@@ -131,11 +134,6 @@ class ConfigPropertiesAdapterTest {
 
   @Test
   void invalidMap() {
-    assertThatThrownBy(
-            () ->
-                createConfig(Collections.singletonMap("map", "a=1,b=")).getCommaSeparatedMap("map"))
-        .isInstanceOf(ConfigurationException.class)
-        .hasMessage("Invalid map property: map=a=1,b=");
     assertThatThrownBy(
             () ->
                 createConfig(Collections.singletonMap("map", "a=1,b")).getCommaSeparatedMap("map"))


### PR DESCRIPTION
I think this is the behavior we want based on https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4032/files#r698964347

Also renamed `filterBlanksAndNulls` to `filterBlanks` since it doesn't filter nulls.