### PR TITLE
Update to InstrumentationContext javadoc

### DIFF
--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/InstrumentationContext.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/InstrumentationContext.java
@@ -18,12 +18,8 @@ public class InstrumentationContext {
    * <p>In reality, the <em>calls</em> to this method are re-written to something more performant
    * while injecting advice into a method.
    *
-   * <p>When this method is called from outside of an Advice class it can only access {@link
-   * ContextStore} when it is already created. For this {@link ContextStore} either needs to be
-   * registered in {@code
-   * io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule#registerMuzzleContextStoreClasses(InstrumentationContextBuilder)}
-   * or be used in an Advice or Helper class which automatically adds it to {@code
-   * InstrumentationModule#registerMuzzleContextStoreClasses(InstrumentationContextBuilder)}.
+   * <p>When using this method outside of Advice method, the {@link ContextStore} should be looked
+   * up once and stored in a field to avoid repeatedly calling this method.
    *
    * @param keyClass The key class context is attached to.
    * @param contextClass The context class attached to the user class.


### PR DESCRIPTION
Context store class pairs appear to be collected when traversing helper classes (otherwise #3987 wouldn't work), so no need to call `registerMuzzleContextStoreClasses` explicitly when using `InstrumentationContext.get` outside of Advice methods.