### PR TITLE
Remove references to bintray from spring doc

### DIFF
--- a/instrumentation/spring/README.md
+++ b/instrumentation/spring/README.md
@@ -24,7 +24,6 @@ Add the dependencies below to enable OpenTelemetry in `MainService` and `TimeSer
 
 Replace `OPENTELEMETRY_VERSION` with the latest stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
  - Minimum version: `1.1.0`
- - Note: You may need to include our bintray maven repository to your build file: `https://dl.bintray.com/open-telemetry/maven/`. As of August 2020 the latest opentelemetry-java-instrumentation artifacts are not published to maven-central. Please check the [releasing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/RELEASING.md) doc for updates to this process.
  
 ### Maven
 
@@ -599,7 +598,6 @@ Add the following dependencies to your build file.
 
 Replace `OPENTELEMETRY_VERSION` with the latest stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
  - Minimum version: `1.1.0`
- - Note: You may need to include our bintray maven repository to your build file: `https://dl.bintray.com/open-telemetry/maven/`. As of August 2020 the latest opentelemetry-java-instrumentation artifacts are not published to maven-central. Please check the [releasing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/RELEASING.md) doc for updates to this process.
 
 #### Maven
 ```xml

--- a/instrumentation/spring/spring-boot-autoconfigure/README.md
+++ b/instrumentation/spring/spring-boot-autoconfigure/README.md
@@ -8,7 +8,6 @@ Auto-configures OpenTelemetry instrumentation for [spring-web](../spring-web-3.1
 
 Replace `OPENTELEMETRY_VERSION` with the latest stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
  - Minimum version: `0.17.0`
- - Note: You may need to include our bintray maven repository to your build file: `https://dl.bintray.com/open-telemetry/maven/`. As of August 2020 the latest opentelemetry-java-instrumentation artifacts are not published to maven-central. Please check the [releasing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/RELEASING.md) doc for updates to this process.
 
 
 For Maven add to your `pom.xml`:

--- a/instrumentation/spring/starters/jaeger-exporter-starter/README.md
+++ b/instrumentation/spring/starters/jaeger-exporter-starter/README.md
@@ -8,7 +8,6 @@ OpenTelemetry Jaeger Exporter Starter is a starter package that includes the ope
 
 Replace `OPENTELEMETRY_VERSION` with the latest stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
  - Minimum version: `1.1.0`
- - Note: You may need to include our bintray maven repository to your build file: `https://dl.bintray.com/open-telemetry/maven/`. As of August 2020 the latest opentelemetry-java-instrumentation artifacts are not published to maven-central. Please check the [releasing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/RELEASING.md) doc for updates to this process.
 
 
 #### Maven

--- a/instrumentation/spring/starters/otlp-exporter-starter/README.md
+++ b/instrumentation/spring/starters/otlp-exporter-starter/README.md
@@ -8,7 +8,6 @@ OpenTelemetry OTLP Exporter Starter is a starter package that includes the opent
 
 Replace `OPENTELEMETRY_VERSION` with the latest stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
  - Minimum version: `1.1.0`
- - Note: You may need to include our bintray maven repository to your build file: `https://dl.bintray.com/open-telemetry/maven/`. As of August 2020 the latest opentelemetry-java-instrumentation artifacts are not published to maven-central. Please check the [releasing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/RELEASING.md) doc for updates to this process.
 
 
 #### Maven

--- a/instrumentation/spring/starters/spring-starter/README.md
+++ b/instrumentation/spring/starters/spring-starter/README.md
@@ -10,7 +10,6 @@ This version is compatible with Spring Boot 2.0.
 
 Replace `OPENTELEMETRY_VERSION` with the latest stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
  - Minimum version: `1.1.0`
- - Note: You may need to include our bintray maven repository to your build file: `https://dl.bintray.com/open-telemetry/maven/`. As of August 2020 the latest opentelemetry-java-instrumentation artifacts are not published to maven-central. Please check the [releasing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/RELEASING.md) doc for updates to this process.
 
 
 ### Maven

--- a/instrumentation/spring/starters/zipkin-exporter-starter/README.md
+++ b/instrumentation/spring/starters/zipkin-exporter-starter/README.md
@@ -10,7 +10,6 @@ OpenTelemetry Zipkin Exporter Starter is a starter package that includes the ope
 
 Replace `OPENTELEMETRY_VERSION` with the latest stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
  - Minimum version: `1.1.0`
- - Note: You may need to include our bintray maven repository to your build file: `https://dl.bintray.com/open-telemetry/maven/`. As of August 2020 the latest opentelemetry-java-instrumentation artifacts are not published to maven-central. Please check the [releasing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/RELEASING.md) doc for updates to this process.
 
 
 #### Maven


### PR DESCRIPTION
We are publishing these to central so bintray is not relevant any more.