### PR TITLE
Remove unneeded catch blocks

### DIFF
--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
@@ -147,9 +147,6 @@ final class TracingClientInterceptor implements ClientInterceptor {
         span.addEvent("message", attributes);
         try (Scope ignored = context.makeCurrent()) {
           delegate().onMessage(message);
-        } catch (Throwable e) {
-          instrumenter.end(context, request, null, e);
-          throw e;
         }
       }
 
@@ -165,9 +162,6 @@ final class TracingClientInterceptor implements ClientInterceptor {
       public void onReady() {
         try (Scope ignored = context.makeCurrent()) {
           delegate().onReady();
-        } catch (Throwable e) {
-          instrumenter.end(context, request, null, e);
-          throw e;
         }
       }
     }

--- a/instrumentation/grpc-1.6/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.groovy
+++ b/instrumentation/grpc-1.6/testing/src/main/groovy/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.groovy
@@ -870,6 +870,7 @@ abstract class AbstractGrpcTest extends InstrumentationSpecification {
             "${SemanticAttributes.RPC_SERVICE.key}" "example.Greeter"
             "${SemanticAttributes.RPC_METHOD.key}" "SayHello"
             "${SemanticAttributes.NET_TRANSPORT.key}" SemanticAttributes.NetTransportValues.IP_TCP
+            "${SemanticAttributes.RPC_GRPC_STATUS_CODE.key}" Status.CANCELLED.code.value()
           }
         }
         span(2) {


### PR DESCRIPTION
I tested this by throwing an exception inside of the try block, and it still called `onClose` (and so ended the span twice).