### PR TITLE
[overhead] Append and update results (redux)

### DIFF
--- a/.github/workflows/nightly-benchmark-overhead.yml
+++ b/.github/workflows/nightly-benchmark-overhead.yml
@@ -18,13 +18,19 @@ jobs:
           path: gh-pages
       - name: copy results from gh-pages branch
         run: |
-          rsync -avv gh-pages/benchmark-overhead/results/ benchmark-overhead/results/ && rm -rf gh-pages
+          rsync -avv gh-pages/benchmark-overhead/results/ benchmark-overhead/results/
       - name: run tests
-        run: ./gradlew test
         working-directory: benchmark-overhead
+        run: ./gradlew test
+      - name: inspect the results dir
+        working-directory: benchmark-overhead
+        run: ls -lR results
+      - name: copy results back to gh-pages branch
+        run: rsync -avv benchmark-overhead/results/ gh-pages/benchmark-overhead/results/ && rm -rf benchmark-overhead/results
       - name: commit updated results
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: EndBug/add-and-commit@v7
         with:
-          branch: gh-pages
-          commit_message: update test result data
-          file_pattern: benchmark-overhead/results
+          add: 'benchmark-overhead/results'
+          cwd: './gh-pages'
+          branch: 'gh-pages'
+          message: 'update test result data'

--- a/benchmark-overhead/results/README.md
+++ b/benchmark-overhead/results/README.md
@@ -1,1 +1,0 @@
-This directory contains the results data.


### PR DESCRIPTION
Switch from `stefanzweifel/git-auto-commit-action` to `EndBug/add-and-commit` (it's more of what we need and is less targeted at static site generation).  We leverage the gh-branch as a cloned subdir, copy the results into a local dir that is appended to by the test run. After the tests finish, we rsync the dir back into the subdir and remove the local copy. 

Tested multiple times in another repo and seems to work fine -- we can append the gh-pages this way without needing to commit back to main.  🤞🏻 🍀 🐰 🦶🏻 