### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
 
   snapshot:
     runs-on: ubuntu-latest
-    needs: [ build, test, testLatestDeps, smoke-test, examples ]
+    needs: [ build, test, testLatestDeps, smoke-test, examples, muzzle ]
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
Require successful `muzzle` step before publishing snapshots