### PR TITLE
Remove outdated section from servlet instrumentation readme

### DIFF
--- a/instrumentation/servlet/README.md
+++ b/instrumentation/servlet/README.md
@@ -80,10 +80,6 @@ Of course, still adhering to OpenTelemetry
 [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md).
 
 ## Additional instrumentations
-`RequestDispatcherInstrumentationModule` instruments `javax.servlet.RequestDispatcher.forward` and
-`javax.servlet.RequestDispatcher.include` methods to create new `INTERNAL` spans around their
-invocations.
-
-`HttpServletResponseInstrumentationModule` instruments `javax.servlet.http.HttpServletResponse.sendError`
+`HttpServletResponseInstrumentation` instruments `javax.servlet.http.HttpServletResponse.sendError`
 and `javax.servlet.http.HttpServletResponse.sendRedirect` methods to create new `INTERNAL` spans
 around their invocations.


### PR DESCRIPTION
Forward and include spans were removed in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2816