### PR TITLE
Add more args to RequestListener

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -69,7 +69,7 @@ public class Instrumenter<REQUEST, RESPONSE> {
   private final List<? extends SpanLinksExtractor<? super REQUEST>> spanLinksExtractors;
   private final List<? extends AttributesExtractor<? super REQUEST, ? super RESPONSE>>
       attributesExtractors;
-  private final List<? extends RequestListener> requestListeners;
+  private final List<? extends RequestListener<REQUEST, RESPONSE>> requestListeners;
   private final ErrorCauseExtractor errorCauseExtractor;
   @Nullable private final StartTimeExtractor<REQUEST> startTimeExtractor;
   @Nullable private final EndTimeExtractor<REQUEST, RESPONSE> endTimeExtractor;
@@ -144,8 +144,8 @@ public class Instrumenter<REQUEST, RESPONSE> {
 
     Context context = parentContext;
 
-    for (RequestListener requestListener : requestListeners) {
-      context = requestListener.start(context, attributes);
+    for (RequestListener<REQUEST, RESPONSE> requestListener : requestListeners) {
+      context = requestListener.start(context, attributes, request);
     }
 
     spanBuilder.setAllAttributes(attributes);
@@ -177,8 +177,8 @@ public class Instrumenter<REQUEST, RESPONSE> {
     Attributes attributes = attributesBuilder;
     span.setAllAttributes(attributes);
 
-    for (RequestListener requestListener : requestListeners) {
-      requestListener.end(context, attributes);
+    for (RequestListener<REQUEST, RESPONSE> requestListener : requestListeners) {
+      requestListener.end(context, attributes, request, response, error);
     }
 
     StatusCode statusCode = spanStatusExtractor.extract(request, response, error);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
@@ -42,7 +42,7 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
   final List<SpanLinksExtractor<? super REQUEST>> spanLinksExtractors = new ArrayList<>();
   final List<AttributesExtractor<? super REQUEST, ? super RESPONSE>> attributesExtractors =
       new ArrayList<>();
-  final List<RequestListener> requestListeners = new ArrayList<>();
+  final List<RequestListener<REQUEST, RESPONSE>> requestListeners = new ArrayList<>();
 
   SpanKindExtractor<? super REQUEST> spanKindExtractor = SpanKindExtractor.alwaysInternal();
   SpanStatusExtractor<? super REQUEST, ? super RESPONSE> spanStatusExtractor =

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/RequestListener.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/RequestListener.java
@@ -12,8 +12,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /**
  * A listener of the start and end of a request. Instrumented libraries will call {@link
  * #start(Context, Attributes, Object)} as early as possible in the processing of a request and
- * {@link #end(Context, Attributes, Object, Throwable)} as late as possible when finishing the
- * request. These correspond to the start and end of a span when tracing.
+ * {@link #end(Context, Attributes, Object, Object, Throwable)} as late as possible when finishing
+ * the request. These correspond to the start and end of a span when tracing.
  */
 public interface RequestListener<REQUEST, RESPONSE> {
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/RequestListener.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/RequestListener.java
@@ -7,22 +7,28 @@ package io.opentelemetry.instrumentation.api.instrumenter;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A listener of the start and end of a request. Instrumented libraries will call {@link
- * #start(Context, Attributes)} as early as possible in the processing of a request and {@link
- * #end(Context, Attributes)} as late as possible when finishing the request. These correspond to
- * the start and end of a span when tracing.
+ * #start(Context, Attributes, Object)} as early as possible in the processing of a request and
+ * {@link #end(Context, Attributes, Object, Throwable)} as late as possible when finishing the
+ * request. These correspond to the start and end of a span when tracing.
  */
-public interface RequestListener {
+public interface RequestListener<REQUEST, RESPONSE> {
 
   /**
    * Listener method that is called at the start of a request. If any state needs to be kept between
    * the start and end of the request, e.g., an in-progress span, it should be added to the passed
    * in {@link Context} and returned.
    */
-  Context start(Context context, Attributes startAttributes);
+  Context start(Context context, Attributes startAttributes, REQUEST request);
 
   /** Listener method that is called at the end of a request. */
-  void end(Context context, Attributes endAttributes);
+  void end(
+      Context context,
+      Attributes endAttributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error);
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/RequestMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/RequestMetrics.java
@@ -13,5 +13,5 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 @UnstableApi
 public interface RequestMetrics {
   /** Returns a {@link RequestListener} for recording metrics using the given {@link Meter}. */
-  RequestListener create(Meter meter);
+  <REQUEST, RESPONSE> RequestListener<REQUEST, RESPONSE> create(Meter meter);
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
@@ -17,6 +17,7 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestListener;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestMetrics;
 import java.util.concurrent.TimeUnit;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +30,8 @@ import org.slf4j.LoggerFactory;
  * dependencies.
  */
 @UnstableApi
-public final class HttpClientMetrics implements RequestListener {
+public final class HttpClientMetrics<REQUEST, RESPONSE>
+    implements RequestListener<REQUEST, RESPONSE> {
 
   private static final double NANOS_PER_MS = TimeUnit.MILLISECONDS.toNanos(1);
 
@@ -60,7 +62,7 @@ public final class HttpClientMetrics implements RequestListener {
   }
 
   @Override
-  public Context start(Context context, Attributes startAttributes) {
+  public Context start(Context context, Attributes startAttributes, REQUEST request) {
     long startTimeNanos = System.nanoTime();
 
     return context.with(
@@ -69,7 +71,12 @@ public final class HttpClientMetrics implements RequestListener {
   }
 
   @Override
-  public void end(Context context, Attributes endAttributes) {
+  public void end(
+      Context context,
+      Attributes endAttributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
     State state = context.get(HTTP_CLIENT_REQUEST_METRICS_STATE);
     if (state == null) {
       logger.debug(

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
@@ -19,6 +19,7 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestListener;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestMetrics;
 import java.util.concurrent.TimeUnit;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +32,8 @@ import org.slf4j.LoggerFactory;
  * dependencies.
  */
 @UnstableApi
-public final class HttpServerMetrics implements RequestListener {
+public final class HttpServerMetrics<REQUEST, RESPONSE>
+    implements RequestListener<REQUEST, RESPONSE> {
 
   private static final double NANOS_PER_MS = TimeUnit.MILLISECONDS.toNanos(1);
 
@@ -70,7 +72,7 @@ public final class HttpServerMetrics implements RequestListener {
   }
 
   @Override
-  public Context start(Context context, Attributes startAttributes) {
+  public Context start(Context context, Attributes startAttributes, REQUEST request) {
     long startTimeNanos = System.nanoTime();
     activeRequests.add(1, applyActiveRequestsView(startAttributes));
 
@@ -80,7 +82,12 @@ public final class HttpServerMetrics implements RequestListener {
   }
 
   @Override
-  public void end(Context context, Attributes endAttributes) {
+  public void end(
+      Context context,
+      Attributes endAttributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
     State state = context.get(HTTP_SERVER_REQUEST_METRICS_STATE);
     if (state == null) {
       logger.debug(

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsTest.java
@@ -41,17 +41,17 @@ class HttpClientMetricsTest {
             .put("http.status_code", 200)
             .build();
 
-    Context context1 = listener.start(Context.current(), requestAttributes);
+    Context context1 = listener.start(Context.current(), requestAttributes, null);
 
     Collection<MetricData> metrics = meterProvider.collectAllMetrics();
     assertThat(metrics).isEmpty();
 
-    Context context2 = listener.start(Context.current(), requestAttributes);
+    Context context2 = listener.start(Context.current(), requestAttributes, null);
 
     metrics = meterProvider.collectAllMetrics();
     assertThat(metrics).isEmpty();
 
-    listener.end(context1, responseAttributes);
+    listener.end(context1, responseAttributes, null, null, null);
 
     metrics = meterProvider.collectAllMetrics();
     assertThat(metrics).hasSize(1);
@@ -75,7 +75,7 @@ class HttpClientMetricsTest {
                                   attributeEntry("net.host.port", 1234L));
                         }));
 
-    listener.end(context2, responseAttributes);
+    listener.end(context2, responseAttributes, null, null, null);
 
     metrics = meterProvider.collectAllMetrics();
     assertThat(metrics).hasSize(1);

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsTest.java
@@ -41,7 +41,7 @@ class HttpServerMetricsTest {
             .put("http.status_code", 200)
             .build();
 
-    Context context1 = listener.start(Context.current(), requestAttributes);
+    Context context1 = listener.start(Context.current(), requestAttributes, null);
 
     Collection<MetricData> metrics = meterProvider.collectAllMetrics();
     assertThat(metrics).hasSize(1);
@@ -65,7 +65,7 @@ class HttpServerMetricsTest {
                                     attributeEntry("http.method", "GET"),
                                     attributeEntry("http.scheme", "https"))));
 
-    Context context2 = listener.start(Context.current(), requestAttributes);
+    Context context2 = listener.start(Context.current(), requestAttributes, null);
 
     metrics = meterProvider.collectAllMetrics();
     assertThat(metrics).hasSize(1);
@@ -78,7 +78,7 @@ class HttpServerMetricsTest {
                     .points()
                     .satisfiesExactly(point -> assertThat(point).hasValue(2)));
 
-    listener.end(context1, responseAttributes);
+    listener.end(context1, responseAttributes, null, null, null);
 
     metrics = meterProvider.collectAllMetrics();
     assertThat(metrics).hasSize(2);
@@ -110,7 +110,7 @@ class HttpServerMetricsTest {
                                   attributeEntry("net.host.port", 1234L));
                         }));
 
-    listener.end(context2, responseAttributes);
+    listener.end(context2, responseAttributes, null, null, null);
 
     metrics = meterProvider.collectAllMetrics();
     assertThat(metrics).hasSize(2);


### PR DESCRIPTION
@HaloFour [in slack](https://cloud-native.slack.com/archives/C0150QF88FL/p1630504134014100) asked about passing the request to `RequestListener.start()` in order to amend the context with info from the request, which seems to be a common use case, e.g. `HttpServerTracer.customizeContext(Context, REQUEST) -> Context`.

And if we're going to pass request to `start()`, for consistency it seems to make sense to pass `request, response, error` to `end()`.

Though I'm not sure adding those to `end()` has a real use case.

An alternative to this PR is a more targeted approach which adds a new interface that just supports the "customize context" use case, something like just a single method `Context start(Context, REQUEST)`.

I'm kind of torn between the two options. I do prefer the more targeted solution, but the kitchen sink option (this PR) may be more future proof.

cc: @anuraaga @mateuszrzeszutek