### PR TITLE
JaxRS-client: remove our context when request is done

### DIFF
--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ClientTracingFilter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ClientTracingFilter.java
@@ -31,10 +31,12 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
   @Override
   public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
     Object contextObj = requestContext.getProperty(CONTEXT_PROPERTY_NAME);
-    requestContext.removeProperty(CONTEXT_PROPERTY_NAME);
     if (contextObj instanceof Context) {
       Context context = (Context) contextObj;
       instrumenter().end(context, requestContext, responseContext, null);
     }
+    // we are done with this request, remove context so it could be gcd immediately in case request
+    // context stays around for whatever reason
+    requestContext.removeProperty(CONTEXT_PROPERTY_NAME);
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ClientTracingFilter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ClientTracingFilter.java
@@ -31,6 +31,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
   @Override
   public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
     Object contextObj = requestContext.getProperty(CONTEXT_PROPERTY_NAME);
+    requestContext.removeProperty(CONTEXT_PROPERTY_NAME);
     if (contextObj instanceof Context) {
       Context context = (Context) contextObj;
       instrumenter().end(context, requestContext, responseContext, null);


### PR DESCRIPTION
Remove our context from request properties when request is done.
I saw a heap dump where `ClientRequestContext` implementation is finalizable. There was a bunch of these queued for finalization and each had reference to our context due to which one could see `ArrayBasedContext` and `RecordEventsReadableSpan` instances consuming a bit of memory. This change should ensure that our context instances don't show up in such heap dumps.