### PR TITLE
Make CONSUMER receive span a parent of CONSUMER process spans in Kafka…

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,8 +29,8 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("io.opentelemetry.instrumentation.muzzle-generation:io.opentelemetry.instrumentation.muzzle-generation.gradle.plugin:0.7.0")
-  implementation("io.opentelemetry.instrumentation.muzzle-check:io.opentelemetry.instrumentation.muzzle-check.gradle.plugin:0.7.0")
+  implementation("io.opentelemetry.instrumentation.muzzle-generation:io.opentelemetry.instrumentation.muzzle-generation.gradle.plugin:0.8.0-SNAPSHOT")
+  implementation("io.opentelemetry.instrumentation.muzzle-check:io.opentelemetry.instrumentation.muzzle-check.gradle.plugin:0.8.0-SNAPSHOT")
 
   implementation("org.eclipse.aether:aether-connector-basic:1.1.0")
   implementation("org.eclipse.aether:aether-transport-http:1.1.0")

--- a/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/TracingList.java
+++ b/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/TracingList.java
@@ -5,16 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaclients;
 
+import io.opentelemetry.api.trace.SpanContext;
 import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TracingList<K, V> extends TracingIterable<K, V> implements List<ConsumerRecord<K, V>> {
   private final List<ConsumerRecord<K, V>> delegate;
 
-  public TracingList(List<ConsumerRecord<K, V>> delegate) {
-    super(delegate);
+  public TracingList(
+      List<ConsumerRecord<K, V>> delegate, @Nullable SpanContext receiveSpanContext) {
+    super(delegate, receiveSpanContext);
     this.delegate = delegate;
   }
 

--- a/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
+++ b/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
@@ -3,12 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.CONSUMER
-import static io.opentelemetry.api.trace.SpanKind.PRODUCER
-
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
@@ -16,6 +11,12 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.listener.KafkaMessageListenerContainer
 import org.springframework.kafka.listener.MessageListener
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
 

--- a/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
+++ b/instrumentation/kafka-clients/kafka-clients-0.11/javaagent/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
@@ -3,12 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.api.trace.SpanKind.*
-
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -23,6 +19,13 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.listener.KafkaMessageListenerContainer
 import org.springframework.kafka.listener.MessageListener
 import org.springframework.kafka.test.utils.KafkaTestUtils
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 
 class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
 

--- a/instrumentation/kafka-clients/kafka-clients-2.4.0-testing/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
+++ b/instrumentation/kafka-clients/kafka-clients-2.4.0-testing/src/test/groovy/KafkaClientPropagationDisabledTest.groovy
@@ -55,7 +55,7 @@ class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
     // check that the message was received
     records.poll(5, TimeUnit.SECONDS) != null
 
-    assertTraces(3) {
+    assertTraces(2) {
       trace(0, 1) {
         span(0) {
           name SHARED_TOPIC + " send"
@@ -68,7 +68,7 @@ class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
           }
         }
       }
-      trace(1, 1) {
+      trace(1, 2) {
         span(0) {
           name SHARED_TOPIC + " receive"
           kind CONSUMER
@@ -80,12 +80,11 @@ class KafkaClientPropagationDisabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "receive"
           }
         }
-      }
-      trace(2, 1) {
-        span(0) {
+        span(1) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
-          hasNoParent()
+          childOf span(0)
+          hasNoLinks()
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
             "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC

--- a/instrumentation/kafka-clients/kafka-clients-2.4.0-testing/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
+++ b/instrumentation/kafka-clients/kafka-clients-2.4.0-testing/src/test/groovy/KafkaClientPropagationEnabledTest.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -84,7 +85,9 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
     assertTraces(2) {
       traces.sort(orderByRootSpanKind(INTERNAL, CONSUMER))
 
-      trace(0, 4) {
+      SpanData producerSpan
+
+      trace(0, 3) {
         span(0) {
           name "parent"
           kind INTERNAL
@@ -101,27 +104,14 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
           }
         }
         span(2) {
-          name SHARED_TOPIC + " process"
-          kind CONSUMER
-          childOf span(1)
-          attributes {
-            "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
-            "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
-            "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
-            "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
-            "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
-            "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
-            "kafka.offset" 0
-            "kafka.record.queue_time_ms" { it >= 0 }
-          }
-        }
-        span(3) {
           name "producer callback"
           kind INTERNAL
           childOf span(0)
         }
+
+        producerSpan = span(1)
       }
-      trace(1, 1) {
+      trace(1, 2) {
         span(0) {
           name SHARED_TOPIC + " receive"
           kind CONSUMER
@@ -131,6 +121,22 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
             "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "receive"
+          }
+        }
+        span(1) {
+          name SHARED_TOPIC + " process"
+          kind CONSUMER
+          childOf span(0)
+          hasLink producerSpan
+          attributes {
+            "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
+            "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
+            "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
+            "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
+            "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
+            "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
+            "kafka.offset" 0
+            "kafka.record.queue_time_ms" { it >= 0 }
           }
         }
       }
@@ -195,7 +201,9 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
     assertTraces(2) {
       traces.sort(orderByRootSpanKind(INTERNAL, CONSUMER))
 
-      trace(0, 4) {
+      SpanData producerSpan
+
+      trace(0, 3) {
         span(0) {
           name "parent"
           kind INTERNAL
@@ -212,27 +220,14 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
           }
         }
         span(2) {
-          name SHARED_TOPIC + " process"
-          kind CONSUMER
-          childOf span(1)
-          attributes {
-            "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
-            "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
-            "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
-            "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
-            "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
-            "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
-            "kafka.offset" 0
-            "kafka.record.queue_time_ms" { it >= 0 }
-          }
-        }
-        span(3) {
           name "producer callback"
           kind INTERNAL
           childOf span(0)
         }
+
+        producerSpan = span(1)
       }
-      trace(1, 1) {
+      trace(1, 2) {
         span(0) {
           name SHARED_TOPIC + " receive"
           kind CONSUMER
@@ -242,6 +237,22 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
             "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "receive"
+          }
+        }
+        span(1) {
+          name SHARED_TOPIC + " process"
+          kind CONSUMER
+          childOf span(0)
+          hasLink producerSpan
+          attributes {
+            "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
+            "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
+            "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
+            "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
+            "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
+            "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
+            "kafka.offset" 0
+            "kafka.record.queue_time_ms" { it >= 0 }
           }
         }
       }
@@ -299,8 +310,9 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
     assertTraces(2) {
       traces.sort(orderByRootSpanKind(PRODUCER, CONSUMER))
 
-      trace(0, 2) {
-        // PRODUCER span 0
+      SpanData producerSpan
+
+      trace(0, 1) {
         span(0) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
@@ -312,11 +324,26 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_KAFKA_TOMBSTONE.key}" true
           }
         }
-        // CONSUMER span 0
+
+        producerSpan = span(0)
+      }
+      trace(1, 2) {
+        span(0) {
+          name SHARED_TOPIC + " receive"
+          kind CONSUMER
+          hasNoParent()
+          attributes {
+            "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
+            "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
+            "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
+            "${SemanticAttributes.MESSAGING_OPERATION.key}" "receive"
+          }
+        }
         span(1) {
           name SHARED_TOPIC + " process"
           kind CONSUMER
           childOf span(0)
+          hasLink producerSpan
           attributes {
             "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
             "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
@@ -327,19 +354,6 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_KAFKA_TOMBSTONE.key}" true
             "kafka.offset" 0
             "kafka.record.queue_time_ms" { it >= 0 }
-          }
-        }
-      }
-      trace(1, 1) {
-        span(0) {
-          name SHARED_TOPIC + " receive"
-          kind CONSUMER
-          hasNoParent()
-          attributes {
-            "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
-            "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
-            "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
-            "${SemanticAttributes.MESSAGING_OPERATION.key}" "receive"
           }
         }
       }
@@ -388,7 +402,9 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
     assertTraces(2) {
       traces.sort(orderByRootSpanKind(PRODUCER, CONSUMER))
 
-      trace(0, 2) {
+      SpanData producerSpan
+
+      trace(0, 1) {
         span(0) {
           name SHARED_TOPIC + " send"
           kind PRODUCER
@@ -400,23 +416,10 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
           }
         }
-        span(1) {
-          name SHARED_TOPIC + " process"
-          kind CONSUMER
-          childOf span(0)
-          attributes {
-            "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
-            "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
-            "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
-            "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
-            "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
-            "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
-            "kafka.offset" 0
-            "kafka.record.queue_time_ms" { it >= 0 }
-          }
-        }
+
+        producerSpan = span(0)
       }
-      trace(1, 1) {
+      trace(1, 2) {
         span(0) {
           name SHARED_TOPIC + " receive"
           kind CONSUMER
@@ -426,6 +429,22 @@ class KafkaClientPropagationEnabledTest extends KafkaClientBaseTest {
             "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
             "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "receive"
+          }
+        }
+        span(1) {
+          name SHARED_TOPIC + " process"
+          kind CONSUMER
+          childOf span(0)
+          hasLink producerSpan
+          attributes {
+            "${SemanticAttributes.MESSAGING_SYSTEM.key}" "kafka"
+            "${SemanticAttributes.MESSAGING_DESTINATION.key}" SHARED_TOPIC
+            "${SemanticAttributes.MESSAGING_DESTINATION_KIND.key}" "topic"
+            "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
+            "${SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES.key}" Long
+            "${SemanticAttributes.MESSAGING_KAFKA_PARTITION.key}" { it >= 0 }
+            "kafka.offset" 0
+            "kafka.record.queue_time_ms" { it >= 0 }
           }
         }
       }

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/KafkaBatchProcessSpanLinksExtractor.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/KafkaBatchProcessSpanLinksExtractor.java
@@ -33,8 +33,6 @@ public class KafkaBatchProcessSpanLinksExtractor
 
     // this will forcefully suppress the kafka-clients CONSUMER instrumentation even though there's
     // no current CONSUMER span
-    // this instrumentation will create CONSUMER receive spans for each record instead of
-    // kafka-clients
     if (it instanceof KafkaConsumerIteratorWrapper) {
       it = ((KafkaConsumerIteratorWrapper<?, ?>) it).unwrap();
     }

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/groovy/SpringKafkaInstrumentationTest.groovy
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/groovy/SpringKafkaInstrumentationTest.groovy
@@ -69,7 +69,7 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    assertTraces(3) {
+    assertTraces(2) {
       traces.sort(orderByRootSpanName("producer", "testTopic receive", "testTopic process"))
 
       SpanData producer1, producer2
@@ -102,7 +102,7 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
         producer1 = span(1)
         producer2 = span(2)
       }
-      trace(1, 1) {
+      trace(1, 3) {
         span(0) {
           name "testTopic receive"
           kind CONSUMER
@@ -114,11 +114,10 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "receive"
           }
         }
-      }
-      trace(2, 2) {
-        span(0) {
+        span(1) {
           name "testTopic process"
           kind CONSUMER
+          childOf span(0)
           hasLink producer1
           hasLink producer2
           attributes {
@@ -128,9 +127,9 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
           }
         }
-        span(1) {
+        span(2) {
           name "consumer"
-          childOf span(0)
+          childOf span(1)
         }
       }
     }
@@ -148,8 +147,8 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    assertTraces(3) {
-      traces.sort(orderByRootSpanName("producer", "testTopic receive", "testTopic process"))
+    assertTraces(2) {
+      traces.sort(orderByRootSpanName("producer", "testTopic receive"))
 
       SpanData producer
 
@@ -170,7 +169,7 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
 
         producer = span(1)
       }
-      trace(1, 1) {
+      trace(1, 3) {
         span(0) {
           name "testTopic receive"
           kind CONSUMER
@@ -182,11 +181,10 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "receive"
           }
         }
-      }
-      trace(2, 2) {
-        span(0) {
+        span(1) {
           name "testTopic process"
           kind CONSUMER
+          childOf span(0)
           hasLink producer
           status ERROR
           errorEvent IllegalArgumentException, "boom"
@@ -197,9 +195,9 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
             "${SemanticAttributes.MESSAGING_OPERATION.key}" "process"
           }
         }
-        span(1) {
+        span(2) {
           name "consumer"
-          childOf span(0)
+          childOf span(1)
         }
       }
     }


### PR DESCRIPTION
… instrumentations. `kafka-clients` and `spring-kafka` to be more precise -- `kafka-streams` needs to be converted to Instrumenter API first (another PR). Now `kafka-clients` and `spring-kafka` implement the batch receive (and process) conventions correctly. 