### PR TITLE
Use the latest collector (from new repo) in smoke test images.

### DIFF
--- a/smoke-tests/fake-backend/build.gradle
+++ b/smoke-tests/fake-backend/build.gradle
@@ -64,18 +64,33 @@ task windowsBackendImageBuild(type: DockerBuildImage) {
 
 def collectorDockerBuildDir = new File(project.buildDir, "docker-collector")
 
-task windowsCollectorBinaryDownload(type: Download) {
-  doFirst {
-    collectorDockerBuildDir.mkdirs()
-  }
+task windowsCollectorBinaryDownload(){
 
-  // TODO (trask) update this to point to new opentelemetry-collector-releases repo
-  //   this involves making two further changes:
-  //     * all the artifacts in the new repo now have version in their name (so no single url for "latest")
-  //     * the artifacts are now tar.gz format, so need to extract the exe
-  //   note: version is hardcoded below because that is last version in the collector repo that has the releases attached
-  src("https://github.com/open-telemetry/opentelemetry-collector/releases/download/v0.33.0/otelcol_windows_amd64.exe")
-  dest(collectorDockerBuildDir)
+  def latestDownloadUrl = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/latest/download"
+  def conn = new URL(latestDownloadUrl).openConnection()
+  conn.followRedirects = false
+  def latestVersion = conn.headerFields["Location"][0].replaceFirst(/^.*\/v/, '')
+  def versionedTarFile = new File("${collectorDockerBuildDir}/otelcol_${latestVersion}_windows_amd64.tar.gz")
+
+  outputs.files(versionedTarFile, "${collectorDockerBuildDir}/otelcol_windows_amd64.exe")
+
+  doLast {
+    collectorDockerBuildDir.mkdirs()
+    println("Latest version is: ${latestVersion}")
+    def latestUrlTgz = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${latestVersion}/otelcol_${latestVersion}_windows_amd64.tar.gz"
+    println("Full URL: ${latestUrlTgz}")
+    if(versionedTarFile.exists()){
+      println("File already exists, skipping download")
+    }
+    else {
+      conn = new URL( latestUrlTgz ).openConnection()
+      conn.followRedirects = false
+      def actualUrl = conn.headerFields["Location"][0]
+      versionedTarFile << new URL(actualUrl).openConnection().content
+      "tar -xvzf ${versionedTarFile} otelcol.exe".execute()
+      "mv otelcol.exe ${collectorDockerBuildDir}/otelcol_windows_amd64.exe".execute()
+    }
+  }
 }
 
 task windowsCollectorImagePrepare(type: Copy) {

--- a/smoke-tests/fake-backend/build.gradle
+++ b/smoke-tests/fake-backend/build.gradle
@@ -64,28 +64,30 @@ task windowsBackendImageBuild(type: DockerBuildImage) {
 
 def collectorDockerBuildDir = new File(project.buildDir, "docker-collector")
 
+// Returns the location header from a url that we know redirects (in advance)
+def getRedirect(url){
+  def conn = new URL(url).openConnection()
+  conn.followRedirects = false
+  return conn.headerFields["Location"][0]
+}
+
 task windowsCollectorBinaryDownload(){
 
   def latestDownloadUrl = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/latest/download"
-  def conn = new URL(latestDownloadUrl).openConnection()
-  conn.followRedirects = false
-  def latestVersion = conn.headerFields["Location"][0].replaceFirst(/^.*\/v/, '')
+  def latestVersion = getRedirect(latestDownloadUrl).replaceFirst(/^.*\/v/, '')
   def versionedTarFile = new File("${collectorDockerBuildDir}/otelcol_${latestVersion}_windows_amd64.tar.gz")
-
   outputs.files(versionedTarFile, "${collectorDockerBuildDir}/otelcol_windows_amd64.exe")
 
   doLast {
     collectorDockerBuildDir.mkdirs()
-    println("Latest version is: ${latestVersion}")
+    println("Latest collector version is: ${latestVersion}")
     def latestUrlTgz = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${latestVersion}/otelcol_${latestVersion}_windows_amd64.tar.gz"
     println("Full URL: ${latestUrlTgz}")
     if(versionedTarFile.exists()){
       println("File already exists, skipping download")
     }
     else {
-      conn = new URL( latestUrlTgz ).openConnection()
-      conn.followRedirects = false
-      def actualUrl = conn.headerFields["Location"][0]
+      def actualUrl = getRedirect(latestUrlTgz)
       versionedTarFile << new URL(actualUrl).openConnection().content
       "tar -xvzf ${versionedTarFile} otelcol.exe".execute()
       "mv otelcol.exe ${collectorDockerBuildDir}/otelcol_windows_amd64.exe".execute()


### PR DESCRIPTION
Maybe a pretty inelegant way of tackling #4136.

It's leveraging the github `latest` redirect URLs for finding the latest version number, and then using that in url building (which breaks my RESTful sensibilities...but might be ok).

I'm not a gradle expert, but this seems to get the right files in the right places for the rest to continue.