### PR TITLE
[#4042] docs fix

### DIFF
--- a/docs/contributing/muzzle.md
+++ b/docs/contributing/muzzle.md
@@ -77,13 +77,13 @@ The gradle plugin defines two tasks:
 
 * `muzzle` task runs the runtime muzzle verification against different library versions:
     ```sh
-    ./gradlew :instrumentation:google-http-client-1.19:muzzle
+    ./gradlew :instrumentation:google-http-client-1.19:javaagent:muzzle
     ```
     If a new, incompatible version of the instrumented library is published it fails the build.
 
 * `printMuzzleReferences` task prints all API references in a given module:
     ```sh
-    ./gradlew :instrumentation:google-http-client-1.19:printMuzzleReferences
+    ./gradlew :instrumentation:google-http-client-1.19:javaagent:printMuzzleReferences
     ```
 
 The muzzle plugin needs to be configured in the module's `.gradle` file.


### PR DESCRIPTION
I figured out there is missing string in between while running:
```
./gradlew help --task muzzle
...
    :instrumentation:google-http-client-1.19:javaagent:muzzle
    :instrumentation:grails-3.0:javaagent:muzzle
    :instrumentation:grizzly-2.0:javaagent:muzzle
    :instrumentation:grpc-1.6:javaagent:muzzle
...
```

tracked with: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4042