### PR TITLE
Format java files in standalone projects

### DIFF
--- a/benchmark-overhead/src/test/java/io/opentelemetry/agents/Agent.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/agents/Agent.java
@@ -9,11 +9,14 @@ import java.util.List;
 
 public class Agent {
 
-  final static String OTEL_LATEST = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent-all.jar";
+  static final String OTEL_LATEST =
+      "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent-all.jar";
 
-  public final static Agent NONE = new Agent("none", "no agent at all");
-  public final static Agent LATEST_RELEASE = new Agent("latest", "latest mainstream release", OTEL_LATEST);
-  public final static Agent LATEST_SNAPSHOT = new Agent("snapshot", "latest available snapshot version from main");
+  public static final Agent NONE = new Agent("none", "no agent at all");
+  public static final Agent LATEST_RELEASE =
+      new Agent("latest", "latest mainstream release", OTEL_LATEST);
+  public static final Agent LATEST_SNAPSHOT =
+      new Agent("snapshot", "latest available snapshot version from main");
 
   private final String name;
   private final String description;
@@ -25,7 +28,7 @@ public class Agent {
   }
 
   public Agent(String name, String description, String url) {
-      this(name, description, url, Collections.emptyList());
+    this(name, description, url, Collections.emptyList());
   }
 
   public Agent(String name, String description, String url, List<String> additionalJvmArgs) {
@@ -43,7 +46,7 @@ public class Agent {
     return description;
   }
 
-  public boolean hasUrl(){
+  public boolean hasUrl() {
     return url != null;
   }
 
@@ -57,7 +60,9 @@ public class Agent {
 
   private static URL makeUrl(String url) {
     try {
-      if(url == null) return null;
+      if (url == null) {
+        return null;
+      }
       return URI.create(url).toURL();
     } catch (MalformedURLException e) {
       throw new RuntimeException("Error parsing url", e);

--- a/benchmark-overhead/src/test/java/io/opentelemetry/agents/AgentResolver.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/agents/AgentResolver.java
@@ -20,20 +20,20 @@ public class AgentResolver {
   private final LatestAgentSnapshotResolver snapshotResolver = new LatestAgentSnapshotResolver();
 
   public Optional<Path> resolve(Agent agent) throws Exception {
-    if(Agent.NONE.equals(agent)){
+    if (Agent.NONE.equals(agent)) {
       return Optional.empty();
     }
-    if(Agent.LATEST_SNAPSHOT.equals(agent)){
+    if (Agent.LATEST_SNAPSHOT.equals(agent)) {
       return snapshotResolver.resolve();
     }
-    if(agent.hasUrl()){
+    if (agent.hasUrl()) {
       return Optional.of(downloadAgent(agent.getUrl()));
     }
     throw new IllegalArgumentException("Unknown agent: " + agent);
   }
 
   private Path downloadAgent(URL agentUrl) throws Exception {
-    if(agentUrl.getProtocol().equals("file")){
+    if (agentUrl.getProtocol().equals("file")) {
       Path source = Path.of(agentUrl.toURI());
       Path result = Paths.get(".", source.getFileName().toString());
       Files.copy(source, result, StandardCopyOption.REPLACE_EXISTING);
@@ -44,7 +44,12 @@ public class AgentResolver {
     Response response = client.newCall(request).execute();
     byte[] raw = response.body().bytes();
     Path path = Paths.get(".", "opentelemetry-javaagent-all.jar");
-    Files.write(path, raw, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    Files.write(
+        path,
+        raw,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.WRITE,
+        StandardOpenOption.TRUNCATE_EXISTING);
     return path;
   }
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/agents/LatestAgentSnapshotResolver.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/agents/LatestAgentSnapshotResolver.java
@@ -6,7 +6,6 @@ package io.opentelemetry.agents;
 
 import static org.joox.JOOX.$;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,17 +25,23 @@ public class LatestAgentSnapshotResolver {
 
   private static final Logger logger = LoggerFactory.getLogger(LatestAgentSnapshotResolver.class);
 
-  final static String BASE_URL = "https://oss.sonatype.org/content/repositories/snapshots/io/opentelemetry/javaagent/opentelemetry-javaagent";
-  final static String LATEST_SNAPSHOT_META = BASE_URL + "/maven-metadata.xml";
+  static final String BASE_URL =
+      "https://oss.sonatype.org/content/repositories/snapshots/io/opentelemetry/javaagent/opentelemetry-javaagent";
+  static final String LATEST_SNAPSHOT_META = BASE_URL + "/maven-metadata.xml";
 
   Optional<Path> resolve() throws IOException {
     String version = fetchLatestSnapshotVersion();
     logger.info("Latest snapshot version is {}", version);
     String latestFilename = fetchLatestFilename(version);
-    String url = BASE_URL +  "/" + version + "/" + latestFilename;
+    String url = BASE_URL + "/" + version + "/" + latestFilename;
     byte[] jarBytes = fetchBodyBytesFrom(url);
     Path path = Paths.get(".", "opentelemetry-javaagent-SNAPSHOT-all.jar");
-    Files.write(path, jarBytes, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    Files.write(
+        path,
+        jarBytes,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.WRITE,
+        StandardOpenOption.TRUNCATE_EXISTING);
     return Optional.of(path);
   }
 
@@ -46,11 +51,12 @@ public class LatestAgentSnapshotResolver {
     Document document = $(body).document();
     Match match = $(document).xpath("/metadata/versioning/snapshotVersions/snapshotVersion");
     return match.get().stream()
-        .filter(elem -> {
-          String classifier = $(elem).child("classifier").content();
-          String extension = $(elem).child("extension").content();
-          return "all".equals(classifier) && "jar".equals(extension);
-        })
+        .filter(
+            elem -> {
+              String classifier = $(elem).child("classifier").content();
+              String extension = $(elem).child("extension").content();
+              return "all".equals(classifier) && "jar".equals(extension);
+            })
         .map(e -> $(e).child("value").content())
         .findFirst()
         .map(value -> "opentelemetry-javaagent-" + value + "-all.jar")
@@ -64,7 +70,6 @@ public class LatestAgentSnapshotResolver {
     Match match = $(document).xpath("/metadata/versioning/latest");
     return match.get(0).getTextContent();
   }
-
 
   private String fetchBodyStringFrom(String url) throws IOException {
     return fetchBodyFrom(url).string();

--- a/benchmark-overhead/src/test/java/io/opentelemetry/config/Configs.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/config/Configs.java
@@ -8,37 +8,33 @@ import io.opentelemetry.agents.Agent;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
-/**
- * Defines all test configurations
- */
+/** Defines all test configurations */
 public enum Configs {
-
-  RELEASE(TestConfig.builder()
-      .name("release")
-      .description("compares the latest stable release to no agent")
-      .withAgents(Agent.NONE, Agent.LATEST_RELEASE)
-      .warmupSeconds(30)
-      .build()
-  ),
-  SNAPSHOT(TestConfig.builder()
-      .name("snapshot")
-      .description("compares the latest snapshot to no agent")
-      .withAgents(Agent.NONE, Agent.LATEST_SNAPSHOT)
-      .warmupSeconds(30)
-      .build()
-  ),
-  SNAPSHOT_REGRESSION(TestConfig.builder()
-      .name("snapshot-regression")
-      .description("compares the latest snapshot to the latest stable release")
-      .withAgents(Agent.LATEST_RELEASE, Agent.LATEST_SNAPSHOT)
-      .warmupSeconds(30)
-      .build()
-  )
-  ;
+  RELEASE(
+      TestConfig.builder()
+          .name("release")
+          .description("compares the latest stable release to no agent")
+          .withAgents(Agent.NONE, Agent.LATEST_RELEASE)
+          .warmupSeconds(30)
+          .build()),
+  SNAPSHOT(
+      TestConfig.builder()
+          .name("snapshot")
+          .description("compares the latest snapshot to no agent")
+          .withAgents(Agent.NONE, Agent.LATEST_SNAPSHOT)
+          .warmupSeconds(30)
+          .build()),
+  SNAPSHOT_REGRESSION(
+      TestConfig.builder()
+          .name("snapshot-regression")
+          .description("compares the latest snapshot to the latest stable release")
+          .withAgents(Agent.LATEST_RELEASE, Agent.LATEST_SNAPSHOT)
+          .warmupSeconds(30)
+          .build());
 
   public final TestConfig config;
 
-  public static Stream<TestConfig> all(){
+  public static Stream<TestConfig> all() {
     return Arrays.stream(Configs.values()).map(x -> x.config);
   }
 

--- a/benchmark-overhead/src/test/java/io/opentelemetry/config/TestConfig.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/config/TestConfig.java
@@ -10,14 +10,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Defines a test config.
- */
+/** Defines a test config. */
 public class TestConfig {
 
-  private final static int DEFAULT_MAX_REQUEST_RATE = 0;  // none
-  private final static int DEFAULT_CONCURRENT_CONNECTIONS = 5;
-  private final static int DEFAULT_TOTAL_ITERATIONS = 5000;
+  private static final int DEFAULT_MAX_REQUEST_RATE = 0; // none
+  private static final int DEFAULT_CONCURRENT_CONNECTIONS = 5;
+  private static final int DEFAULT_TOTAL_ITERATIONS = 5000;
 
   private final String name;
   private final String description;
@@ -88,7 +86,7 @@ public class TestConfig {
       return this;
     }
 
-    Builder withAgents(Agent ...agents) {
+    Builder withAgents(Agent... agents) {
       this.agents.addAll(Arrays.asList(agents));
       return this;
     }
@@ -108,12 +106,12 @@ public class TestConfig {
       return this;
     }
 
-    Builder warmupSeconds(int warmupSeconds){
+    Builder warmupSeconds(int warmupSeconds) {
       this.warmupSeconds = warmupSeconds;
       return this;
     }
 
-    TestConfig build(){
+    TestConfig build() {
       return new TestConfig(this);
     }
   }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/containers/CollectorContainer.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/containers/CollectorContainer.java
@@ -23,7 +23,7 @@ public class CollectorContainer {
   public static GenericContainer<?> build(Network network) {
 
     return new GenericContainer<>(
-        DockerImageName.parse("otel/opentelemetry-collector-contrib:latest"))
+            DockerImageName.parse("otel/opentelemetry-collector-contrib:latest"))
         .withNetwork(network)
         .withNetworkAliases("collector")
         .withLogConsumer(new Slf4jLogConsumer(logger))

--- a/benchmark-overhead/src/test/java/io/opentelemetry/containers/K6Container.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/containers/K6Container.java
@@ -25,34 +25,35 @@ public class K6Container {
   private final TestConfig config;
   private final NamingConventions namingConventions;
 
-  public K6Container(Network network, Agent agent, TestConfig config, NamingConventions namingConvention) {
+  public K6Container(
+      Network network, Agent agent, TestConfig config, NamingConventions namingConvention) {
     this.network = network;
     this.agent = agent;
     this.config = config;
     this.namingConventions = namingConvention;
   }
 
-  public GenericContainer<?> build(){
+  public GenericContainer<?> build() {
     Path k6OutputFile = namingConventions.container.k6Results(agent);
-    return new GenericContainer<>(
-        DockerImageName.parse("loadimpact/k6"))
+    return new GenericContainer<>(DockerImageName.parse("loadimpact/k6"))
         .withNetwork(network)
         .withNetworkAliases("k6")
         .withLogConsumer(new Slf4jLogConsumer(logger))
-        .withCopyFileToContainer(
-            MountableFile.forHostPath("./k6"), "/app")
+        .withCopyFileToContainer(MountableFile.forHostPath("./k6"), "/app")
         .withFileSystemBind(namingConventions.localResults(), namingConventions.containerResults())
         .withCreateContainerCmdModifier(cmd -> cmd.withUser("root"))
         .withCommand(
             "run",
-            "-u", String.valueOf(config.getConcurrentConnections()),
-            "-i", String.valueOf(config.getTotalIterations()),
-            "--rps", String.valueOf(config.getMaxRequestRate()),
-            "--summary-export", k6OutputFile.toString(),
-            "/app/basic.js"
-        )
+            "-u",
+            String.valueOf(config.getConcurrentConnections()),
+            "-i",
+            String.valueOf(config.getTotalIterations()),
+            "--rps",
+            String.valueOf(config.getMaxRequestRate()),
+            "--summary-export",
+            k6OutputFile.toString(),
+            "/app/basic.js")
         .withStartupCheckStrategy(
-            new OneShotStartupCheckStrategy().withTimeout(Duration.ofMinutes(15))
-        );
+            new OneShotStartupCheckStrategy().withTimeout(Duration.ofMinutes(15)));
   }
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/containers/PetClinicRestContainer.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/containers/PetClinicRestContainer.java
@@ -34,7 +34,8 @@ public class PetClinicRestContainer {
   private final Agent agent;
   private final NamingConventions namingConventions;
 
-  public PetClinicRestContainer(Network network, Startable collector, Agent agent, NamingConventions namingConventions) {
+  public PetClinicRestContainer(
+      Network network, Startable collector, Agent agent, NamingConventions namingConventions) {
     this.network = network;
     this.collector = collector;
     this.agent = agent;
@@ -45,40 +46,46 @@ public class PetClinicRestContainer {
 
     Optional<Path> agentJar = agentResolver.resolve(this.agent);
 
-    GenericContainer<?> container = new GenericContainer<>(
-        DockerImageName.parse("ghcr.io/open-telemetry/opentelemetry-java-instrumentation/petclinic-rest-base:latest"))
-        .withNetwork(network)
-        .withNetworkAliases("petclinic")
-        .withLogConsumer(new Slf4jLogConsumer(logger))
-        .withExposedPorts(PETCLINIC_PORT)
-        .withFileSystemBind(namingConventions.localResults(), namingConventions.containerResults())
-        .waitingFor(Wait.forHttp("/petclinic/actuator/health").forPort(PETCLINIC_PORT))
-        .withEnv("spring_profiles_active", "postgresql,spring-data-jpa")
-        .withEnv("spring_datasource_url", "jdbc:postgresql://postgres:5432/" + PostgresContainer.DATABASE_NAME)
-        .withEnv("spring_datasource_username", PostgresContainer.USERNAME)
-        .withEnv("spring_datasource_password", PostgresContainer.PASSWORD)
-        .withEnv("spring_jpa_hibernate_ddl-auto", "none")
-        .dependsOn(collector)
-        .withCommand(buildCommandline(agentJar));
+    GenericContainer<?> container =
+        new GenericContainer<>(
+                DockerImageName.parse(
+                    "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/petclinic-rest-base:latest"))
+            .withNetwork(network)
+            .withNetworkAliases("petclinic")
+            .withLogConsumer(new Slf4jLogConsumer(logger))
+            .withExposedPorts(PETCLINIC_PORT)
+            .withFileSystemBind(
+                namingConventions.localResults(), namingConventions.containerResults())
+            .waitingFor(Wait.forHttp("/petclinic/actuator/health").forPort(PETCLINIC_PORT))
+            .withEnv("spring_profiles_active", "postgresql,spring-data-jpa")
+            .withEnv(
+                "spring_datasource_url",
+                "jdbc:postgresql://postgres:5432/" + PostgresContainer.DATABASE_NAME)
+            .withEnv("spring_datasource_username", PostgresContainer.USERNAME)
+            .withEnv("spring_datasource_password", PostgresContainer.PASSWORD)
+            .withEnv("spring_jpa_hibernate_ddl-auto", "none")
+            .dependsOn(collector)
+            .withCommand(buildCommandline(agentJar));
 
     agentJar.ifPresent(
-        agentPath -> container.withCopyFileToContainer(
-            MountableFile.forHostPath(agentPath),
-            "/app/" + agentPath.getFileName().toString())
-    );
+        agentPath ->
+            container.withCopyFileToContainer(
+                MountableFile.forHostPath(agentPath),
+                "/app/" + agentPath.getFileName().toString()));
     return container;
   }
 
   @NotNull
   private String[] buildCommandline(Optional<Path> agentJar) {
-    List<String> result = new ArrayList<>(Arrays.asList(
-        "java",
-        "-Dotel.traces.exporter=otlp",
-        "-Dotel.imr.export.interval=5000",
-        "-Dotel.exporter.otlp.insecure=true",
-        "-Dotel.exporter.otlp.endpoint=http://collector:4317",
-        "-Dotel.resource.attributes=service.name=petclinic-otel-overhead"
-    ));
+    List<String> result =
+        new ArrayList<>(
+            Arrays.asList(
+                "java",
+                "-Dotel.traces.exporter=otlp",
+                "-Dotel.imr.export.interval=5000",
+                "-Dotel.exporter.otlp.insecure=true",
+                "-Dotel.exporter.otlp.endpoint=http://collector:4317",
+                "-Dotel.resource.attributes=service.name=petclinic-otel-overhead"));
     result.addAll(this.agent.getAdditionalJvmArgs());
     agentJar.ifPresent(path -> result.add("-javaagent:/app/" + path.getFileName()));
 

--- a/benchmark-overhead/src/test/java/io/opentelemetry/containers/PostgresContainer.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/containers/PostgresContainer.java
@@ -33,10 +33,11 @@ public class PostgresContainer {
         .withPassword(PASSWORD)
         .withDatabaseName(DATABASE_NAME)
         .withCopyFileToContainer(
-            MountableFile.forClasspathResource("initDB.sql"), "/docker-entrypoint-initdb.d/initDB.sql")
+            MountableFile.forClasspathResource("initDB.sql"),
+            "/docker-entrypoint-initdb.d/initDB.sql")
         .withCopyFileToContainer(
-            MountableFile.forClasspathResource("populateDB.sql"), "/docker-entrypoint-initdb.d/populateDB.sql")
+            MountableFile.forClasspathResource("populateDB.sql"),
+            "/docker-entrypoint-initdb.d/populateDB.sql")
         .withReuse(false);
   }
-
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/AppPerfResults.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/AppPerfResults.java
@@ -26,7 +26,6 @@ public class AppPerfResults {
   final float averageJvmUserCpu;
   final float maxJvmUserCpu;
 
-
   private AppPerfResults(Builder builder) {
     this.agent = builder.agent;
     this.config = builder.config;
@@ -53,6 +52,7 @@ public class AppPerfResults {
   String getAgentName() {
     return agent.getName();
   }
+
   static Builder builder() {
     return new Builder();
   }
@@ -139,47 +139,45 @@ public class AppPerfResults {
       return this;
     }
 
-    Builder averageNetworkRead(long averageNetworkRead){
+    Builder averageNetworkRead(long averageNetworkRead) {
       this.averageNetworkRead = averageNetworkRead;
       return this;
     }
 
-    Builder averageNetworkWrite(long averageNetworkWrite){
+    Builder averageNetworkWrite(long averageNetworkWrite) {
       this.averageNetworkWrite = averageNetworkWrite;
       return this;
     }
 
-    Builder averageJvmUserCpu(float averageJvmUserCpu){
+    Builder averageJvmUserCpu(float averageJvmUserCpu) {
       this.averageJvmUserCpu = averageJvmUserCpu;
       return this;
     }
 
-    Builder maxJvmUserCpu(float maxJvmUserCpu){
+    Builder maxJvmUserCpu(float maxJvmUserCpu) {
       this.maxJvmUserCpu = maxJvmUserCpu;
       return this;
     }
   }
 
-
-
   public static class MinMax {
     public final long min;
     public final long max;
 
-    public MinMax(){
+    public MinMax() {
       this(Long.MAX_VALUE, Long.MIN_VALUE);
     }
 
-    public MinMax(long min, long max){
+    public MinMax(long min, long max) {
       this.min = min;
       this.max = max;
     }
 
-    public MinMax withMin(long min){
+    public MinMax withMin(long min) {
       return new MinMax(min, max);
     }
 
-    public MinMax withMax(long max){
+    public MinMax withMax(long max) {
       return new MinMax(min, max);
     }
   }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/CsvPersister.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/CsvPersister.java
@@ -16,7 +16,9 @@ class CsvPersister implements ResultsPersister {
 
   private final Path resultsFile;
 
-  public CsvPersister(Path resultsFile) {this.resultsFile = resultsFile;}
+  public CsvPersister(Path resultsFile) {
+    this.resultsFile = resultsFile;
+  }
 
   @Override
   public void write(List<AppPerfResults> results) {
@@ -28,23 +30,25 @@ class CsvPersister implements ResultsPersister {
     // Each result is for a given agent run, and we want all the fields for all agents on the same
     // line so that we can create a columnar structure that allows us to more easily compare agent
     // to agent for a given run.
-    doSorted(results, result -> {
-      sb.append(",").append(result.startupDurationMs);
-      sb.append(",").append(result.heapUsed.min);
-      sb.append(",").append(result.heapUsed.max);
-      sb.append(",").append(result.getTotalAllocatedMB());
-      sb.append(",").append(result.totalGCTime);
-      sb.append(",").append(result.maxThreadContextSwitchRate);
-      sb.append(",").append(result.iterationAvg);
-      sb.append(",").append(result.iterationP95);
-      sb.append(",").append(result.requestAvg);
-      sb.append(",").append(result.requestP95);
-      sb.append(",").append(result.averageNetworkRead);
-      sb.append(",").append(result.averageNetworkWrite);
-      sb.append(",").append(result.peakThreadCount);
-      sb.append(",").append(result.averageJvmUserCpu);
-      sb.append(",").append(result.maxJvmUserCpu);
-    });
+    doSorted(
+        results,
+        result -> {
+          sb.append(",").append(result.startupDurationMs);
+          sb.append(",").append(result.heapUsed.min);
+          sb.append(",").append(result.heapUsed.max);
+          sb.append(",").append(result.getTotalAllocatedMB());
+          sb.append(",").append(result.totalGCTime);
+          sb.append(",").append(result.maxThreadContextSwitchRate);
+          sb.append(",").append(result.iterationAvg);
+          sb.append(",").append(result.iterationP95);
+          sb.append(",").append(result.requestAvg);
+          sb.append(",").append(result.requestP95);
+          sb.append(",").append(result.averageNetworkRead);
+          sb.append(",").append(result.averageNetworkWrite);
+          sb.append(",").append(result.peakThreadCount);
+          sb.append(",").append(result.averageJvmUserCpu);
+          sb.append(",").append(result.maxJvmUserCpu);
+        });
     sb.append("\n");
     try {
       Files.writeString(resultsFile, sb.toString(), StandardOpenOption.APPEND);
@@ -71,31 +75,31 @@ class CsvPersister implements ResultsPersister {
     // Each result is for a given agent run, and we want all the fields for all agents on the same
     // line so that we can create a columnar structure that allows us to more easily compare agent
     // to agent for a given run.
-    doSorted(results, result -> {
-      String agent = result.getAgentName();
-      sb.append(",").append(agent).append(":startupTimeMs");
-      sb.append(",").append(agent).append(":minHeapUsed");
-      sb.append(",").append(agent).append(":maxHeapUsed");
-      sb.append(",").append(agent).append(":totalAllocatedMB");
-      sb.append(",").append(agent).append(":totalGCTime");
-      sb.append(",").append(agent).append(":maxThreadContextSwitchRate");
-      sb.append(",").append(agent).append(":iterationAvg");
-      sb.append(",").append(agent).append(":iterationP95");
-      sb.append(",").append(agent).append(":requestAvg");
-      sb.append(",").append(agent).append(":requestP95");
-      sb.append(",").append(agent).append(":netReadAvg");
-      sb.append(",").append(agent).append(":netWriteAvg");
-      sb.append(",").append(agent).append(":peakThreadCount");
-      sb.append(",").append(agent).append(":averageCpuUser");
-      sb.append(",").append(agent).append(":maxCpuUser");
-    });
+    doSorted(
+        results,
+        result -> {
+          String agent = result.getAgentName();
+          sb.append(",").append(agent).append(":startupTimeMs");
+          sb.append(",").append(agent).append(":minHeapUsed");
+          sb.append(",").append(agent).append(":maxHeapUsed");
+          sb.append(",").append(agent).append(":totalAllocatedMB");
+          sb.append(",").append(agent).append(":totalGCTime");
+          sb.append(",").append(agent).append(":maxThreadContextSwitchRate");
+          sb.append(",").append(agent).append(":iterationAvg");
+          sb.append(",").append(agent).append(":iterationP95");
+          sb.append(",").append(agent).append(":requestAvg");
+          sb.append(",").append(agent).append(":requestP95");
+          sb.append(",").append(agent).append(":netReadAvg");
+          sb.append(",").append(agent).append(":netWriteAvg");
+          sb.append(",").append(agent).append(":peakThreadCount");
+          sb.append(",").append(agent).append(":averageCpuUser");
+          sb.append(",").append(agent).append(":maxCpuUser");
+        });
     sb.append("\n");
     return sb.toString();
   }
 
   private void doSorted(List<AppPerfResults> results, Consumer<AppPerfResults> consumer) {
-    results.stream()
-        .sorted(Comparator.comparing(AppPerfResults::getAgentName))
-        .forEach(consumer);
+    results.stream().sorted(Comparator.comparing(AppPerfResults::getAgentName)).forEach(consumer);
   }
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/FileSummaryPersister.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/FileSummaryPersister.java
@@ -9,17 +9,18 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.List;
 
-/**
- * Writes the summary file of the last run into the results dir.
- */
+/** Writes the summary file of the last run into the results dir. */
 class FileSummaryPersister implements ResultsPersister {
 
   private final Path file;
-  public FileSummaryPersister(Path file) {this.file = file;}
+
+  public FileSummaryPersister(Path file) {
+    this.file = file;
+  }
 
   @Override
   public void write(List<AppPerfResults> results) {
-    try (PrintStream out = new PrintStream(file.toFile())){
+    try (PrintStream out = new PrintStream(file.toFile())) {
       new PrintStreamPersister(out).write(results);
     } catch (FileNotFoundException e) {
       throw new RuntimeException("Error opening output file for results", e);

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/PrintStreamPersister.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/PrintStreamPersister.java
@@ -16,17 +16,23 @@ class PrintStreamPersister implements ResultsPersister {
 
   private final PrintStream out;
 
-  public PrintStreamPersister(PrintStream out) {this.out = out;}
+  public PrintStreamPersister(PrintStream out) {
+    this.out = out;
+  }
 
   @Override
   public void write(List<AppPerfResults> results) {
-    List<AppPerfResults> sorted = results.stream()
-        .sorted(Comparator.comparing(AppPerfResults::getAgentName)).collect(Collectors.toList());
+    List<AppPerfResults> sorted =
+        results.stream()
+            .sorted(Comparator.comparing(AppPerfResults::getAgentName))
+            .collect(Collectors.toList());
     TestConfig config = sorted.stream().findFirst().get().config;
     out.println("----------------------------------------------------------");
     out.println(" Run at " + new Date());
     out.printf(" %s : %s\n", config.getName(), config.getDescription());
-    out.printf(" %d users, %d iterations\n", config.getConcurrentConnections(), config.getTotalIterations());
+    out.printf(
+        " %d users, %d iterations\n",
+        config.getConcurrentConnections(), config.getTotalIterations());
     out.println("----------------------------------------------------------");
 
     display(sorted, "Agent", appPerfResults -> appPerfResults.agent.getName());
@@ -36,8 +42,7 @@ class PrintStreamPersister implements ResultsPersister {
     display(sorted, "Total allocated MB", res -> format(res.getTotalAllocatedMB()));
     display(sorted, "Heap (min)", res -> String.valueOf(res.heapUsed.min));
     display(sorted, "Heap (max)", res -> String.valueOf(res.heapUsed.max));
-    display(sorted, "Thread switch rate",
-        res -> String.valueOf(res.maxThreadContextSwitchRate));
+    display(sorted, "Thread switch rate", res -> String.valueOf(res.maxThreadContextSwitchRate));
     display(sorted, "GC time", res -> String.valueOf(res.totalGCTime));
     display(sorted, "Req. mean", res -> format(res.requestAvg));
     display(sorted, "Req. p95", res -> format(res.requestP95));
@@ -48,17 +53,17 @@ class PrintStreamPersister implements ResultsPersister {
     display(sorted, "Peak threads", res -> String.valueOf(res.peakThreadCount));
   }
 
-  private void display(List<AppPerfResults> results, String pref,
-      Function<AppPerfResults, String> vs) {
+  private void display(
+      List<AppPerfResults> results, String pref, Function<AppPerfResults, String> vs) {
     out.printf("%-20s: ", pref);
-    results.forEach(result -> {
+    results.forEach(
+        result -> {
           out.printf("%17s", vs.apply(result));
-      });
+        });
     out.println();
   }
 
   private String format(double d) {
     return String.format("%.2f", d);
   }
-
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/ResultsCollector.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/ResultsCollector.java
@@ -20,7 +20,9 @@ public class ResultsCollector {
 
   private final NamingConvention namingConvention;
 
-  public ResultsCollector(NamingConvention namingConvention) {this.namingConvention = namingConvention; }
+  public ResultsCollector(NamingConvention namingConvention) {
+    this.namingConvention = namingConvention;
+  }
 
   public List<AppPerfResults> collect(TestConfig config) {
     return config.getAgents().stream()
@@ -30,9 +32,7 @@ public class ResultsCollector {
 
   private AppPerfResults readAgentResults(Agent agent, TestConfig config) {
     try {
-      AppPerfResults.Builder builder = AppPerfResults.builder()
-          .agent(agent)
-          .config(config);
+      AppPerfResults.Builder builder = AppPerfResults.builder().agent(agent).config(config);
 
       builder = addStartupTime(builder, agent);
       builder = addK6Results(builder, agent);
@@ -44,15 +44,14 @@ public class ResultsCollector {
     }
   }
 
-  private AppPerfResults.Builder addStartupTime(
-      AppPerfResults.Builder builder, Agent agent) throws IOException {
+  private AppPerfResults.Builder addStartupTime(AppPerfResults.Builder builder, Agent agent)
+      throws IOException {
     Path file = namingConvention.startupDurationFile(agent);
     long startupDuration = Long.parseLong(new String(Files.readAllBytes(file)).trim());
     return builder.startupDurationMs(startupDuration);
   }
 
-  private AppPerfResults.Builder addK6Results(
-      AppPerfResults.Builder builder, Agent agent)
+  private AppPerfResults.Builder addK6Results(AppPerfResults.Builder builder, Agent agent)
       throws IOException {
     Path k6File = namingConvention.k6Results(agent);
     String json = new String(Files.readAllBytes(k6File));
@@ -67,8 +66,8 @@ public class ResultsCollector {
         .requestP95(requestP95);
   }
 
-  private AppPerfResults.Builder addJfrResults(
-      AppPerfResults.Builder builder, Agent agent) throws IOException {
+  private AppPerfResults.Builder addJfrResults(AppPerfResults.Builder builder, Agent agent)
+      throws IOException {
     Path jfrFile = namingConvention.jfrFile(agent);
     return builder
         .totalGCTime(readTotalGCTime(jfrFile))
@@ -118,5 +117,4 @@ public class ResultsCollector {
   private float readMaxThreadContextSwitchRate(Path jfrFile) throws IOException {
     return JFRUtils.findMaxFloat(jfrFile, "jdk.ThreadContextSwitchRate", "switchRate");
   }
-
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/util/JFRUtils.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/util/JFRUtils.java
@@ -13,41 +13,49 @@ import jdk.jfr.consumer.RecordingFile;
 
 public class JFRUtils {
 
-  public static long sumLongEventValues(Path jfrFile, String eventName,
-      String longValueKey) throws IOException {
+  public static long sumLongEventValues(Path jfrFile, String eventName, String longValueKey)
+      throws IOException {
     return reduce(jfrFile, eventName, longValueKey, 0L, Long::sum);
   }
 
-  public static float findMaxFloat(Path jfrFile, String eventName, String valueKey) throws IOException {
+  public static float findMaxFloat(Path jfrFile, String eventName, String valueKey)
+      throws IOException {
     return reduce(jfrFile, eventName, valueKey, 0.0f, (BiFunction<Float, Float, Float>) Math::max);
   }
 
-  public static MinMax findMinMax(Path jfrFile, String eventName, String valueKey) throws IOException {
-    return reduce(jfrFile, eventName, valueKey, new MinMax(), (MinMax acc, Long value) -> {
-      if (value > acc.max) {
-          acc = acc.withMax(value);
-        }
-        if (value < acc.min) {
-          acc = acc.withMin(value);
-        }
-        return acc;
-    });
+  public static MinMax findMinMax(Path jfrFile, String eventName, String valueKey)
+      throws IOException {
+    return reduce(
+        jfrFile,
+        eventName,
+        valueKey,
+        new MinMax(),
+        (MinMax acc, Long value) -> {
+          if (value > acc.max) {
+            acc = acc.withMax(value);
+          }
+          if (value < acc.min) {
+            acc = acc.withMin(value);
+          }
+          return acc;
+        });
   }
 
-  public static long findAverageLong(Path jfrFile, String eventName, String valueKey) throws IOException {
-    return reduce(jfrFile, eventName, valueKey,
-        new AverageSupport(),
-        AverageSupport::add).average();
+  public static long findAverageLong(Path jfrFile, String eventName, String valueKey)
+      throws IOException {
+    return reduce(jfrFile, eventName, valueKey, new AverageSupport(), AverageSupport::add)
+        .average();
   }
 
-  public static float computeAverageFloat(Path jfrFile, String eventName, String valueKey) throws IOException {
-    return reduce(jfrFile, eventName, valueKey,
-        new AverageFloatSupport(),
-        AverageFloatSupport::add).average();
+  public static float computeAverageFloat(Path jfrFile, String eventName, String valueKey)
+      throws IOException {
+    return reduce(jfrFile, eventName, valueKey, new AverageFloatSupport(), AverageFloatSupport::add)
+        .average();
   }
 
-  private static <T, V> T reduce(Path jfrFile, String eventName,
-      String valueKey, T initial, BiFunction<T,V,T> reducer) throws IOException {
+  private static <T, V> T reduce(
+      Path jfrFile, String eventName, String valueKey, T initial, BiFunction<T, V, T> reducer)
+      throws IOException {
     RecordingFile recordingFile = new RecordingFile(jfrFile);
     T result = initial;
     while (recordingFile.hasMoreEvents()) {
@@ -63,28 +71,32 @@ public class JFRUtils {
   static class AverageSupport {
     long count;
     long total;
-    AverageSupport add(long value){
+
+    AverageSupport add(long value) {
       count++;
       total += value;
       return this;
     }
-    long average(){
-      if(count == 0) return -1;
-      return total/count;
+
+    long average() {
+      if (count == 0) return -1;
+      return total / count;
     }
   }
 
   static class AverageFloatSupport {
     long count;
     float total;
-    AverageFloatSupport add(float value){
+
+    AverageFloatSupport add(float value) {
       count++;
       total += value;
       return this;
     }
-    float average(){
-      if(count == 0) return -1;
-      return total/count;
+
+    float average() {
+      if (count == 0) return -1;
+      return total / count;
     }
   }
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/util/NamingConvention.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/util/NamingConvention.java
@@ -9,27 +9,30 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * This utility class provides the standard file naming conventions, primarily
- * for files that are shared between containers and the test runner. It consolidates
- * the naming logic into one place to ensure consistency, reduce duplication, and
- * decrease errors.
+ * This utility class provides the standard file naming conventions, primarily for files that are
+ * shared between containers and the test runner. It consolidates the naming logic into one place to
+ * ensure consistency, reduce duplication, and decrease errors.
  */
 public class NamingConvention {
 
   private final String dir;
 
-  public NamingConvention(String dir) {this.dir = dir;}
+  public NamingConvention(String dir) {
+    this.dir = dir;
+  }
 
   /**
    * Returns a path to the location of the k6 results json file.
+   *
    * @param agent The agent to get results file path for
    */
-  public Path k6Results(Agent agent){
+  public Path k6Results(Agent agent) {
     return Paths.get(dir, "k6_out_" + agent.getName() + ".json");
   }
 
   /**
    * Returns a path to the location of the jfr output file for a given agent run.
+   *
    * @param agent The agent to get the jfr file path for.
    */
   public Path jfrFile(Agent agent) {
@@ -38,13 +41,14 @@ public class NamingConvention {
 
   /**
    * Returns the path to the file that contains the startup duration for a given agent run.
+   *
    * @param agent The agent to get the startup duration for.
    */
-  public Path startupDurationFile(Agent agent) { return Paths.get(dir, "startup-time-" + agent.getName() + ".txt"); }
+  public Path startupDurationFile(Agent agent) {
+    return Paths.get(dir, "startup-time-" + agent.getName() + ".txt");
+  }
 
-  /**
-   * Returns the root path that this naming convention was configured with.
-   */
+  /** Returns the root path that this naming convention was configured with. */
   public String root() {
     return dir;
   }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/util/NamingConventions.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/util/NamingConventions.java
@@ -1,23 +1,17 @@
 package io.opentelemetry.util;
 
-/**
- * An container to hold both the local and container naming conventions.
- */
+/** An container to hold both the local and container naming conventions. */
 public class NamingConventions {
 
   public final NamingConvention container = new NamingConvention("/results");
   public final NamingConvention local = new NamingConvention(".");
 
-  /**
-   * @return Root path for the local naming convention (where results are output)
-   */
+  /** @return Root path for the local naming convention (where results are output) */
   public String localResults() {
     return local.root();
   }
 
-  /**
-   * @return Root path for the container naming convention (where results are output)
-   */
+  /** @return Root path for the container naming convention (where results are output) */
   public String containerResults() {
     return container.root();
   }

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoPropagator.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoPropagator.java
@@ -9,14 +9,16 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * See <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md">
+ * See <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md">
  * OpenTelemetry Specification</a> for more information about Propagators.
  *
  * @see DemoPropagatorProvider
  */
 public class DemoPropagator implements TextMapPropagator {
   private static final String FIELD = "X-demo-field";
-  private static final ContextKey<Long> PROPAGATION_START_KEY = ContextKey.named("propagation.start");
+  private static final ContextKey<Long> PROPAGATION_START_KEY =
+      ContextKey.named("propagation.start");
 
   @Override
   public List<String> fields() {

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoSampler.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoSampler.java
@@ -11,16 +11,22 @@ import java.util.List;
 
 /**
  * This demo sampler filters out all internal spans whose name contains string "greeting".
- * <p>
- * See <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling">
+ *
+ * <p>See <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling">
  * OpenTelemetry Specification</a> for more information about span sampling.
  *
  * @see DemoSdkTracerProviderConfigurer
  */
 public class DemoSampler implements Sampler {
   @Override
-  public SamplingResult shouldSample(Context parentContext, String traceId, String name,
-      SpanKind spanKind, Attributes attributes, List<LinkData> parentLinks) {
+  public SamplingResult shouldSample(
+      Context parentContext,
+      String traceId,
+      String name,
+      SpanKind spanKind,
+      Attributes attributes,
+      List<LinkData> parentLinks) {
     if (spanKind == SpanKind.INTERNAL && name.contains("greeting")) {
       return SamplingResult.create(SamplingDecision.DROP);
     } else {

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoSdkTracerProviderConfigurer.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoSdkTracerProviderConfigurer.java
@@ -6,11 +6,11 @@ import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 
 /**
- * This is one of the main entry points for Instrumentation Agent's customizations.
- * It allows configuring {@link SdkTracerProviderBuilder}.
- * See the {@link #configure(SdkTracerProviderBuilder)} method below.
- * <p>
- * Also see https://github.com/open-telemetry/opentelemetry-java/issues/2022
+ * This is one of the main entry points for Instrumentation Agent's customizations. It allows
+ * configuring {@link SdkTracerProviderBuilder}. See the {@link
+ * #configure(SdkTracerProviderBuilder)} method below.
+ *
+ * <p>Also see https://github.com/open-telemetry/opentelemetry-java/issues/2022
  *
  * @see SdkTracerProviderConfigurer
  * @see DemoPropagatorProvider

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoSpanExporter.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoSpanExporter.java
@@ -6,7 +6,8 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
 
 /**
- * See <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-exporter">
+ * See <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-exporter">
  * OpenTelemetry Specification</a> for more information about {@link SpanExporter}.
  *
  * @see DemoSdkTracerProviderConfigurer

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoSpanProcessor.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoSpanProcessor.java
@@ -7,7 +7,8 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 
 /**
- * See <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-processor">
+ * See <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-processor">
  * OpenTelemetry Specification</a> for more information about {@link SpanProcessor}.
  *
  * @see DemoSdkTracerProviderConfigurer
@@ -24,9 +25,7 @@ public class DemoSpanProcessor implements SpanProcessor {
   }
 
   @Override
-  public void onEnd(ReadableSpan span) {
-
-  }
+  public void onEnd(ReadableSpan span) {}
 
   @Override
   public boolean isEndRequired() {

--- a/examples/distro/instrumentation/servlet-3/src/main/java/com/example/javaagent/instrumentation/DemoServlet3Instrumentation.java
+++ b/examples/distro/instrumentation/servlet-3/src/main/java/com/example/javaagent/instrumentation/DemoServlet3Instrumentation.java
@@ -23,7 +23,8 @@ public class DemoServlet3Instrumentation implements TypeInstrumentation {
 
   @Override
   public void transform(TypeTransformer transformer) {
-    transformer.applyAdviceToMethod(namedOneOf("doFilter", "service")
+    transformer.applyAdviceToMethod(
+        namedOneOf("doFilter", "service")
             .and(takesArgument(0, named("javax.servlet.ServletRequest")))
             .and(takesArgument(1, named("javax.servlet.ServletResponse")))
             .and(isPublic()),

--- a/examples/distro/instrumentation/servlet-3/src/test/java/com/example/javaagent/instrumentation/DemoServlet3InstrumentationTest.java
+++ b/examples/distro/instrumentation/servlet-3/src/test/java/com/example/javaagent/instrumentation/DemoServlet3InstrumentationTest.java
@@ -23,12 +23,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * This is a demo instrumentation test that verifies that the custom servlet instrumentation was applied.
+ * This is a demo instrumentation test that verifies that the custom servlet instrumentation was
+ * applied.
  */
 class DemoServlet3InstrumentationTest {
   @RegisterExtension
-  static final AgentInstrumentationExtension instrumentation = AgentInstrumentationExtension
-      .create();
+  static final AgentInstrumentationExtension instrumentation =
+      AgentInstrumentationExtension.create();
 
   static final OkHttpClient httpClient = new OkHttpClient();
 
@@ -75,14 +76,19 @@ class DemoServlet3InstrumentationTest {
 
     assertThat(instrumentation.waitForTraces(1))
         .hasSize(1)
-        .hasTracesSatisfyingExactly(trace -> trace.hasSize(1)
-            .hasSpansSatisfyingExactly(span -> span.hasName("/servlet").hasKind(SpanKind.SERVER)));
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace
+                    .hasSize(1)
+                    .hasSpansSatisfyingExactly(
+                        span -> span.hasName("/servlet").hasKind(SpanKind.SERVER)));
 
     var traceId = instrumentation.spans().get(0).getTraceId();
     assertEquals(traceId, response.header("X-server-id"));
   }
 
   public static class TestServlet extends HttpServlet {
+    @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
       try (Writer writer = response.getWriter()) {

--- a/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
+++ b/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
@@ -41,9 +41,7 @@ abstract class SmokeTest {
 
   protected abstract String getTargetImage(int jdk);
 
-  /**
-   * Subclasses can override this method to customise target application's environment
-   */
+  /** Subclasses can override this method to customise target application's environment */
   protected Map<String, String> getExtraEnv() {
     return Collections.emptyMap();
   }
@@ -55,7 +53,7 @@ abstract class SmokeTest {
   static void setupSpec() {
     backend =
         new GenericContainer<>(
-            "ghcr.io/open-telemetry/java-test-containers:smoke-fake-backend-20210324.684269693")
+                "ghcr.io/open-telemetry/java-test-containers:smoke-fake-backend-20210324.684269693")
             .withExposedPorts(8080)
             .waitingFor(Wait.forHttp("/health").forPort(8080))
             .withNetwork(network)
@@ -98,9 +96,7 @@ abstract class SmokeTest {
     client
         .newCall(
             new Request.Builder()
-                .url(
-                    String.format(
-                        "http://localhost:%d/clear", backend.getMappedPort(8080)))
+                .url(String.format("http://localhost:%d/clear", backend.getMappedPort(8080)))
                 .build())
         .execute()
         .close();
@@ -116,12 +112,17 @@ abstract class SmokeTest {
     collector.stop();
   }
 
-  protected static int countResourcesByValue(Collection<ExportTraceServiceRequest> traces, String resourceName, String value) {
-    return (int) traces.stream()
-        .flatMap(it -> it.getResourceSpansList().stream())
-        .flatMap(it -> it.getResource().getAttributesList().stream())
-        .filter(kv -> kv.getKey().equals(resourceName) && kv.getValue().getStringValue().equals(value))
-        .count();
+  protected static int countResourcesByValue(
+      Collection<ExportTraceServiceRequest> traces, String resourceName, String value) {
+    return (int)
+        traces.stream()
+            .flatMap(it -> it.getResourceSpansList().stream())
+            .flatMap(it -> it.getResource().getAttributesList().stream())
+            .filter(
+                kv ->
+                    kv.getKey().equals(resourceName)
+                        && kv.getValue().getStringValue().equals(value))
+            .count();
   }
 
   protected static int countSpansByName(
@@ -131,10 +132,14 @@ abstract class SmokeTest {
 
   protected static int countSpansByAttributeValue(
       Collection<ExportTraceServiceRequest> traces, String attributeName, String attributeValue) {
-    return (int) getSpanStream(traces)
-        .flatMap(it -> it.getAttributesList().stream())
-        .filter(kv -> kv.getKey().equals(attributeName) && kv.getValue().getStringValue().equals(attributeValue))
-        .count();
+    return (int)
+        getSpanStream(traces)
+            .flatMap(it -> it.getAttributesList().stream())
+            .filter(
+                kv ->
+                    kv.getKey().equals(attributeName)
+                        && kv.getValue().getStringValue().equals(attributeValue))
+            .count();
   }
 
   protected static Stream<Span> getSpanStream(Collection<ExportTraceServiceRequest> traces) {

--- a/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SpringBootSmokeTest.java
+++ b/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SpringBootSmokeTest.java
@@ -13,8 +13,10 @@ import org.junit.jupiter.api.Test;
 
 class SpringBootSmokeTest extends SmokeTest {
 
+  @Override
   protected String getTargetImage(int jdk) {
-    return "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk" + jdk
+    return "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk"
+        + jdk
         + "-20210218.577304949";
   }
 
@@ -25,10 +27,11 @@ class SpringBootSmokeTest extends SmokeTest {
     Request request = new Request.Builder().url(url).get().build();
 
     String currentAgentVersion =
-        (String) new JarFile(agentPath)
-            .getManifest()
-            .getMainAttributes()
-            .get(Attributes.Name.IMPLEMENTATION_VERSION);
+        (String)
+            new JarFile(agentPath)
+                .getManifest()
+                .getMainAttributes()
+                .get(Attributes.Name.IMPLEMENTATION_VERSION);
 
     Response response = client.newCall(request).execute();
     System.out.println(response.headers().toString());
@@ -43,8 +46,8 @@ class SpringBootSmokeTest extends SmokeTest {
     Assertions.assertEquals(0, countSpansByName(traces, "WebController.greeting"));
     Assertions.assertEquals(1, countSpansByName(traces, "WebController.withSpan"));
     Assertions.assertEquals(2, countSpansByAttributeValue(traces, "custom", "demo"));
-    Assertions.assertNotEquals(0,
-        countResourcesByValue(traces, "telemetry.auto.version", currentAgentVersion));
+    Assertions.assertNotEquals(
+        0, countResourcesByValue(traces, "telemetry.auto.version", currentAgentVersion));
     Assertions.assertNotEquals(0, countResourcesByValue(traces, "custom.resource", "demo"));
 
     stopTarget();

--- a/examples/extension/src/main/java/com/example/javaagent/DemoPropagator.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoPropagator.java
@@ -9,14 +9,16 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * See <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md">
+ * See <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md">
  * OpenTelemetry Specification</a> for more information about Propagators.
  *
  * @see DemoPropagatorProvider
  */
 public class DemoPropagator implements TextMapPropagator {
   private static final String FIELD = "X-demo-field";
-  private static final ContextKey<Long> PROPAGATION_START_KEY = ContextKey.named("propagation.start");
+  private static final ContextKey<Long> PROPAGATION_START_KEY =
+      ContextKey.named("propagation.start");
 
   @Override
   public List<String> fields() {

--- a/examples/extension/src/main/java/com/example/javaagent/DemoSampler.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoSampler.java
@@ -11,16 +11,22 @@ import java.util.List;
 
 /**
  * This demo sampler filters out all internal spans whose name contains string "greeting".
- * <p>
- * See <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling">
+ *
+ * <p>See <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling">
  * OpenTelemetry Specification</a> for more information about span sampling.
  *
  * @see DemoSdkTracerProviderConfigurer
  */
 public class DemoSampler implements Sampler {
   @Override
-  public SamplingResult shouldSample(Context parentContext, String traceId, String name,
-      SpanKind spanKind, Attributes attributes, List<LinkData> parentLinks) {
+  public SamplingResult shouldSample(
+      Context parentContext,
+      String traceId,
+      String name,
+      SpanKind spanKind,
+      Attributes attributes,
+      List<LinkData> parentLinks) {
     if (spanKind == SpanKind.INTERNAL && name.contains("greeting")) {
       return SamplingResult.create(SamplingDecision.DROP);
     } else {

--- a/examples/extension/src/main/java/com/example/javaagent/DemoSdkTracerProviderConfigurer.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoSdkTracerProviderConfigurer.java
@@ -7,11 +7,11 @@ import io.opentelemetry.sdk.trace.SpanLimits;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 
 /**
- * This is one of the main entry points for Instrumentation Agent's customizations.
- * It allows configuring {@link SdkTracerProviderBuilder}.
- * See the {@link #configure(SdkTracerProviderBuilder)} method below.
- * <p>
- * Also see https://github.com/open-telemetry/opentelemetry-java/issues/2022
+ * This is one of the main entry points for Instrumentation Agent's customizations. It allows
+ * configuring {@link SdkTracerProviderBuilder}. See the {@link
+ * #configure(SdkTracerProviderBuilder)} method below.
+ *
+ * <p>Also see https://github.com/open-telemetry/opentelemetry-java/issues/2022
  *
  * @see SdkTracerProviderConfigurer
  * @see DemoPropagatorProvider

--- a/examples/extension/src/main/java/com/example/javaagent/DemoSpanExporter.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoSpanExporter.java
@@ -6,7 +6,8 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
 
 /**
- * See <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-exporter">
+ * See <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-exporter">
  * OpenTelemetry Specification</a> for more information about {@link SpanExporter}.
  *
  * @see DemoSdkTracerProviderConfigurer

--- a/examples/extension/src/main/java/com/example/javaagent/DemoSpanProcessor.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoSpanProcessor.java
@@ -8,7 +8,8 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 import org.apache.commons.lang3.RandomStringUtils;
 
 /**
- * See <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-processor">
+ * See <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-processor">
  * OpenTelemetry Specification</a> for more information about {@link SpanProcessor}.
  *
  * @see DemoSdkTracerProviderConfigurer
@@ -31,9 +32,7 @@ public class DemoSpanProcessor implements SpanProcessor {
   }
 
   @Override
-  public void onEnd(ReadableSpan span) {
-
-  }
+  public void onEnd(ReadableSpan span) {}
 
   @Override
   public boolean isEndRequired() {

--- a/examples/extension/src/test/java/com/example/javaagent/smoketest/IntegrationTest.java
+++ b/examples/extension/src/test/java/com/example/javaagent/smoketest/IntegrationTest.java
@@ -38,7 +38,7 @@ abstract class IntegrationTest {
   private static final Network network = Network.newNetwork();
   protected static final String agentPath =
       System.getProperty("io.opentelemetry.smoketest.agentPath");
-  //Javaagent with extensions embedded inside it
+  // Javaagent with extensions embedded inside it
   protected static final String extendedAgentPath =
       System.getProperty("io.opentelemetry.smoketest.extendedAgentPath");
   protected static final String extensionPath =
@@ -46,9 +46,7 @@ abstract class IntegrationTest {
 
   protected abstract String getTargetImage(int jdk);
 
-  /**
-   * Subclasses can override this method to customise target application's environment
-   */
+  /** Subclasses can override this method to customise target application's environment */
   protected Map<String, String> getExtraEnv() {
     return Collections.emptyMap();
   }
@@ -60,7 +58,7 @@ abstract class IntegrationTest {
   static void setupSpec() {
     backend =
         new GenericContainer<>(
-            "ghcr.io/open-telemetry/java-test-containers:smoke-fake-backend-20210324.684269693")
+                "ghcr.io/open-telemetry/java-test-containers:smoke-fake-backend-20210324.684269693")
             .withExposedPorts(8080)
             .waitingFor(Wait.forHttp("/health").forPort(8080))
             .withNetwork(network)
@@ -100,19 +98,22 @@ abstract class IntegrationTest {
             .withLogConsumer(new Slf4jLogConsumer(logger))
             .withCopyFileToContainer(
                 MountableFile.forHostPath(agentPath), "/opentelemetry-javaagent.jar")
-            //Adds instrumentation agent with debug configuration to the target application
-            .withEnv("JAVA_TOOL_OPTIONS",
+            // Adds instrumentation agent with debug configuration to the target application
+            .withEnv(
+                "JAVA_TOOL_OPTIONS",
                 "-javaagent:/opentelemetry-javaagent.jar -Dotel.javaagent.debug=true")
             .withEnv("OTEL_BSP_MAX_EXPORT_BATCH", "1")
             .withEnv("OTEL_BSP_SCHEDULE_DELAY", "10")
             .withEnv("OTEL_PROPAGATORS", "tracecontext,baggage,demo")
             .withEnv(getExtraEnv());
-    //If external extensions are requested
+    // If external extensions are requested
     if (extensionLocation != null) {
-      //Asks instrumentation agent to include extensions from given location into its runtime
-      result = result.withCopyFileToContainer(
-          MountableFile.forHostPath(extensionPath), "/opentelemetry-extensions.jar")
-          .withEnv("OTEL_JAVAAGENT_EXTENSIONS", extensionLocation);
+      // Asks instrumentation agent to include extensions from given location into its runtime
+      result =
+          result
+              .withCopyFileToContainer(
+                  MountableFile.forHostPath(extensionPath), "/opentelemetry-extensions.jar")
+              .withEnv("OTEL_JAVAAGENT_EXTENSIONS", extensionLocation);
     }
     return result;
   }
@@ -122,9 +123,7 @@ abstract class IntegrationTest {
     client
         .newCall(
             new Request.Builder()
-                .url(
-                    String.format(
-                        "http://localhost:%d/clear", backend.getMappedPort(8080)))
+                .url(String.format("http://localhost:%d/clear", backend.getMappedPort(8080)))
                 .build())
         .execute()
         .close();
@@ -140,14 +139,17 @@ abstract class IntegrationTest {
     collector.stop();
   }
 
-  protected static int countResourcesByValue(Collection<ExportTraceServiceRequest> traces,
-      String resourceName, String value) {
-    return (int) traces.stream()
-        .flatMap(it -> it.getResourceSpansList().stream())
-        .flatMap(it -> it.getResource().getAttributesList().stream())
-        .filter(
-            kv -> kv.getKey().equals(resourceName) && kv.getValue().getStringValue().equals(value))
-        .count();
+  protected static int countResourcesByValue(
+      Collection<ExportTraceServiceRequest> traces, String resourceName, String value) {
+    return (int)
+        traces.stream()
+            .flatMap(it -> it.getResourceSpansList().stream())
+            .flatMap(it -> it.getResource().getAttributesList().stream())
+            .filter(
+                kv ->
+                    kv.getKey().equals(resourceName)
+                        && kv.getValue().getStringValue().equals(value))
+            .count();
   }
 
   protected static int countSpansByName(
@@ -157,11 +159,14 @@ abstract class IntegrationTest {
 
   protected static int countSpansByAttributeValue(
       Collection<ExportTraceServiceRequest> traces, String attributeName, String attributeValue) {
-    return (int) getSpanStream(traces)
-        .flatMap(it -> it.getAttributesList().stream())
-        .filter(kv -> kv.getKey().equals(attributeName) && kv.getValue().getStringValue()
-            .equals(attributeValue))
-        .count();
+    return (int)
+        getSpanStream(traces)
+            .flatMap(it -> it.getAttributesList().stream())
+            .filter(
+                kv ->
+                    kv.getKey().equals(attributeName)
+                        && kv.getValue().getStringValue().equals(attributeValue))
+            .count();
   }
 
   protected static Stream<Span> getSpanStream(Collection<ExportTraceServiceRequest> traces) {

--- a/examples/extension/src/test/java/com/example/javaagent/smoketest/SpringBootIntegrationTest.java
+++ b/examples/extension/src/test/java/com/example/javaagent/smoketest/SpringBootIntegrationTest.java
@@ -13,8 +13,10 @@ import org.junit.jupiter.api.Test;
 
 class SpringBootIntegrationTest extends IntegrationTest {
 
+  @Override
   protected String getTargetImage(int jdk) {
-    return "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk" + jdk
+    return "ghcr.io/open-telemetry/java-test-containers:smoke-springboot-jdk"
+        + jdk
         + "-20210218.577304949";
   }
 
@@ -50,10 +52,11 @@ class SpringBootIntegrationTest extends IntegrationTest {
     Request request = new Request.Builder().url(url).get().build();
 
     String currentAgentVersion =
-        (String) new JarFile(agentPath)
-            .getManifest()
-            .getMainAttributes()
-            .get(Attributes.Name.IMPLEMENTATION_VERSION);
+        (String)
+            new JarFile(agentPath)
+                .getManifest()
+                .getMainAttributes()
+                .get(Attributes.Name.IMPLEMENTATION_VERSION);
 
     Response response = client.newCall(request).execute();
 
@@ -67,8 +70,8 @@ class SpringBootIntegrationTest extends IntegrationTest {
     Assertions.assertEquals(0, countSpansByName(traces, "WebController.greeting"));
     Assertions.assertEquals(1, countSpansByName(traces, "WebController.withSpan"));
     Assertions.assertEquals(2, countSpansByAttributeValue(traces, "custom", "demo"));
-    Assertions.assertNotEquals(0,
-        countResourcesByValue(traces, "telemetry.auto.version", currentAgentVersion));
+    Assertions.assertNotEquals(
+        0, countResourcesByValue(traces, "telemetry.auto.version", currentAgentVersion));
     Assertions.assertNotEquals(0, countResourcesByValue(traces, "custom.resource", "demo"));
   }
 }

--- a/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
+++ b/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
@@ -91,11 +91,12 @@ public class FakeBackendMain {
     var server =
         Server.builder()
             .http(8080)
-            .service(GrpcService.builder()
-                .addService(traceCollector)
-                .addService(metricsCollector)
-                .addService(logsCollector)
-                .build())
+            .service(
+                GrpcService.builder()
+                    .addService(traceCollector)
+                    .addService(metricsCollector)
+                    .addService(logsCollector)
+                    .build())
             .service(
                 "/clear",
                 (ctx, req) -> {

--- a/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeLogsCollectorService.java
+++ b/smoke-tests/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeLogsCollectorService.java
@@ -9,9 +9,10 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 
-public class FakeLogsCollectorService extends LogsServiceGrpc.LogsServiceImplBase{
+public class FakeLogsCollectorService extends LogsServiceGrpc.LogsServiceImplBase {
 
-  private final BlockingQueue<ExportLogsServiceRequest> exportRequests = new LinkedBlockingDeque<>();
+  private final BlockingQueue<ExportLogsServiceRequest> exportRequests =
+      new LinkedBlockingDeque<>();
 
   List<ExportLogsServiceRequest> getRequests() {
     return ImmutableList.copyOf(exportRequests);
@@ -22,7 +23,8 @@ public class FakeLogsCollectorService extends LogsServiceGrpc.LogsServiceImplBas
   }
 
   @Override
-  public void export(ExportLogsServiceRequest request,
+  public void export(
+      ExportLogsServiceRequest request,
       StreamObserver<ExportLogsServiceResponse> responseObserver) {
     exportRequests.add(request);
     responseObserver.onNext(ExportLogsServiceResponse.getDefaultInstance());

--- a/smoke-tests/grpc/src/main/java/io/opentelemetry/smoketest/grpc/TestMain.java
+++ b/smoke-tests/grpc/src/main/java/io/opentelemetry/smoketest/grpc/TestMain.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.smoketest.grpc;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TestMain {
 
@@ -16,7 +16,8 @@ public class TestMain {
 
   public static void main(String[] args) throws Exception {
     TestService service = new TestService();
-    Server server = ServerBuilder.forPort(8080).addService(service).directExecutor().build().start();
+    Server server =
+        ServerBuilder.forPort(8080).addService(service).directExecutor().build().start();
     Runtime.getRuntime().addShutdownHook(new Thread(server::shutdownNow));
     logger.info("Server started at port 8080.");
     server.awaitTermination();

--- a/smoke-tests/matrix/servlet-3.0/src/main/java/io/opentelemetry/smoketest/matrix/AsyncGreetingServlet.java
+++ b/smoke-tests/matrix/servlet-3.0/src/main/java/io/opentelemetry/smoketest/matrix/AsyncGreetingServlet.java
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.smoketest.matrix;
 
-import javax.servlet.AsyncContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public class AsyncGreetingServlet extends GreetingServlet {
   private static final BlockingQueue<AsyncContext> jobQueue = new LinkedBlockingQueue<>();
@@ -20,20 +20,20 @@ public class AsyncGreetingServlet extends GreetingServlet {
 
   @Override
   public void init() throws ServletException {
-    executor.submit(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          while (true) {
-            AsyncContext ac = jobQueue.take();
-            executor.submit(() -> handleRequest(ac));
-         }
-        }
-        catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-      }
-    });
+    executor.submit(
+        new Runnable() {
+          @Override
+          public void run() {
+            try {
+              while (true) {
+                AsyncContext ac = jobQueue.take();
+                executor.submit(() -> handleRequest(ac));
+              }
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+          }
+        });
   }
 
   @Override
@@ -50,5 +50,4 @@ public class AsyncGreetingServlet extends GreetingServlet {
   private void handleRequest(AsyncContext ac) {
     ac.dispatch("/greeting");
   }
-
 }

--- a/smoke-tests/matrix/servlet-5.0/src/main/java/io/opentelemetry/smoketest/matrix/AsyncGreetingServlet.java
+++ b/smoke-tests/matrix/servlet-5.0/src/main/java/io/opentelemetry/smoketest/matrix/AsyncGreetingServlet.java
@@ -20,20 +20,20 @@ public class AsyncGreetingServlet extends GreetingServlet {
 
   @Override
   public void init() throws ServletException {
-    executor.submit(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          while (true) {
-            AsyncContext ac = jobQueue.take();
-            executor.submit(() -> handleRequest(ac));
-         }
-        }
-        catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-      }
-    });
+    executor.submit(
+        new Runnable() {
+          @Override
+          public void run() {
+            try {
+              while (true) {
+                AsyncContext ac = jobQueue.take();
+                executor.submit(() -> handleRequest(ac));
+              }
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+          }
+        });
   }
 
   @Override
@@ -50,5 +50,4 @@ public class AsyncGreetingServlet extends GreetingServlet {
   private void handleRequest(AsyncContext ac) {
     ac.dispatch("/greeting");
   }
-
 }

--- a/smoke-tests/springboot/src/main/java/io/opentelemetry/smoketest/springboot/controller/PropagatingController.java
+++ b/smoke-tests/springboot/src/main/java/io/opentelemetry/smoketest/springboot/controller/PropagatingController.java
@@ -26,11 +26,11 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 /**
- * This controller demonstrates that context propagation works across http calls.
- * Calling <code>/front</code> should return a string which contains two traceId separated by ";".
- * First traceId was reported by <code>/front</code> handler, the second one was returned by
- * <code>/back</code> handler which was called by <code>/front</code>. If context propagation
- * works correctly, then both values should be the same.
+ * This controller demonstrates that context propagation works across http calls. Calling <code>
+ * /front</code> should return a string which contains two traceId separated by ";". First traceId
+ * was reported by <code>/front</code> handler, the second one was returned by <code>/back</code>
+ * handler which was called by <code>/front</code>. If context propagation works correctly, then
+ * both values should be the same.
  */
 @RestController
 public class PropagatingController {
@@ -44,12 +44,12 @@ public class PropagatingController {
 
   @RequestMapping("/front")
   public String front() {
-    URI backend = ServletUriComponentsBuilder
-        .fromCurrentContextPath()
-        .port(environment.getProperty("local.server.port"))
-        .path("/back")
-        .build()
-        .toUri();
+    URI backend =
+        ServletUriComponentsBuilder.fromCurrentContextPath()
+            .port(environment.getProperty("local.server.port"))
+            .path("/back")
+            .build()
+            .toUri();
     String backendTraceId = restTemplate.getForObject(backend, String.class);
     String frontendTraceId = Span.current().getSpanContext().getTraceId();
     return String.format("%s;%s", frontendTraceId, backendTraceId);


### PR DESCRIPTION
Ideally we should apply spotless to these projects (#4104), but in the meantime they could use a format.

This PR just auto-formats all Java files in Intellij (with the google-java-format Intellij plugin installed).