### PR TITLE
Fix smoke test play build

### DIFF
--- a/smoke-tests/play/build.gradle
+++ b/smoke-tests/play/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "org.gradle.playframework" version "0.9"
+  id "org.gradle.playframework" version "0.12"
   id 'com.google.cloud.tools.jib' version '2.5.0'
 }
 


### PR DESCRIPTION
This failed on the CI build after #4107 but we didn't notice.

I'll open an issue to track adding (a non-publishing) PR workflow to verify this.

And maybe auto-open a github issue when the smoke test image publishing builds fail, since we don't (and probably don't want to) run them nightly.