### PR TITLE
#1708 - Update groovy import order to match default IntelliJ

### DIFF
--- a/docs/contributing/intellij-setup.md
+++ b/docs/contributing/intellij-setup.md
@@ -1,17 +1,28 @@
 ### IntelliJ setup
 
-**NB!** Please ensure that Intellij uses the same java installation as you do for building this project
-from command line.
-This ensures that Gradle task avoidance and build cache work properly and can greatly reduce
-build time.
+**NB!** Please ensure that Intellij uses the same java installation as you do for building this
+project from command line. This ensures that Gradle task avoidance and build cache work properly and
+can greatly reduce build time.
 
 Suggested plugins and settings:
 
 * Editor > Code Style > Java/Groovy > Imports
-  * Class count to use import with '*': `9999` (some number sufficiently large that is unlikely to matter)
+  * Class count to use import with '*': `9999` (some number sufficiently large that is unlikely to
+    matter)
   * Names count to use static import with '*': `9999`
-  * Import Layout:
+  * Default Import Layout should be used:
+
     ![import layout](https://user-images.githubusercontent.com/734411/43430811-28442636-94ae-11e8-86f1-f270ddcba023.png)
-* [Google Java Format](https://plugins.jetbrains.com/plugin/8527-google-java-format)
-* [Save Actions](https://plugins.jetbrains.com/plugin/7642-save-actions)
+  
+* [Google Java Format](https://plugins.jetbrains.com/plugin/8527-google-java-format) plugin is
+  suggested to be installed
+  ![google format](https://user-images.githubusercontent.com/5099946/131758519-14d27c17-5fc2-4447-84b0-dbe7a7329022.png)
+  Enable google-java-format
+  ![enable google format](https://user-images.githubusercontent.com/5099946/131759832-36437aa0-a5f7-42c0-9425-8c5b45c16765.png)
+
+
+* Install [Save Actions](https://plugins.jetbrains.com/plugin/7642-save-actions)
+
+  ![save action](https://user-images.githubusercontent.com/5099946/131758940-7a1820db-3cf4-4e30-b346-c45c1ff4646e.png)
+  Configure Save Actions as follows:
   ![Recommended Settings](save-actions.png)

--- a/instrumentation-api-annotation-support/src/test/groovy/io/opentelemetry/instrumentation/api/annotation/support/AnnotationReflectionHelperTest.groovy
+++ b/instrumentation-api-annotation-support/src/test/groovy/io/opentelemetry/instrumentation/api/annotation/support/AnnotationReflectionHelperTest.groovy
@@ -56,5 +56,5 @@ class AnnotationReflectionHelperTest extends Specification {
   }
 
   @CustomAnnotation(value = "Value")
-  class Annotated { }
+  class Annotated {}
 }

--- a/instrumentation-api-annotation-support/src/test/groovy/io/opentelemetry/instrumentation/api/annotation/support/AttributeBindingFactoryTest.groovy
+++ b/instrumentation-api-annotation-support/src/test/groovy/io/opentelemetry/instrumentation/api/annotation/support/AttributeBindingFactoryTest.groovy
@@ -18,7 +18,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", String).apply(setter, "value")
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.STRING && it.getKey() == "key"}, "value")
+    1 * setter.setAttribute({ it.getType() == AttributeType.STRING && it.getKey() == "key" }, "value")
   }
 
   def "creates attribute binding for int"() {
@@ -26,7 +26,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", int).apply(setter, 1234)
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG && it.getKey() == "key"}, 1234L)
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG && it.getKey() == "key" }, 1234L)
   }
 
   def "creates attribute binding for Integer"() {
@@ -34,7 +34,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", Integer).apply(setter, 1234)
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG && it.getKey() == "key"}, 1234L)
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG && it.getKey() == "key" }, 1234L)
   }
 
   def "creates attribute binding for long"() {
@@ -42,7 +42,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", long).apply(setter, 1234L)
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG && it.getKey() == "key"}, 1234L)
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG && it.getKey() == "key" }, 1234L)
   }
 
   def "creates attribute binding for Long"() {
@@ -50,7 +50,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", Long).apply(setter, 1234L)
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG && it.getKey() == "key"}, 1234L)
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG && it.getKey() == "key" }, 1234L)
   }
 
   def "creates attribute binding for float"() {
@@ -58,7 +58,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", float).apply(setter, 1234.0F)
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE && it.getKey() == "key"}, 1234.0)
+    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE && it.getKey() == "key" }, 1234.0)
   }
 
   def "creates attribute binding for Float"() {
@@ -66,7 +66,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", Float).apply(setter, 1234.0F)
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE && it.getKey() == "key"}, 1234.0)
+    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE && it.getKey() == "key" }, 1234.0)
   }
 
   def "creates attribute binding for double"() {
@@ -74,7 +74,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", double).apply(setter, Double.valueOf(1234.0))
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE && it.getKey() == "key"}, Double.valueOf(1234.0))
+    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE && it.getKey() == "key" }, Double.valueOf(1234.0))
   }
 
   def "creates attribute binding for Double"() {
@@ -82,7 +82,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", Double).apply(setter, Double.valueOf(1234.0))
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE && it.getKey() == "key"}, Double.valueOf(1234.0))
+    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE && it.getKey() == "key" }, Double.valueOf(1234.0))
   }
 
   def "creates attribute binding for boolean"() {
@@ -90,7 +90,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", boolean).apply(setter, true)
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.BOOLEAN && it.getKey() == "key"}, true)
+    1 * setter.setAttribute({ it.getType() == AttributeType.BOOLEAN && it.getKey() == "key" }, true)
   }
 
   def "creates attribute binding for Boolean"() {
@@ -98,95 +98,95 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", Boolean).apply(setter, true)
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.BOOLEAN && it.getKey() == "key"}, true)
+    1 * setter.setAttribute({ it.getType() == AttributeType.BOOLEAN && it.getKey() == "key" }, true)
   }
 
   def "creates attribute binding for String[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", String[]).apply(setter, ["x", "y", "z", null ] as String[])
+    AttributeBindingFactory.createBinding("key", String[]).apply(setter, ["x", "y", "z", null] as String[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.STRING_ARRAY && it.getKey() == "key"}, ["x", "y", "z", null ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.STRING_ARRAY && it.getKey() == "key" }, ["x", "y", "z", null])
   }
 
   def "creates attribute binding for int[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", int[]).apply(setter, [1, 2, 3 ] as int[])
+    AttributeBindingFactory.createBinding("key", int[]).apply(setter, [1, 2, 3] as int[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key"}, [1L, 2L, 3L ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key" }, [1L, 2L, 3L])
   }
 
   def "creates attribute binding for Integer[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", Integer[]).apply(setter, [1, 2, 3, null ] as Integer[])
+    AttributeBindingFactory.createBinding("key", Integer[]).apply(setter, [1, 2, 3, null] as Integer[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key"}, [1L, 2L, 3L, null ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key" }, [1L, 2L, 3L, null])
   }
 
   def "creates attribute binding for long[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", long[]).apply(setter, [1L, 2L, 3L ] as long[])
+    AttributeBindingFactory.createBinding("key", long[]).apply(setter, [1L, 2L, 3L] as long[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key"}, [1L, 2L, 3L ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key" }, [1L, 2L, 3L])
   }
 
   def "creates attribute binding for Long[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", Long[]).apply(setter, [1L, 2L, 3L, null ] as Long[])
+    AttributeBindingFactory.createBinding("key", Long[]).apply(setter, [1L, 2L, 3L, null] as Long[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key"}, [1L, 2L, 3L, null ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key" }, [1L, 2L, 3L, null])
   }
 
   def "creates attribute binding for float[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", float[]).apply(setter, [1.0F, 2.0F, 3.0F ] as float[])
+    AttributeBindingFactory.createBinding("key", float[]).apply(setter, [1.0F, 2.0F, 3.0F] as float[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key"}, [1.0, 2.0, 3.0 ] as List<Double>)
+    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key" }, [1.0, 2.0, 3.0] as List<Double>)
   }
 
   def "creates attribute binding for Float[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", Float[]).apply(setter, [1.0F, 2.0F, 3.0F, null ] as Float[])
+    AttributeBindingFactory.createBinding("key", Float[]).apply(setter, [1.0F, 2.0F, 3.0F, null] as Float[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key"}, [1.0, 2.0, 3.0, null ] as List<Double>)
+    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key" }, [1.0, 2.0, 3.0, null] as List<Double>)
   }
 
   def "creates attribute binding for double[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", double[]).apply(setter, [1.0, 2.0, 3.0 ] as double[])
+    AttributeBindingFactory.createBinding("key", double[]).apply(setter, [1.0, 2.0, 3.0] as double[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key"}, [1.0, 2.0, 3.0 ] as List<Double>)
+    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key" }, [1.0, 2.0, 3.0] as List<Double>)
   }
 
   def "creates attribute binding for Double[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", Double[]).apply(setter, [1.0, 2.0, 3.0, null ] as Double[])
+    AttributeBindingFactory.createBinding("key", Double[]).apply(setter, [1.0, 2.0, 3.0, null] as Double[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key"}, [1.0, 2.0, 3.0, null ] as List<Double>)
+    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key" }, [1.0, 2.0, 3.0, null] as List<Double>)
   }
 
   def "creates attribute binding for boolean[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", boolean[]).apply(setter, [true, false ] as boolean[])
