### PR TITLE
Remove incorrect lettuce-4.0 db.statement attribute

### DIFF
--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceDbAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceDbAttributesExtractor.java
@@ -37,7 +37,7 @@ final class LettuceDbAttributesExtractor
 
   @Override
   protected String statement(RedisCommand<?, ?, ?> request) {
-    return request.getType().name();
+    return null;
   }
 
   @Override

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -169,7 +169,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "SET"
-            "${SemanticAttributes.DB_STATEMENT.key}" "SET"
           }
         }
       }
@@ -212,7 +211,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "GET"
-            "${SemanticAttributes.DB_STATEMENT.key}" "GET"
           }
         }
         span(2) {
@@ -276,7 +274,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "GET"
-            "${SemanticAttributes.DB_STATEMENT.key}" "GET"
           }
         }
         span(2) {
@@ -329,7 +326,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "RANDOMKEY"
-            "${SemanticAttributes.DB_STATEMENT.key}" "RANDOMKEY"
           }
         }
         span(2) {
@@ -386,7 +382,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "HMSET"
-            "${SemanticAttributes.DB_STATEMENT.key}" "HMSET"
           }
         }
       }
@@ -397,7 +392,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "HGETALL"
-            "${SemanticAttributes.DB_STATEMENT.key}" "HGETALL"
           }
         }
       }
@@ -440,7 +434,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "DEL"
-            "${SemanticAttributes.DB_STATEMENT.key}" "DEL"
           }
         }
       }
@@ -485,7 +478,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "SADD"
-            "${SemanticAttributes.DB_STATEMENT.key}" "SADD"
             "lettuce.command.cancelled" true
           }
         }
@@ -511,7 +503,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "DEBUG"
-            "${SemanticAttributes.DB_STATEMENT.key}" "DEBUG"
           }
         }
       }
@@ -532,7 +523,6 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "SHUTDOWN"
-            "${SemanticAttributes.DB_STATEMENT.key}" "SHUTDOWN"
           }
         }
       }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceSyncClientTest.groovy
@@ -149,7 +149,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "SET"
-            "${SemanticAttributes.DB_STATEMENT.key}" "SET"
           }
         }
       }
@@ -170,7 +169,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "GET"
-            "${SemanticAttributes.DB_STATEMENT.key}" "GET"
           }
         }
       }
@@ -191,7 +189,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "GET"
-            "${SemanticAttributes.DB_STATEMENT.key}" "GET"
           }
         }
       }
@@ -212,7 +209,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "RANDOMKEY"
-            "${SemanticAttributes.DB_STATEMENT.key}" "RANDOMKEY"
           }
         }
       }
@@ -233,7 +229,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "LPUSH"
-            "${SemanticAttributes.DB_STATEMENT.key}" "LPUSH"
           }
         }
       }
@@ -254,7 +249,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "HMSET"
-            "${SemanticAttributes.DB_STATEMENT.key}" "HMSET"
           }
         }
       }
@@ -275,7 +269,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "HGETALL"
-            "${SemanticAttributes.DB_STATEMENT.key}" "HGETALL"
           }
         }
       }
@@ -295,7 +288,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "DEBUG"
-            "${SemanticAttributes.DB_STATEMENT.key}" "DEBUG"
           }
         }
       }
@@ -315,7 +307,6 @@ class LettuceSyncClientTest extends AgentInstrumentationSpecification {
           attributes {
             "${SemanticAttributes.DB_SYSTEM.key}" "redis"
             "${SemanticAttributes.DB_OPERATION.key}" "SHUTDOWN"
-            "${SemanticAttributes.DB_STATEMENT.key}" "SHUTDOWN"
           }
         }
       }


### PR DESCRIPTION
following #4152, and removing `db.statement` since it's not really capturing `db.statement`

(note: lettuce-5.0 and lettuce-5.1 do capture `db.statement` correctly, I looked and it wasn't straight forward to port that back to lettuce-4.0)