### PR TITLE
Suppress strict scope check for reactor-netty

### DIFF
--- a/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/build.gradle.kts
+++ b/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/build.gradle.kts
@@ -44,3 +44,7 @@ tasks {
     }
   }
 }
+
+tasks.withType<Test>().configureEach {
+  jvmArgs("-Dio.opentelemetry.javaagent.shaded.io.opentelemetry.context.enableStrictContext=false")
+}

--- a/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/build.gradle.kts
@@ -43,3 +43,7 @@ tasks {
     }
   }
 }
+
+tasks.withType<Test>().configureEach {
+  jvmArgs("-Dio.opentelemetry.javaagent.shaded.io.opentelemetry.context.enableStrictContext=false")
+}


### PR DESCRIPTION
reactor-netty-0.9 scope check caused nightly failure: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4083

and I verified using `otel.javaagent.testing.strict-context-stressor-millis` that scope leaks occur in reactor-netty-1.0 also

added these modules to #3916