### PR TITLE
Add otlp http exporters

### DIFF
--- a/javaagent-exporters/build.gradle.kts
+++ b/javaagent-exporters/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-exporter-jaeger")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp-metrics")
+  implementation("io.opentelemetry:opentelemetry-exporter-otlp-http-trace")
+  implementation("io.opentelemetry:opentelemetry-exporter-otlp-http-metrics")
   implementation("io.opentelemetry:opentelemetry-exporter-logging-otlp")
 
   implementation("io.opentelemetry:opentelemetry-exporter-prometheus")


### PR DESCRIPTION
So that `OTEL_EXPERIMENTAL_EXPORTER_OTLP_PROTOCOL=http/protobuf` will work once we pull in Java SDK 1.6.0 which introduces autoconfigure support for this https://github.com/open-telemetry/opentelemetry-java/pull/3522