### PR TITLE
Improve reactor test

### DIFF
--- a/instrumentation/reactor-3.1/testing/src/main/groovy/io/opentelemetry/instrumentation/reactor/AbstractSubscriptionTest.groovy
+++ b/instrumentation/reactor-3.1/testing/src/main/groovy/io/opentelemetry/instrumentation/reactor/AbstractSubscriptionTest.groovy
@@ -10,21 +10,24 @@ import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import reactor.core.publisher.Mono
 
+import java.time.Duration
 import java.util.concurrent.CountDownLatch
 
 abstract class AbstractSubscriptionTest extends InstrumentationSpecification {
 
   def "subscription test"() {
     when:
+    Mono<Connection> connection = Mono.create {
+      it.success(new Connection())
+    }
     CountDownLatch latch = new CountDownLatch(1)
     runWithSpan("parent") {
-      Mono<Connection> connection = Mono.create {
-        it.success(new Connection())
-      }
-      connection.subscribe {
-        it.query()
-        latch.countDown()
-      }
+      connection
+        .delayElement(Duration.ofMillis(1))
+        .subscribe {
+          it.query()
+          latch.countDown()
+        }
     }
     latch.await()
 
@@ -43,7 +46,6 @@ abstract class AbstractSubscriptionTest extends InstrumentationSpecification {
         }
       }
     }
-
   }
 
   static class Connection {


### PR DESCRIPTION
Javaagent tests still pass even with the instrumentation commented out (#2777, probably because of executor instrumentation), but this "fixes" the library instrumentation test so that it fails with the library instrumentation commented out.