+    AttributeBindingFactory.createBinding("key", boolean[]).apply(setter, [true, false] as boolean[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.BOOLEAN_ARRAY && it.getKey() == "key"}, [true, false ] as List<Boolean>)
+    1 * setter.setAttribute({ it.getType() == AttributeType.BOOLEAN_ARRAY && it.getKey() == "key" }, [true, false] as List<Boolean>)
   }
 
   def "creates attribute binding for Boolean[]"() {
     when:
-    AttributeBindingFactory.createBinding("key", Boolean[]).apply(setter, [true, false, null ] as Boolean[])
+    AttributeBindingFactory.createBinding("key", Boolean[]).apply(setter, [true, false, null] as Boolean[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.BOOLEAN_ARRAY && it.getKey() == "key"}, [true, false, null ] as List<Boolean>)
+    1 * setter.setAttribute({ it.getType() == AttributeType.BOOLEAN_ARRAY && it.getKey() == "key" }, [true, false, null] as List<Boolean>)
   }
 
   def "creates default attribute binding"() {
@@ -194,7 +194,7 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", TestClass).apply(setter, new TestClass("foo"))
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.STRING && it.getKey() == "key"}, "TestClass{value = foo}")
+    1 * setter.setAttribute({ it.getType() == AttributeType.STRING && it.getKey() == "key" }, "TestClass{value = foo}")
   }
 
   def "creates default attribute binding for array"() {
@@ -202,79 +202,79 @@ class AttributeBindingFactoryTest extends Specification {
     AttributeBindingFactory.createBinding("key", TestClass[]).apply(setter, [new TestClass("foo"), new TestClass("bar"), null] as TestClass[])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.STRING_ARRAY && it.getKey() == "key"}, ["TestClass{value = foo}", "TestClass{value = bar}", null ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.STRING_ARRAY && it.getKey() == "key" }, ["TestClass{value = foo}", "TestClass{value = bar}", null])
   }
 
   def "creates attribute binding for List<String>"() {
     when:
     def type = TestFields.getDeclaredField("stringList").getGenericType()
-    AttributeBindingFactory.createBinding("key", type).apply(setter, ["x", "y", "z" ])
+    AttributeBindingFactory.createBinding("key", type).apply(setter, ["x", "y", "z"])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.STRING_ARRAY && it.getKey() == "key"}, ["x", "y", "z" ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.STRING_ARRAY && it.getKey() == "key" }, ["x", "y", "z"])
   }
 
   def "creates attribute binding for List<Integer>"() {
     when:
     def type = TestFields.getDeclaredField("integerList").getGenericType()
-    AttributeBindingFactory.createBinding("key", type).apply(setter, [1, 2, 3 ])
+    AttributeBindingFactory.createBinding("key", type).apply(setter, [1, 2, 3])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key"}, [1L, 2L, 3L ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key" }, [1L, 2L, 3L])
   }
 
   def "creates attribute binding for List<Long>"() {
     when:
     def type = TestFields.getDeclaredField("longList").getGenericType()
-    AttributeBindingFactory.createBinding("key", type).apply(setter, [1L, 2L, 3L ])
+    AttributeBindingFactory.createBinding("key", type).apply(setter, [1L, 2L, 3L])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key"}, [1L, 2L, 3L ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key" }, [1L, 2L, 3L])
   }
 
   def "creates attribute binding for List<Float>"() {
     when:
     def type = TestFields.getDeclaredField("floatList").getGenericType()
-    AttributeBindingFactory.createBinding("key", type).apply(setter, [1.0F, 2.0F, 3.0F ])
+    AttributeBindingFactory.createBinding("key", type).apply(setter, [1.0F, 2.0F, 3.0F])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key"}, [1.0, 2.0, 3.0 ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key" }, [1.0, 2.0, 3.0])
   }
 
   def "creates attribute binding for List<Double>"() {
     when:
     def type = TestFields.getDeclaredField("doubleList").getGenericType()
-    AttributeBindingFactory.createBinding("key", type).apply(setter, [1.0, 2.0, 3.0 ])
+    AttributeBindingFactory.createBinding("key", type).apply(setter, [1.0, 2.0, 3.0])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key"}, [1.0, 2.0, 3.0 ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.DOUBLE_ARRAY && it.getKey() == "key" }, [1.0, 2.0, 3.0])
   }
 
   def "creates attribute binding for List<Boolean>"() {
     when:
     def type = TestFields.getDeclaredField("booleanList").getGenericType()
-    AttributeBindingFactory.createBinding("key", type).apply(setter, [true, false, null ])
+    AttributeBindingFactory.createBinding("key", type).apply(setter, [true, false, null])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.BOOLEAN_ARRAY && it.getKey() == "key"}, [true, false, null ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.BOOLEAN_ARRAY && it.getKey() == "key" }, [true, false, null])
   }
 
   def "creates attribute binding for List<?>"() {
     when:
     def type = TestFields.getDeclaredField("otherList").getGenericType()
-    AttributeBindingFactory.createBinding("key", type).apply(setter, [new TestClass("foo"), new TestClass("bar") ])
+    AttributeBindingFactory.createBinding("key", type).apply(setter, [new TestClass("foo"), new TestClass("bar")])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.STRING_ARRAY && it.getKey() == "key"}, ["TestClass{value = foo}", "TestClass{value = bar}" ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.STRING_ARRAY && it.getKey() == "key" }, ["TestClass{value = foo}", "TestClass{value = bar}"])
   }
 
   def "creates attribute binding for ArrayList<Long>"() {
     when:
     def type = TestFields.getDeclaredField("longArrayList").getGenericType()
-    AttributeBindingFactory.createBinding("key", type).apply(setter, [1L, 2L, 3L ])
+    AttributeBindingFactory.createBinding("key", type).apply(setter, [1L, 2L, 3L])
 
     then:
-    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key"}, [1L, 2L, 3L ])
+    1 * setter.setAttribute({ it.getType() == AttributeType.LONG_ARRAY && it.getKey() == "key" }, [1L, 2L, 3L])
   }
 
   class TestClass {

--- a/instrumentation-api-annotation-support/src/test/groovy/io/opentelemetry/instrumentation/api/annotation/support/MethodSpanAttributesExtractorTest.groovy
+++ b/instrumentation-api-annotation-support/src/test/groovy/io/opentelemetry/instrumentation/api/annotation/support/MethodSpanAttributesExtractorTest.groovy
@@ -26,8 +26,8 @@ class MethodSpanAttributesExtractorTest extends Specification {
 
     def extractor = new MethodSpanAttributesExtractor<Object, Object>(
       { r -> method },
-      { m, p -> [ "x", "y", "z" ] as String[] },
-      { r -> [ "a", "b", "c" ] as String[] },
+      { m, p -> ["x", "y", "z"] as String[] },
+      { r -> ["a", "b", "c"] as String[] },
       cache
     )
 
@@ -53,7 +53,7 @@ class MethodSpanAttributesExtractorTest extends Specification {
     def extractor = new MethodSpanAttributesExtractor<Object, Object>(
       { r -> method },
       { m, p -> new String[0] },
-      { r -> [ "a", "b", "c" ] as String[] },
+      { r -> ["a", "b", "c"] as String[] },
       cache
     )
 
@@ -76,8 +76,8 @@ class MethodSpanAttributesExtractorTest extends Specification {
 
     def extractor = new MethodSpanAttributesExtractor<Object, Object>(
       { r -> method },
-      { m, p -> [ "x", "y" ] as String[] },
-      { r -> [ "a", "b", "c" ] as String[] },
+      { m, p -> ["x", "y"] as String[] },
+      { r -> ["a", "b", "c"] as String[] },
       cache
     )
 
@@ -100,8 +100,8 @@ class MethodSpanAttributesExtractorTest extends Specification {
 
     def extractor = new MethodSpanAttributesExtractor<Object, Object>(
       { r -> method },
-      { m, p -> [ "x", null, "z" ] as String[] },
-      { r -> [ "a", "b", "c" ] as String[] },
+      { m, p -> ["x", null, "z"] as String[] },
+      { r -> ["a", "b", "c"] as String[] },
       cache
     )
 
@@ -126,8 +126,8 @@ class MethodSpanAttributesExtractorTest extends Specification {
 
     def extractor = new MethodSpanAttributesExtractor<Object, Object>(
       { r -> method },
-      { m, p -> [ "x", "y", "z" ] as String[] },
-      { r -> [ "a", "b", null ] as String[] },
+      { m, p -> ["x", "y", "z"] as String[] },
+      { r -> ["a", "b", null] as String[] },
       cache
     )
 
@@ -156,7 +156,7 @@ class MethodSpanAttributesExtractorTest extends Specification {
     def extractor = new MethodSpanAttributesExtractor<Object, Object>(
       { r -> method },
       { m, p -> throw new Exception() },
-      { r -> [ "a", "b", "c" ] as String[] },
+      { r -> ["a", "b", "c"] as String[] },
       cache
     )
 
@@ -164,7 +164,7 @@ class MethodSpanAttributesExtractorTest extends Specification {
     extractor.onStart(builder, request)
 
     then:
-    1 * bindings.apply(_, [ "a", "b", "c" ])
+    1 * bindings.apply(_, ["a", "b", "c"])
   }
 
   def "does not apply cached empty bindings"() {
@@ -195,6 +195,6 @@ class MethodSpanAttributesExtractorTest extends Specification {
   }
 
   class TestClass {
-    void method(String x, String y, String z) { }
+    void method(String x, String y, String z) {}
   }
 }

--- a/instrumentation-api-annotation-support/src/test/groovy/io/opentelemetry/instrumentation/api/annotation/support/ParameterizedClassTest.groovy
+++ b/instrumentation-api-annotation-support/src/test/groovy/io/opentelemetry/instrumentation/api/annotation/support/ParameterizedClassTest.groovy
@@ -5,17 +5,17 @@
 
 package io.opentelemetry.instrumentation.api.annotation.support
 
-import spock.lang.Shared
-import spock.lang.Specification
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
-
-import static spock.util.matcher.HamcrestSupport.*
-import static org.hamcrest.Matchers.*
+import spock.lang.Shared
+import spock.lang.Specification
 
 import java.lang.reflect.Type
 import java.lang.reflect.TypeVariable
+
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder
+import static spock.util.matcher.HamcrestSupport.expect
 
 class ParameterizedClassTest extends Specification {
   @Shared
@@ -39,7 +39,7 @@ class ParameterizedClassTest extends Specification {
 
     then:
     underTest.getRawClass() == ArrayList
-    underTest.getActualTypeArguments() == [ String ] as Type[]
+    underTest.getActualTypeArguments() == [String] as Type[]
   }
 
   def "gets parameterized superclass with mapped type arguments"() {
@@ -48,7 +48,7 @@ class ParameterizedClassTest extends Specification {
 
     then:
     underTest.getRawClass() == AbstractList
-    underTest.getActualTypeArguments() == [ String ] as Type[]
+    underTest.getActualTypeArguments() == [String] as Type[]
   }
 
   def "gets parameterized interfaces with mapped type arguments"() {
@@ -57,10 +57,10 @@ class ParameterizedClassTest extends Specification {
 
     then:
     expect underTest, arrayContainingInAnyOrder(
-      matchesParameterizedClass(List, [ String ] as Type[]),
-      matchesParameterizedClass(Cloneable, [ ] as Type[]),
-      matchesParameterizedClass(RandomAccess, [ ] as Type[]),
-      matchesParameterizedClass(Serializable, [ ] as Type[]),
+      matchesParameterizedClass(List, [String] as Type[]),
+      matchesParameterizedClass(Cloneable, [] as Type[]),
+      matchesParameterizedClass(RandomAccess, [] as Type[]),
+      matchesParameterizedClass(Serializable, [] as Type[]),
     )
   }
 
@@ -71,7 +71,7 @@ class ParameterizedClassTest extends Specification {
     then:
     underTest.isPresent()
     underTest.get().getRawClass() == List
-    underTest.get().getActualTypeArguments() == [ String ] as Type[]
+    underTest.get().getActualTypeArguments() == [String] as Type[]
   }
 
   def "finds parameterized interface of superclass with mapped type arguments"() {
@@ -81,7 +81,7 @@ class ParameterizedClassTest extends Specification {
     then:
     underTest.isPresent()
     underTest.get().getRawClass() == Collection
-    underTest.get().getActualTypeArguments() == [ String ] as Type[]
+    underTest.get().getActualTypeArguments() == [String] as Type[]
   }
 
   def "does not find parameterized superclass that type does not extend"() {
@@ -100,8 +100,9 @@ class ParameterizedClassTest extends Specification {
     !underTest.isPresent()
   }
 
-  interface I { }
-  abstract class C { }
+  interface I {}
+
+  abstract class C {}
 
   static class TestFields {
     public static List<String> stringListField

--- a/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/HttpClientTracerTest.groovy
+++ b/instrumentation-api/src/test/groovy/io/opentelemetry/instrumentation/api/tracer/HttpClientTracerTest.groovy
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.instrumentation.api.tracer
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.propagation.TextMapSetter
 import io.opentelemetry.instrumentation.api.tracer.net.NetPeerAttributes
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Shared
+
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class HttpClientTracerTest extends BaseTracerTest {
 

--- a/instrumentation/akka-actor-fork-join-2.5/javaagent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/instrumentation/akka-actor-fork-join-2.5/javaagent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -3,10 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import akka.dispatch.forkjoin.ForkJoinPool
 import akka.dispatch.forkjoin.ForkJoinTask
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import spock.lang.Shared
+
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.Callable
@@ -14,7 +17,7 @@ import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import spock.lang.Shared
+
 /**
  * Test executor instrumentation for Akka specific classes.
  * This is to large extent a copy of ExecutorInstrumentationTest.

--- a/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import akka.actor.ActorSystem
 import akka.http.javadsl.Http
@@ -17,8 +15,12 @@ import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection
-import java.util.concurrent.TimeUnit
 import spock.lang.Shared
+
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class AkkaHttpClientInstrumentationTest extends HttpClientTest<HttpRequest> implements AgentTestTrait {
 
@@ -48,7 +50,7 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<HttpRequest> impl
 
   @Override
   void sendRequestWithCallback(HttpRequest request, String method, URI uri, Map<String, String> headers, AbstractHttpClientTest.RequestResult requestResult) {
-    Http.get(system).singleRequest(request, materializer).whenComplete {response, throwable ->
+    Http.get(system).singleRequest(request, materializer).whenComplete { response, throwable ->
       if (throwable == null) {
         response.discardEntityBytes(materializer)
       }

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/DirectCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/DirectCamelTest.groovy
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.apache.camel.CamelContext
 import org.apache.camel.ProducerTemplate
@@ -14,52 +12,54 @@ import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import spock.lang.Shared
 
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+
 class DirectCamelTest extends AgentInstrumentationSpecification {
 
-    @Shared
-    ConfigurableApplicationContext server
+  @Shared
+  ConfigurableApplicationContext server
 
-    def setupSpec() {
-        def app = new SpringApplication(DirectConfig)
-        server = app.run()
+  def setupSpec() {
+    def app = new SpringApplication(DirectConfig)
+    server = app.run()
+  }
+
+  def cleanupSpec() {
+    if (server != null) {
+      server.close()
+      server = null
     }
+  }
 
-    def cleanupSpec() {
-        if (server != null) {
-            server.close()
-            server = null
+  def "simple direct to a single services"() {
+    setup:
+    def camelContext = server.getBean(CamelContext)
+    ProducerTemplate template = camelContext.createProducerTemplate()
+
+    when:
+    template.sendBody("direct:input", "Example request")
+
+    then:
+    assertTraces(1) {
+      trace(0, 2) {
+        def parent = it
+        it.span(0) {
+          name "input"
+          kind INTERNAL
+          hasNoParent()
+          attributes {
+            "apache-camel.uri" "direct://input"
+          }
         }
-    }
-
-    def "simple direct to a single services"() {
-        setup:
-        def camelContext = server.getBean(CamelContext)
-        ProducerTemplate template = camelContext.createProducerTemplate()
-
-        when:
-        template.sendBody("direct:input", "Example request")
-
-        then:
-        assertTraces(1) {
-            trace(0, 2) {
-                def parent = it
-                it.span(0) {
-                    name "input"
-                    kind INTERNAL
-                    hasNoParent()
-                    attributes {
-                        "apache-camel.uri" "direct://input"
-                    }
-                }
-                it.span(1) {
-                    name "receiver"
-                    kind INTERNAL
-                    parentSpanId parent.span(0).spanId
-                    attributes {
-                        "apache-camel.uri" "direct://receiver"
-                    }
-                }
-            }
+        it.span(1) {
+          name "receiver"
+          kind INTERNAL
+          parentSpanId parent.span(0).spanId
+          attributes {
+            "apache-camel.uri" "direct://receiver"
+          }
         }
+      }
     }
+  }
 }

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/MulticastDirectCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/MulticastDirectCamelTest.groovy
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.apache.camel.CamelContext
 import org.apache.camel.ProducerTemplate
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class MulticastDirectCamelTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.groovy
@@ -5,10 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.RetryOnAddressAlreadyInUseTrait
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -18,6 +14,10 @@ import org.apache.camel.ProducerTemplate
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 class RestCamelTest extends AgentInstrumentationSpecification implements RetryOnAddressAlreadyInUseTrait {
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/SingleServiceCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/SingleServiceCamelTest.groovy
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.RetryOnAddressAlreadyInUseTrait
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -15,6 +13,8 @@ import io.opentelemetry.testing.internal.armeria.client.WebClient
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 class SingleServiceCamelTest extends AgentInstrumentationSpecification implements RetryOnAddressAlreadyInUseTrait {
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
@@ -5,10 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.RetryOnAddressAlreadyInUseTrait
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -20,6 +16,10 @@ import org.apache.camel.impl.DefaultCamelContext
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 class TwoServicesWithDirectClientCamelTest extends AgentInstrumentationSpecification implements RetryOnAddressAlreadyInUseTrait {
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsConnector.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsConnector.groovy
@@ -41,7 +41,7 @@ class AwsConnector {
     awsConnector.sqsRestServer = SQSRestServerBuilder.withPort(sqsPort).withInterface("localhost").start()
 
     def credentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials("x", "x"))
-    def endpointConfiguration = new AwsClientBuilder.EndpointConfiguration("http://localhost:"+sqsPort, "elasticmq")
+    def endpointConfiguration = new AwsClientBuilder.EndpointConfiguration("http://localhost:" + sqsPort, "elasticmq")
     awsConnector.sqsClient = AmazonSQSAsyncClient.asyncBuilder().withCredentials(credentials).withEndpointConfiguration(endpointConfiguration).build()
 
     return awsConnector

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpan.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpan.groovy
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel.aws
 
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
-import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 
 class AwsSpan {
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/CamelSpan.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/CamelSpan.groovy
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel.aws
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class CamelSpan {
 
@@ -22,7 +22,7 @@ class CamelSpan {
     }
   }
 
-  static sqsProduce(TraceAssert traceAssert, int index, queueName, parentSpan=null) {
+  static sqsProduce(TraceAssert traceAssert, int index, queueName, parentSpan = null) {
     return traceAssert.span(index) {
       name queueName
       kind INTERNAL
@@ -38,7 +38,7 @@ class CamelSpan {
     }
   }
 
-  static sqsConsume(TraceAssert traceAssert, int index, queueName, parentSpan=null) {
+  static sqsConsume(TraceAssert traceAssert, int index, queueName, parentSpan = null) {
     return traceAssert.span(index) {
       name queueName
       kind INTERNAL
@@ -55,7 +55,7 @@ class CamelSpan {
     }
   }
 
-  static snsPublish(TraceAssert traceAssert, int index, topicName, parentSpan=null) {
+  static snsPublish(TraceAssert traceAssert, int index, topicName, parentSpan = null) {
     return traceAssert.span(index) {
       name topicName
       kind INTERNAL
@@ -67,7 +67,7 @@ class CamelSpan {
     }
   }
 
-  static s3(TraceAssert traceAssert, int index, parentSpan=null) {
+  static s3(TraceAssert traceAssert, int index, parentSpan = null) {
     return traceAssert.span(index) {
       name "aws-s3"
       kind INTERNAL

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/S3CamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/S3CamelTest.groovy
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel.aws
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap
 import spock.lang.Ignore
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 
 @Ignore("Does not work with localstack - X-Ray features needed")
 class S3CamelTest extends AgentInstrumentationSpecification {

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/S3Config.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/S3Config.groovy
@@ -40,7 +40,7 @@ class S3Config {
           .log(LoggingLevel.INFO, "test", "SENDING body: \${body}")
           .log(LoggingLevel.INFO, "test", "SENDING headers: \${headers}")
           .convertBodyTo(byte[].class)
-          .setHeader(S3Constants.KEY,simple("test-data"))
+          .setHeader(S3Constants.KEY, simple("test-data"))
           .to("aws-s3://${bucketName}?amazonS3Client=#s3Client")
       }
     }

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/SnsCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/SnsCamelTest.groovy
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel.aws
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap
 import spock.lang.Ignore
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 
 @Ignore("Does not work with localstack - X-Ray features needed")
 class SnsCamelTest extends AgentInstrumentationSpecification {

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/SqsCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/SqsCamelTest.groovy
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel.aws
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 class SqsCamelTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/CassandraTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/CassandraTest.groovy
@@ -7,14 +7,14 @@ package io.opentelemetry.javaagent.instrumentation.apachecamel.decorators
 
 import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.Session
-import org.apache.camel.CamelContext
-import org.apache.camel.ProducerTemplate
-import org.testcontainers.containers.CassandraContainer
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.RetryOnAddressAlreadyInUseTrait
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import org.apache.camel.CamelContext
+import org.apache.camel.ProducerTemplate
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
+import org.testcontainers.containers.CassandraContainer
 import org.testcontainers.containers.GenericContainer
 import spock.lang.Shared
 
@@ -97,7 +97,7 @@ class CassandraTest extends AgentInstrumentationSpecification implements RetryOn
             "apache-camel.uri" "direct://input"
           }
         }
-        span(1){
+        span(1) {
           kind CLIENT
           attributes {
             "apache-camel.uri" "cql://$host:$port/test"

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.groovy
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.groovy
@@ -5,10 +5,6 @@
 
 package io.opentelemetry.instrumentation.apachedubbo.v2_7
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-
-
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.api.HelloService
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.impl.HelloServiceImpl
@@ -26,6 +22,9 @@ import org.apache.dubbo.config.utils.ReferenceConfigCache
 import org.apache.dubbo.rpc.service.GenericService
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 @Unroll
 abstract class AbstractDubboTest extends InstrumentationSpecification {

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.CancellationException
 import org.apache.http.HttpHost
 import org.apache.http.HttpResponse
 import org.apache.http.client.config.RequestConfig
@@ -17,6 +17,8 @@ import org.apache.http.impl.nio.client.HttpAsyncClients
 import org.apache.http.message.BasicHeader
 import spock.lang.AutoCleanup
 import spock.lang.Shared
+
+import java.util.concurrent.CancellationException
 
 abstract class ApacheHttpAsyncClientTest extends HttpClientTest<HttpUriRequest> implements AgentTestTrait {
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/groovy/ApacheHttpClientTest.groovy
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.function.Consumer
 import org.apache.http.HttpHost
 import org.apache.http.HttpRequest
 import org.apache.http.HttpResponse
@@ -19,6 +19,8 @@ import org.apache.http.params.HttpConnectionParams
 import org.apache.http.params.HttpParams
 import org.apache.http.protocol.BasicHttpContext
 import spock.lang.Shared
+
+import java.util.function.Consumer
 
 abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest<T> implements AgentTestTrait {
   @Shared

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/testing/src/main/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/testing/src/main/groovy/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTest.groovy
@@ -9,7 +9,6 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.function.Consumer
 import org.apache.http.HttpHost
 import org.apache.http.HttpRequest
 import org.apache.http.HttpResponse
@@ -18,6 +17,8 @@ import org.apache.http.message.BasicHeader
 import org.apache.http.message.BasicHttpRequest
 import org.apache.http.protocol.BasicHttpContext
 import spock.lang.Shared
+
+import java.util.function.Consumer
 
 abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest<T> {
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/test/groovy/ApacheHttpClientTest.groovy
@@ -3,13 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.TimeUnit
-import java.util.function.Consumer
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase
 import org.apache.hc.client5.http.config.RequestConfig
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
@@ -24,6 +23,9 @@ import org.apache.hc.core5.http.message.BasicHeader
 import org.apache.hc.core5.http.protocol.BasicHttpContext
 import spock.lang.AutoCleanup
 import spock.lang.Shared
+
+import java.util.concurrent.TimeUnit
+import java.util.function.Consumer
 
 abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest<T> implements AgentTestTrait {
   @Shared

--- a/instrumentation/armeria-1.3/library/src/test/groovy/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerTest.groovy
+++ b/instrumentation/armeria-1.3/library/src/test/groovy/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerTest.groovy
@@ -8,7 +8,7 @@ package io.opentelemetry.instrumentation.armeria.v1_3
 import com.linecorp.armeria.server.ServerBuilder
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
 
-class ArmeriaHttpServerTest extends AbstractArmeriaHttpServerTest implements LibraryTestTrait{
+class ArmeriaHttpServerTest extends AbstractArmeriaHttpServerTest implements LibraryTestTrait {
   @Override
   ServerBuilder configureServer(ServerBuilder sb) {
     return sb.decorator(ArmeriaTracing.create(getOpenTelemetry()).newServiceDecorator())

--- a/instrumentation/armeria-1.3/testing/src/main/groovy/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpServerTest.groovy
+++ b/instrumentation/armeria-1.3/testing/src/main/groovy/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpServerTest.groovy
@@ -5,13 +5,6 @@
 
 package io.opentelemetry.instrumentation.armeria.v1_3
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
 import com.linecorp.armeria.common.HttpHeaderNames
 import com.linecorp.armeria.common.HttpRequest
 import com.linecorp.armeria.common.HttpResponse
@@ -28,7 +21,15 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
 import java.util.function.Function
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 abstract class AbstractArmeriaHttpServerTest extends HttpServerTest<Server> {
 

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsMessageHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AwsLambdaSqsMessageHandlerTest.groovy
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 class AwsLambdaSqsMessageHandlerTest extends LibraryInstrumentationSpecification {
 

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapperTest.groovy
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
@@ -14,6 +12,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.google.common.collect.ImmutableMap
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 class TracingRequestApiGatewayWrapperTest extends TracingRequestWrapperTestBase {
 

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperPropagationTest.groovy
@@ -5,19 +5,20 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.nio.charset.Charset
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Shared
+
+import java.nio.charset.Charset
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class TracingRequestStreamWrapperPropagationTest extends LibraryInstrumentationSpecification {
 

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestStreamWrapperTest.groovy
@@ -5,18 +5,19 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler
 import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.nio.charset.Charset
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Shared
+
+import java.nio.charset.Charset
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class TracingRequestStreamWrapperTest extends LibraryInstrumentationSpecification {
 

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
 

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
@@ -9,7 +9,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
-import spock.lang.Shared 
+import spock.lang.Shared
 
 class TracingRequestWrapperTestBase extends LibraryInstrumentationSpecification {
 

--- a/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaRequestHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaRequestHandlerTest.groovy
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.github.stefanbirkner.systemlambda.SystemLambda
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 abstract class AbstractAwsLambdaRequestHandlerTest extends InstrumentationSpecification {
 

--- a/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaSqsHandlerTest.groovy
+++ b/instrumentation/aws-lambda-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/AbstractAwsLambdaSqsHandlerTest.groovy
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 abstract class AbstractAwsLambdaSqsHandlerTest extends InstrumentationSpecification {
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/S3TracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/S3TracingTest.groovy
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import spock.lang.Ignore
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 @Ignore("Requires https://github.com/localstack/localstack/issues/3686 and #3669")
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SnsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SnsTracingTest.groovy
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import spock.lang.Ignore
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 @Ignore("Requires https://github.com/localstack/localstack/issues/3669 to work with localstack")
 class SnsTracingTest extends AgentInstrumentationSpecification {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/Aws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/Aws1ClientTest.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.awssdk.v1_11
 
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import com.amazonaws.AmazonWebServiceClient
 import com.amazonaws.Request
 import com.amazonaws.auth.BasicAWSCredentials
@@ -20,6 +17,9 @@ import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.awssdk.v1_11.AbstractAws1ClientTest
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class Aws1ClientTest extends AbstractAws1ClientTest implements AgentTestTrait {
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 import com.amazonaws.AmazonClientException
 import com.amazonaws.ClientConfiguration
@@ -32,8 +28,14 @@ import io.opentelemetry.testing.internal.armeria.common.HttpResponse
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus
 import io.opentelemetry.testing.internal.armeria.common.MediaType
 import io.opentelemetry.testing.internal.armeria.testing.junit5.server.mock.MockWebServerExtension
-import java.time.Duration
 import spock.lang.Shared
+
+import java.time.Duration
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class Aws0ClientTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
@@ -5,12 +5,6 @@
 
 package io.opentelemetry.instrumentation.awssdk.v1_11
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import com.amazonaws.AmazonClientException
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.SDKGlobalConfiguration
@@ -40,9 +34,16 @@ import io.opentelemetry.testing.internal.armeria.common.HttpResponse
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus
 import io.opentelemetry.testing.internal.armeria.common.MediaType
 import io.opentelemetry.testing.internal.armeria.testing.junit5.server.mock.MockWebServerExtension
-import java.time.Duration
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import java.time.Duration
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.groovy
@@ -5,11 +5,6 @@
 
 package io.opentelemetry.instrumentation.awssdk.v1_11
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder
@@ -21,6 +16,11 @@ import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import org.elasticmq.rest.sqs.SQSRestServerBuilder
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 abstract class AbstractSqsTracingTest extends InstrumentationSpecification {
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -5,19 +5,12 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2
 
-import static com.google.common.collect.ImmutableMap.of
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus
 import io.opentelemetry.testing.internal.armeria.common.MediaType
 import io.opentelemetry.testing.internal.armeria.testing.junit5.server.mock.MockWebServerExtension
-import java.time.Duration
-import java.util.concurrent.Future
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.core.ResponseInputStream
@@ -58,6 +51,14 @@ import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import java.time.Duration
+import java.util.concurrent.Future
+
+import static com.google.common.collect.ImmutableMap.of
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 @Unroll
 abstract class AbstractAws2ClientTest extends InstrumentationSpecification {

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/groovy/CassandraClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.Session
@@ -12,14 +11,17 @@ import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.time.Duration
-import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicBoolean
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
+
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 class CassandraClientTest extends AgentInstrumentationSpecification {
   private static final Logger logger = LoggerFactory.getLogger(CassandraClientTest)

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/test/groovy/CassandraClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption
@@ -14,12 +13,15 @@ import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
+
+import java.time.Duration
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 class CassandraClientTest extends AgentInstrumentationSpecification {
   private static final Logger logger = LoggerFactory.getLogger(CassandraClientTest)

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 class CouchbaseSpanUtil {
   // Reusable span assertion method.  Cannot directly override AbstractCouchbaseTest.assertCouchbaseSpan because
@@ -31,7 +32,7 @@ class CouchbaseSpanUtil {
         "${SemanticAttributes.DB_SYSTEM.key}" "couchbase"
         "${SemanticAttributes.DB_NAME.key}" bucketName
         "${SemanticAttributes.DB_STATEMENT.key}" statement
-        "${SemanticAttributes.DB_OPERATION.key}" (operation ?: spanName)
+        "${SemanticAttributes.DB_OPERATION.key}"(operation ?: spanName)
 
         // Because of caching, not all requests hit the server so these attributes may be absent
         "${SemanticAttributes.NET_PEER_NAME.key}" { it == "localhost" || it == "127.0.0.1" || it == null }

--- a/instrumentation/couchbase/couchbase-3.1.6/javaagent/src/test/groovy/CouchbaseClient316Test.groovy
+++ b/instrumentation/couchbase/couchbase-3.1.6/javaagent/src/test/groovy/CouchbaseClient316Test.groovy
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.couchbase.client.core.error.DocumentNotFoundException
 import com.couchbase.client.java.Cluster
 import com.couchbase.client.java.Collection
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.testcontainers.containers.output.Slf4jLogConsumer
@@ -15,6 +15,8 @@ import org.testcontainers.couchbase.BucketDefinition
 import org.testcontainers.couchbase.CouchbaseContainer
 import org.testcontainers.couchbase.CouchbaseService
 import spock.lang.Shared
+
+import java.time.Duration
 
 // Couchbase instrumentation is owned upstream so we don't assert on the contents of the spans, only
 // that the instrumentation is properly registered by the agent, meaning some spans were generated.

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/src/test/groovy/CouchbaseClient31Test.groovy
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/src/test/groovy/CouchbaseClient31Test.groovy
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.couchbase.client.core.error.DocumentNotFoundException
 import com.couchbase.client.java.Cluster
 import com.couchbase.client.java.Collection
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.testcontainers.containers.output.Slf4jLogConsumer
@@ -15,6 +15,8 @@ import org.testcontainers.couchbase.BucketDefinition
 import org.testcontainers.couchbase.CouchbaseContainer
 import org.testcontainers.couchbase.CouchbaseService
 import spock.lang.Shared
+
+import java.time.Duration
 
 // Couchbase instrumentation is owned upstream so we don't assert on the contents of the spans, only
 // that the instrumentation is properly registered by the agent, meaning some spans were generated.

--- a/instrumentation/couchbase/couchbase-3.2/javaagent/src/test/groovy/CouchbaseClient32Test.groovy
+++ b/instrumentation/couchbase/couchbase-3.2/javaagent/src/test/groovy/CouchbaseClient32Test.groovy
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.couchbase.client.core.error.DocumentNotFoundException
 import com.couchbase.client.java.Cluster
 import com.couchbase.client.java.Collection
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.testcontainers.containers.output.Slf4jLogConsumer
@@ -15,6 +15,8 @@ import org.testcontainers.couchbase.BucketDefinition
 import org.testcontainers.couchbase.CouchbaseContainer
 import org.testcontainers.couchbase.CouchbaseService
 import spock.lang.Shared
+
+import java.time.Duration
 
 // Couchbase instrumentation is owned upstream so we don't assert on the contents of the spans, only
 // that the instrumentation is properly registered by the agent, meaning some spans were generated.

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/AbstractCouchbaseAsyncClientTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/AbstractCouchbaseAsyncClientTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.couchbase.client.java.AsyncCluster
 import com.couchbase.client.java.CouchbaseAsyncCluster
 import com.couchbase.client.java.document.JsonDocument
@@ -10,10 +11,11 @@ import com.couchbase.client.java.document.json.JsonObject
 import com.couchbase.client.java.env.CouchbaseEnvironment
 import com.couchbase.client.java.query.N1qlQuery
 import io.opentelemetry.api.trace.SpanKind
-import java.util.concurrent.TimeUnit
 import spock.lang.Unroll
 import spock.util.concurrent.BlockingVariable
 import util.AbstractCouchbaseTest
+
+import java.util.concurrent.TimeUnit
 
 @Unroll
 abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbaseTest {

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringRepositoryTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringRepositoryTest.groovy
@@ -6,7 +6,6 @@
 package springdata
 
 
-
 import com.couchbase.client.java.Cluster
 import com.couchbase.client.java.CouchbaseCluster
 import com.couchbase.client.java.env.CouchbaseEnvironment

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringTemplateTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/AbstractCouchbaseSpringTemplateTest.groovy
@@ -6,7 +6,6 @@
 package springdata
 
 
-
 import com.couchbase.client.java.Bucket
 import com.couchbase.client.java.Cluster
 import com.couchbase.client.java.CouchbaseCluster

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/CouchbaseConfig.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/springdata/CouchbaseConfig.groovy
@@ -5,14 +5,14 @@
 
 package springdata
 
-import static java.util.Objects.requireNonNull
-
 import com.couchbase.client.java.cluster.BucketSettings
 import com.couchbase.client.java.env.CouchbaseEnvironment
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.couchbase.config.AbstractCouchbaseConfiguration
 import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories
+
+import static java.util.Objects.requireNonNull
 
 @Configuration
 @EnableCouchbaseRepositories(basePackages = "springdata")

--- a/instrumentation/couchbase/couchbase-testing/src/main/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-testing/src/main/groovy/util/AbstractCouchbaseTest.groovy
@@ -5,8 +5,6 @@
 
 package util
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-
 import com.couchbase.client.core.metrics.DefaultLatencyMetricsCollectorConfig
 import com.couchbase.client.core.metrics.DefaultMetricsCollectorConfig
 import com.couchbase.client.java.bucket.BucketType
@@ -22,8 +20,11 @@ import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.TimeUnit
 import spock.lang.Shared
+
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 abstract class AbstractCouchbaseTest extends AgentInstrumentationSpecification {
 
@@ -122,7 +123,7 @@ abstract class AbstractCouchbaseTest extends AgentInstrumentationSpecification {
         "${SemanticAttributes.DB_SYSTEM.key}" "couchbase"
         "${SemanticAttributes.DB_NAME.key}" bucketName
         "${SemanticAttributes.DB_STATEMENT.key}" statement
-        "${SemanticAttributes.DB_OPERATION.key}" (operation ?: spanName)
+        "${SemanticAttributes.DB_OPERATION.key}"(operation ?: spanName)
       }
     }
   }

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardAsyncTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardAsyncTest.groovy
@@ -3,18 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.dropwizard.Application
 import io.dropwizard.Configuration
 import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
-import java.util.concurrent.Executors
+
 import javax.ws.rs.GET
 import javax.ws.rs.Path
 import javax.ws.rs.PathParam
@@ -22,6 +16,14 @@ import javax.ws.rs.QueryParam
 import javax.ws.rs.container.AsyncResponse
 import javax.ws.rs.container.Suspended
 import javax.ws.rs.core.Response
+import java.util.concurrent.Executors
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class DropwizardAsyncTest extends DropwizardTest {
 

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -3,15 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.dropwizard.Application
 import io.dropwizard.Configuration
@@ -26,11 +17,22 @@ import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
 import javax.ws.rs.GET
 import javax.ws.rs.Path
 import javax.ws.rs.PathParam
 import javax.ws.rs.QueryParam
 import javax.ws.rs.core.Response
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class DropwizardTest extends HttpServerTest<DropwizardTestSupport> implements AgentTestTrait {
 

--- a/instrumentation/dropwizard-views-0.7/javaagent/src/test/groovy/ViewRenderTest.groovy
+++ b/instrumentation/dropwizard-views-0.7/javaagent/src/test/groovy/ViewRenderTest.groovy
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.dropwizard.views.View
 import io.dropwizard.views.freemarker.FreemarkerViewRenderer
 import io.dropwizard.views.mustache.MustacheViewRenderer
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+
 import java.nio.charset.StandardCharsets
 
 class ViewRenderTest extends AgentInstrumentationSpecification {

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -3,13 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import groovy.json.JsonSlurper
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.CountDownLatch
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -19,6 +16,11 @@ import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestClientBuilder
 import org.testcontainers.elasticsearch.ElasticsearchContainer
 import spock.lang.Shared
+
+import java.util.concurrent.CountDownLatch
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class Elasticsearch5RestClientTest extends AgentInstrumentationSpecification {
   @Shared

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -3,13 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import groovy.json.JsonSlurper
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.CountDownLatch
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -19,6 +16,11 @@ import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestClientBuilder
 import org.testcontainers.elasticsearch.ElasticsearchContainer
 import spock.lang.Shared
+
+import java.util.concurrent.CountDownLatch
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class Elasticsearch6RestClientTest extends AgentInstrumentationSpecification {
   @Shared

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/groovy/Elasticsearch7RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/groovy/Elasticsearch7RestClientTest.groovy
@@ -3,13 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import groovy.json.JsonSlurper
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.CountDownLatch
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.util.EntityUtils
@@ -20,6 +17,11 @@ import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.RestClientBuilder
 import org.testcontainers.elasticsearch.ElasticsearchContainer
 import spock.lang.Shared
+
+import java.util.concurrent.CountDownLatch
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class Elasticsearch7RestClientTest extends AgentInstrumentationSpecification {
   @Shared

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticsearch.client.Client
@@ -19,6 +15,11 @@ import org.elasticsearch.node.internal.InternalSettingsPreparer
 import org.elasticsearch.transport.Netty3Plugin
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch5NodeClientTest extends AbstractElasticsearchNodeClientTest {
   public static final long TIMEOUT = 10000 // 10 seconds
@@ -161,8 +162,8 @@ class Elasticsearch5NodeClientTest extends AbstractElasticsearchNodeClientTest {
     indexType = "test-type"
     id = "1"
     callKind | call
-    "sync"   | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
-    "async"  | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
+    "sync" | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
+    "async" | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
   }
 
   def "test elasticsearch get"() {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticsearch.client.transport.TransportClient
@@ -23,6 +19,11 @@ import org.elasticsearch.transport.TransportService
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch5TransportClientTest extends AbstractElasticsearchTransportClientTest {
   public static final long TIMEOUT = 10000 // 10 seconds
@@ -175,8 +176,8 @@ class Elasticsearch5TransportClientTest extends AbstractElasticsearchTransportCl
     indexType = "test-type"
     id = "1"
     callKind | call
-    "sync"   | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
-    "async"  | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
+    "sync" | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
+    "async" | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
   }
 
   def "test elasticsearch get"() {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
@@ -20,6 +16,11 @@ import org.elasticsearch.node.Node
 import org.elasticsearch.transport.Netty3Plugin
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch53NodeClientTest extends AbstractElasticsearchNodeClientTest {
   public static final long TIMEOUT = 10000 // 10 seconds
@@ -164,8 +165,8 @@ class Elasticsearch53NodeClientTest extends AbstractElasticsearchNodeClientTest 
     indexType = "test-type"
     id = "1"
     callKind | call
-    "sync"   | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
-    "async"  | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
+    "sync" | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
+    "async" | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
   }
 
   def "test elasticsearch get"() {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
@@ -24,6 +20,11 @@ import org.elasticsearch.transport.TransportService
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch53TransportClientTest extends AbstractElasticsearchTransportClientTest {
   public static final long TIMEOUT = 10000 // 10 seconds
@@ -180,8 +181,8 @@ class Elasticsearch53TransportClientTest extends AbstractElasticsearchTransportC
     indexType = "test-type"
     id = "1"
     callKind | call
-    "sync"   | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
-    "async"  | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
+    "sync" | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
+    "async" | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
   }
 
   def "test elasticsearch get"() {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -5,16 +5,17 @@
 
 package springdata
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import spock.lang.Shared
+
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
-import org.springframework.context.annotation.AnnotationConfigApplicationContext
-import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecification {
   // Setting up appContext & repo with @Shared doesn't allow

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -5,13 +5,8 @@
 
 package springdata
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.atomic.AtomicLong
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.common.io.FileSystemUtils
@@ -29,6 +24,12 @@ import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder
 import spock.lang.Shared
+
+import java.util.concurrent.atomic.AtomicLong
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecification {
   public static final long TIMEOUT = 10000 // 10 seconds

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
@@ -17,6 +13,11 @@ import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.Node
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch6NodeClientTest extends AbstractElasticsearchNodeClientTest {
   public static final long TIMEOUT = 10000 // 10 seconds
@@ -158,8 +159,8 @@ class Elasticsearch6NodeClientTest extends AbstractElasticsearchNodeClientTest {
     indexType = "test-type"
     id = "1"
     callKind | call
-    "sync"   | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
-    "async"  | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
+    "sync" | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
+    "async" | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
   }
 
   def "test elasticsearch get"() {

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
@@ -21,6 +17,11 @@ import org.elasticsearch.transport.TransportService
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
 
 class Elasticsearch6TransportClientTest extends AbstractElasticsearchTransportClientTest {
   public static final long TIMEOUT = 10000 // 10 seconds
@@ -173,8 +174,8 @@ class Elasticsearch6TransportClientTest extends AbstractElasticsearchTransportCl
     indexType = "test-type"
     id = "1"
     callKind | call
-    "sync"   | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
-    "async"  | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
+    "sync" | { indexName, indexType, id -> prepareGetSync(indexName, indexType, id) }
+    "async" | { indexName, indexType, id -> prepareGetAsync(indexName, indexType, id) }
   }
 
   def "test elasticsearch get"() {

--- a/instrumentation/elasticsearch/elasticsearch-transport-testing/src/main/groovy/AbstractElasticsearchClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-testing/src/main/groovy/AbstractElasticsearchClientTest.groovy
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import org.elasticsearch.action.ActionListener
 import org.elasticsearch.transport.RemoteTransportException
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 abstract class AbstractElasticsearchClientTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/executors/javaagent/src/test/groovy/CompletableFutureTest.groovy
+++ b/instrumentation/executors/javaagent/src/test/groovy/CompletableFutureTest.groovy
@@ -3,17 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import spock.lang.Requires
+
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.function.Function
 import java.util.function.Supplier
-import spock.lang.Requires
+
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 @Requires({ javaVersion >= 1.8 })
 class CompletableFutureTest extends AgentInstrumentationSpecification {

--- a/instrumentation/executors/javaagent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/instrumentation/executors/javaagent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import spock.lang.Shared
+
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.AbstractExecutorService
 import java.util.concurrent.ArrayBlockingQueue
@@ -21,7 +24,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import spock.lang.Shared
 
 class ExecutorInstrumentationTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/executors/javaagent/src/test/groovy/ForkJoinTaskTest.groovy
+++ b/instrumentation/executors/javaagent/src/test/groovy/ForkJoinTaskTest.groovy
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+
 import java.util.stream.IntStream
+
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 class ForkJoinTaskTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/executors/javaagent/src/test/groovy/ModuleInjectionTest.groovy
+++ b/instrumentation/executors/javaagent/src/test/groovy/ModuleInjectionTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+
 import javax.swing.*
 
 /**

--- a/instrumentation/external-annotations/javaagent-unit-tests/src/test/groovy/IncludeTest.groovy
+++ b/instrumentation/external-annotations/javaagent-unit-tests/src/test/groovy/IncludeTest.groovy
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.javaagent.instrumentation.extannotations.ExternalAnnotationInstrumentation.DEFAULT_ANNOTATIONS
 
 import io.opentelemetry.instrumentation.api.config.Config
 import io.opentelemetry.instrumentation.api.config.ConfigBuilder
 import io.opentelemetry.javaagent.instrumentation.extannotations.ExternalAnnotationInstrumentation
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import static io.opentelemetry.javaagent.instrumentation.extannotations.ExternalAnnotationInstrumentation.DEFAULT_ANNOTATIONS
 
 class IncludeTest extends Specification {
 

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.test.annotation.SayTracedHello
+
 import java.util.concurrent.Callable
 
 class ConfiguredTraceAnnotationsTest extends AgentInstrumentationSpecification {

--- a/instrumentation/external-annotations/javaagent/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/instrumentation/external-annotations/javaagent/src/test/groovy/TraceAnnotationsTest.groovy
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.test.annotation.SayTracedHello
 import io.opentracing.contrib.dropwizard.Trace
+
 import java.util.concurrent.Callable
+
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class TraceAnnotationsTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/finatra-2.9/javaagent/src/latestDepTest/groovy/FinatraServerLatestTest.groovy
+++ b/instrumentation/finatra-2.9/javaagent/src/latestDepTest/groovy/FinatraServerLatestTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import com.twitter.app.lifecycle.Event
 import com.twitter.app.lifecycle.Observer
@@ -18,6 +15,10 @@ import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class FinatraServerLatestTest extends HttpServerTest<HttpServer> implements AgentTestTrait {
   private static final Duration TIMEOUT = Duration.fromSeconds(5)

--- a/instrumentation/finatra-2.9/javaagent/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/javaagent/src/test/groovy/FinatraServerTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static org.awaitility.Awaitility.await
 
 import com.twitter.finatra.http.HttpServer
 import com.twitter.util.Await
@@ -16,7 +12,13 @@ import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
+
 import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static org.awaitility.Awaitility.await
 
 class FinatraServerTest extends HttpServerTest<HttpServer> implements AgentTestTrait {
   private static final Duration TIMEOUT = Duration.fromSeconds(5)

--- a/instrumentation/geode-1.4/javaagent/src/test/groovy/PutGetTest.groovy
+++ b/instrumentation/geode-1.4/javaagent/src/test/groovy/PutGetTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -13,6 +11,9 @@ import org.apache.geode.cache.client.ClientCacheFactory
 import org.apache.geode.cache.client.ClientRegionShortcut
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 @Unroll
 class PutGetTest extends AgentInstrumentationSpecification {

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpRequest
@@ -15,6 +12,10 @@ import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 abstract class AbstractGoogleHttpClientTest extends HttpClientTest<HttpRequest> implements AgentTestTrait {
 

--- a/instrumentation/grails-3.0/javaagent/src/test/groovy/test/ErrorController.groovy
+++ b/instrumentation/grails-3.0/javaagent/src/test/groovy/test/ErrorController.groovy
@@ -5,10 +5,10 @@
 
 package test
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-
 import grails.artefact.Controller
 import grails.web.Action
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 
 class ErrorController implements Controller {
 

--- a/instrumentation/grails-3.0/javaagent/src/test/groovy/test/GrailsTest.groovy
+++ b/instrumentation/grails-3.0/javaagent/src/test/groovy/test/GrailsTest.groovy
@@ -5,14 +5,6 @@
 
 package test
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-
 import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
 import groovy.transform.CompileStatic
@@ -24,6 +16,14 @@ import io.opentelemetry.sdk.trace.data.SpanData
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.web.ServerProperties
 import org.springframework.context.ConfigurableApplicationContext
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 
 class GrailsTest extends HttpServerTest<ConfigurableApplicationContext> implements AgentTestTrait {
 

--- a/instrumentation/grails-3.0/javaagent/src/test/groovy/test/TestController.groovy
+++ b/instrumentation/grails-3.0/javaagent/src/test/groovy/test/TestController.groovy
@@ -5,16 +5,16 @@
 
 package test
 
+import grails.artefact.Controller
+import grails.web.Action
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import grails.artefact.Controller
-import grails.web.Action
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
 
 class TestController implements Controller {
 

--- a/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyAsyncTest.groovy
+++ b/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyAsyncTest.groovy
@@ -3,23 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
+import org.glassfish.grizzly.http.server.HttpServer
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
+import org.glassfish.jersey.server.ResourceConfig
+
 import javax.ws.rs.GET
 import javax.ws.rs.Path
 import javax.ws.rs.QueryParam
 import javax.ws.rs.container.AsyncResponse
 import javax.ws.rs.container.Suspended
 import javax.ws.rs.core.Response
-import org.glassfish.grizzly.http.server.HttpServer
-import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
-import org.glassfish.jersey.server.ResourceConfig
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class GrizzlyAsyncTest extends GrizzlyTest {
 

--- a/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyFilterchainServerTest.groovy
+++ b/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyFilterchainServerTest.groovy
@@ -3,22 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static java.lang.String.valueOf
-import static java.nio.charset.Charset.defaultCharset
-import static java.util.concurrent.TimeUnit.MILLISECONDS
-import static org.glassfish.grizzly.memory.Buffers.wrap
 
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import java.util.concurrent.Executors
 import org.glassfish.grizzly.filterchain.BaseFilter
 import org.glassfish.grizzly.filterchain.FilterChain
 import org.glassfish.grizzly.filterchain.FilterChainBuilder
@@ -36,6 +23,21 @@ import org.glassfish.grizzly.nio.transport.TCPNIOTransport
 import org.glassfish.grizzly.nio.transport.TCPNIOTransportBuilder
 import org.glassfish.grizzly.utils.DelayedExecutor
 import org.glassfish.grizzly.utils.IdleTimeoutFilter
+
+import java.util.concurrent.Executors
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static java.lang.String.valueOf
+import static java.nio.charset.Charset.defaultCharset
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static org.glassfish.grizzly.memory.Buffers.wrap
 
 class GrizzlyFilterchainServerTest extends HttpServerTest<HttpServer> implements AgentTestTrait {
 

--- a/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyTest.groovy
+++ b/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyTest.groovy
@@ -3,25 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import org.glassfish.grizzly.http.server.HttpHandler
+import org.glassfish.grizzly.http.server.HttpServer
+import org.glassfish.grizzly.http.server.Request
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
+import org.glassfish.jersey.server.ResourceConfig
+
 import javax.ws.rs.GET
 import javax.ws.rs.NotFoundException
 import javax.ws.rs.Path
 import javax.ws.rs.QueryParam
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.ExceptionMapper
-import org.glassfish.grizzly.http.server.HttpHandler
-import org.glassfish.grizzly.http.server.HttpServer
-import org.glassfish.grizzly.http.server.Request
-import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
-import org.glassfish.jersey.server.ResourceConfig
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class GrizzlyTest extends HttpServerTest<HttpServer> implements AgentTestTrait {
 

--- a/instrumentation/grpc-1.6/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.groovy
+++ b/instrumentation/grpc-1.6/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-
 import example.GreeterGrpc
 import example.Helloworld
 import io.grpc.BindableService
@@ -20,10 +17,14 @@ import io.grpc.stub.StreamObserver
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import spock.lang.Unroll
+
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
-import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 @Unroll
 abstract class AbstractGrpcStreamingTest extends InstrumentationSpecification {

--- a/instrumentation/grpc-1.6/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.groovy
+++ b/instrumentation/grpc-1.6/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.groovy
@@ -5,11 +5,6 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-
-
 import example.GreeterGrpc
 import example.Helloworld
 import io.grpc.BindableService
@@ -39,10 +34,15 @@ import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import spock.lang.Unroll
+
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
-import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 @Unroll
 abstract class AbstractGrpcTest extends InstrumentationSpecification {

--- a/instrumentation/guava-10.0/javaagent/src/test/groovy/GuavaWithSpanInstrumentationTest.groovy
+++ b/instrumentation/guava-10.0/javaagent/src/test/groovy/GuavaWithSpanInstrumentationTest.groovy
@@ -53,7 +53,7 @@ class GuavaWithSpanInstrumentationTest extends AgentInstrumentationSpecification
 
   def "should capture span for eventually done ListenableFuture"() {
     setup:
-    def future = SettableFuture.<String>create()
+    def future = SettableFuture.<String> create()
     new TracedWithSpan().listenableFuture(future)
 
     expect:
@@ -78,7 +78,7 @@ class GuavaWithSpanInstrumentationTest extends AgentInstrumentationSpecification
   def "should capture span for eventually failed ListenableFuture"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def future = SettableFuture.<String>create()
+    def future = SettableFuture.<String> create()
     new TracedWithSpan().listenableFuture(future)
 
     expect:
@@ -104,7 +104,7 @@ class GuavaWithSpanInstrumentationTest extends AgentInstrumentationSpecification
 
   def "should capture span for canceled ListenableFuture"() {
     setup:
-    def future = SettableFuture.<String>create()
+    def future = SettableFuture.<String> create()
     new TracedWithSpan().listenableFuture(future)
 
     expect:

--- a/instrumentation/guava-10.0/javaagent/src/test/groovy/ListenableFutureTest.groovy
+++ b/instrumentation/guava-10.0/javaagent/src/test/groovy/ListenableFutureTest.groovy
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import io.opentelemetry.instrumentation.test.base.AbstractPromiseTest
-import java.util.concurrent.Executors
 import spock.lang.Shared
+
+import java.util.concurrent.Executors
 
 class ListenableFutureTest extends AbstractPromiseTest<SettableFuture<Boolean>, ListenableFuture<String>> {
   @Shared

--- a/instrumentation/guava-10.0/library/src/test/groovy/GuavaAsyncOperationEndStrategyTest.groovy
+++ b/instrumentation/guava-10.0/library/src/test/groovy/GuavaAsyncOperationEndStrategyTest.groovy
@@ -12,7 +12,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import io.opentelemetry.instrumentation.guava.GuavaAsyncOperationEndStrategy
 import spock.lang.Specification
 
-class GuavaAsyncOperationEndStrategyTest extends Specification  {
+class GuavaAsyncOperationEndStrategyTest extends Specification {
   String request = "request"
   String response = "response"
 
@@ -66,7 +66,7 @@ class GuavaAsyncOperationEndStrategyTest extends Specification  {
 
   def "ends span on eventually done future"() {
     given:
-    def future = SettableFuture.<String>create()
+    def future = SettableFuture.<String> create()
 
     when:
     underTest.end(instrumenter, context, request, future, String)
@@ -83,7 +83,7 @@ class GuavaAsyncOperationEndStrategyTest extends Specification  {
 
   def "ends span on eventually failed future"() {
     given:
-    def future = SettableFuture.<String>create()
+    def future = SettableFuture.<String> create()
     def exception = new IllegalStateException()
 
     when:
@@ -101,7 +101,7 @@ class GuavaAsyncOperationEndStrategyTest extends Specification  {
 
   def "ends span on eventually canceled future"() {
     given:
-    def future = SettableFuture.<String>create()
+    def future = SettableFuture.<String> create()
     def context = span.storeInContext(Context.root())
 
     when:
@@ -120,7 +120,7 @@ class GuavaAsyncOperationEndStrategyTest extends Specification  {
 
   def "ends span on eventually canceled future and capturing experimental span attributes"() {
     given:
-    def future = SettableFuture.<String>create()
+    def future = SettableFuture.<String> create()
     def context = span.storeInContext(Context.root())
 
     when:

--- a/instrumentation/gwt-2.0/javaagent/src/test/groovy/GwtTest.groovy
+++ b/instrumentation/gwt-2.0/javaagent/src/test/groovy/GwtTest.groovy
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.TimeUnit
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.util.resource.Resource
 import org.eclipse.jetty.webapp.WebAppContext
@@ -19,6 +19,8 @@ import org.testcontainers.Testcontainers
 import org.testcontainers.containers.BrowserWebDriverContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
+
+import java.util.concurrent.TimeUnit
 
 class GwtTest extends AgentInstrumentationSpecification implements HttpServerTestTrait<Server> {
   private static final Logger logger = LoggerFactory.getLogger(GwtTest)

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/CriteriaTest.groovy
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.hibernate.Criteria
 import org.hibernate.Session
 import org.hibernate.criterion.Order
 import org.hibernate.criterion.Restrictions
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class CriteriaTest extends AbstractHibernateTest {
 

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/QueryTest.groovy
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.hibernate.Query
 import org.hibernate.Session
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class QueryTest extends AbstractHibernateTest {
 
@@ -104,26 +105,26 @@ class QueryTest extends AbstractHibernateTest {
     }
 
     where:
-    queryMethodName       | expectedSpanName            | requiresTransaction | queryInteraction
-    "Query.list"          | "SELECT Value"              | false               | { sess ->
+    queryMethodName       | expectedSpanName | requiresTransaction | queryInteraction
+    "Query.list"          | "SELECT Value"   | false               | { sess ->
       Query q = sess.createQuery("from Value")
       q.list()
     }
-    "Query.executeUpdate" | "UPDATE Value"              | true                | { sess ->
+    "Query.executeUpdate" | "UPDATE Value"   | true                | { sess ->
       Query q = sess.createQuery("update Value set name = ?")
       q.setParameter(0, "alyx")
       q.executeUpdate()
     }
-    "Query.uniqueResult"  | "SELECT Value"              | false               | { sess ->
+    "Query.uniqueResult"  | "SELECT Value"   | false               | { sess ->
       Query q = sess.createQuery("from Value where id = ?")
       q.setParameter(0, 1L)
       q.uniqueResult()
     }
-    "Query.iterate"       | "SELECT Value"              | false               | { sess ->
+    "Query.iterate"       | "SELECT Value"   | false               | { sess ->
       Query q = sess.createQuery("from Value")
       q.iterate()
     }
-    "Query.scroll"        | "SELECT Value"              | false               | { sess ->
+    "Query.scroll"        | "SELECT Value"   | false               | { sess ->
       Query q = sess.createQuery("from Value")
       q.scroll()
     }

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/test/groovy/SessionTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.hibernate.LockMode
@@ -14,6 +11,10 @@ import org.hibernate.Query
 import org.hibernate.ReplicationMode
 import org.hibernate.Session
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class SessionTest extends AbstractHibernateTest {
 

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/hibernate6Test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/hibernate6Test/groovy/SpringJpaTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -12,6 +11,8 @@ import spock.lang.Shared
 import spring.jpa.Customer
 import spring.jpa.CustomerRepository
 import spring.jpa.PersistenceConfig
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 /**
  * Unfortunately this test verifies that our hibernate instrumentation doesn't currently work with Spring Data Repositories.

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/CriteriaTest.groovy
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.hibernate.Criteria
 import org.hibernate.Session
 import org.hibernate.criterion.Order
 import org.hibernate.criterion.Restrictions
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class CriteriaTest extends AbstractHibernateTest {
 

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/EntityManagerTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/EntityManagerTest.groovy
@@ -3,18 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import spock.lang.Shared
+import spock.lang.Unroll
+
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
 import javax.persistence.LockModeType
 import javax.persistence.Persistence
 import javax.persistence.Query
-import spock.lang.Shared
-import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class EntityManagerTest extends AbstractHibernateTest {
 
@@ -132,24 +134,24 @@ class EntityManagerTest extends AbstractHibernateTest {
     }
 
     where:
-    testName                                  | methodName   | resource | attach | flushOnCommit | sessionMethodTest
-    "lock"                                    | "lock"       | "Value"  | true   | false         | { em, val ->
+    testName  | methodName   | resource | attach | flushOnCommit | sessionMethodTest
+    "lock"    | "lock"       | "Value"  | true   | false         | { em, val ->
       em.lock(val, LockModeType.PESSIMISTIC_READ)
     }
-    "refresh"                                 | "refresh"    | "Value"  | true   | false         | { em, val ->
+    "refresh" | "refresh"    | "Value"  | true   | false         | { em, val ->
       em.refresh(val)
     }
-    "find"                                    | "(get|find)" | "Value"  | false  | false         | { em, val ->
+    "find"    | "(get|find)" | "Value"  | false  | false         | { em, val ->
       em.find(Value, val.getId())
     }
-    "persist"                                 | "persist"    | "Value"  | false  | true          | { em, val ->
+    "persist" | "persist"    | "Value"  | false  | true          | { em, val ->
       em.persist(new Value("insert me"))
     }
-    "merge"                                   | "merge"      | "Value"  | true   | true          | { em, val ->
+    "merge"   | "merge"      | "Value"  | true   | true          | { em, val ->
       val.setName("New name")
       em.merge(val)
     }
-    "remove"                                  | "delete"     | "Value"  | true   | true          | { em, val ->
+    "remove"  | "delete"     | "Value"  | true   | true          | { em, val ->
       em.remove(val)
     }
   }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/QueryTest.groovy
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.hibernate.Query
 import org.hibernate.Session
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class QueryTest extends AbstractHibernateTest {
 
@@ -104,26 +105,26 @@ class QueryTest extends AbstractHibernateTest {
     }
 
     where:
-    queryMethodName       | expectedSpanName            | requiresTransaction | queryInteraction
-    "query/list"          | "SELECT Value"              | false               | { sess ->
+    queryMethodName       | expectedSpanName | requiresTransaction | queryInteraction
+    "query/list"          | "SELECT Value"   | false               | { sess ->
       Query q = sess.createQuery("from Value")
       q.list()
     }
-    "query/executeUpdate" | "UPDATE Value"              | true                | { sess ->
+    "query/executeUpdate" | "UPDATE Value"   | true                | { sess ->
       Query q = sess.createQuery("update Value set name = :name")
       q.setParameter("name", "alyx")
       q.executeUpdate()
     }
-    "query/uniqueResult"  | "SELECT Value"              | false               | { sess ->
+    "query/uniqueResult"  | "SELECT Value"   | false               | { sess ->
       Query q = sess.createQuery("from Value where id = :id")
       q.setParameter("id", 1L)
       q.uniqueResult()
     }
-    "iterate"             | "SELECT Value"              | false               | { sess ->
+    "iterate"             | "SELECT Value"   | false               | { sess ->
       Query q = sess.createQuery("from Value")
       q.iterate()
     }
-    "query/scroll"        | "SELECT Value"              | false               | { sess ->
+    "query/scroll"        | "SELECT Value"   | false               | { sess ->
       Query q = sess.createQuery("from Value")
       q.scroll()
     }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/SessionTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.hibernate.LockMode
@@ -15,6 +12,10 @@ import org.hibernate.Query
 import org.hibernate.ReplicationMode
 import org.hibernate.Session
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class SessionTest extends AbstractHibernateTest {
 

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/test/groovy/SpringJpaTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -14,6 +12,9 @@ import spock.lang.Shared
 import spring.jpa.Customer
 import spring.jpa.CustomerRepository
 import spring.jpa.PersistenceConfig
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class SpringJpaTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/groovy/ProcedureCallTest.groovy
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/groovy/ProcedureCallTest.groovy
@@ -3,16 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.sql.Connection
-import java.sql.DriverManager
-import java.sql.Statement
-import javax.persistence.ParameterMode
 import org.hibernate.Session
 import org.hibernate.SessionFactory
 import org.hibernate.cfg.Configuration
@@ -20,6 +13,15 @@ import org.hibernate.exception.SQLGrammarException
 import org.hibernate.procedure.ProcedureCall
 import org.junit.Assume
 import spock.lang.Shared
+
+import javax.persistence.ParameterMode
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.Statement
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class ProcedureCallTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.test.AgentTestTrait
@@ -14,6 +11,10 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Requires
 import spock.lang.Unroll
 import sun.net.www.protocol.https.HttpsURLConnectionImpl
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements AgentTestTrait {
 

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/UrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/UrlConnectionTest.groovy
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class UrlConnectionTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 import com.netflix.hystrix.HystrixObservableCommand
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import rx.Observable
 import rx.schedulers.Schedulers
+
+import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 class HystrixObservableChainTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
@@ -3,18 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 import com.netflix.hystrix.HystrixObservable
 import com.netflix.hystrix.HystrixObservableCommand
 import com.netflix.hystrix.exception.HystrixRuntimeException
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.util.concurrent.BlockingQueue
-import java.util.concurrent.LinkedBlockingQueue
 import rx.Observable
 import rx.schedulers.Schedulers
+
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+
+import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 class HystrixObservableTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
@@ -3,14 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 import com.netflix.hystrix.HystrixCommand
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
+
+import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 class HystrixTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/internal/internal-class-loader/javaagent-integration-tests/src/test/groovy/ResourceInjectionTest.groovy
+++ b/instrumentation/internal/internal-class-loader/javaagent-integration-tests/src/test/groovy/ResourceInjectionTest.groovy
@@ -3,20 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.utils.GcUtils.awaitGc
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import org.apache.commons.lang3.SystemUtils
 
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicReference
-import org.apache.commons.lang3.SystemUtils
+
+import static io.opentelemetry.instrumentation.test.utils.GcUtils.awaitGc
 
 class ResourceInjectionTest extends AgentInstrumentationSpecification {
 
   def "resources injected to non-delegating classloader"() {
     setup:
     String resourceName = 'test-resources/test-resource.txt'
-    URL[] urls = [ SystemUtils.getProtectionDomain().getCodeSource().getLocation() ]
+    URL[] urls = [SystemUtils.getProtectionDomain().getCodeSource().getLocation()]
     AtomicReference<URLClassLoader> emptyLoader = new AtomicReference<>(new URLClassLoader(urls, (ClassLoader) null))
 
     when:

--- a/instrumentation/internal/internal-proxy/javaagent-unit-tests/src/test/groovy/ProxyHelperTest.groovy
+++ b/instrumentation/internal/internal-proxy/javaagent-unit-tests/src/test/groovy/ProxyHelperTest.groovy
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.javaagent.bootstrap.FieldBackedContextStoreAppliedMarker
 import io.opentelemetry.javaagent.instrumentation.internal.proxy.ProxyHelper
-import java.util.concurrent.Callable
 import spock.lang.Specification
+
+import java.util.concurrent.Callable
 
 class ProxyHelperTest extends Specification {
 

--- a/instrumentation/internal/internal-proxy/javaagent/src/test/groovy/NewProxyInstanceTest.groovy
+++ b/instrumentation/internal/internal-proxy/javaagent/src/test/groovy/NewProxyInstanceTest.groovy
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.javaagent.bootstrap.FieldBackedContextStoreAppliedMarker
+
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy

--- a/instrumentation/java-http-client/javaagent/src/test/groovy/JdkHttpClientTest.groovy
+++ b/instrumentation/java-http-client/javaagent/src/test/groovy/JdkHttpClientTest.groovy
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
+import spock.lang.Shared
+
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 import java.time.temporal.ChronoUnit
-import spock.lang.Shared
 
 class JdkHttpClientTest extends HttpClientTest<HttpRequest> implements AgentTestTrait {
 

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxMultithreadedClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxMultithreadedClientTest.groovy
@@ -3,16 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus
 import io.opentelemetry.testing.internal.armeria.common.MediaType
 import io.opentelemetry.testing.internal.armeria.server.ServerBuilder
 import io.opentelemetry.testing.internal.armeria.testing.junit5.server.ServerExtension
-import javax.ws.rs.client.Client
 import org.glassfish.jersey.client.JerseyClientBuilder
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
+
+import javax.ws.rs.client.Client
 
 class JaxMultithreadedClientTest extends AgentInstrumentationSpecification {
 
@@ -20,7 +22,7 @@ class JaxMultithreadedClientTest extends AgentInstrumentationSpecification {
   def server = new ServerExtension() {
     @Override
     protected void configure(ServerBuilder sb) throws Exception {
-      sb.service("/success") {ctx, req ->
+      sb.service("/success") { ctx, req ->
         HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT, "Hello.")
       }
     }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
@@ -3,16 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.TimeUnit
+import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl
+import org.glassfish.jersey.client.ClientConfig
+import org.glassfish.jersey.client.ClientProperties
+import org.glassfish.jersey.client.JerseyClientBuilder
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
+import spock.lang.Unroll
+
 import javax.ws.rs.ProcessingException
 import javax.ws.rs.client.ClientBuilder
 import javax.ws.rs.client.Entity
@@ -20,12 +23,11 @@ import javax.ws.rs.client.Invocation
 import javax.ws.rs.client.InvocationCallback
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
-import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl
-import org.glassfish.jersey.client.ClientConfig
-import org.glassfish.jersey.client.ClientProperties
-import org.glassfish.jersey.client.JerseyClientBuilder
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
-import spock.lang.Unroll
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 abstract class JaxRsClientTest extends HttpClientTest<Invocation.Builder> implements AgentTestTrait {
 

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/ResteasyProxyClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/ResteasyProxyClientTest.groovy
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
-import java.nio.charset.StandardCharsets
+import org.apache.http.client.utils.URLEncodedUtils
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
+import org.jboss.resteasy.specimpl.ResteasyUriBuilder
+
 import javax.ws.rs.GET
 import javax.ws.rs.HeaderParam
 import javax.ws.rs.POST
@@ -13,9 +17,7 @@ import javax.ws.rs.PUT
 import javax.ws.rs.Path
 import javax.ws.rs.QueryParam
 import javax.ws.rs.core.Response
-import org.apache.http.client.utils.URLEncodedUtils
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
-import org.jboss.resteasy.specimpl.ResteasyUriBuilder
+import java.nio.charset.StandardCharsets
 
 class ResteasyProxyClientTest extends HttpClientTest<ResteasyProxyResource> implements AgentTestTrait {
 

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/ResteasySingleConnection.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/ResteasySingleConnection.groovy
@@ -3,13 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection
+import org.jboss.resteasy.client.jaxrs.ResteasyClient
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
+
+import javax.ws.rs.core.MediaType
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import javax.ws.rs.core.MediaType
-import org.jboss.resteasy.client.jaxrs.ResteasyClient
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
 
 class ResteasySingleConnection implements SingleConnection {
   private final ResteasyClient client

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.instrumentation.test.utils.ClassUtils.getClassName
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import spock.lang.Unroll
+
 import javax.ws.rs.DELETE
 import javax.ws.rs.GET
 import javax.ws.rs.HEAD
@@ -16,7 +15,10 @@ import javax.ws.rs.OPTIONS
 import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
-import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.instrumentation.test.utils.ClassUtils.getClassName
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
 class JaxRsAnnotations1InstrumentationTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JerseyTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JerseyTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
 import io.dropwizard.testing.junit.ResourceTestRule
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
@@ -13,6 +10,10 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.junit.ClassRule
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
 class JerseyTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-arquillian-testing/src/main/groovy/ArquillianRestTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-arquillian-testing/src/main/groovy/ArquillianRestTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.testing.internal.armeria.client.WebClient
@@ -20,6 +19,8 @@ import spock.lang.Unroll
 import test.CdiRestResource
 import test.EjbRestResource
 import test.RestApplication
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 @RunWith(ArquillianSputnik)
 @RunAsClient

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/javaagent/src/test/groovy/CxfFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/javaagent/src/test/groovy/CxfFilterTest.groovy
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static Resource.Test1
-import static Resource.Test2
-import static Resource.Test3
 
 import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
 import org.apache.cxf.endpoint.Server
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean
+
+import static Resource.Test1
+import static Resource.Test2
+import static Resource.Test3
 
 class CxfFilterTest extends JaxRsFilterTest implements HttpServerTestTrait<Server> {
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/javaagent/src/test/groovy/CxfHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/javaagent/src/test/groovy/CxfHttpServerTest.groovy
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import javax.ws.rs.core.MediaType
-import javax.ws.rs.core.Response
-import javax.ws.rs.ext.ExceptionMapper
+
 import org.apache.cxf.endpoint.Server
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean
 import test.JaxRsTestApplication
+
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+import javax.ws.rs.ext.ExceptionMapper
 
 class CxfHttpServerTest extends JaxRsHttpServerTest<Server> {
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/src/test/groovy/JerseyFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/src/test/groovy/JerseyFilterTest.groovy
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.dropwizard.testing.junit.ResourceTestRule
+import org.junit.ClassRule
+import spock.lang.Shared
+
+import javax.ws.rs.client.Entity
+import javax.ws.rs.core.Response
+
 import static Resource.Test1
 import static Resource.Test2
 import static Resource.Test3
-
-import io.dropwizard.testing.junit.ResourceTestRule
-import javax.ws.rs.client.Entity
-import javax.ws.rs.core.Response
-import org.junit.ClassRule
-import spock.lang.Shared
 
 class JerseyFilterTest extends JaxRsFilterTest {
   @Shared

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/src/test/groovy/JerseyStartupListener.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/src/test/groovy/JerseyStartupListener.groovy
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import javax.servlet.ServletContextEvent
-import javax.servlet.ServletContextListener
+
 import org.glassfish.jersey.servlet.init.JerseyServletContainerInitializer
 import test.JaxRsApplicationPathTestApplication
+
+import javax.servlet.ServletContextEvent
+import javax.servlet.ServletContextListener
 
 // ServletContainerInitializer isn't automatically called due to the way this test is set up
 // so we call it ourself

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/src/test/groovy/ResteasyFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/src/test/groovy/ResteasyFilterTest.groovy
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static Resource.Test1
-import static Resource.Test2
-import static Resource.Test3
 
-import javax.ws.rs.core.MediaType
 import org.jboss.resteasy.mock.MockDispatcherFactory
 import org.jboss.resteasy.mock.MockHttpRequest
 import org.jboss.resteasy.mock.MockHttpResponse
 import spock.lang.Shared
+
+import javax.ws.rs.core.MediaType
+
+import static Resource.Test1
+import static Resource.Test2
+import static Resource.Test3
 
 class ResteasyFilterTest extends JaxRsFilterTest {
   @Shared

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/src/test/groovy/ResteasyStartupListener.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/src/test/groovy/ResteasyStartupListener.groovy
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import javax.servlet.ServletContextEvent
-import javax.servlet.ServletContextListener
+
 import org.jboss.resteasy.plugins.servlet.ResteasyServletInitializer
 import test.JaxRsApplicationPathTestApplication
+
+import javax.servlet.ServletContextEvent
+import javax.servlet.ServletContextListener
 
 // ServletContainerInitializer isn't automatically called due to the way this test is set up
 // so we call it ourself

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/src/test/groovy/ResteasyFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/src/test/groovy/ResteasyFilterTest.groovy
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static Resource.Test1
-import static Resource.Test2
-import static Resource.Test3
 
-import javax.ws.rs.core.MediaType
 import org.jboss.resteasy.mock.MockDispatcherFactory
 import org.jboss.resteasy.mock.MockHttpRequest
 import org.jboss.resteasy.mock.MockHttpResponse
 import spock.lang.Shared
+
+import javax.ws.rs.core.MediaType
+
+import static Resource.Test1
+import static Resource.Test2
+import static Resource.Test3
 
 class ResteasyFilterTest extends JaxRsFilterTest {
   @Shared

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/src/test/groovy/ResteasyStartupListener.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/src/test/groovy/ResteasyStartupListener.groovy
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import javax.servlet.ServletContextEvent
-import javax.servlet.ServletContextListener
+
 import org.jboss.resteasy.plugins.servlet.ResteasyServletInitializer
 import test.JaxRsApplicationPathTestApplication
+
+import javax.servlet.ServletContextEvent
+import javax.servlet.ServletContextListener
 
 // ServletContainerInitializer isn't automatically called due to the way this test is set up
 // so we call it ourself

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsFilterTest.groovy
@@ -3,22 +3,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import org.junit.Assume
+import spock.lang.Shared
+import spock.lang.Unroll
+
 import javax.ws.rs.container.ContainerRequestContext
 import javax.ws.rs.container.ContainerRequestFilter
 import javax.ws.rs.container.PreMatching
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.Provider
-import org.junit.Assume
-import spock.lang.Shared
-import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
 @Unroll
 abstract class JaxRsFilterTest extends AgentInstrumentationSpecification {

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsHttpServerTest.groovy
@@ -3,14 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static java.util.concurrent.TimeUnit.SECONDS
-import static org.junit.Assume.assumeTrue
 
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -19,6 +11,15 @@ import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Unroll
 import test.JaxRsTestResource
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static java.util.concurrent.TimeUnit.SECONDS
+import static org.junit.Assume.assumeTrue
 
 abstract class JaxRsHttpServerTest<S> extends HttpServerTest<S> implements AgentTestTrait {
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsJettyHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxRsJettyHttpServerTest.groovy
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static org.eclipse.jetty.util.resource.Resource.newResource
 
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.webapp.WebAppContext
+
+import static org.eclipse.jetty.util.resource.Resource.newResource
 
 class JaxRsJettyHttpServerTest extends JaxRsHttpServerTest<Server> {
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxrsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/JaxrsAnnotationsInstrumentationTest.groovy
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.instrumentation.test.utils.ClassUtils.getClassName
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import spock.lang.Unroll
+
 import javax.ws.rs.DELETE
 import javax.ws.rs.GET
 import javax.ws.rs.HEAD
@@ -16,7 +15,10 @@ import javax.ws.rs.OPTIONS
 import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
-import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.instrumentation.test.utils.ClassUtils.getClassName
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderServerTrace
 
 abstract class JaxrsAnnotationsInstrumentationTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/test/JaxRsTestResource.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-testing/src/main/groovy/test/JaxRsTestResource.groovy
@@ -5,19 +5,8 @@
 
 package test
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static java.util.concurrent.TimeUnit.SECONDS
-
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionStage
-import java.util.concurrent.CyclicBarrier
+
 import javax.ws.rs.ApplicationPath
 import javax.ws.rs.GET
 import javax.ws.rs.Path
@@ -30,6 +19,18 @@ import javax.ws.rs.core.Context
 import javax.ws.rs.core.Response
 import javax.ws.rs.core.UriInfo
 import javax.ws.rs.ext.ExceptionMapper
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.CyclicBarrier
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static java.util.concurrent.TimeUnit.SECONDS
 
 @Path("")
 class JaxRsTestResource {

--- a/instrumentation/jaxws/jaxws-2.0-arquillian-testing/src/main/groovy/ArquillianJaxWsTest.groovy
+++ b/instrumentation/jaxws/jaxws-2.0-arquillian-testing/src/main/groovy/ArquillianJaxWsTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -25,6 +22,10 @@ import spock.lang.Unroll
 import test.EjbHelloServiceImpl
 import test.HelloService
 import test.HelloServiceImpl
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 @RunWith(ArquillianSputnik)
 @RunAsClient

--- a/instrumentation/jaxws/jaxws-2.0-cxf-3.0/javaagent/src/test/groovy/TestWsServlet.groovy
+++ b/instrumentation/jaxws/jaxws-2.0-cxf-3.0/javaagent/src/test/groovy/TestWsServlet.groovy
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import hello.HelloServiceImpl
-import javax.servlet.ServletConfig
 import org.apache.cxf.jaxws.EndpointImpl
 import org.apache.cxf.transport.servlet.CXFNonSpringServlet
+
+import javax.servlet.ServletConfig
 
 class TestWsServlet extends CXFNonSpringServlet {
   @Override

--- a/instrumentation/jaxws/jaxws-2.0-testing/src/main/groovy/AbstractJaxWsTest.groovy
+++ b/instrumentation/jaxws/jaxws-2.0-testing/src/main/groovy/AbstractJaxWsTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -23,6 +20,10 @@ import org.springframework.ws.client.core.WebServiceTemplate
 import org.springframework.ws.soap.client.SoapFaultClientException
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 abstract class AbstractJaxWsTest extends AgentInstrumentationSpecification implements HttpServerTestTrait<Server> {
 

--- a/instrumentation/jaxws/jaxws-jws-api-1.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/jaxws/jws/v1_1/JwsAnnotationsTest.groovy
+++ b/instrumentation/jaxws/jaxws-jws-api-1.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/jaxws/jws/v1_1/JwsAnnotationsTest.groovy
@@ -10,6 +10,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.test.WebServiceClass
 import io.opentelemetry.test.WebServiceDefinitionInterface
 import io.opentelemetry.test.WebServiceFromInterface
+
 import java.lang.reflect.Proxy
 
 class JwsAnnotationsTest extends AgentInstrumentationSpecification {

--- a/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
+++ b/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import com.mchange.v2.c3p0.ComboPooledDataSource
 import com.zaxxer.hikari.HikariConfig
@@ -14,14 +12,6 @@ import io.opentelemetry.instrumentation.jdbc.TestConnection
 import io.opentelemetry.instrumentation.jdbc.TestDriver
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.sql.CallableStatement
-import java.sql.Connection
-import java.sql.DatabaseMetaData
-import java.sql.PreparedStatement
-import java.sql.ResultSet
-import java.sql.SQLException
-import java.sql.Statement
-import javax.sql.DataSource
 import org.apache.derby.jdbc.EmbeddedDataSource
 import org.apache.derby.jdbc.EmbeddedDriver
 import org.h2.Driver
@@ -29,6 +19,18 @@ import org.h2.jdbcx.JdbcDataSource
 import org.hsqldb.jdbc.JDBCDriver
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import javax.sql.DataSource
+import java.sql.CallableStatement
+import java.sql.Connection
+import java.sql.DatabaseMetaData
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Statement
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 @Unroll
 class JdbcInstrumentationTest extends AgentInstrumentationSpecification {

--- a/instrumentation/jdbc/library/src/test/groovy/io/opentelemetry/instrumentation/jdbc/OpenTelemetryConnectionTest.groovy
+++ b/instrumentation/jdbc/library/src/test/groovy/io/opentelemetry/instrumentation/jdbc/OpenTelemetryConnectionTest.groovy
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.jdbc
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.jdbc.internal.DbInfo
 import io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryCallableStatement
@@ -16,6 +14,8 @@ import io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryStatement
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 class OpenTelemetryConnectionTest extends InstrumentationSpecification implements LibraryTestTrait {
 
@@ -180,15 +180,15 @@ class OpenTelemetryConnectionTest extends InstrumentationSpecification implement
 
   private DbInfo getDbInfo() {
     DbInfo.builder()
-        .system("my_system")
-        .subtype("my_sub_type")
-        .shortUrl("my_connection_string")
-        .user("my_user")
-        .name("my_name")
-        .db("my_db")
-        .host("my_host")
-        .port(1234)
-        .build()
+      .system("my_system")
+      .subtype("my_sub_type")
+      .shortUrl("my_connection_string")
+      .user("my_user")
+      .name("my_name")
+      .db("my_db")
+      .host("my_host")
+      .port(1234)
+      .build()
   }
 
 }

--- a/instrumentation/jdbc/library/src/test/groovy/io/opentelemetry/instrumentation/jdbc/OpenTelemetryDriverTest.groovy
+++ b/instrumentation/jdbc/library/src/test/groovy/io/opentelemetry/instrumentation/jdbc/OpenTelemetryDriverTest.groovy
@@ -7,9 +7,10 @@ package io.opentelemetry.instrumentation.jdbc
 
 import io.opentelemetry.instrumentation.api.InstrumentationVersion
 import io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryConnection
+import spock.lang.Specification
+
 import java.sql.DriverManager
 import java.sql.SQLFeatureNotSupportedException
-import spock.lang.Specification
 
 class OpenTelemetryDriverTest extends Specification {
 

--- a/instrumentation/jdbc/library/src/test/groovy/io/opentelemetry/instrumentation/jdbc/datasource/TestDataSource.groovy
+++ b/instrumentation/jdbc/library/src/test/groovy/io/opentelemetry/instrumentation/jdbc/datasource/TestDataSource.groovy
@@ -6,11 +6,12 @@
 package io.opentelemetry.instrumentation.jdbc.datasource
 
 import io.opentelemetry.instrumentation.jdbc.TestConnection
+
+import javax.sql.DataSource
 import java.sql.Connection
 import java.sql.SQLException
 import java.sql.SQLFeatureNotSupportedException
 import java.util.logging.Logger
-import javax.sql.DataSource
 
 class TestDataSource implements DataSource {
 

--- a/instrumentation/jdbc/library/src/test/groovy/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.groovy
+++ b/instrumentation/jdbc/library/src/test/groovy/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.groovy
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal
 
-import static io.opentelemetry.instrumentation.jdbc.internal.JdbcConnectionUrlParser.parse
-
 import spock.lang.Shared
 import spock.lang.Specification
+
+import static io.opentelemetry.instrumentation.jdbc.internal.JdbcConnectionUrlParser.parse
 
 class JdbcConnectionUrlParserTest extends Specification {
 

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/test/groovy/JedisClientTest.groovy
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.testcontainers.containers.GenericContainer
 import redis.clients.jedis.Jedis
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 class JedisClientTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/test/groovy/Jedis30ClientTest.groovy
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.testcontainers.containers.GenericContainer
 import redis.clients.jedis.Jedis
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 class Jedis30ClientTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/testing/src/main/groovy/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/AbstractJettyClient9Test.groovy
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/testing/src/main/groovy/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/AbstractJettyClient9Test.groovy
@@ -9,7 +9,6 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.TimeUnit
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.api.ContentResponse
 import org.eclipse.jetty.client.api.Request
@@ -19,6 +18,8 @@ import org.eclipse.jetty.http.HttpMethod
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import java.util.concurrent.TimeUnit
 
 abstract class AbstractJettyClient9Test extends HttpClientTest<Request> {
 

--- a/instrumentation/jetty/jetty-11.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty/jetty-11.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -23,6 +17,13 @@ import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
 import org.eclipse.jetty.server.handler.ErrorHandler
 import spock.lang.Shared
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class JettyHandlerTest extends HttpServerTest<Server> implements AgentTestTrait {
 

--- a/instrumentation/jetty/jetty-8.0/javaagent/src/test/groovy/JettyContinuationHandlerTest.groovy
+++ b/instrumentation/jetty/jetty-8.0/javaagent/src/test/groovy/JettyContinuationHandlerTest.groovy
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import javax.servlet.ServletException
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
+
 import org.eclipse.jetty.continuation.Continuation
 import org.eclipse.jetty.continuation.ContinuationSupport
 import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.handler.AbstractHandler
+
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 // FIXME: We don't currently handle jetty continuations properly (at all).
 abstract class JettyContinuationHandlerTest extends JettyHandlerTest {

--- a/instrumentation/jetty/jetty-8.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty/jetty-8.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
@@ -3,26 +3,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import javax.servlet.DispatcherType
-import javax.servlet.ServletException
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Response
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
 import org.eclipse.jetty.server.handler.ErrorHandler
 import spock.lang.Shared
+
+import javax.servlet.DispatcherType
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class JettyHandlerTest extends HttpServerTest<Server> implements AgentTestTrait {
 

--- a/instrumentation/jetty/jetty-8.0/javaagent/src/test/groovy/QueuedThreadPoolTest.groovy
+++ b/instrumentation/jetty/jetty-8.0/javaagent/src/test/groovy/QueuedThreadPoolTest.groovy
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static org.junit.Assume.assumeTrue
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.javaagent.instrumentation.jetty.JavaLambdaMaker
 import org.eclipse.jetty.util.thread.QueuedThreadPool
+
+import static org.junit.Assume.assumeTrue
 
 class QueuedThreadPoolTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/Jms2Test.groovy
@@ -3,20 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 import com.google.common.io.Files
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicReference
-import javax.jms.Message
-import javax.jms.MessageListener
-import javax.jms.Session
-import javax.jms.TextMessage
 import org.hornetq.api.core.TransportConfiguration
 import org.hornetq.api.core.client.HornetQClient
 import org.hornetq.api.jms.HornetQJMSClient
@@ -30,6 +22,16 @@ import org.hornetq.core.server.HornetQServer
 import org.hornetq.core.server.HornetQServers
 import org.hornetq.jms.client.HornetQTextMessage
 import spock.lang.Shared
+
+import javax.jms.Message
+import javax.jms.MessageListener
+import javax.jms.Session
+import javax.jms.TextMessage
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 class Jms2Test extends AgentInstrumentationSpecification {
   @Shared

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/SpringListenerJms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/SpringListenerJms2Test.groovy
@@ -3,16 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import listener.Config
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.jms.core.JmsTemplate
+
+import javax.jms.ConnectionFactory
+
 import static Jms2Test.consumerSpan
 import static Jms2Test.producerSpan
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-
-import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import javax.jms.ConnectionFactory
-import listener.Config
-import org.springframework.context.annotation.AnnotationConfigApplicationContext
-import org.springframework.jms.core.JmsTemplate
 
 class SpringListenerJms2Test extends AgentInstrumentationSpecification {
   def "receiving message in spring listener generates spans"() {

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/SpringTemplateJms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/SpringTemplateJms2Test.groovy
@@ -3,15 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static Jms2Test.consumerSpan
-import static Jms2Test.producerSpan
 
 import com.google.common.io.Files
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
-import javax.jms.Session
-import javax.jms.TextMessage
 import org.hornetq.api.core.TransportConfiguration
 import org.hornetq.api.core.client.HornetQClient
 import org.hornetq.api.jms.HornetQJMSClient
@@ -25,6 +19,14 @@ import org.hornetq.core.server.HornetQServer
 import org.hornetq.core.server.HornetQServers
 import org.springframework.jms.core.JmsTemplate
 import spock.lang.Shared
+
+import javax.jms.Session
+import javax.jms.TextMessage
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+import static Jms2Test.consumerSpan
+import static Jms2Test.producerSpan
 
 class SpringTemplateJms2Test extends AgentInstrumentationSpecification {
   @Shared

--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/listener/Config.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/listener/Config.groovy
@@ -6,8 +6,6 @@
 package listener
 
 import com.google.common.io.Files
-import javax.annotation.PreDestroy
-import javax.jms.ConnectionFactory
 import org.hornetq.api.core.TransportConfiguration
 import org.hornetq.api.core.client.HornetQClient
 import org.hornetq.api.jms.HornetQJMSClient
@@ -24,6 +22,9 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.jms.annotation.EnableJms
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory
 import org.springframework.jms.config.JmsListenerContainerFactory
+
+import javax.annotation.PreDestroy
+import javax.jms.ConnectionFactory
 
 @Configuration
 @ComponentScan

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/Jms1Test.groovy
@@ -3,20 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicReference
-import javax.jms.Connection
-import javax.jms.Message
-import javax.jms.MessageListener
-import javax.jms.Session
-import javax.jms.TextMessage
 import org.apache.activemq.ActiveMQConnectionFactory
 import org.apache.activemq.command.ActiveMQTextMessage
 import org.slf4j.Logger
@@ -25,6 +16,17 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import javax.jms.Connection
+import javax.jms.Message
+import javax.jms.MessageListener
+import javax.jms.Session
+import javax.jms.TextMessage
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 @Unroll
 class Jms1Test extends AgentInstrumentationSpecification {

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringListenerJms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringListenerJms1Test.groovy
@@ -3,16 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import listener.Config
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.jms.core.JmsTemplate
+
+import javax.jms.ConnectionFactory
+
 import static Jms1Test.consumerSpan
 import static Jms1Test.producerSpan
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-
-import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import javax.jms.ConnectionFactory
-import listener.Config
-import org.springframework.context.annotation.AnnotationConfigApplicationContext
-import org.springframework.jms.core.JmsTemplate
 
 class SpringListenerJms1Test extends AgentInstrumentationSpecification {
 

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringTemplateJms1Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringTemplateJms1Test.groovy
@@ -3,16 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static Jms1Test.consumerSpan
-import static Jms1Test.producerSpan
 
 import com.google.common.base.Stopwatch
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
-import javax.jms.Connection
-import javax.jms.Session
-import javax.jms.TextMessage
 import org.apache.activemq.ActiveMQConnectionFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -20,6 +13,15 @@ import org.springframework.jms.core.JmsTemplate
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
+
+import javax.jms.Connection
+import javax.jms.Session
+import javax.jms.TextMessage
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+import static Jms1Test.consumerSpan
+import static Jms1Test.producerSpan
 
 class SpringTemplateJms1Test extends AgentInstrumentationSpecification {
   private static final Logger logger = LoggerFactory.getLogger(SpringTemplateJms1Test)

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/listener/Config.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/listener/Config.groovy
@@ -5,9 +5,6 @@
 
 package listener
 
-import java.time.Duration
-import javax.annotation.PreDestroy
-import javax.jms.ConnectionFactory
 import org.apache.activemq.ActiveMQConnectionFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
@@ -17,6 +14,10 @@ import org.springframework.jms.config.DefaultJmsListenerContainerFactory
 import org.springframework.jms.config.JmsListenerContainerFactory
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
+
+import javax.annotation.PreDestroy
+import javax.jms.ConnectionFactory
+import java.time.Duration
 
 @Configuration
 @ComponentScan

--- a/instrumentation/jsf/jsf-testing-common/src/main/groovy/BaseJsfTest.groovy
+++ b/instrumentation/jsf/jsf-testing-common/src/main/groovy/BaseJsfTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
@@ -24,6 +22,9 @@ import org.eclipse.jetty.util.resource.Resource
 import org.eclipse.jetty.webapp.WebAppContext
 import org.jsoup.Jsoup
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 abstract class BaseJsfTest extends AgentInstrumentationSpecification implements HttpServerTestTrait<Server> {
 

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -14,12 +12,16 @@ import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
 import io.opentelemetry.testing.internal.armeria.common.HttpMethod
 import io.opentelemetry.testing.internal.armeria.common.MediaType
 import io.opentelemetry.testing.internal.armeria.common.RequestHeaders
-import java.nio.file.Files
 import org.apache.catalina.Context
 import org.apache.catalina.startup.Tomcat
 import org.apache.jasper.JasperException
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import java.nio.file.Files
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 //TODO should this be HttpServerTest?
 class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
@@ -3,20 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.testing.internal.armeria.client.WebClient
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
-import java.nio.file.Files
 import org.apache.catalina.Context
 import org.apache.catalina.startup.Tomcat
 import org.apache.jasper.JasperException
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import java.nio.file.Files
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
 

--- a/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientBaseTest.groovy
+++ b/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientBaseTest.groovy
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.junit.Rule
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
@@ -17,6 +16,9 @@ import org.springframework.kafka.test.rule.KafkaEmbedded
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Unroll
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 
 abstract class KafkaClientBaseTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
+++ b/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
@@ -3,12 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
@@ -16,6 +12,12 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.listener.KafkaMessageListenerContainer
 import org.springframework.kafka.listener.MessageListener
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
 

--- a/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
+++ b/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
@@ -3,13 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -24,6 +20,12 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.listener.KafkaMessageListenerContainer
 import org.springframework.kafka.listener.MessageListener
 import org.springframework.kafka.test.utils.KafkaTestUtils
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
 

--- a/instrumentation/kafka-clients/kafka-clients-2.4.0-testing/src/test/groovy/KafkaClientBaseTest.groovy
+++ b/instrumentation/kafka-clients/kafka-clients-2.4.0-testing/src/test/groovy/KafkaClientBaseTest.groovy
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.junit.Rule
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
@@ -17,6 +16,9 @@ import org.springframework.kafka.test.rule.EmbeddedKafkaRule
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Unroll
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 
 abstract class KafkaClientBaseTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/kafka-clients/kafka-clients-2.4.0-testing/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
+++ b/instrumentation/kafka-clients/kafka-clients-2.4.0-testing/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
@@ -3,12 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
@@ -16,6 +12,12 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.listener.KafkaMessageListenerContainer
 import org.springframework.kafka.listener.MessageListener
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
 

--- a/instrumentation/kafka-clients/kafka-clients-2.4.0-testing/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
+++ b/instrumentation/kafka-clients/kafka-clients-2.4.0-testing/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
@@ -3,13 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -24,6 +20,12 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.listener.KafkaMessageListenerContainer
 import org.springframework.kafka.listener.MessageListener
 import org.springframework.kafka.test.utils.KafkaTestUtils
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
 

--- a/instrumentation/kafka-streams-0.11/javaagent/src/latestDepTest/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/javaagent/src/latestDepTest/groovy/KafkaStreamsTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
@@ -12,8 +10,6 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.TextMapGetter
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.streams.KafkaStreams
@@ -30,6 +26,12 @@ import org.springframework.kafka.test.rule.EmbeddedKafkaRule
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Shared
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 class KafkaStreamsTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/javaagent/src/test/groovy/KafkaStreamsTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
@@ -12,8 +10,6 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.TextMapGetter
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.streams.KafkaStreams
@@ -30,6 +26,12 @@ import org.springframework.kafka.test.rule.KafkaEmbedded
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
 import spock.lang.Shared
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 class KafkaStreamsTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/test/groovy/KubernetesClientTest.groovy
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/test/groovy/KubernetesClientTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 import io.kubernetes.client.openapi.ApiCallback
 import io.kubernetes.client.openapi.ApiClient
@@ -20,9 +16,15 @@ import io.opentelemetry.testing.internal.armeria.common.HttpResponse
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus
 import io.opentelemetry.testing.internal.armeria.common.MediaType
 import io.opentelemetry.testing.internal.armeria.testing.junit5.server.mock.MockWebServerExtension
+import spock.lang.Shared
+
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
-import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class KubernetesClientTest extends AgentInstrumentationSpecification {
   private static final String TEST_USER_AGENT = "test-user-agent"

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient
@@ -20,15 +17,20 @@ import com.lambdaworks.redis.protocol.AsyncCommand
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import org.testcontainers.containers.FixedHostPortGenericContainer
+import spock.lang.Shared
+import spock.util.concurrent.AsyncConditions
+
 import java.util.concurrent.CancellationException
 import java.util.concurrent.TimeUnit
 import java.util.function.BiConsumer
 import java.util.function.BiFunction
 import java.util.function.Consumer
 import java.util.function.Function
-import org.testcontainers.containers.FixedHostPortGenericContainer
-import spock.lang.Shared
-import spock.util.concurrent.AsyncConditions
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
   public static final String HOST = "localhost"

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import com.lambdaworks.redis.ClientOptions
 import com.lambdaworks.redis.RedisClient
@@ -16,6 +14,9 @@ import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.testcontainers.containers.FixedHostPortGenericContainer
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class LettuceSyncClientTest extends AgentInstrumentationSpecification {
   public static final String HOST = "localhost"

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.ConnectionFuture
@@ -21,6 +18,10 @@ import io.netty.channel.AbstractChannel
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import org.testcontainers.containers.FixedHostPortGenericContainer
+import spock.lang.Shared
+import spock.util.concurrent.AsyncConditions
+
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
@@ -28,9 +29,10 @@ import java.util.function.BiConsumer
 import java.util.function.BiFunction
 import java.util.function.Consumer
 import java.util.function.Function
-import org.testcontainers.containers.FixedHostPortGenericContainer
-import spock.lang.Shared
-import spock.util.concurrent.AsyncConditions
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
   public static final String PEER_NAME = "localhost"

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
@@ -14,11 +12,15 @@ import io.lettuce.core.api.sync.RedisCommands
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.function.Consumer
 import org.testcontainers.containers.FixedHostPortGenericContainer
 import reactor.core.scheduler.Schedulers
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
+
+import java.util.function.Consumer
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
   public static final String PEER_HOST = "localhost"

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
@@ -17,6 +15,9 @@ import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.testcontainers.containers.FixedHostPortGenericContainer
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class LettuceSyncClientTest extends AgentInstrumentationSpecification {
   public static final String PEER_NAME = "localhost"

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/LettuceReactiveClientTest.groovy
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_1
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.lettuce.core.RedisClient
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.lettuce.v5_1.AbstractLettuceReactiveClientTest
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import reactor.core.scheduler.Schedulers
+
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class LettuceReactiveClientTest extends AbstractLettuceReactiveClientTest implements AgentTestTrait {
   @Override

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.groovy
@@ -5,10 +5,6 @@
 
 package io.opentelemetry.instrumentation.lettuce.v5_1
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.lettuce.core.ConnectionFuture
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisFuture
@@ -20,15 +16,20 @@ import io.lettuce.core.codec.StringCodec
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import org.testcontainers.containers.FixedHostPortGenericContainer
+import spock.lang.Shared
+import spock.util.concurrent.AsyncConditions
+
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.function.BiConsumer
 import java.util.function.BiFunction
 import java.util.function.Consumer
 import java.util.function.Function
-import org.testcontainers.containers.FixedHostPortGenericContainer
-import spock.lang.Shared
-import spock.util.concurrent.AsyncConditions
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecification {
   public static final String HOST = "127.0.0.1"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.groovy
@@ -5,10 +5,6 @@
 
 package io.opentelemetry.instrumentation.lettuce.v5_1
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.api.reactive.RedisReactiveCommands
@@ -16,10 +12,15 @@ import io.lettuce.core.api.sync.RedisCommands
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.function.Consumer
 import org.testcontainers.containers.FixedHostPortGenericContainer
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
+
+import java.util.function.Consumer
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecification {
   public static final String HOST = "127.0.0.1"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.groovy
@@ -5,15 +5,15 @@
 
 package io.opentelemetry.instrumentation.lettuce.v5_1
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.lettuce.core.RedisClient
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.testcontainers.containers.FixedHostPortGenericContainer
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 abstract class AbstractLettuceSyncClientAuthTest extends InstrumentationSpecification {
   public static final String HOST = "127.0.0.1"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.groovy
@@ -5,11 +5,6 @@
 
 package io.opentelemetry.instrumentation.lettuce.v5_1
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-import static java.nio.charset.StandardCharsets.UTF_8
-
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisConnectionException
 import io.lettuce.core.RedisException
@@ -21,6 +16,11 @@ import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.testcontainers.containers.FixedHostPortGenericContainer
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
+import static java.nio.charset.StandardCharsets.UTF_8
 
 abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecification {
   public static final String HOST = "127.0.0.1"

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTestUtil.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTestUtil.groovy
@@ -15,7 +15,7 @@ final class LettuceTestUtil {
 
   static {
     def options = ClientOptions.builder()
-      // Disable autoreconnect so we do not get stray traces popping up on server shutdown
+    // Disable autoreconnect so we do not get stray traces popping up on server shutdown
       .autoReconnect(false)
     if (Boolean.getBoolean("testLatestDeps")) {
       // Force RESP2 on 6+ for consistency in tests

--- a/instrumentation/methods/javaagent/src/test/groovy/MethodTest.groovy
+++ b/instrumentation/methods/javaagent/src/test/groovy/MethodTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+
 import java.util.concurrent.Callable
 
 class MethodTest extends AgentInstrumentationSpecification {

--- a/instrumentation/mongo/mongo-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/mongo/v3_1/MongoClientTracerTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/mongo/v3_1/MongoClientTracerTest.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.instrumentation.mongo.v3_1
 
-import static io.opentelemetry.instrumentation.mongo.v3_1.MongoTracingBuilder.DEFAULT_MAX_NORMALIZED_QUERY_LENGTH
-import static java.util.Arrays.asList
-
 import com.mongodb.event.CommandStartedEvent
 import io.opentelemetry.api.OpenTelemetry
 import org.bson.BsonArray
@@ -15,6 +12,9 @@ import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonString
 import spock.lang.Specification
+
+import static io.opentelemetry.instrumentation.mongo.v3_1.MongoTracingBuilder.DEFAULT_MAX_NORMALIZED_QUERY_LENGTH
+import static java.util.Arrays.asList
 
 class MongoClientTracerTest extends Specification {
   def 'should sanitize statements to json'() {

--- a/instrumentation/mongo/mongo-3.7/javaagent/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/javaagent/src/test/groovy/MongoClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 
 import com.mongodb.MongoClientSettings
 import com.mongodb.MongoTimeoutException
@@ -18,6 +17,8 @@ import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
+
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 
 class MongoClientTest extends AbstractMongoClientTest<MongoCollection<Document>> implements AgentTestTrait {
 

--- a/instrumentation/mongo/mongo-4.0/javaagent/src/test/groovy/Mongo4ReactiveClientTest.groovy
+++ b/instrumentation/mongo/mongo-4.0/javaagent/src/test/groovy/Mongo4ReactiveClientTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.mongodb.MongoClientSettings
 import com.mongodb.ServerAddress
 import com.mongodb.client.result.DeleteResult
@@ -13,8 +14,6 @@ import com.mongodb.reactivestreams.client.MongoCollection
 import com.mongodb.reactivestreams.client.MongoDatabase
 import io.opentelemetry.instrumentation.mongo.testing.AbstractMongoClientTest
 import io.opentelemetry.instrumentation.test.AgentTestTrait
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CountDownLatch
 import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
@@ -22,6 +21,9 @@ import org.junit.AssumptionViolatedException
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import spock.lang.Shared
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
 
 class Mongo4ReactiveClientTest extends AbstractMongoClientTest<MongoCollection<Document>> implements AgentTestTrait {
 

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/src/test/groovy/MongoAsyncClientTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.mongodb.ConnectionString
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.async.client.MongoClient
@@ -15,15 +16,16 @@ import com.mongodb.client.result.UpdateResult
 import com.mongodb.connection.ClusterSettings
 import io.opentelemetry.instrumentation.mongo.testing.AbstractMongoClientTest
 import io.opentelemetry.instrumentation.test.AgentTestTrait
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CountDownLatch
 import org.bson.BsonDocument
 import org.bson.BsonString
 import org.bson.Document
 import org.junit.AssumptionViolatedException
 import spock.lang.Shared
 
-class MongoAsyncClientTest extends AbstractMongoClientTest<MongoCollection<Document>> implements AgentTestTrait{
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+
+class MongoAsyncClientTest extends AbstractMongoClientTest<MongoCollection<Document>> implements AgentTestTrait {
 
   @Shared
   MongoClient client

--- a/instrumentation/mongo/mongo-testing/src/main/groovy/io/opentelemetry/instrumentation/mongo/testing/AbstractMongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-testing/src/main/groovy/io/opentelemetry/instrumentation/mongo/testing/AbstractMongoClientTest.groovy
@@ -5,18 +5,19 @@
 
 package io.opentelemetry.instrumentation.mongo.testing
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.atomic.AtomicInteger
 import org.slf4j.LoggerFactory
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 abstract class AbstractMongoClientTest<T> extends InstrumentationSpecification {
 
@@ -56,15 +57,19 @@ abstract class AbstractMongoClientTest<T> extends InstrumentationSpecification {
   abstract int getCollection(String dbName, String collectionName)
 
   abstract T setupInsert(String dbName, String collectionName)
+
   abstract int insert(T collection)
 
   abstract T setupUpdate(String dbName, String collectionName)
+
   abstract int update(T collection)
 
   abstract T setupDelete(String dbName, String collectionName)
+
   abstract int delete(T collection)
 
   abstract T setupGetMore(String dbName, String collectionName)
+
   abstract void getMore(T collection)
 
   abstract void error(String dbName, String collectionName)

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.ning.http.client.AsyncCompletionHandler
 import com.ning.http.client.AsyncHttpClient
 import com.ning.http.client.AsyncHttpClientConfig
@@ -13,9 +14,10 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
-import java.nio.channels.ClosedChannelException
 import spock.lang.AutoCleanup
 import spock.lang.Shared
+
+import java.nio.channels.ClosedChannelException
 
 class Netty38ClientTest extends HttpClientTest<Request> implements AgentTestTrait {
 

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
@@ -3,18 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.forPath
-import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
-import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
-import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.LOCATION
-import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1
 
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -43,6 +31,19 @@ import org.jboss.netty.logging.InternalLogLevel
 import org.jboss.netty.logging.InternalLoggerFactory
 import org.jboss.netty.logging.Slf4JLoggerFactory
 import org.jboss.netty.util.CharsetUtil
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.forPath
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.LOCATION
+import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1
 
 class Netty38ServerTest extends HttpServerTest<ServerBootstrap> implements AgentTestTrait {
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/ChannelFutureTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/ChannelFutureTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.netty.channel.ChannelHandler
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.embedded.EmbeddedChannel
@@ -11,6 +12,7 @@ import io.netty.util.concurrent.GenericFutureListener
 import io.netty.util.concurrent.GenericProgressiveFutureListener
 import io.netty.util.concurrent.ProgressiveFuture
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ClientTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ClientTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.Unpooled
 import io.netty.channel.Channel
@@ -23,9 +24,10 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
+import spock.lang.Shared
+
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
-import spock.lang.Shared
 
 class Netty40ClientTest extends HttpClientTest<DefaultFullHttpRequest> implements AgentTestTrait {
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ConnectionSpanTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ConnectionSpanTest.groovy
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.Unpooled
@@ -27,9 +22,16 @@ import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import spock.lang.Shared
+
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
-import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class Netty40ConnectionSpanTest extends InstrumentationSpecification implements AgentTestTrait {
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
@@ -3,17 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
-import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.ByteBuf
@@ -38,6 +27,18 @@ import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class Netty40ServerTest extends HttpServerTest<EventLoopGroup> implements AgentTestTrait {
 

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/ChannelFutureTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/ChannelFutureTest.groovy
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.util.concurrent.Future
 import io.netty.util.concurrent.GenericFutureListener
 import io.netty.util.concurrent.GenericProgressiveFutureListener
 import io.netty.util.concurrent.ProgressiveFuture
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static org.junit.Assume.assumeTrue
 
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.Unpooled
@@ -33,10 +32,13 @@ import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection
 import io.opentelemetry.javaagent.instrumentation.netty.v4_1.client.HttpClientTracingHandler
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+import static org.junit.Assume.assumeTrue
 
 @Unroll
 class Netty41ClientTest extends HttpClientTest<DefaultFullHttpRequest> implements AgentTestTrait {

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ConnectionSpanTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ConnectionSpanTest.groovy
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.Unpooled
@@ -27,9 +22,16 @@ import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import spock.lang.Shared
+
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
-import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class Netty41ConnectionSpanTest extends InstrumentationSpecification implements AgentTestTrait {
 

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ServerTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ServerTest.groovy
@@ -3,17 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH
-import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
-import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.ByteBuf
@@ -37,6 +26,18 @@ import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class Netty41ServerTest extends HttpServerTest<EventLoopGroup> implements AgentTestTrait {
 

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/test/groovy/OkHttp2Test.groovy
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/test/groovy/OkHttp2Test.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.squareup.okhttp.Callback
 import com.squareup.okhttp.MediaType
 import com.squareup.okhttp.OkHttpClient
@@ -15,8 +16,9 @@ import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.TimeUnit
 import spock.lang.Shared
+
+import java.util.concurrent.TimeUnit
 
 class OkHttp2Test extends HttpClientTest<Request> implements AgentTestTrait {
   @Shared

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/test/groovy/WithSpanInstrumentationTest.groovy
@@ -3,17 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.extension.annotations.WithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.test.annotation.TracedWithSpan
-import java.lang.reflect.Modifier
-import java.util.concurrent.CompletableFuture
 import net.bytebuddy.ByteBuddy
 import net.bytebuddy.ClassFileVersion
 import net.bytebuddy.asm.MemberAttributeExtension
@@ -22,6 +15,15 @@ import net.bytebuddy.implementation.MethodDelegation
 import net.bytebuddy.implementation.bind.annotation.RuntimeType
 import net.bytebuddy.implementation.bind.annotation.This
 import net.bytebuddy.matcher.ElementMatchers
+
+import java.lang.reflect.Modifier
+import java.util.concurrent.CompletableFuture
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 /**
  * This test verifies that auto instrumentation supports {@link io.opentelemetry.extension.annotations.WithSpan} contrib annotation.

--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/ContextBridgeTest.groovy
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/ContextBridgeTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.baggage.Baggage
 import io.opentelemetry.api.trace.Span
@@ -10,6 +11,7 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
 import io.opentelemetry.extension.annotations.WithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference

--- a/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/TracerTest.groovy
+++ b/instrumentation/opentelemetry-api-1.0/javaagent/src/test/groovy/TracerTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.Attributes
@@ -13,6 +11,9 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.context.Scope
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class TracerTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/oshi/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/oshi/OshiTest.groovy
+++ b/instrumentation/oshi/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/oshi/OshiTest.groovy
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.oshi
 
-import static java.util.concurrent.TimeUnit.SECONDS
-
 import com.google.common.base.Stopwatch
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+
+import static java.util.concurrent.TimeUnit.SECONDS
 
 class OshiTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/play-ws/play-ws-testing/src/main/groovy/PlayWsClientTestBase.groovy
+++ b/instrumentation/play-ws/play-ws-testing/src/main/groovy/PlayWsClientTestBase.groovy
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
-import java.util.concurrent.CompletionStage
-import java.util.concurrent.TimeUnit
 import play.libs.ws.StandaloneWSClient
 import play.libs.ws.StandaloneWSRequest
 import play.libs.ws.StandaloneWSResponse
@@ -18,6 +17,9 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.util.Try
 import spock.lang.Shared
+
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.TimeUnit
 
 class PlayJavaWsClientTestBase extends PlayWsClientTestBaseBase<StandaloneWSRequest> {
   @Shared

--- a/instrumentation/play/play-2.4/javaagent/src/test/groovy/client/PlayWsClientTest.groovy
+++ b/instrumentation/play/play-2.4/javaagent/src/test/groovy/client/PlayWsClientTest.groovy
@@ -11,13 +11,14 @@ import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.CompletionStage
 import play.libs.ws.WS
 import play.libs.ws.WSRequest
 import play.libs.ws.WSResponse
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Subject
+
+import java.util.concurrent.CompletionStage
 
 // Play 2.6+ uses a separately versioned client that shades the underlying dependency
 // This means our built in instrumentation won't work.

--- a/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -5,6 +5,14 @@
 
 package server
 
+import play.libs.concurrent.HttpExecution
+import play.mvc.Results
+import play.routing.RoutingDsl
+import play.server.Server
+
+import java.util.concurrent.CompletableFuture
+import java.util.function.Supplier
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -12,13 +20,6 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static play.mvc.Http.Context.Implicit.request
-
-import java.util.concurrent.CompletableFuture
-import java.util.function.Supplier
-import play.libs.concurrent.HttpExecution
-import play.mvc.Results
-import play.routing.RoutingDsl
-import play.server.Server
 
 class PlayAsyncServerTest extends PlayServerTest {
   @Override

--- a/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -5,6 +5,17 @@
 
 package server
 
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.instrumentation.test.AgentTestTrait
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.sdk.trace.data.SpanData
+import play.mvc.Results
+import play.routing.RoutingDsl
+import play.server.Server
+
+import java.util.function.Supplier
+
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -13,16 +24,6 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static play.mvc.Http.Context.Implicit.request
-
-import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.instrumentation.test.AgentTestTrait
-import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import io.opentelemetry.sdk.trace.data.SpanData
-import java.util.function.Supplier
-import play.mvc.Results
-import play.routing.RoutingDsl
-import play.server.Server
 
 class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
   @Override

--- a/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -5,15 +5,6 @@
 
 package server
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Executors
-import java.util.function.Supplier
 import play.BuiltInComponents
 import play.Mode
 import play.libs.concurrent.HttpExecution
@@ -21,6 +12,16 @@ import play.mvc.Results
 import play.routing.RoutingDsl
 import play.server.Server
 import spock.lang.Shared
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.function.Supplier
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class PlayAsyncServerTest extends PlayServerTest {
   @Shared

--- a/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -5,24 +5,25 @@
 
 package server
 
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.instrumentation.test.AgentTestTrait
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.sdk.trace.data.SpanData
+import play.BuiltInComponents
+import play.Mode
+import play.mvc.Results
+import play.routing.RoutingDsl
+import play.server.Server
+
+import java.util.function.Supplier
+
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.instrumentation.test.AgentTestTrait
-import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import io.opentelemetry.sdk.trace.data.SpanData
-import java.util.function.Supplier
-import play.BuiltInComponents
-import play.Mode
-import play.mvc.Results
-import play.routing.RoutingDsl
-import play.server.Server
 
 class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
   @Override

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMqTest.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/RabbitMqTest.groovy
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import com.rabbitmq.client.AMQP
 import com.rabbitmq.client.Channel
@@ -27,6 +23,11 @@ import org.springframework.amqp.core.Queue
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory
 import org.springframework.amqp.rabbit.core.RabbitAdmin
 import org.springframework.amqp.rabbit.core.RabbitTemplate
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class RabbitMqTest extends AgentInstrumentationSpecification implements WithRabbitMqTrait {
 

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/WithRabbitMqTrait.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/WithRabbitMqTrait.groovy
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.rabbitmq.client.ConnectionFactory
-import java.time.Duration
 import org.testcontainers.containers.GenericContainer
+
+import java.time.Duration
 
 trait WithRabbitMqTrait {
 

--- a/instrumentation/ratpack-1.4/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/server/RatpackAsyncHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/server/RatpackAsyncHttpServerTest.groovy
@@ -19,6 +19,7 @@ class RatpackAsyncHttpServerTest extends AbstractRatpackAsyncHttpServerTest impl
       tracing.configureServerRegistry(it)
     }
   }
+
   @Override
   boolean hasHandlerSpan(ServerEndpoint endpoint) {
     false

--- a/instrumentation/ratpack-1.4/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/server/RatpackForkedHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/server/RatpackForkedHttpServerTest.groovy
@@ -19,6 +19,7 @@ class RatpackForkedHttpServerTest extends AbstractRatpackForkedHttpServerTest im
       tracing.configureServerRegistry(it)
     }
   }
+
   @Override
   boolean hasHandlerSpan(ServerEndpoint endpoint) {
     false

--- a/instrumentation/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackAsyncHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackAsyncHttpServerTest.groovy
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.instrumentation.ratpack.server
 
+import ratpack.error.ServerErrorHandler
+import ratpack.exec.Promise
+import ratpack.server.RatpackServer
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -12,10 +16,6 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import ratpack.error.ServerErrorHandler
-import ratpack.exec.Promise
-import ratpack.server.RatpackServer
 
 abstract class AbstractRatpackAsyncHttpServerTest extends AbstractRatpackHttpServerTest {
 
@@ -31,7 +31,7 @@ abstract class AbstractRatpackAsyncHttpServerTest extends AbstractRatpackHttpSer
           it.add(ServerErrorHandler, new TestErrorHandler())
         }
         it.prefix(SUCCESS.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             Promise.sync {
               SUCCESS
             } then { endpoint ->
@@ -42,7 +42,7 @@ abstract class AbstractRatpackAsyncHttpServerTest extends AbstractRatpackHttpSer
           }
         }
         it.prefix(INDEXED_CHILD.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             Promise.sync {
               INDEXED_CHILD
             } then {
@@ -65,7 +65,7 @@ abstract class AbstractRatpackAsyncHttpServerTest extends AbstractRatpackHttpSer
           }
         }
         it.prefix(REDIRECT.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             Promise.sync {
               REDIRECT
             } then { endpoint ->
@@ -76,7 +76,7 @@ abstract class AbstractRatpackAsyncHttpServerTest extends AbstractRatpackHttpSer
           }
         }
         it.prefix(ERROR.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             Promise.sync {
               ERROR
             } then { endpoint ->
@@ -98,7 +98,7 @@ abstract class AbstractRatpackAsyncHttpServerTest extends AbstractRatpackHttpSer
           }
         }
         it.prefix("path/:id/param") {
-          it.all {context ->
+          it.all { context ->
             Promise.sync {
               PATH_PARAM
             } then { endpoint ->

--- a/instrumentation/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackForkedHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackForkedHttpServerTest.groovy
@@ -5,14 +5,6 @@
 
 package io.opentelemetry.instrumentation.ratpack.server
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
@@ -23,6 +15,14 @@ import ratpack.exec.Promise
 import ratpack.exec.Result
 import ratpack.exec.util.ParallelBatch
 import ratpack.server.RatpackServer
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 abstract class AbstractRatpackForkedHttpServerTest extends AbstractRatpackHttpServerTest {
 
@@ -39,7 +39,7 @@ abstract class AbstractRatpackForkedHttpServerTest extends AbstractRatpackHttpSe
           it.add(ServerErrorHandler, new TestErrorHandler())
         }
         it.prefix(SUCCESS.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             Promise.sync {
               SUCCESS
             }.fork().then { endpoint ->
@@ -50,7 +50,7 @@ abstract class AbstractRatpackForkedHttpServerTest extends AbstractRatpackHttpSe
           }
         }
         it.prefix(INDEXED_CHILD.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             Promise.sync {
               INDEXED_CHILD
             }.fork().then {
@@ -73,7 +73,7 @@ abstract class AbstractRatpackForkedHttpServerTest extends AbstractRatpackHttpSe
           }
         }
         it.prefix(REDIRECT.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             Promise.sync {
               REDIRECT
             }.fork().then { endpoint ->
@@ -84,7 +84,7 @@ abstract class AbstractRatpackForkedHttpServerTest extends AbstractRatpackHttpSe
           }
         }
         it.prefix(ERROR.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             Promise.sync {
               ERROR
             }.fork().then { endpoint ->
@@ -106,7 +106,7 @@ abstract class AbstractRatpackForkedHttpServerTest extends AbstractRatpackHttpSe
           }
         }
         it.prefix("path/:id/param") {
-          it.all {context ->
+          it.all { context ->
             Promise.sync {
               PATH_PARAM
             }.fork().then { endpoint ->
@@ -117,7 +117,7 @@ abstract class AbstractRatpackForkedHttpServerTest extends AbstractRatpackHttpSe
           }
         }
         it.prefix("fork_and_yieldAll") {
-          it.all {context ->
+          it.all { context ->
             def promise = Promise.async { upstream ->
               Execution.fork().start({
                 upstream.accept(Result.success(SUCCESS))
@@ -143,7 +143,7 @@ abstract class AbstractRatpackForkedHttpServerTest extends AbstractRatpackHttpSe
 
   def "test fork and yieldAll"() {
     setup:
-    def url =  address.resolve("fork_and_yieldAll").toString()
+    def url = address.resolve("fork_and_yieldAll").toString()
     url = url.replace("http://", "h1c://")
     def request = AggregatedHttpRequest.of(HttpMethod.GET, url)
     AggregatedHttpResponse response = client.execute(request).aggregate().join()

--- a/instrumentation/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackHttpServerTest.groovy
@@ -5,15 +5,6 @@
 
 package io.opentelemetry.instrumentation.ratpack.server
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -22,6 +13,15 @@ import ratpack.error.ServerErrorHandler
 import ratpack.handling.Context
 import ratpack.server.RatpackServer
 import ratpack.server.RatpackServerSpec
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 abstract class AbstractRatpackHttpServerTest extends HttpServerTest<RatpackServer> {
 
@@ -39,14 +39,14 @@ abstract class AbstractRatpackHttpServerTest extends HttpServerTest<RatpackServe
           it.add(ServerErrorHandler, new TestErrorHandler())
         }
         it.prefix(SUCCESS.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             controller(SUCCESS) {
               context.response.status(SUCCESS.status).send(SUCCESS.body)
             }
           }
         }
         it.prefix(INDEXED_CHILD.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             controller(INDEXED_CHILD) {
               INDEXED_CHILD.collectSpanAttributes { context.request.queryParams.get(it) }
               context.response.status(INDEXED_CHILD.status).send()
@@ -61,14 +61,14 @@ abstract class AbstractRatpackHttpServerTest extends HttpServerTest<RatpackServe
           }
         }
         it.prefix(REDIRECT.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             controller(REDIRECT) {
               context.redirect(REDIRECT.body)
             }
           }
         }
         it.prefix(ERROR.rawPath()) {
-          it.all {context ->
+          it.all { context ->
             controller(ERROR) {
               context.response.status(ERROR.status).send(ERROR.body)
             }
@@ -82,7 +82,7 @@ abstract class AbstractRatpackHttpServerTest extends HttpServerTest<RatpackServe
           }
         }
         it.prefix("path/:id/param") {
-          it.all {context ->
+          it.all { context ->
             controller(PATH_PARAM) {
               context.response.status(PATH_PARAM.status).send(context.pathTokens.id)
             }

--- a/instrumentation/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
+++ b/instrumentation/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
@@ -5,10 +5,6 @@
 
 package io.opentelemetry.instrumentation.ratpack.server
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -19,6 +15,10 @@ import ratpack.server.RatpackServer
 import ratpack.server.RatpackServerSpec
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 @Unroll
 abstract class AbstractRatpackRoutesTest extends InstrumentationSpecification {

--- a/instrumentation/reactor-3.1/javaagent/src/test/groovy/ReactorWithSpanInstrumentationTest.groovy
+++ b/instrumentation/reactor-3.1/javaagent/src/test/groovy/ReactorWithSpanInstrumentationTest.groovy
@@ -40,7 +40,7 @@ class ReactorWithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed Mono"() {
     setup:
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def mono = source.singleOrEmpty()
     def result = new TracedWithSpan()
       .mono(mono)
@@ -99,7 +99,7 @@ class ReactorWithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored Mono"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def mono = source.singleOrEmpty()
     def result = new TracedWithSpan()
       .mono(mono)
@@ -132,7 +132,7 @@ class ReactorWithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for canceled Mono"() {
     setup:
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def mono = source.singleOrEmpty()
     def result = new TracedWithSpan()
       .mono(mono)
@@ -185,7 +185,7 @@ class ReactorWithSpanInstrumentationTest extends AgentInstrumentationSpecificati
 
   def "should capture span for eventually completed Flux"() {
     setup:
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def result = new TracedWithSpan()
       .flux(source)
     def verifier = StepVerifier.create(result)
@@ -243,7 +243,7 @@ class ReactorWithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for eventually errored Flux"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def result = new TracedWithSpan()
       .flux(source)
     def verifier = StepVerifier.create(result)
@@ -275,7 +275,7 @@ class ReactorWithSpanInstrumentationTest extends AgentInstrumentationSpecificati
   def "should capture span for canceled Flux"() {
     setup:
     def error = new IllegalArgumentException("Boom")
-    def source = UnicastProcessor.<String>create()
+    def source = UnicastProcessor.<String> create()
     def result = new TracedWithSpan()
       .flux(source)
     def verifier = StepVerifier.create(result)

--- a/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/HooksTest.groovy
+++ b/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/HooksTest.groovy
@@ -6,9 +6,10 @@
 package io.opentelemetry.instrumentation.reactor
 
 import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
-import java.util.concurrent.atomic.AtomicReference
 import reactor.core.CoreSubscriber
 import reactor.core.publisher.Mono
+
+import java.util.concurrent.atomic.AtomicReference
 
 class HooksTest extends LibraryInstrumentationSpecification {
 

--- a/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorAsyncOperationEndStrategyTest.groovy
+++ b/instrumentation/reactor-3.1/library/src/test/groovy/io/opentelemetry/instrumentation/reactor/ReactorAsyncOperationEndStrategyTest.groovy
@@ -17,7 +17,7 @@ import spock.lang.Specification
 class ReactorAsyncOperationEndStrategyTest extends Specification {
   String request = "request"
   String response = "response"
-  
+
   Instrumenter<String, String> instrumenter
 
   Context context
@@ -71,7 +71,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
       when:
       def result = (Mono<?>) underTest.end(instrumenter, context, request, Mono.error(exception), String)
       StepVerifier.create(result)
-        .verifyErrorMatches({  it == exception })
+        .verifyErrorMatches({ it == exception })
 
       then:
       1 * instrumenter.end(context, request, null, exception)
@@ -79,7 +79,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
 
     def "ends span when completed"() {
       given:
-      def source = UnicastProcessor.<String>create()
+      def source = UnicastProcessor.<String> create()
       def mono = source.singleOrEmpty()
 
       when:
@@ -102,7 +102,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
 
     def "ends span when empty"() {
       given:
-      def source = UnicastProcessor.<String>create()
+      def source = UnicastProcessor.<String> create()
       def mono = source.singleOrEmpty()
 
       when:
@@ -124,7 +124,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
     def "ends span when errored"() {
       given:
       def exception = new IllegalStateException()
-      def source = UnicastProcessor.<String>create()
+      def source = UnicastProcessor.<String> create()
       def mono = source.singleOrEmpty()
 
       when:
@@ -145,7 +145,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
 
     def "ends span when cancelled"() {
       given:
-      def source = UnicastProcessor.<String>create()
+      def source = UnicastProcessor.<String> create()
       def mono = source.singleOrEmpty()
       def context = span.storeInContext(Context.root())
 
@@ -167,7 +167,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
 
     def "ends span when cancelled and capturing experimental span attributes"() {
       given:
-      def source = UnicastProcessor.<String>create()
+      def source = UnicastProcessor.<String> create()
       def mono = source.singleOrEmpty()
       def context = span.storeInContext(Context.root())
 
@@ -240,7 +240,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
       when:
       def result = (Flux<?>) underTest.end(instrumenter, context, request, Flux.error(exception), String)
       StepVerifier.create(result)
-        .verifyErrorMatches({  it == exception })
+        .verifyErrorMatches({ it == exception })
 
       then:
       1 * instrumenter.end(context, request, null, exception)
@@ -248,7 +248,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
 
     def "ends span when completed"() {
       given:
-      def source = UnicastProcessor.<String>create()
+      def source = UnicastProcessor.<String> create()
 
       when:
       def result = (Flux<?>) underTest.end(instrumenter, context, request, source, String)
@@ -270,7 +270,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
 
     def "ends span when empty"() {
       given:
-      def source = UnicastProcessor.<String>create()
+      def source = UnicastProcessor.<String> create()
 
       when:
       def result = (Flux<?>) underTest.end(instrumenter, context, request, source, String)
@@ -291,7 +291,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
     def "ends span when errored"() {
       given:
       def exception = new IllegalStateException()
-      def source = UnicastProcessor.<String>create()
+      def source = UnicastProcessor.<String> create()
 
       when:
       def result = (Flux<?>) underTest.end(instrumenter, context, request, source, String)
@@ -311,7 +311,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
 
     def "ends span when cancelled"() {
       given:
-      def source = UnicastProcessor.<String>create()
+      def source = UnicastProcessor.<String> create()
       def context = span.storeInContext(Context.root())
 
       when:
@@ -333,7 +333,7 @@ class ReactorAsyncOperationEndStrategyTest extends Specification {
 
     def "ends span when cancelled and capturing experimental span attributes"() {
       given:
-      def source = UnicastProcessor.<String>create()
+      def source = UnicastProcessor.<String> create()
       def context = span.storeInContext(Context.root())
 
       when:

--- a/instrumentation/reactor-3.1/testing/src/main/groovy/io/opentelemetry/instrumentation/reactor/AbstractReactorCoreTest.groovy
+++ b/instrumentation/reactor-3.1/testing/src/main/groovy/io/opentelemetry/instrumentation/reactor/AbstractReactorCoreTest.groovy
@@ -5,16 +5,12 @@
 
 package io.opentelemetry.instrumentation.reactor
 
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
-
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
-import java.time.Duration
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
@@ -22,6 +18,11 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import java.time.Duration
+
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 @Unroll
 abstract class AbstractReactorCoreTest extends InstrumentationSpecification {
@@ -315,10 +316,10 @@ abstract class AbstractReactorCoreTest extends InstrumentationSpecification {
   def "Nested delayed mono with high concurrency"() {
     setup:
     def iterations = 100
-    def remainingIterations = new HashSet<>((0L ..< iterations).toList())
+    def remainingIterations = new HashSet<>((0L..<iterations).toList())
 
     when:
-    (0L ..< iterations).forEach { iteration ->
+    (0L..<iterations).forEach { iteration ->
       def outer = Mono.just("")
         .map({ it })
         .delayElement(Duration.ofMillis(10))
@@ -377,10 +378,10 @@ abstract class AbstractReactorCoreTest extends InstrumentationSpecification {
   def "Nested delayed flux with high concurrency"() {
     setup:
     def iterations = 100
-    def remainingIterations = new HashSet<>((0L ..< iterations).toList())
+    def remainingIterations = new HashSet<>((0L..<iterations).toList())
 
     when:
-    (0L ..< iterations).forEach { iteration ->
+    (0L..<iterations).forEach { iteration ->
       def outer = Flux.just("a", "b")
         .map({ it })
         .delayElements(Duration.ofMillis(10))

--- a/instrumentation/reactor-3.1/testing/src/main/groovy/io/opentelemetry/instrumentation/reactor/AbstractSubscriptionTest.groovy
+++ b/instrumentation/reactor-3.1/testing/src/main/groovy/io/opentelemetry/instrumentation/reactor/AbstractSubscriptionTest.groovy
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.reactor
 
-
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
-import java.util.concurrent.CountDownLatch
 import reactor.core.publisher.Mono
+
+import java.util.concurrent.CountDownLatch
 
 abstract class AbstractSubscriptionTest extends InstrumentationSpecification {
 

--- a/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/AbstractReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/AbstractReactorNettyHttpClientTest.groovy
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9
 
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
@@ -15,8 +13,11 @@ import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.sdk.trace.data.SpanData
-import java.util.concurrent.atomic.AtomicReference
 import reactor.netty.http.client.HttpClient
+
+import java.util.concurrent.atomic.AtomicReference
+
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 
 abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpClient.ResponseReceiver> implements AgentTestTrait {
 
@@ -42,7 +43,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
 
   @Override
   int sendRequest(HttpClient.ResponseReceiver request, String method, URI uri, Map<String, String> headers) {
-    return request.responseSingle {resp, content ->
+    return request.responseSingle { resp, content ->
       // Make sure to consume content since that's when we close the span.
       content.map {
         resp
@@ -52,7 +53,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
 
   @Override
   void sendRequestWithCallback(HttpClient.ResponseReceiver request, String method, URI uri, Map<String, String> headers, AbstractHttpClientTest.RequestResult requestResult) {
-    request.responseSingle {resp, content ->
+    request.responseSingle { resp, content ->
       // Make sure to consume content since that's when we close the span.
       content.map { resp }
     }.subscribe({
@@ -115,7 +116,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
       httpClient.baseUrl(resolveAddress("").toString())
         .get()
         .uri("/success")
-        .responseSingle {resp, content ->
+        .responseSingle { resp, content ->
           // Make sure to consume content since that's when we close the span.
           content.map { resp }
         }
@@ -155,7 +156,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
     runWithSpan("parent") {
       httpClient.get()
         .uri("http://localhost:$UNUSABLE_PORT/")
-        .responseSingle {resp, content ->
+        .responseSingle { resp, content ->
           // Make sure to consume content since that's when we close the span.
           content.map { resp }
         }

--- a/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.groovy
@@ -5,12 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -18,6 +12,12 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import reactor.netty.http.client.HttpClient
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implements AgentTestTrait {
 

--- a/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyHttpClientTest.groovy
@@ -7,9 +7,10 @@ package io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9
 
 import io.netty.channel.ChannelOption
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection
+import reactor.netty.http.client.HttpClient
+
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeoutException
-import reactor.netty.http.client.HttpClient
 
 class ReactorNettyHttpClientTest extends AbstractReactorNettyHttpClientTest {
 
@@ -40,7 +41,7 @@ class ReactorNettyHttpClientTest extends AbstractReactorNettyHttpClientTest {
           .headers({ h -> headers.each { k, v -> h.add(k, v) } })
           .get()
           .uri(path)
-          .responseSingle {resp, content ->
+          .responseSingle { resp, content ->
             // Make sure to consume content since that's when we close the span.
             content.map { resp }
           }

--- a/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyHttpClientUsingFromTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyHttpClientUsingFromTest.groovy
@@ -13,7 +13,7 @@ class ReactorNettyHttpClientUsingFromTest extends AbstractReactorNettyHttpClient
 
   HttpClient createHttpClient() {
     return HttpClient.from(TcpClient.create()).tcpConfiguration({ tcpClient ->
-        tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MS)
+      tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MS)
     })
   }
 }

--- a/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/AbstractReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/AbstractReactorNettyHttpClientTest.groovy
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0
 
-import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
-
 import io.netty.resolver.AddressResolver
 import io.netty.resolver.AddressResolverGroup
 import io.netty.resolver.InetNameResolver
@@ -20,8 +18,11 @@ import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.sdk.trace.data.SpanData
-import java.util.concurrent.atomic.AtomicReference
 import reactor.netty.http.client.HttpClient
+
+import java.util.concurrent.atomic.AtomicReference
+
+import static io.opentelemetry.instrumentation.test.utils.PortUtils.UNUSABLE_PORT
 
 abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpClient.ResponseReceiver> implements AgentTestTrait {
 
@@ -47,7 +48,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
 
   @Override
   int sendRequest(HttpClient.ResponseReceiver request, String method, URI uri, Map<String, String> headers) {
-    return request.responseSingle {resp, content ->
+    return request.responseSingle { resp, content ->
       // Make sure to consume content since that's when we close the span.
       content.map {
         resp
@@ -57,7 +58,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
 
   @Override
   void sendRequestWithCallback(HttpClient.ResponseReceiver request, String method, URI uri, Map<String, String> headers, AbstractHttpClientTest.RequestResult requestResult) {
-    request.responseSingle {resp, content ->
+    request.responseSingle { resp, content ->
       // Make sure to consume content since that's when we close the span.
       content.map { resp }
     }.subscribe({
@@ -124,7 +125,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
       httpClient.baseUrl(resolveAddress("").toString())
         .get()
         .uri("/success")
-        .responseSingle {resp, content ->
+        .responseSingle { resp, content ->
           // Make sure to consume content since that's when we close the span.
           content.map { resp }
         }

--- a/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.groovy
@@ -5,12 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -18,6 +12,12 @@ import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestServer
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import reactor.netty.http.client.HttpClient
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implements AgentTestTrait {
 

--- a/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientTest.groovy
@@ -7,9 +7,10 @@ package io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0
 
 import io.netty.channel.ChannelOption
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection
+import reactor.netty.http.client.HttpClient
+
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeoutException
-import reactor.netty.http.client.HttpClient
 
 class ReactorNettyHttpClientTest extends AbstractReactorNettyHttpClientTest {
 
@@ -34,7 +35,7 @@ class ReactorNettyHttpClientTest extends AbstractReactorNettyHttpClientTest {
           .headers({ h -> headers.each { k, v -> h.add(k, v) } })
           .get()
           .uri(path)
-          .responseSingle {resp, content ->
+          .responseSingle { resp, content ->
             // Make sure to consume content since that's when we close the span.
             content.map { resp }
           }

--- a/instrumentation/rediscala-1.8/javaagent/src/test/groovy/RediscalaClientTest.groovy
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/groovy/RediscalaClientTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import akka.actor.ActorSystem
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
@@ -17,6 +16,8 @@ import scala.Option
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 class RediscalaClientTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonAsyncClientTest.groovy
+++ b/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonAsyncClientTest.groovy
@@ -3,11 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.TimeUnit
 import org.redisson.Redisson
 import org.redisson.api.RBucket
 import org.redisson.api.RFuture
@@ -18,6 +16,10 @@ import org.redisson.config.Config
 import org.redisson.config.SingleServerConfig
 import org.testcontainers.containers.GenericContainer
 import spock.lang.Shared
+
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 class RedissonAsyncClientTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonClientTest.groovy
+++ b/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonClientTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static java.util.regex.Pattern.compile
-import static java.util.regex.Pattern.quote
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -23,6 +20,10 @@ import org.redisson.config.Config
 import org.redisson.config.SingleServerConfig
 import org.testcontainers.containers.GenericContainer
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static java.util.regex.Pattern.compile
+import static java.util.regex.Pattern.quote
 
 class RedissonClientTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/rocketmq-client-4.8/testing/src/main/groovy/io/opentelemetry/instrumentation/rocketmq/AbstractRocketMqClientTest.groovy
+++ b/instrumentation/rocketmq-client-4.8/testing/src/main/groovy/io/opentelemetry/instrumentation/rocketmq/AbstractRocketMqClientTest.groovy
@@ -5,10 +5,6 @@
 
 package io.opentelemetry.instrumentation.rocketmq
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-
 import base.BaseConf
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -20,6 +16,10 @@ import org.apache.rocketmq.common.message.Message
 import org.apache.rocketmq.remoting.common.RemotingHelper
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 @Unroll
 abstract class AbstractRocketMqClientTest extends InstrumentationSpecification {

--- a/instrumentation/rocketmq-client-4.8/testing/src/main/groovy/io/opentelemetry/instrumentation/rocketmq/TracingMessageListener.groovy
+++ b/instrumentation/rocketmq-client-4.8/testing/src/main/groovy/io/opentelemetry/instrumentation/rocketmq/TracingMessageListener.groovy
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.rocketmq
 
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
-
 import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyContext
 import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus
 import org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly
 import org.apache.rocketmq.common.message.MessageExt
+
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 class TracingMessageListener implements MessageListenerOrderly {
   @Override

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2SubscriptionTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2SubscriptionTest.groovy
@@ -7,5 +7,5 @@ import io.opentelemetry.instrumentation.rxjava2.AbstractRxJava2SubscriptionTest
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 
 class RxJava2SubscriptionTest extends AbstractRxJava2SubscriptionTest implements AgentTestTrait {
-  
+
 }

--- a/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/javaagent/src/test/groovy/RxJava2WithSpanInstrumentationTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.rxjava2.TracedWithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
@@ -23,6 +21,9 @@ import io.reactivex.subscribers.TestSubscriber
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class RxJava2WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/rxjava/rxjava-2.0/library/src/test/groovy/RxJava2AsyncOperationEndStrategyTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/library/src/test/groovy/RxJava2AsyncOperationEndStrategyTest.groovy
@@ -1037,9 +1037,9 @@ class RxJava2AsyncOperationEndStrategyTest extends Specification {
     }
 
     @Override
-    void request(long l) { }
+    void request(long l) {}
 
     @Override
-    void cancel() { }
+    void cancel() {}
   }
 }

--- a/instrumentation/rxjava/rxjava-2.0/testing/src/main/groovy/io/opentelemetry/instrumentation/rxjava2/AbstractRxJava2SubscriptionTest.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/testing/src/main/groovy/io/opentelemetry/instrumentation/rxjava2/AbstractRxJava2SubscriptionTest.groovy
@@ -5,16 +5,16 @@
 
 package io.opentelemetry.instrumentation.rxjava2
 
-
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
-
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.functions.Consumer
+
 import java.util.concurrent.CountDownLatch
+
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 abstract class AbstractRxJava2SubscriptionTest extends InstrumentationSpecification {
 

--- a/instrumentation/rxjava/rxjava-2.0/testing/src/main/groovy/io/opentelemetry/instrumentation/rxjava2/AbstractRxJava2Test.groovy
+++ b/instrumentation/rxjava/rxjava-2.0/testing/src/main/groovy/io/opentelemetry/instrumentation/rxjava2/AbstractRxJava2Test.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.instrumentation.rxjava2
 
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTraceWithoutExceptionCatch
-import static java.util.concurrent.TimeUnit.MILLISECONDS
-
 import com.google.common.collect.Lists
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.SpanKind
@@ -25,6 +22,9 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTraceWithoutExceptionCatch
+import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 /**
  * <p>Tests in this class may seem not exhaustive due to the fact that some classes are converted

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3SubscriptionTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3SubscriptionTest.groovy
@@ -7,5 +7,5 @@ import io.opentelemetry.instrumentation.rxjava3.AbstractRxJava3SubscriptionTest
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 
 class RxJava3SubscriptionTest extends AbstractRxJava3SubscriptionTest implements AgentTestTrait {
-  
+
 }

--- a/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/javaagent/src/test/groovy/RxJava3WithSpanInstrumentationTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.rxjava3.TracedWithSpan
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
@@ -23,6 +21,9 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class RxJava3WithSpanInstrumentationTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/rxjava/rxjava-3.0/library/src/test/groovy/RxJava3AsyncOperationEndStrategyTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/library/src/test/groovy/RxJava3AsyncOperationEndStrategyTest.groovy
@@ -1037,9 +1037,9 @@ class RxJava3AsyncOperationEndStrategyTest extends Specification {
     }
 
     @Override
-    void request(long l) { }
+    void request(long l) {}
 
     @Override
-    void cancel() { }
+    void cancel() {}
   }
 }

--- a/instrumentation/rxjava/rxjava-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/rxjava3/AbstractRxJava3SubscriptionTest.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/rxjava3/AbstractRxJava3SubscriptionTest.groovy
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.rxjava3
 
-
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.functions.Consumer
+
 import java.util.concurrent.CountDownLatch
 
 abstract class AbstractRxJava3SubscriptionTest extends InstrumentationSpecification {

--- a/instrumentation/rxjava/rxjava-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/rxjava3/AbstractRxJava3Test.groovy
+++ b/instrumentation/rxjava/rxjava-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/rxjava3/AbstractRxJava3Test.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.instrumentation.rxjava3
 
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTraceWithoutExceptionCatch
-import static java.util.concurrent.TimeUnit.MILLISECONDS
-
 import com.google.common.collect.Lists
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.SpanKind
@@ -25,6 +22,10 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTraceWithoutExceptionCatch
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+
 /**
  * <p>Tests in this class may seem not exhaustive due to the fact that some classes are converted
  * into others, ie. {@link Completable#toMaybe()}. Fortunately, RxJava3 uses helper classes like

--- a/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/scala-executors/javaagent/src/slickTest/groovy/SlickTest.groovy
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
 
 class SlickTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/scala-executors/javaagent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/instrumentation/scala-executors/javaagent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -3,8 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import scala.concurrent.forkjoin.ForkJoinPool
+import scala.concurrent.forkjoin.ForkJoinTask
+import spock.lang.Shared
+
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.Callable
@@ -13,9 +18,6 @@ import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import scala.concurrent.forkjoin.ForkJoinPool
-import scala.concurrent.forkjoin.ForkJoinTask
-import spock.lang.Shared
 
 /**
  * Test executor instrumentation for Scala specific classes.

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/JettyServlet2Test.groovy
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/JettyServlet2Test.groovy
@@ -3,6 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.sdk.trace.data.SpanData
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.handler.ErrorHandler
+import org.eclipse.jetty.servlet.ServletContextHandler
+
+import javax.servlet.http.HttpServletRequest
+
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
@@ -10,15 +21,6 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import io.opentelemetry.instrumentation.test.AgentTestTrait
-import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import io.opentelemetry.sdk.trace.data.SpanData
-import javax.servlet.http.HttpServletRequest
-import org.eclipse.jetty.server.Server
-import org.eclipse.jetty.server.handler.ErrorHandler
-import org.eclipse.jetty.servlet.ServletContextHandler
 
 class JettyServlet2Test extends HttpServerTest<Server> implements AgentTestTrait {
 

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/TestServlet2.groovy
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/TestServlet2.groovy
@@ -3,16 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import groovy.servlet.AbstractHttpServlet
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import groovy.servlet.AbstractHttpServlet
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 
 class TestServlet2 {
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3MappingTest.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3MappingTest.groovy
@@ -3,18 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
+import spock.lang.Unroll
+
 import javax.servlet.Servlet
 import javax.servlet.ServletException
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 abstract class AbstractServlet3MappingTest<SERVER, CONTEXT> extends AgentInstrumentationSpecification implements HttpServerTestTrait<SERVER> {
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest
+
+import javax.servlet.Servlet
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -10,12 +18,6 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import io.opentelemetry.instrumentation.test.AgentTestTrait
-import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest
-import javax.servlet.Servlet
 
 abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERVER> implements AgentTestTrait {
   @Override

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServlet3MappingTest.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServlet3MappingTest.groovy
@@ -3,13 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.servlet.ServletContextHandler
+
 import javax.servlet.Servlet
 import javax.servlet.ServletException
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import org.eclipse.jetty.server.Server
-import org.eclipse.jetty.servlet.ServletContextHandler
 
 class JettyServlet3MappingTest extends AbstractServlet3MappingTest<Server, ServletContextHandler> {
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServlet3Test.groovy
@@ -3,20 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.handler.ErrorHandler
+import org.eclipse.jetty.servlet.ServletContextHandler
+
+import javax.servlet.Servlet
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServletRequest
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import javax.servlet.Servlet
-import javax.servlet.ServletException
-import javax.servlet.http.HttpServletRequest
-import org.eclipse.jetty.server.Server
-import org.eclipse.jetty.server.handler.ErrorHandler
-import org.eclipse.jetty.servlet.ServletContextHandler
 
 abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletContextHandler> {
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import javax.servlet.Servlet
-import javax.servlet.ServletException
-import javax.servlet.http.HttpServletRequest
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.servlet.ServletHandler
+
+import javax.servlet.Servlet
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServletRequest
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 
 class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandler> {
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TestServlet3.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TestServlet3.groovy
@@ -3,21 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import groovy.servlet.AbstractHttpServlet
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+
+import javax.servlet.RequestDispatcher
+import javax.servlet.ServletException
+import javax.servlet.annotation.WebServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import java.util.concurrent.CountDownLatch
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import groovy.servlet.AbstractHttpServlet
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import java.util.concurrent.CountDownLatch
-import javax.servlet.RequestDispatcher
-import javax.servlet.ServletException
-import javax.servlet.annotation.WebServlet
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 
 class TestServlet3 {
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3FilterMappingTest.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3FilterMappingTest.groovy
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import org.apache.catalina.Context
+import org.apache.catalina.startup.Tomcat
+import org.apache.tomcat.util.descriptor.web.FilterDef
+import org.apache.tomcat.util.descriptor.web.FilterMap
+
 import javax.servlet.Filter
 import javax.servlet.FilterChain
 import javax.servlet.FilterConfig
@@ -12,10 +18,6 @@ import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import org.apache.catalina.Context
-import org.apache.catalina.startup.Tomcat
-import org.apache.tomcat.util.descriptor.web.FilterDef
-import org.apache.tomcat.util.descriptor.web.FilterMap
 
 abstract class TomcatServlet3FilterMappingTest extends TomcatServlet3MappingTest {
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3MappingTest.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3MappingTest.groovy
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import java.nio.file.Files
-import javax.servlet.Servlet
+
 import org.apache.catalina.Context
 import org.apache.catalina.startup.Tomcat
 import org.apache.tomcat.JarScanFilter
 import org.apache.tomcat.JarScanType
+
+import javax.servlet.Servlet
+import java.nio.file.Files
 
 class TomcatServlet3MappingTest extends AbstractServlet3MappingTest<Tomcat, Context> {
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3Test.groovy
@@ -3,22 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static org.junit.Assume.assumeTrue
 
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
-import java.nio.file.Files
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
-import javax.servlet.Servlet
-import javax.servlet.ServletException
 import org.apache.catalina.AccessLog
 import org.apache.catalina.Context
 import org.apache.catalina.connector.Request
@@ -31,6 +18,21 @@ import org.apache.tomcat.JarScanFilter
 import org.apache.tomcat.JarScanType
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import javax.servlet.Servlet
+import javax.servlet.ServletException
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static org.junit.Assume.assumeTrue
 
 @Unroll
 abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> {

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5MappingTest.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5MappingTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
@@ -15,6 +14,8 @@ import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import spock.lang.Unroll
+
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 abstract class AbstractServlet5MappingTest<SERVER, CONTEXT> extends AgentInstrumentationSpecification implements HttpServerTestTrait<SERVER> {
 

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentTestTrait
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest
+import jakarta.servlet.Servlet
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -10,12 +17,6 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import io.opentelemetry.instrumentation.test.AgentTestTrait
-import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest
-import jakarta.servlet.Servlet
 
 abstract class AbstractServlet5Test<SERVER, CONTEXT> extends HttpServerTest<SERVER> implements AgentTestTrait {
   @Override

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServlet5Test.groovy
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import jakarta.servlet.Servlet
 import jakarta.servlet.ServletException
@@ -17,6 +11,13 @@ import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
 import spock.lang.IgnoreIf
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 abstract class JettyServlet5Test extends AbstractServlet5Test<Object, Object> {
 

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TestServlet5.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TestServlet5.groovy
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import jakarta.servlet.RequestDispatcher
@@ -17,7 +11,15 @@ import jakarta.servlet.annotation.WebServlet
 import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+
 import java.util.concurrent.CountDownLatch
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class TestServlet5 {
 

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5MappingTest.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5MappingTest.groovy
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import jakarta.servlet.Servlet
-import java.nio.file.Files
 import org.apache.catalina.Context
 import org.apache.catalina.startup.Tomcat
 import org.apache.tomcat.JarScanFilter
 import org.apache.tomcat.JarScanType
+
+import java.nio.file.Files
 
 class TomcatServlet5MappingTest extends AbstractServlet5MappingTest<Tomcat, Context> {
 

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5Test.groovy
@@ -3,22 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static org.junit.Assume.assumeTrue
 
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
 import jakarta.servlet.Servlet
 import jakarta.servlet.ServletException
-import java.nio.file.Files
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import org.apache.catalina.AccessLog
 import org.apache.catalina.Context
 import org.apache.catalina.connector.Request
@@ -31,6 +20,19 @@ import org.apache.tomcat.JarScanFilter
 import org.apache.tomcat.JarScanType
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static org.junit.Assume.assumeTrue
 
 @Unroll
 abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> {

--- a/instrumentation/servlet/servlet-javax-common/javaagent/src/test/groovy/HttpServletResponseTest.groovy
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/src/test/groovy/HttpServletResponseTest.groovy
@@ -3,19 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static java.util.Collections.emptyEnumeration
 
 import groovy.servlet.AbstractHttpServlet
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import spock.lang.Subject
+
 import javax.servlet.ServletOutputStream
 import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 import javax.servlet.http.Cookie
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import spock.lang.Subject
+
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static java.util.Collections.emptyEnumeration
 
 class HttpServletResponseTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/spark-2.3/javaagent/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/instrumentation/spark-2.3/javaagent/src/test/groovy/SparkJavaBasedTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -11,6 +10,8 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.testing.internal.armeria.client.WebClient
 import spark.Spark
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 class SparkJavaBasedTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ChunkRootSpanTest.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ChunkRootSpanTest.groovy
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static java.util.Collections.emptyMap
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.springframework.batch.core.JobParameter
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.support.ClassPathXmlApplicationContext
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static java.util.Collections.emptyMap
 
 abstract class ChunkRootSpanTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/CustomSpanEventTest.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/CustomSpanEventTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static java.util.Collections.emptyMap
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -12,6 +10,9 @@ import org.springframework.batch.core.JobParameter
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.support.ClassPathXmlApplicationContext
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static java.util.Collections.emptyMap
 
 abstract class CustomSpanEventTest extends AgentInstrumentationSpecification {
   static final boolean VERSION_GREATER_THAN_4_0 = Boolean.getBoolean("testLatestDeps")

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ItemLevelSpanTest.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ItemLevelSpanTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static java.util.Collections.emptyMap
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -12,6 +10,9 @@ import org.springframework.batch.core.JobParameter
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.support.ClassPathXmlApplicationContext
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static java.util.Collections.emptyMap
 
 abstract class ItemLevelSpanTest extends AgentInstrumentationSpecification {
   abstract runJob(String jobName, Map<String, JobParameter> params = emptyMap())
@@ -143,7 +144,7 @@ abstract class ItemLevelSpanTest extends AgentInstrumentationSpecification {
         def childCount = new HashMap<SpanData, Number>()
         spans.forEach { span ->
           if (span.name == "BatchJob parallelItemsJob.parallelItemsStep.Chunk") {
-            childCount.put(span, spans.count {it.parentSpanId == span.spanId })
+            childCount.put(span, spans.count { it.parentSpanId == span.spanId })
           }
         }
         // sort spans with a ranking function
@@ -160,7 +161,7 @@ abstract class ItemLevelSpanTest extends AgentInstrumentationSpecification {
           // find the chunk this span belongs to
           def chunkSpan = it
           while (chunkSpan != null && chunkSpan.name != "BatchJob parallelItemsJob.parallelItemsStep.Chunk") {
-            chunkSpan = spans.find {it.spanId == chunkSpan.parentSpanId }
+            chunkSpan = spans.find { it.spanId == chunkSpan.parentSpanId }
           }
           if (chunkSpan != null) {
             // sort larger chunks first

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/JavaxBatchConfigTrait.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/JavaxBatchConfigTrait.groovy
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import java.util.concurrent.atomic.AtomicInteger
+
+import org.springframework.batch.core.JobParameter
+
 import javax.batch.operations.JobOperator
 import javax.batch.runtime.BatchRuntime
-import org.springframework.batch.core.JobParameter
+import java.util.concurrent.atomic.AtomicInteger
 
 trait JavaxBatchConfigTrait {
   static JobOperator jobOperator
@@ -25,7 +27,7 @@ trait JavaxBatchConfigTrait {
 
   def runJob(String jobName, Map<String, JobParameter> params) {
     def jobParams = new Properties()
-    params.forEach({k, v ->
+    params.forEach({ k, v ->
       jobParams.setProperty(k, v.toString())
     })
     // each job instance with the same name needs to be unique

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/SpringBatchTest.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/SpringBatchTest.groovy
@@ -3,15 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static java.util.Collections.emptyMap
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import org.springframework.batch.core.JobParameter
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.support.ClassPathXmlApplicationContext
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static java.util.Collections.emptyMap
 
 abstract class SpringBatchTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventChunkListener.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventChunkListener.groovy
@@ -6,6 +6,7 @@
 package jsr
 
 import io.opentelemetry.api.trace.Span
+
 import javax.batch.api.chunk.listener.ChunkListener
 
 class CustomEventChunkListener implements ChunkListener {

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventItemProcessListener.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventItemProcessListener.groovy
@@ -6,6 +6,7 @@
 package jsr
 
 import io.opentelemetry.api.trace.Span
+
 import javax.batch.api.chunk.listener.ItemProcessListener
 
 class CustomEventItemProcessListener implements ItemProcessListener {

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventItemReadListener.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventItemReadListener.groovy
@@ -6,6 +6,7 @@
 package jsr
 
 import io.opentelemetry.api.trace.Span
+
 import javax.batch.api.chunk.listener.ItemReadListener
 
 class CustomEventItemReadListener implements ItemReadListener {

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventItemWriteListener.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventItemWriteListener.groovy
@@ -6,6 +6,7 @@
 package jsr
 
 import io.opentelemetry.api.trace.Span
+
 import javax.batch.api.chunk.listener.ItemWriteListener
 
 class CustomEventItemWriteListener implements ItemWriteListener {

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventJobListener.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventJobListener.groovy
@@ -6,6 +6,7 @@
 package jsr
 
 import io.opentelemetry.api.trace.Span
+
 import javax.batch.api.listener.JobListener
 
 class CustomEventJobListener implements JobListener {

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventStepListener.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/CustomEventStepListener.groovy
@@ -6,6 +6,7 @@
 package jsr
 
 import io.opentelemetry.api.trace.Span
+
 import javax.batch.api.listener.StepListener
 
 class CustomEventStepListener implements StepListener {

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/SingleItemReader.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/SingleItemReader.groovy
@@ -5,8 +5,8 @@
 
 package jsr
 
-import java.util.concurrent.atomic.AtomicReference
 import javax.batch.api.chunk.ItemReader
+import java.util.concurrent.atomic.AtomicReference
 
 class SingleItemReader implements ItemReader {
   final AtomicReference<String> item = new AtomicReference<>("42")

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/TestItemReader.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/jsr/TestItemReader.groovy
@@ -5,9 +5,9 @@
 
 package jsr
 
+import javax.batch.api.chunk.ItemReader
 import java.util.stream.Collectors
 import java.util.stream.IntStream
-import javax.batch.api.chunk.ItemReader
 
 class TestItemReader implements ItemReader {
   private final List<String> items = IntStream.range(0, 13).mapToObj(String.&valueOf).collect(Collectors.toList())

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/springbatch/SingleItemReader.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/springbatch/SingleItemReader.groovy
@@ -5,8 +5,9 @@
 
 package springbatch
 
-import java.util.concurrent.atomic.AtomicReference
 import org.springframework.batch.item.ItemReader
+
+import java.util.concurrent.atomic.AtomicReference
 
 class SingleItemReader implements ItemReader<String> {
   final AtomicReference<String> item = new AtomicReference<>("42")

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/springbatch/TestItemReader.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/springbatch/TestItemReader.groovy
@@ -5,9 +5,10 @@
 
 package springbatch
 
+import org.springframework.batch.item.support.ListItemReader
+
 import java.util.stream.Collectors
 import java.util.stream.IntStream
-import org.springframework.batch.item.support.ListItemReader
 
 class TestItemReader extends ListItemReader<String> {
   TestItemReader() {

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/springbatch/TestSyncItemReader.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/springbatch/TestSyncItemReader.groovy
@@ -5,9 +5,10 @@
 
 package springbatch
 
+import org.springframework.batch.item.ItemReader
+
 import java.util.stream.Collectors
 import java.util.stream.IntStream
-import org.springframework.batch.item.ItemReader
 
 class TestSyncItemReader implements ItemReader<String> {
   private final Iterator<String> items

--- a/instrumentation/spring/spring-core-2.0/javaagent/src/test/groovy/SimpleAsyncTaskExecutorInstrumentationTest.groovy
+++ b/instrumentation/spring/spring-core-2.0/javaagent/src/test/groovy/SimpleAsyncTaskExecutorInstrumentationTest.groovy
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.util.concurrent.Callable
-import java.util.concurrent.CountDownLatch
 import org.springframework.core.task.SimpleAsyncTaskExecutor
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class SimpleAsyncTaskExecutorInstrumentationTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/test/groovy/SpringJpaTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -13,6 +11,9 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spring.jpa.JpaCustomer
 import spring.jpa.JpaCustomerRepository
 import spring.jpa.JpaPersistenceConfig
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 
 class SpringJpaTest extends AgentInstrumentationSpecification {
   def "test object method"() {

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/test/groovy/SpringIntegrationAndRabbitTest.groovy
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/test/groovy/SpringIntegrationAndRabbitTest.groovy
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.instrumentation.test.server.ServerTraceUtils.runUnderServerTrace
-
-import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 class SpringIntegrationAndRabbitTest extends AgentInstrumentationSpecification implements WithRabbitProducerConsumerTrait {
   def setupSpec() {

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/AbstractComplexPropagationTest.groovy
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/AbstractComplexPropagationTest.groovy
@@ -3,14 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
-import java.util.concurrent.BlockingQueue
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.stream.Collectors
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -24,6 +18,14 @@ import org.springframework.messaging.Message
 import org.springframework.messaging.SubscribableChannel
 import org.springframework.messaging.support.MessageBuilder
 import spock.lang.Shared
+
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.stream.Collectors
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 
 abstract class AbstractComplexPropagationTest extends InstrumentationSpecification {
 

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/AbstractSpringCloudStreamRabbitTest.groovy
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/AbstractSpringCloudStreamRabbitTest.groovy
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 
 abstract class AbstractSpringCloudStreamRabbitTest extends InstrumentationSpecification implements WithRabbitProducerConsumerTrait {
 

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/AbstractSpringIntegrationTracingTest.groovy
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/AbstractSpringIntegrationTracingTest.groovy
@@ -3,11 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.sdk.trace.data.SpanData
-import java.util.concurrent.Executors
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -23,6 +21,10 @@ import org.springframework.messaging.support.ExecutorSubscribableChannel
 import org.springframework.messaging.support.MessageBuilder
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import java.util.concurrent.Executors
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 
 @Unroll
 abstract class AbstractSpringIntegrationTracingTest extends InstrumentationSpecification {
@@ -57,8 +59,8 @@ abstract class AbstractSpringIntegrationTracingTest extends InstrumentationSpeci
     channel.subscribe(messageHandler)
 
     when:
-      channel.send(MessageBuilder.withPayload("test")
-        .build())
+    channel.send(MessageBuilder.withPayload("test")
+      .build())
 
     then:
     def capturedMessage = messageHandler.join()

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/CapturingMessageHandler.groovy
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/CapturingMessageHandler.groovy
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
-import java.util.concurrent.CompletableFuture
 import org.springframework.messaging.Message
 import org.springframework.messaging.MessageHandler
 import org.springframework.messaging.MessagingException
+
+import java.util.concurrent.CompletableFuture
+
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 class CapturingMessageHandler implements MessageHandler {
   final CompletableFuture<Message<?>> captured = new CompletableFuture<>()

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/WithRabbitProducerConsumerTrait.groovy
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/WithRabbitProducerConsumerTrait.groovy
@@ -3,10 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
-import java.time.Duration
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.SpringBootConfiguration
@@ -19,6 +16,11 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.messaging.support.MessageBuilder
 import org.testcontainers.containers.GenericContainer
+
+import java.time.Duration
+
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
 
 trait WithRabbitProducerConsumerTrait {
 

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
@@ -3,15 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 import com.rabbitmq.client.ConnectionFactory
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.time.Duration
 import org.springframework.amqp.core.AmqpTemplate
 import org.springframework.amqp.core.Queue
 import org.springframework.amqp.rabbit.annotation.RabbitListener
@@ -22,6 +17,13 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
 import org.testcontainers.containers.GenericContainer
 import spock.lang.Shared
+
+import java.time.Duration
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 class ContextPropagationTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.util.concurrent.TimeUnit
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
+
+import java.util.concurrent.TimeUnit
 
 class SpringSchedulingTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SingleThreadedSpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SingleThreadedSpringWebfluxTest.groovy
@@ -9,6 +9,7 @@ import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory
 import org.springframework.boot.web.embedded.netty.NettyServerCustomizer
 import org.springframework.context.annotation.Bean
 import server.SpringWebFluxTestApplication
+
 /**
  * Run all Webflux tests under netty event loop having only 1 thread.
  * Some of the bugs are better visible in this setup because same thread is reused

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -28,6 +25,10 @@ import server.SpringWebFluxTestApplication
 import server.TestController
 import spock.lang.Unroll
 import util.SpringWebfluxTestUtil
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [SpringWebFluxTestApplication, ForceNettyAutoConfiguration])
 class SpringWebfluxTest extends AgentInstrumentationSpecification {
@@ -53,7 +54,7 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
         // https://github.com/line/armeria/issues/2489
         @Override
         HttpResponse execute(HttpClient delegate, ClientRequestContext ctx, HttpRequest req) throws Exception {
-          return HttpResponse.from(delegate.execute(ctx, req).aggregate().thenApply {resp ->
+          return HttpResponse.from(delegate.execute(ctx, req).aggregate().thenApply { resp ->
             if (resp.status().isRedirection()) {
               return delegate.execute(ctx, HttpRequest.of(req.method(), resp.headers().get(HttpHeaderNames.LOCATION)))
             }
@@ -214,6 +215,7 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
   merely wraps handler call into Mono and thus actual invocation of handler function happens later,
   when INTERNAL handler span has already finished. Thus, "tracedMethod" has SERVER Netty span as its parent.
    */
+
   def "Create span during handler function"() {
     when:
     def response = client.get(urlPath).aggregate().join()

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/client/SpringWebFluxSingleConnection.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/client/SpringWebFluxSingleConnection.groovy
@@ -8,8 +8,6 @@ package client
 import io.netty.channel.ChannelOption
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.TimeoutException
 import org.springframework.http.HttpMethod
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
@@ -17,6 +15,9 @@ import reactor.ipc.netty.http.client.HttpClientOptions
 import reactor.ipc.netty.resources.PoolResources
 import reactor.netty.http.client.HttpClient
 import reactor.netty.resources.LoopResources
+
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeoutException
 
 class SpringWebFluxSingleConnection implements SingleConnection {
   private final ReactorClientHttpConnector connector

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/SpringWebFluxTestApplication.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/SpringWebFluxTestApplication.groovy
@@ -5,13 +5,8 @@
 
 package server
 
-import static org.springframework.web.reactive.function.server.RequestPredicates.GET
-import static org.springframework.web.reactive.function.server.RequestPredicates.POST
-import static org.springframework.web.reactive.function.server.RouterFunctions.route
-
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Tracer
-import java.time.Duration
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
@@ -24,6 +19,12 @@ import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
+
+import java.time.Duration
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST
+import static org.springframework.web.reactive.function.server.RouterFunctions.route
 
 @SpringBootApplication
 @ComponentScan(basePackages = ["server"], excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "server.base.*"))

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/TestController.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/TestController.groovy
@@ -7,11 +7,12 @@ package server
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Tracer
-import java.time.Duration
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
+
+import java.time.Duration
 
 @RestController
 class TestController {

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/ControllerSpringWebFluxServerTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/ControllerSpringWebFluxServerTest.groovy
@@ -5,15 +5,15 @@
 
 package server.base
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
 import org.springframework.web.server.ResponseStatusException
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 
 abstract class ControllerSpringWebFluxServerTest extends SpringWebFluxServerTest {
   @Override

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/DelayedControllerSpringWebFluxServerTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/DelayedControllerSpringWebFluxServerTest.groovy
@@ -6,14 +6,15 @@
 package server.base
 
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import java.time.Duration
-import java.util.concurrent.Callable
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
+
+import java.time.Duration
+import java.util.concurrent.Callable
 
 /**
  * Tests the case which uses annotated controller methods, and where "controller" span is created

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/DelayedHandlerSpringWebFluxServerTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/DelayedHandlerSpringWebFluxServerTest.groovy
@@ -6,7 +6,6 @@
 package server.base
 
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import java.time.Duration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory
 import org.springframework.context.annotation.Bean
@@ -14,6 +13,8 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
+
+import java.time.Duration
 
 /**
  * Tests the case which uses route handlers, and where "controller" span is created within a Mono

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/HandlerSpringWebFluxServerTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/HandlerSpringWebFluxServerTest.groovy
@@ -5,15 +5,15 @@
 
 package server.base
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
 import org.springframework.web.server.ResponseStatusException
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 
 abstract class HandlerSpringWebFluxServerTest extends SpringWebFluxServerTest {
   @Override

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/ImmediateControllerSpringWebFluxServerTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/ImmediateControllerSpringWebFluxServerTest.groovy
@@ -6,13 +6,14 @@
 package server.base
 
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import java.util.concurrent.Callable
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
+
+import java.util.concurrent.Callable
 
 /**
  * Tests the case where "controller" span is created within the controller method scope, and the

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/SpringWebFluxServerTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/SpringWebFluxServerTest.groovy
@@ -5,16 +5,16 @@
 
 package server.base
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import util.SpringWebfluxTestUtil
 
-abstract class SpringWebFluxServerTest extends HttpServerTest<ConfigurableApplicationContext> implements AgentTestTrait  {
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+
+abstract class SpringWebFluxServerTest extends HttpServerTest<ConfigurableApplicationContext> implements AgentTestTrait {
   protected abstract Class<?> getApplicationClass();
 
   @Override

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/util/SpringWebfluxTestUtil.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/util/SpringWebfluxTestUtil.groovy
@@ -5,9 +5,9 @@
 
 package util
 
-import static org.awaitility.Awaitility.await
-
 import java.util.concurrent.TimeUnit
+
+import static org.awaitility.Awaitility.await
 
 class SpringWebfluxTestUtil {
 
@@ -22,7 +22,7 @@ class SpringWebfluxTestUtil {
   }
 
   static boolean isRequestRunning() {
-    def result = Thread.getAllStackTraces().values().find {stackTrace ->
+    def result = Thread.getAllStackTraces().values().find { stackTrace ->
       def element = stackTrace.find {
         return ((it.className == "reactor.ipc.netty.http.server.HttpServerOperations" && it.methodName == "onHandlerStart")
           || (it.className == "io.netty.channel.nio.NioEventLoop" && it.methodName == "processSelectedKey"))

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -5,15 +5,6 @@
 
 package test.boot
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.LOGIN
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -26,6 +17,15 @@ import io.opentelemetry.testing.internal.armeria.common.QueryParams
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.web.servlet.view.RedirectView
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.LOGIN
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext> implements AgentTestTrait {
 

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/TestController.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/TestController.groovy
@@ -5,13 +5,6 @@
 
 package test.boot
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -22,6 +15,13 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.view.RedirectView
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 @Controller
 class TestController {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/FilteredAppConfig.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/FilteredAppConfig.groovy
@@ -5,23 +5,7 @@
 
 package test.filter
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import java.nio.charset.StandardCharsets
-import javax.servlet.Filter
-import javax.servlet.FilterChain
-import javax.servlet.FilterConfig
-import javax.servlet.ServletException
-import javax.servlet.ServletRequest
-import javax.servlet.ServletResponse
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.http.HttpInputMessage
@@ -37,6 +21,23 @@ import org.springframework.web.accept.ContentNegotiationStrategy
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
+
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.FilterConfig
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import java.nio.charset.StandardCharsets
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 @SpringBootApplication
 class FilteredAppConfig extends WebMvcConfigurerAdapter {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -5,14 +5,6 @@
 
 package test.filter
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -20,6 +12,14 @@ import io.opentelemetry.sdk.trace.data.SpanData
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 import test.boot.SecurityConfig
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> implements AgentTestTrait {
 

--- a/instrumentation/spring/spring-webmvc-3.1/wildfly-testing/src/test/groovy/OpenTelemetryHandlerMappingFilterTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/wildfly-testing/src/test/groovy/OpenTelemetryHandlerMappingFilterTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 import com.example.hello.HelloController
 import com.example.hello.TestFilter
@@ -22,6 +20,9 @@ import org.jboss.shrinkwrap.api.ShrinkWrap
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive
 import org.jboss.shrinkwrap.api.spec.WebArchive
 import org.junit.runner.RunWith
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.SERVER
 
 @RunWith(ArquillianSputnik)
 @RunAsClient

--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/test/groovy/test/boot/SpringWsTest.groovy
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/test/groovy/test/boot/SpringWsTest.groovy
@@ -5,9 +5,6 @@
 
 package test.boot
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -28,6 +25,9 @@ import org.springframework.ws.soap.addressing.client.ActionCallback
 import org.springframework.ws.soap.client.SoapFaultClientException
 import org.springframework.ws.soap.client.core.SoapActionCallback
 import spock.lang.Shared
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class SpringWsTest extends AgentInstrumentationSpecification implements HttpServerTestTrait<ConfigurableApplicationContext> {
 

--- a/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/javaagent/src/test/groovy/SpymemcachedTest.groovy
@@ -3,20 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-import static net.spy.memcached.ConnectionFactoryBuilder.Protocol.BINARY
 
 import com.google.common.util.concurrent.MoreExecutors
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.javaagent.instrumentation.spymemcached.CompletionListener
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.time.Duration
-import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.BlockingQueue
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.locks.ReentrantLock
 import net.spy.memcached.CASResponse
 import net.spy.memcached.ConnectionFactory
 import net.spy.memcached.ConnectionFactoryBuilder
@@ -27,6 +19,16 @@ import net.spy.memcached.ops.Operation
 import net.spy.memcached.ops.OperationQueueFactory
 import org.testcontainers.containers.GenericContainer
 import spock.lang.Shared
+
+import java.time.Duration
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.locks.ReentrantLock
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static net.spy.memcached.ConnectionFactoryBuilder.Protocol.BINARY
 
 class SpymemcachedTest extends AgentInstrumentationSpecification {
 

--- a/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
+++ b/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.INTERNAL
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
@@ -18,12 +12,20 @@ import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.struts.GreetingServlet
-import javax.servlet.DispatcherType
 import org.apache.struts2.dispatcher.ng.filter.StrutsPrepareAndExecuteFilter
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.DefaultServlet
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.util.resource.FileResource
+
+import javax.servlet.DispatcherType
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 
 class Struts2ActionSpanTest extends HttpServerTest<Server> implements AgentTestTrait {
 

--- a/instrumentation/tapestry-5.4/javaagent/src/test/groovy/TapestryTest.groovy
+++ b/instrumentation/tapestry-5.4/javaagent/src/test/groovy/TapestryTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
@@ -21,6 +20,8 @@ import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.util.resource.Resource
 import org.eclipse.jetty.webapp.WebAppContext
 import org.jsoup.Jsoup
+
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class TapestryTest extends AgentInstrumentationSpecification implements HttpServerTestTrait<Server> {
 
@@ -61,7 +62,7 @@ class TapestryTest extends AgentInstrumentationSpecification implements HttpServ
         // https://github.com/line/armeria/issues/2489
         @Override
         HttpResponse execute(HttpClient delegate, ClientRequestContext ctx, HttpRequest req) throws Exception {
-          return HttpResponse.from(delegate.execute(ctx, req).aggregate().thenApply {resp ->
+          return HttpResponse.from(delegate.execute(ctx, req).aggregate().thenApply { resp ->
             if (resp.status().isRedirection()) {
               return delegate.execute(ctx, HttpRequest.of(req.method(), URI.create(resp.headers().get(HttpHeaderNames.LOCATION)).path))
             }

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/AsyncServlet.groovy
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/AsyncServlet.groovy
@@ -5,19 +5,20 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.v10_0
 
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import jakarta.servlet.annotation.WebServlet
+import jakarta.servlet.http.HttpServlet
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+import java.util.concurrent.CountDownLatch
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import jakarta.servlet.annotation.WebServlet
-import jakarta.servlet.http.HttpServlet
-import jakarta.servlet.http.HttpServletRequest
-import jakarta.servlet.http.HttpServletResponse
-import java.util.concurrent.CountDownLatch
 
 @WebServlet(asyncSupported = true)
 class AsyncServlet extends HttpServlet {

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatAsyncTest.groovy
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatAsyncTest.groovy
@@ -5,6 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.v10_0
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import jakarta.servlet.Servlet
+import jakarta.servlet.ServletException
+import org.apache.catalina.Context
+import org.apache.catalina.startup.Tomcat
+import org.apache.tomcat.JarScanFilter
+import org.apache.tomcat.JarScanType
+import spock.lang.Unroll
+
+import java.nio.file.Files
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -13,18 +26,6 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import io.opentelemetry.instrumentation.test.AgentTestTrait
-import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import jakarta.servlet.Servlet
-import jakarta.servlet.ServletException
-import java.nio.file.Files
-import org.apache.catalina.Context
-import org.apache.catalina.startup.Tomcat
-import org.apache.tomcat.JarScanFilter
-import org.apache.tomcat.JarScanType
-import spock.lang.Unroll
 
 @Unroll
 class TomcatAsyncTest extends HttpServerTest<Tomcat> implements AgentTestTrait {

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatHandlerTest.groovy
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatHandlerTest.groovy
@@ -5,10 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.v10_0
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -18,6 +14,10 @@ import org.apache.catalina.connector.Response
 import org.apache.catalina.core.StandardHost
 import org.apache.catalina.startup.Tomcat
 import org.apache.catalina.valves.ErrorReportValve
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 
 class TomcatHandlerTest extends HttpServerTest<Tomcat> implements AgentTestTrait {
 

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/AsyncServlet.groovy
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/AsyncServlet.groovy
@@ -5,19 +5,20 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.v7_0
 
+import groovy.servlet.AbstractHttpServlet
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+
+import javax.servlet.annotation.WebServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import java.util.concurrent.CountDownLatch
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import groovy.servlet.AbstractHttpServlet
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import java.util.concurrent.CountDownLatch
-import javax.servlet.annotation.WebServlet
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 
 @WebServlet(asyncSupported = true)
 class AsyncServlet extends AbstractHttpServlet {

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatAsyncTest.groovy
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatAsyncTest.groovy
@@ -5,6 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.v7_0
 
+import io.opentelemetry.instrumentation.test.AgentTestTrait
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import org.apache.catalina.Context
+import org.apache.catalina.startup.Tomcat
+import org.apache.tomcat.JarScanFilter
+import org.apache.tomcat.JarScanType
+import spock.lang.Unroll
+
+import javax.servlet.Servlet
+import javax.servlet.ServletException
+import java.nio.file.Files
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -13,19 +26,6 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import io.opentelemetry.instrumentation.test.AgentTestTrait
-import io.opentelemetry.instrumentation.test.asserts.TraceAssert
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import java.nio.file.Files
-import javax.servlet.Servlet
-import javax.servlet.ServletException
-import org.apache.catalina.Context
-import org.apache.catalina.startup.Tomcat
-import org.apache.tomcat.JarScanFilter
-import org.apache.tomcat.JarScanType
-import spock.lang.Unroll
-
 
 @Unroll
 class TomcatAsyncTest extends HttpServerTest<Tomcat> implements AgentTestTrait {

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatHandlerTest.groovy
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatHandlerTest.groovy
@@ -5,10 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.v7_0
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -18,6 +14,10 @@ import org.apache.catalina.connector.Response
 import org.apache.catalina.core.StandardHost
 import org.apache.catalina.startup.Tomcat
 import org.apache.catalina.valves.ErrorReportValve
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 
 class TomcatHandlerTest extends HttpServerTest<Tomcat> implements AgentTestTrait {
 

--- a/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/javaagent/src/test/groovy/test/TwilioClientTest.groovy
@@ -5,9 +5,6 @@
 
 package test
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.StatusCode.ERROR
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.util.concurrent.ListenableFuture
 import com.twilio.Twilio
@@ -19,14 +16,18 @@ import com.twilio.rest.api.v2010.account.Call
 import com.twilio.rest.api.v2010.account.Message
 import com.twilio.type.PhoneNumber
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.TimeUnit
 import org.apache.http.HttpEntity
 import org.apache.http.HttpStatus
 import org.apache.http.StatusLine
 import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.impl.client.HttpClientBuilder
+
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.StatusCode.ERROR
 
 class TwilioClientTest extends AgentInstrumentationSpecification {
   final static String ACCOUNT_SID = "abc"

--- a/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
+++ b/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
@@ -20,6 +15,13 @@ import io.undertow.Handlers
 import io.undertow.Undertow
 import io.undertow.util.Headers
 import io.undertow.util.StatusCodes
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+
 //TODO make test which mixes handlers and servlets
 class UndertowServerTest extends HttpServerTest<Undertow> implements AgentTestTrait {
 

--- a/instrumentation/vaadin-14.2/testing/src/main/groovy/test/vaadin/AbstractVaadinTest.groovy
+++ b/instrumentation/vaadin-14.2/testing/src/main/groovy/test/vaadin/AbstractVaadinTest.groovy
@@ -11,7 +11,6 @@ import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
-import java.util.concurrent.TimeUnit
 import org.openqa.selenium.firefox.FirefoxOptions
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -22,6 +21,8 @@ import org.testcontainers.Testcontainers
 import org.testcontainers.containers.BrowserWebDriverContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import spock.lang.Shared
+
+import java.util.concurrent.TimeUnit
 
 abstract class AbstractVaadinTest extends AgentInstrumentationSpecification implements HttpServerTestTrait<ConfigurableApplicationContext> {
   private static final Logger logger = LoggerFactory.getLogger(AbstractVaadinTest)
@@ -35,9 +36,9 @@ abstract class AbstractVaadinTest extends AgentInstrumentationSpecification impl
     static ConfigurableApplicationContext start(int port, String contextPath) {
       def app = new SpringApplication(TestApplication)
       app.setDefaultProperties([
-        "server.port"                  : port,
-        "server.servlet.contextPath"   : contextPath,
-        "server.error.include-message" : "always"])
+        "server.port"                 : port,
+        "server.servlet.contextPath"  : contextPath,
+        "server.error.include-message": "always"])
       def context = app.run()
       return context
     }

--- a/instrumentation/vertx-http-client/vertx-http-client-3.0/javaagent/src/test/groovy/client/VertxHttpClientTest.groovy
+++ b/instrumentation/vertx-http-client/vertx-http-client-3.0/javaagent/src/test/groovy/client/VertxHttpClientTest.groovy
@@ -14,8 +14,9 @@ import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpClientOptions
 import io.vertx.core.http.HttpClientRequest
 import io.vertx.core.http.HttpMethod
-import java.util.concurrent.CompletableFuture
 import spock.lang.Shared
+
+import java.util.concurrent.CompletableFuture
 
 class VertxHttpClientTest extends HttpClientTest<HttpClientRequest> implements AgentTestTrait {
 
@@ -38,7 +39,7 @@ class VertxHttpClientTest extends HttpClientTest<HttpClientRequest> implements A
 
     request.handler { response ->
       future.complete(response.statusCode())
-    }.exceptionHandler {throwable ->
+    }.exceptionHandler { throwable ->
       future.completeExceptionally(throwable)
     }
     request.end()

--- a/instrumentation/vertx-http-client/vertx-http-client-4.0/javaagent/src/test/groovy/client/VertxHttpClientTest.groovy
+++ b/instrumentation/vertx-http-client/vertx-http-client-4.0/javaagent/src/test/groovy/client/VertxHttpClientTest.groovy
@@ -17,8 +17,9 @@ import io.vertx.core.http.HttpClientOptions
 import io.vertx.core.http.HttpClientRequest
 import io.vertx.core.http.HttpMethod
 import io.vertx.core.http.RequestOptions
-import java.util.concurrent.CompletableFuture
 import spock.lang.Shared
+
+import java.util.concurrent.CompletableFuture
 
 class VertxHttpClientTest extends HttpClientTest<Future<HttpClientRequest>> implements AgentTestTrait {
 
@@ -41,13 +42,15 @@ class VertxHttpClientTest extends HttpClientTest<Future<HttpClientRequest>> impl
   CompletableFuture<Integer> sendRequest(Future<HttpClientRequest> request) {
     CompletableFuture<Integer> future = new CompletableFuture<>()
 
-    request.compose {req -> req.send().onComplete {asyncResult ->
-      if (asyncResult.succeeded()) {
-        future.complete(asyncResult.result().statusCode())
-      } else {
-        future.completeExceptionally(asyncResult.cause())
+    request.compose { req ->
+      req.send().onComplete { asyncResult ->
+        if (asyncResult.succeeded()) {
+          future.complete(asyncResult.result().statusCode())
+        } else {
+          future.completeExceptionally(asyncResult.cause())
+        }
       }
-    }}.onFailure {throwable ->
+    }.onFailure { throwable ->
       future.completeExceptionally(throwable)
     }
 

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/VertxReactivePropagationTest.groovy
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static VertxReactiveWebServer.TEST_REQUEST_ID_ATTRIBUTE
-import static VertxReactiveWebServer.TEST_REQUEST_ID_PARAMETER
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Span
@@ -20,9 +15,16 @@ import io.opentelemetry.testing.internal.armeria.client.WebClient
 import io.opentelemetry.testing.internal.armeria.common.HttpRequest
 import io.opentelemetry.testing.internal.armeria.common.HttpRequestBuilder
 import io.vertx.reactivex.core.Vertx
+import spock.lang.Shared
+
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
-import spock.lang.Shared
+
+import static VertxReactiveWebServer.TEST_REQUEST_ID_ATTRIBUTE
+import static VertxReactiveWebServer.TEST_REQUEST_ID_PARAMETER
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
   @Shared

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -19,9 +19,10 @@ import io.vertx.reactivex.circuitbreaker.CircuitBreaker
 import io.vertx.reactivex.core.Vertx
 import io.vertx.reactivex.ext.web.client.HttpRequest
 import io.vertx.reactivex.ext.web.client.WebClient
+import spock.lang.Shared
+
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
-import spock.lang.Shared
 
 class VertxRxCircuitBreakerWebClientTest extends HttpClientTest<HttpRequest<?>> implements AgentTestTrait {
 

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/server/VertxRxCircuitBreakerHttpServerTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/server/VertxRxCircuitBreakerHttpServerTest.groovy
@@ -5,6 +5,13 @@
 
 package server
 
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.vertx.circuitbreaker.CircuitBreakerOptions
+import io.vertx.core.Promise
+import io.vertx.reactivex.circuitbreaker.CircuitBreaker
+import io.vertx.reactivex.core.AbstractVerticle
+import io.vertx.reactivex.ext.web.Router
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -12,13 +19,6 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import io.vertx.circuitbreaker.CircuitBreakerOptions
-import io.vertx.core.Promise
-import io.vertx.reactivex.circuitbreaker.CircuitBreaker
-import io.vertx.reactivex.core.AbstractVerticle
-import io.vertx.reactivex.ext.web.Router
 
 class VertxRxCircuitBreakerHttpServerTest extends VertxRxHttpServerTest {
 

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/server/VertxRxHttpServerTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/server/VertxRxHttpServerTest.groovy
@@ -5,15 +5,6 @@
 
 package server
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.vertx.core.DeploymentOptions
@@ -23,8 +14,18 @@ import io.vertx.core.VertxOptions
 import io.vertx.core.json.JsonObject
 import io.vertx.reactivex.core.AbstractVerticle
 import io.vertx.reactivex.ext.web.Router
+
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class VertxRxHttpServerTest extends HttpServerTest<Vertx> implements AgentTestTrait {
   public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port"
@@ -32,8 +33,8 @@ class VertxRxHttpServerTest extends HttpServerTest<Vertx> implements AgentTestTr
   @Override
   Vertx startServer(int port) {
     Vertx server = Vertx.vertx(new VertxOptions()
-    // Useful for debugging:
-    // .setBlockedThreadCheckInterval(Integer.MAX_VALUE)
+      // Useful for debugging:
+      // .setBlockedThreadCheckInterval(Integer.MAX_VALUE)
     )
     CompletableFuture<Void> future = new CompletableFuture<>()
     server.deployVerticle(verticle().getName(),

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/VertxReactivePropagationTest.groovy
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static VertxReactiveWebServer.TEST_REQUEST_ID_ATTRIBUTE
-import static VertxReactiveWebServer.TEST_REQUEST_ID_PARAMETER
-import static io.opentelemetry.api.trace.SpanKind.CLIENT
-import static io.opentelemetry.api.trace.SpanKind.SERVER
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Span
@@ -20,9 +15,16 @@ import io.opentelemetry.testing.internal.armeria.client.WebClient
 import io.opentelemetry.testing.internal.armeria.common.HttpRequest
 import io.opentelemetry.testing.internal.armeria.common.HttpRequestBuilder
 import io.vertx.reactivex.core.Vertx
+import spock.lang.Shared
+
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
-import spock.lang.Shared
+
+import static VertxReactiveWebServer.TEST_REQUEST_ID_ATTRIBUTE
+import static VertxReactiveWebServer.TEST_REQUEST_ID_PARAMETER
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
   @Shared

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -18,9 +18,10 @@ import io.vertx.reactivex.circuitbreaker.CircuitBreaker
 import io.vertx.reactivex.core.Vertx
 import io.vertx.reactivex.ext.web.client.HttpRequest
 import io.vertx.reactivex.ext.web.client.WebClient
+import spock.lang.Shared
+
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
-import spock.lang.Shared
 
 class VertxRxCircuitBreakerWebClientTest extends HttpClientTest<HttpRequest<?>> implements AgentTestTrait {
 

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/server/VertxRxCircuitBreakerHttpServerTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/server/VertxRxCircuitBreakerHttpServerTest.groovy
@@ -5,6 +5,13 @@
 
 package server
 
+import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.vertx.circuitbreaker.CircuitBreakerOptions
+import io.vertx.core.Future
+import io.vertx.reactivex.circuitbreaker.CircuitBreaker
+import io.vertx.reactivex.core.AbstractVerticle
+import io.vertx.reactivex.ext.web.Router
+
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -12,13 +19,6 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
-import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import io.vertx.circuitbreaker.CircuitBreakerOptions
-import io.vertx.core.Future
-import io.vertx.reactivex.circuitbreaker.CircuitBreaker
-import io.vertx.reactivex.core.AbstractVerticle
-import io.vertx.reactivex.ext.web.Router
 
 class VertxRxCircuitBreakerHttpServerTest extends VertxRxHttpServerTest {
 

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/server/VertxRxHttpServerTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/server/VertxRxHttpServerTest.groovy
@@ -5,15 +5,6 @@
 
 package server
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.vertx.core.DeploymentOptions
@@ -23,8 +14,18 @@ import io.vertx.core.VertxOptions
 import io.vertx.core.json.JsonObject
 import io.vertx.reactivex.core.AbstractVerticle
 import io.vertx.reactivex.ext.web.Router
+
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 
 class VertxRxHttpServerTest extends HttpServerTest<Vertx> implements AgentTestTrait {
   public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port"

--- a/instrumentation/vertx-web-3.0/testing/src/main/groovy/server/AbstractVertxHttpServerTest.groovy
+++ b/instrumentation/vertx-web-3.0/testing/src/main/groovy/server/AbstractVertxHttpServerTest.groovy
@@ -5,9 +5,6 @@
 
 package server
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.vertx.core.AbstractVerticle
@@ -15,15 +12,19 @@ import io.vertx.core.DeploymentOptions
 import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
 import io.vertx.core.json.JsonObject
+
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 
 abstract class AbstractVertxHttpServerTest extends HttpServerTest<Vertx> implements AgentTestTrait {
   @Override
   Vertx startServer(int port) {
     Vertx server = Vertx.vertx(new VertxOptions()
-    // Useful for debugging:
-    // .setBlockedThreadCheckInterval(Integer.MAX_VALUE)
+      // Useful for debugging:
+      // .setBlockedThreadCheckInterval(Integer.MAX_VALUE)
     )
     CompletableFuture<Void> future = new CompletableFuture<>()
     server.deployVerticle(verticle().getName(),

--- a/instrumentation/wicket-8.0/javaagent/src/test/groovy/WicketTest.groovy
+++ b/instrumentation/wicket-8.0/javaagent/src/test/groovy/WicketTest.groovy
@@ -3,19 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import hello.HelloApplication
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
-import javax.servlet.DispatcherType
 import org.apache.wicket.protocol.http.WicketFilter
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.DefaultServlet
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.util.resource.FileResource
 import org.jsoup.Jsoup
+
+import javax.servlet.DispatcherType
 
 class WicketTest extends AgentInstrumentationSpecification implements HttpServerTestTrait<Server> {
 

--- a/javaagent-bootstrap/src/test/groovy/io/opentelemetry/javaagent/bootstrap/AgentClassLoaderTest.groovy
+++ b/javaagent-bootstrap/src/test/groovy/io/opentelemetry/javaagent/bootstrap/AgentClassLoaderTest.groovy
@@ -6,9 +6,10 @@
 package io.opentelemetry.javaagent.bootstrap
 
 import io.opentelemetry.sdk.internal.JavaVersionSpecific
+import spock.lang.Specification
+
 import java.lang.reflect.Field
 import java.util.concurrent.Phaser
-import spock.lang.Specification
 
 class AgentClassLoaderTest extends Specification {
 

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/test/HelperInjectionTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/test/HelperInjectionTest.groovy
@@ -5,19 +5,20 @@
 
 package io.opentelemetry.javaagent.test
 
-import static io.opentelemetry.instrumentation.test.utils.ClasspathUtils.isClassLoaded
-import static io.opentelemetry.instrumentation.test.utils.GcUtils.awaitGc
-
 import io.opentelemetry.javaagent.tooling.AgentInstaller
 import io.opentelemetry.javaagent.tooling.HelperInjector
 import io.opentelemetry.javaagent.tooling.Utils
-import java.lang.ref.WeakReference
-import java.util.concurrent.atomic.AtomicReference
 import net.bytebuddy.agent.ByteBuddyAgent
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.dynamic.ClassFileLocator
 import net.bytebuddy.dynamic.loading.ClassInjector
 import spock.lang.Specification
+
+import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicReference
+
+import static io.opentelemetry.instrumentation.test.utils.ClasspathUtils.isClassLoaded
+import static io.opentelemetry.instrumentation.test.utils.GcUtils.awaitGc
 
 class HelperInjectionTest extends Specification {
 

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/AddThreadDetailsSpanProcessorTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/AddThreadDetailsSpanProcessorTest.groovy
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.javaagent.tooling
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Specification
 
 class AddThreadDetailsSpanProcessorTest extends Specification {

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/CacheProviderTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/CacheProviderTest.groovy
@@ -6,11 +6,12 @@
 package io.opentelemetry.javaagent.tooling
 
 import io.opentelemetry.javaagent.tooling.muzzle.AgentCachingPoolStrategy
-import java.lang.ref.WeakReference
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.dynamic.ClassFileLocator
 import net.bytebuddy.pool.TypePool
 import spock.lang.Specification
+
+import java.lang.ref.WeakReference
 
 class CacheProviderTest extends Specification {
   def "key bootstrap equivalence"() {

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/ExporterClassLoaderTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/ExporterClassLoaderTest.groovy
@@ -10,13 +10,14 @@ import io.opentelemetry.javaagent.spi.exporter.MetricExporterFactory
 import io.opentelemetry.javaagent.spi.exporter.SpanExporterFactory
 import io.opentelemetry.sdk.metrics.export.MetricExporter
 import io.opentelemetry.sdk.trace.export.SpanExporter
+import spock.lang.Specification
+
 import java.nio.charset.StandardCharsets
 import java.util.jar.Attributes
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
-import spock.lang.Specification
 
 class ExporterClassLoaderTest extends Specification {
 

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/OpenTelemetryInstallerTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/OpenTelemetryInstallerTest.groovy
@@ -13,24 +13,24 @@ import spock.lang.Specification
 class OpenTelemetryInstallerTest extends Specification {
 
 
-  void setup(){
+  void setup() {
     GlobalOpenTelemetry.resetForTest()
   }
 
-  void cleanup(){
+  void cleanup() {
     GlobalOpenTelemetry.resetForTest()
   }
 
 
-  def "should initialize noop"(){
+  def "should initialize noop"() {
 
     given:
     def config = Config.newBuilder()
-    .readProperties([
-        (OpenTelemetryInstaller.JAVAAGENT_NOOP_CONFIG) : "true",
-        (OpenTelemetryInstaller.JAVAAGENT_ENABLED_CONFIG) : "true"
-    ])
-    .build()
+      .readProperties([
+        (OpenTelemetryInstaller.JAVAAGENT_NOOP_CONFIG)   : "true",
+        (OpenTelemetryInstaller.JAVAAGENT_ENABLED_CONFIG): "true"
+      ])
+      .build()
 
     when:
     def otelInstaller = new OpenTelemetryInstaller()
@@ -40,13 +40,13 @@ class OpenTelemetryInstallerTest extends Specification {
     GlobalOpenTelemetry.getTracerProvider() == NoopOpenTelemetry.getInstance().getTracerProvider()
   }
 
-  def "should NOT initialize noop"(){
+  def "should NOT initialize noop"() {
 
     given:
     def config = Config.newBuilder()
       .readProperties([
-        (OpenTelemetryInstaller.JAVAAGENT_NOOP_CONFIG) : "true",
-        (OpenTelemetryInstaller.JAVAAGENT_ENABLED_CONFIG) : "false"
+        (OpenTelemetryInstaller.JAVAAGENT_NOOP_CONFIG)   : "true",
+        (OpenTelemetryInstaller.JAVAAGENT_ENABLED_CONFIG): "false"
       ])
       .build()
 

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ExtendsClassMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ExtendsClassMatcherTest.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.javaagent.tooling.bytebuddy.matcher
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.extendsClass
-import static net.bytebuddy.matcher.ElementMatchers.named
-
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.A
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.B
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.F
@@ -17,6 +14,9 @@ import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.jar.asm.Opcodes
 import spock.lang.Shared
 import spock.lang.Specification
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.extendsClass
+import static net.bytebuddy.matcher.ElementMatchers.named
 
 class ExtendsClassMatcherTest extends Specification {
   @Shared

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.javaagent.tooling.bytebuddy.matcher
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface
-import static net.bytebuddy.matcher.ElementMatchers.named
-
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.A
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.B
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.E
@@ -18,6 +15,9 @@ import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.description.type.TypeList
 import spock.lang.Shared
 import spock.lang.Specification
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface
+import static net.bytebuddy.matcher.ElementMatchers.named
 
 class HasInterfaceMatcherTest extends Specification {
   @Shared

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/HasSuperMethodMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/HasSuperMethodMatcherTest.groovy
@@ -5,13 +5,20 @@
 
 package io.opentelemetry.javaagent.tooling.bytebuddy.matcher
 
+import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.A
+import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.B
+import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.C
+import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.F
+import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.G
+import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.Trace
+import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.TracedClass
+import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.UntracedClass
+import net.bytebuddy.description.method.MethodDescription
+import spock.lang.Specification
+
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperMethod
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith
 import static net.bytebuddy.matcher.ElementMatchers.none
-
-import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.*
-import net.bytebuddy.description.method.MethodDescription
-import spock.lang.Specification
 
 class HasSuperMethodMatcherTest extends Specification {
 

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.javaagent.tooling.bytebuddy.matcher
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface
-import static net.bytebuddy.matcher.ElementMatchers.named
-
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.A
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.B
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.E
@@ -18,6 +15,9 @@ import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.description.type.TypeList
 import spock.lang.Shared
 import spock.lang.Specification
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface
+import static net.bytebuddy.matcher.ElementMatchers.named
 
 class ImplementsInterfaceMatcherTest extends Specification {
   @Shared

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.javaagent.tooling.bytebuddy.matcher
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType
-import static net.bytebuddy.matcher.ElementMatchers.named
-
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.A
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.B
 import io.opentelemetry.javaagent.tooling.bytebuddy.matcher.testclasses.E
@@ -18,6 +15,9 @@ import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.description.type.TypeList
 import spock.lang.Shared
 import spock.lang.Specification
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType
+import static net.bytebuddy.matcher.ElementMatchers.named
 
 class SafeHasSuperTypeMatcherTest extends Specification {
   @Shared

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/config/ConfigurationFileTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/config/ConfigurationFileTest.groovy
@@ -79,7 +79,7 @@ class ConfigurationFileTest extends Specification {
     !properties.propertyNames().hasMoreElements()
   }
 
-  def createFile(String name, String contents){
+  def createFile(String name, String contents) {
     def file = tmpFolder.newFile(name)
     file.write(contents)
     return file.getAbsolutePath()

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/muzzle/InstrumentationClassPredicateTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/muzzle/InstrumentationClassPredicateTest.groovy
@@ -33,10 +33,10 @@ class InstrumentationClassPredicateTest extends Specification {
     !predicate.isInstrumentationClass(className)
 
     where:
-    desc                        | className
-    "Java SDK class"            | "java.util.ArrayList"
-    "javaagent-tooling class"   | "io.opentelemetry.javaagent.tooling.Constants"
-    "instrumentation-api class" | "io.opentelemetry.instrumentation.api.InstrumentationVersion"
-    "javaagent-instrumentation-api class"       | "io.opentelemetry.javaagent.instrumentation.api.ContextStore"
+    desc                                  | className
+    "Java SDK class"                      | "java.util.ArrayList"
+    "javaagent-tooling class"             | "io.opentelemetry.javaagent.tooling.Constants"
+    "instrumentation-api class"           | "io.opentelemetry.instrumentation.api.InstrumentationVersion"
+    "javaagent-instrumentation-api class" | "io.opentelemetry.javaagent.instrumentation.api.ContextStore"
   }
 }

--- a/javaagent/src/test/groovy/io/opentelemetry/javaagent/classloading/ClassLoadingTest.groovy
+++ b/javaagent/src/test/groovy/io/opentelemetry/javaagent/classloading/ClassLoadingTest.groovy
@@ -5,13 +5,14 @@
 
 package io.opentelemetry.javaagent.classloading
 
-import static io.opentelemetry.javaagent.IntegrationTestUtils.createJarWithClasses
-
 import io.opentelemetry.javaagent.util.GcUtils
 import io.opentelemetry.test.ClassToInstrument
 import io.opentelemetry.test.ClassToInstrumentChild
-import java.lang.ref.WeakReference
 import spock.lang.Specification
+
+import java.lang.ref.WeakReference
+
+import static io.opentelemetry.javaagent.IntegrationTestUtils.createJarWithClasses
 
 class ClassLoadingTest extends Specification {
 

--- a/javaagent/src/test/groovy/io/opentelemetry/javaagent/muzzle/MuzzleBytecodeTransformTest.groovy
+++ b/javaagent/src/test/groovy/io/opentelemetry/javaagent/muzzle/MuzzleBytecodeTransformTest.groovy
@@ -6,9 +6,10 @@
 package io.opentelemetry.javaagent.muzzle
 
 import io.opentelemetry.javaagent.IntegrationTestUtils
+import spock.lang.Specification
+
 import java.lang.reflect.Field
 import java.lang.reflect.Method
-import spock.lang.Specification
 
 class MuzzleBytecodeTransformTest extends Specification {
 

--- a/muzzle/src/test/groovy/io/opentelemetry/javaagent/tooling/muzzle/HelperReferenceWrapperTest.groovy
+++ b/muzzle/src/test/groovy/io/opentelemetry/javaagent/tooling/muzzle/HelperReferenceWrapperTest.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.javaagent.tooling.muzzle
 
-import static io.opentelemetry.javaagent.extension.muzzle.Flag.ManifestationFlag
-import static java.util.stream.Collectors.toList
-
 import io.opentelemetry.javaagent.extension.muzzle.ClassRef
 import io.opentelemetry.javaagent.extension.muzzle.Flag
 import io.opentelemetry.javaagent.extension.muzzle.Source
@@ -16,6 +13,9 @@ import net.bytebuddy.jar.asm.Type
 import net.bytebuddy.pool.TypePool
 import spock.lang.Shared
 import spock.lang.Specification
+
+import static io.opentelemetry.javaagent.extension.muzzle.Flag.ManifestationFlag
+import static java.util.stream.Collectors.toList
 
 class HelperReferenceWrapperTest extends Specification {
 

--- a/muzzle/src/test/groovy/io/opentelemetry/javaagent/tooling/muzzle/ReferenceMatcherTest.groovy
+++ b/muzzle/src/test/groovy/io/opentelemetry/javaagent/tooling/muzzle/ReferenceMatcherTest.groovy
@@ -5,15 +5,6 @@
 
 package io.opentelemetry.javaagent.tooling.muzzle
 
-import static io.opentelemetry.javaagent.extension.muzzle.Flag.ManifestationFlag.ABSTRACT
-import static io.opentelemetry.javaagent.extension.muzzle.Flag.ManifestationFlag.INTERFACE
-import static io.opentelemetry.javaagent.extension.muzzle.Flag.ManifestationFlag.NON_INTERFACE
-import static io.opentelemetry.javaagent.extension.muzzle.Flag.MinimumVisibilityFlag.PACKAGE_OR_HIGHER
-import static io.opentelemetry.javaagent.extension.muzzle.Flag.MinimumVisibilityFlag.PRIVATE_OR_HIGHER
-import static io.opentelemetry.javaagent.extension.muzzle.Flag.MinimumVisibilityFlag.PROTECTED_OR_HIGHER
-import static io.opentelemetry.javaagent.extension.muzzle.Flag.OwnershipFlag.NON_STATIC
-import static io.opentelemetry.javaagent.extension.muzzle.Flag.OwnershipFlag.STATIC
-
 import external.LibraryBaseClass
 import io.opentelemetry.instrumentation.TestHelperClasses
 import io.opentelemetry.instrumentation.test.utils.ClasspathUtils
@@ -25,6 +16,15 @@ import net.bytebuddy.jar.asm.Type
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import static io.opentelemetry.javaagent.extension.muzzle.Flag.ManifestationFlag.ABSTRACT
+import static io.opentelemetry.javaagent.extension.muzzle.Flag.ManifestationFlag.INTERFACE
+import static io.opentelemetry.javaagent.extension.muzzle.Flag.ManifestationFlag.NON_INTERFACE
+import static io.opentelemetry.javaagent.extension.muzzle.Flag.MinimumVisibilityFlag.PACKAGE_OR_HIGHER
+import static io.opentelemetry.javaagent.extension.muzzle.Flag.MinimumVisibilityFlag.PRIVATE_OR_HIGHER
+import static io.opentelemetry.javaagent.extension.muzzle.Flag.MinimumVisibilityFlag.PROTECTED_OR_HIGHER
+import static io.opentelemetry.javaagent.extension.muzzle.Flag.OwnershipFlag.NON_STATIC
+import static io.opentelemetry.javaagent.extension.muzzle.Flag.OwnershipFlag.STATIC
 
 @Unroll
 class ReferenceMatcherTest extends Specification {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -5,17 +5,18 @@
 
 package io.opentelemetry.smoketest
 
+import io.opentelemetry.proto.trace.v1.Span
+import org.junit.runner.RunWith
+import spock.lang.Shared
+import spock.lang.Unroll
+
+import java.util.jar.Attributes
+import java.util.jar.JarFile
+
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_TYPE
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OsTypeValues.LINUX
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OsTypeValues.WINDOWS
 import static org.junit.Assume.assumeTrue
-
-import io.opentelemetry.proto.trace.v1.Span
-import java.util.jar.Attributes
-import java.util.jar.JarFile
-import org.junit.runner.RunWith
-import spock.lang.Shared
-import spock.lang.Unroll
 
 @RunWith(AppServerTestRunner)
 abstract class AppServerTest extends SmokeTest {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GrpcSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/GrpcSmokeTest.groovy
@@ -5,16 +5,17 @@
 
 package io.opentelemetry.smoketest
 
-import static java.util.stream.Collectors.toSet
-
 import io.grpc.ManagedChannelBuilder
 import io.opentelemetry.api.trace.TraceId
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc
-import java.util.jar.Attributes
-import java.util.jar.JarFile
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
+
+import java.util.jar.Attributes
+import java.util.jar.JarFile
+
+import static java.util.stream.Collectors.toSet
 
 @IgnoreIf({ os.windows })
 class GrpcSmokeTest extends SmokeTest {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JaegerExporterSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/JaegerExporterSmokeTest.groovy
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.smoketest
 
-import static java.util.stream.Collectors.toSet
-
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import spock.lang.IgnoreIf
+
 import java.util.jar.Attributes
 import java.util.jar.JarFile
-import spock.lang.IgnoreIf
+
+import static java.util.stream.Collectors.toSet
 
 @IgnoreIf({ os.windows })
 class JaegerExporterSmokeTest extends SmokeTest {
@@ -22,8 +23,8 @@ class JaegerExporterSmokeTest extends SmokeTest {
   @Override
   protected Map<String, String> getExtraEnv() {
     return [
-      "OTEL_TRACES_EXPORTER"          : "jaeger",
-      "OTEL_EXPORTER_JAEGER_ENDPOINT" : "http://collector:14250"
+      "OTEL_TRACES_EXPORTER"         : "jaeger",
+      "OTEL_EXPORTER_JAEGER_ENDPOINT": "http://collector:14250"
     ]
   }
 

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PropagationTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PropagationTest.groovy
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.smoketest
 
-import static java.util.stream.Collectors.toSet
-
 import io.opentelemetry.api.trace.TraceId
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
 import spock.lang.IgnoreIf
+
+import static java.util.stream.Collectors.toSet
 
 abstract class PropagationTest extends SmokeTest {
 

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SmokeTest.groovy
@@ -5,19 +5,20 @@
 
 package io.opentelemetry.smoketest
 
-import static java.util.stream.Collectors.toSet
-
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
 import io.opentelemetry.proto.common.v1.AnyValue
 import io.opentelemetry.proto.trace.v1.Span
 import io.opentelemetry.smoketest.windows.WindowsTestContainerManager
 import io.opentelemetry.testing.internal.armeria.client.WebClient
-import java.util.regex.Pattern
-import java.util.stream.Stream
 import org.testcontainers.containers.output.ToStringConsumer
 import spock.lang.Shared
 import spock.lang.Specification
+
+import java.util.regex.Pattern
+import java.util.stream.Stream
+
+import static java.util.stream.Collectors.toSet
 
 abstract class SmokeTest extends Specification {
   private static final Pattern TRACE_ID_PATTERN = Pattern.compile(".*trace_id=(?<traceId>[a-zA-Z0-9]+).*")

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -5,14 +5,15 @@
 
 package io.opentelemetry.smoketest
 
-import static java.util.stream.Collectors.toSet
-
 import io.opentelemetry.api.trace.TraceId
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
-import java.util.jar.Attributes
-import java.util.jar.JarFile
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
+
+import java.util.jar.Attributes
+import java.util.jar.JarFile
+
+import static java.util.stream.Collectors.toSet
 
 @IgnoreIf({ os.windows })
 class SpringBootSmokeTest extends SmokeTest {

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootWithSamplingSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootWithSamplingSmokeTest.groovy
@@ -22,7 +22,7 @@ class SpringBootWithSamplingSmokeTest extends SmokeTest {
   @Override
   protected Map<String, String> getExtraEnv() {
     return [
-      "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+      "OTEL_TRACES_SAMPLER"    : "parentbased_traceidratio",
       "OTEL_TRACES_SAMPLER_ARG": String.valueOf(SAMPLER_PROBABILITY),
     ]
   }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TelemetryRetriever.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/TelemetryRetriever.groovy
@@ -11,6 +11,7 @@ import com.google.protobuf.util.JsonFormat
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
 import io.opentelemetry.testing.internal.armeria.client.WebClient
+
 import java.util.concurrent.TimeUnit
 import java.util.function.Supplier
 

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/ZipkinExporterSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/ZipkinExporterSmokeTest.groovy
@@ -18,8 +18,8 @@ class ZipkinExporterSmokeTest extends SmokeTest {
   @Override
   protected Map<String, String> getExtraEnv() {
     return [
-      "OTEL_TRACES_EXPORTER"          : "zipkin",
-      "OTEL_EXPORTER_ZIPKIN_ENDPOINT" : "http://collector:9411/api/v2/spans"
+      "OTEL_TRACES_EXPORTER"         : "zipkin",
+      "OTEL_EXPORTER_ZIPKIN_ENDPOINT": "http://collector:9411/api/v2/spans"
     ]
   }
 

--- a/testing-common/integration-tests/src/test/groovy/AgentInstrumentationSpecificationTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/AgentInstrumentationSpecificationTest.groovy
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import com.google.common.reflect.ClassPath
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.ClasspathUtils
 import io.opentelemetry.javaagent.tooling.Constants
-import java.util.concurrent.TimeoutException
 import org.slf4j.LoggerFactory
+
+import java.util.concurrent.TimeoutException
 
 // this test is run using
 //   -Dotel.javaagent.exclude-classes=config.exclude.packagename.*,config.exclude.SomeClass,config.exclude.SomeClass$NestedClass

--- a/testing-common/integration-tests/src/test/groovy/context/FieldBackedProviderTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/context/FieldBackedProviderTest.groovy
@@ -9,18 +9,19 @@ import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.ClasspathUtils
 import io.opentelemetry.instrumentation.test.utils.GcUtils
 import io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess
-import java.lang.instrument.ClassDefinition
-import java.lang.ref.WeakReference
-import java.lang.reflect.Field
-import java.lang.reflect.Method
-import java.lang.reflect.Modifier
-import java.util.concurrent.atomic.AtomicReference
 import library.KeyClass
 import library.UntransformableKeyClass
 import net.bytebuddy.agent.ByteBuddyAgent
 import net.sf.cglib.proxy.Enhancer
 import net.sf.cglib.proxy.MethodInterceptor
 import net.sf.cglib.proxy.MethodProxy
+
+import java.lang.instrument.ClassDefinition
+import java.lang.ref.WeakReference
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.util.concurrent.atomic.AtomicReference
 
 // this test is run using
 //   -Dotel.instrumentation.context-test-instrumentation.enabled=true

--- a/testing-common/integration-tests/src/test/groovy/context/FieldInjectionDisabledTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/context/FieldInjectionDisabledTest.groovy
@@ -7,8 +7,9 @@ package context
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess
-import java.lang.reflect.Field
 import library.DisabledKeyClass
+
+import java.lang.reflect.Field
 
 // this test is run using:
 //   -Dotel.javaagent.experimental.field-injection.enabled=false

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/InstrumentationSpecification.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/InstrumentationSpecification.groovy
@@ -16,10 +16,11 @@ import io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil
 import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier
 import io.opentelemetry.sdk.metrics.data.MetricData
 import io.opentelemetry.sdk.trace.data.SpanData
-import java.util.concurrent.TimeUnit
 import org.junit.Rule
 import org.junit.rules.Timeout
 import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
 
 /**
  * Base class for test specifications that are shared between instrumentation libraries and agent.

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/AttributesAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/AttributesAssert.groovy
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.test.asserts
 
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
+
 import java.util.regex.Pattern
 
 class AttributesAssert {

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/EventAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/EventAssert.groovy
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.test.asserts
 
-import static AttributesAssert.assertAttributes
-
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.sdk.trace.data.EventData
+
+import static AttributesAssert.assertAttributes
 
 class EventAssert {
   private final EventData event
@@ -49,7 +49,7 @@ class EventAssert {
 
   private Map<String, Object> toMap(Attributes attributes) {
     def map = new HashMap()
-    attributes.forEach {key, value ->
+    attributes.forEach { key, value ->
       map.put(key.key, value)
     }
     return map

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/InMemoryExporterAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/InMemoryExporterAssert.groovy
@@ -5,18 +5,19 @@
 
 package io.opentelemetry.instrumentation.test.asserts
 
-import static TraceAssert.assertTrace
-
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil
 import io.opentelemetry.sdk.trace.data.SpanData
-import java.util.function.Supplier
 import org.codehaus.groovy.runtime.powerassert.PowerAssertionError
 import org.spockframework.runtime.Condition
 import org.spockframework.runtime.ConditionNotSatisfiedError
 import org.spockframework.runtime.model.TextPosition
+
+import java.util.function.Supplier
+
+import static TraceAssert.assertTrace
 
 class InMemoryExporterAssert {
   private final List<List<SpanData>> traces

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/SpanAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/SpanAssert.groovy
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.instrumentation.test.asserts
 
-import static AttributesAssert.assertAttributes
-import static io.opentelemetry.instrumentation.test.asserts.EventAssert.assertEvent
-
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import io.opentelemetry.api.common.Attributes
@@ -16,7 +13,11 @@ import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+
 import java.util.regex.Pattern
+
+import static AttributesAssert.assertAttributes
+import static io.opentelemetry.instrumentation.test.asserts.EventAssert.assertEvent
 
 class SpanAssert {
   private final SpanData span

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/TraceAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/TraceAssert.groovy
@@ -5,14 +5,15 @@
 
 package io.opentelemetry.instrumentation.test.asserts
 
-import static SpanAssert.assertSpan
-
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil
 import io.opentelemetry.sdk.trace.data.SpanData
+
 import java.util.concurrent.TimeUnit
 import java.util.function.Supplier
+
+import static SpanAssert.assertSpan
 
 class TraceAssert {
   private final List<SpanData> spans

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.test.base
 
-import static org.junit.Assume.assumeTrue
-
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
@@ -20,6 +18,8 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Unroll
+
+import static org.junit.Assume.assumeTrue
 
 @Unroll
 abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
@@ -45,22 +45,17 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
    * for example:
    *
    * @Override
-   * int sendRequest(Request request, String method, URI uri, Map<String, String headers = [:]) {
-   *   HttpResponse response = client.execute(request)
+   * int sendRequest(Request request, String method, URI uri, Map<String, String headers = [:]) {*   HttpResponse response = client.execute(request)
    *   return response.statusCode()
-   * }
-   *
+   *}*
    * If there is no synchronous API available at all, for example as in Vert.X, a CompletableFuture
    * can be used to block on a result, for example:
    *
    * @Override
-   * int sendRequest(Request request, String method, URI uri, Map<String, String> headers) {
-   *   CompletableFuture<Integer> future = new CompletableFuture<>(
-   *   sendRequestWithCallback(request, method, uri, headers) {
-   *     future.complete(it.statusCode())
-   *   }
-   *   return future.get()
-   * }
+   * int sendRequest(Request request, String method, URI uri, Map<String, String> headers) {*   CompletableFuture<Integer> future = new CompletableFuture<>(
+   *   sendRequestWithCallback(request, method, uri, headers) {*     future.complete(it.statusCode())
+   *}*   return future.get()
+   *}
    */
   abstract int sendRequest(REQUEST request, String method, URI uri, Map<String, String> headers)
 
@@ -73,28 +68,19 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
    * the context is propagated correctly to such callbacks.
    *
    * @Override
-   * void sendRequestWithCallback(Request request, String method, URI uri, Map<String, String> headers, RequestResult requestResult) {
-   *   // Hypothetical client accepting a callback
-   *   client.executeAsync(request) {
-   *     void success(Response response) {
-   *       requestResult.complete(response.statusCode())
-   *     }
-   *     void failure(Throwable throwable) {
-   *       requestResult.complete(throwable)
-   *     }
-   *   }
-   *
+   * void sendRequestWithCallback(Request request, String method, URI uri, Map<String, String> headers, RequestResult requestResult) {*   // Hypothetical client accepting a callback
+   *   client.executeAsync(request) {*     void success(Response response) {*       requestResult.complete(response.statusCode())
+   *}*     void failure(Throwable throwable) {*       requestResult.complete(throwable)
+   *}*}*
    *   // Hypothetical client returning a CompletableFuture
    *   client.executeAsync(request).whenComplete { response, throwable ->
    *     requestResult.complete({ response.statusCode() }, throwable)
-   *   }
-   * }
-   *
+   *}*}*
    * If the client offers no APIs that accept callbacks, then this method should not be implemented
    * and instead, {@link #testCallback} should be implemented to return false.
    */
   void sendRequestWithCallback(REQUEST request, String method, URI uri, Map<String, String> headers,
-                               AbstractHttpClientTest.RequestResult  requestResult) {
+                               AbstractHttpClientTest.RequestResult requestResult) {
     // Must be implemented if testAsync is true
     throw new UnsupportedOperationException()
   }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
@@ -5,18 +5,6 @@
 
 package io.opentelemetry.instrumentation.test.base
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-import static org.junit.Assume.assumeTrue
-
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
@@ -32,9 +20,22 @@ import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
 import io.opentelemetry.testing.internal.armeria.common.HttpMethod
 import io.opentelemetry.testing.internal.armeria.common.HttpRequest
 import io.opentelemetry.testing.internal.armeria.common.HttpRequestBuilder
+import spock.lang.Unroll
+
 import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
-import spock.lang.Unroll
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runUnderTrace
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
+import static org.junit.Assume.assumeTrue
 
 @Unroll
 abstract class HttpServerTest<SERVER> extends InstrumentationSpecification implements HttpServerTestTrait<SERVER> {
@@ -398,7 +399,7 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
     when:
     count.times { index ->
       HttpRequestBuilder request = HttpRequest.builder()
-        // Force HTTP/1 via h1c so upgrade requests don't show up as traces
+      // Force HTTP/1 via h1c so upgrade requests don't show up as traces
         .get(endpoint.resolvePath(address).toString().replace("http://", "h1c://"))
         .queryParam(ServerEndpoint.ID_PARAMETER_NAME, "$index")
       runUnderTrace("client " + index) {

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTestTrait.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTestTrait.groovy
@@ -13,11 +13,13 @@ import io.opentelemetry.testing.internal.armeria.client.ClientFactory
 import io.opentelemetry.testing.internal.armeria.client.WebClient
 import io.opentelemetry.testing.internal.armeria.client.logging.LoggingClient
 import io.opentelemetry.testing.internal.armeria.common.HttpHeaderNames
-import java.time.Duration
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+
+import java.time.Duration
+
 /**
  * A trait for testing requests against http server.
  */

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/utils/TraceUtils.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/utils/TraceUtils.groovy
@@ -12,8 +12,10 @@ import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.instrumentation.test.server.ServerTraceUtils
 import io.opentelemetry.instrumentation.testing.util.ThrowingRunnable
+
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutionException
+
 // TODO: convert all usages of this class to the Java TraceUtils one
 class TraceUtils {
 


### PR DESCRIPTION
 - organized imports for .groovy files based on IntelliJ default import settings
 - updated intellij-setup.md
 - reformat lines with missing empty space