### PR TITLE
Prepare gradle-plugins for 0.8.0 release

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.opentelemetry.instrumentation"
-version = "0.8.0-SNAPSHOT"
+version = "0.8.0"
 
 repositories {
   mavenCentral()
@@ -22,9 +22,9 @@ dependencies {
   implementation("com.google.guava:guava:30.1.1-jre")
   implementation("net.bytebuddy:byte-buddy-gradle-plugin:1.11.2")
 
-  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:1.6.0-alpha-SNAPSHOT")
-  implementation("io.opentelemetry.javaagent:opentelemetry-muzzle:1.6.0-alpha-SNAPSHOT")
-  implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:1.6.0-alpha-SNAPSHOT")
+  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:1.6.0-alpha")
+  implementation("io.opentelemetry.javaagent:opentelemetry-muzzle:1.6.0-alpha")
+  implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:1.6.0-alpha")
 
   implementation("org.eclipse.aether:aether-connector-basic:1.1.0")
   implementation("org.eclipse.aether:aether-transport-http:1.1.0")
@@ -37,7 +37,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-instrumentation-api:1.6.0-alpha-SNAPSHOT")
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-instrumentation-api:1.6.0-alpha")
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
I just realized that we haven't updated versions in & released the gradle-plugins project... (and I wanted to change something in the current `muzzle` module)
The sooner we include this project into the "standard" repo lifecycle the better 😂 