### PR TITLE
Separate HTTP client/server AttributesExtractors

### DIFF
--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/InstrumenterBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/InstrumenterBenchmark.java
@@ -8,7 +8,7 @@ package io.opentelemetry.benchmark;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -54,8 +54,8 @@ public class InstrumenterBenchmark {
     return context;
   }
 
-  static class ConstantHttpAttributesExtractor extends HttpAttributesExtractor<Void, Void> {
-    static final HttpAttributesExtractor<Void, Void> INSTANCE =
+  static class ConstantHttpAttributesExtractor extends HttpClientAttributesExtractor<Void, Void> {
+    static final HttpClientAttributesExtractor<Void, Void> INSTANCE =
         new ConstantHttpAttributesExtractor();
 
     @Override
@@ -76,11 +76,6 @@ public class InstrumenterBenchmark {
     @Override
     protected @Nullable String host(Void unused) {
       return "opentelemetry.io";
-    }
-
-    @Override
-    protected @Nullable String route(Void unused) {
-      return "/benchmark";
     }
 
     @Override
@@ -106,11 +101,6 @@ public class InstrumenterBenchmark {
     @Override
     protected @Nullable String flavor(Void unused, @Nullable Void unused2) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
-    }
-
-    @Override
-    protected @Nullable String serverName(Void unused, @Nullable Void unused2) {
-      return null;
     }
 
     @Override

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/AttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/AttributesExtractor.java
@@ -8,7 +8,7 @@ package io.opentelemetry.instrumentation.api.instrumenter;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetAttributesExtractor;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -21,7 +21,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * #onStart(AttributesBuilder, Object)} to have it available during sampling.
  *
  * @see DbAttributesExtractor
- * @see HttpAttributesExtractor
+ * @see HttpClientAttributesExtractor
  * @see NetAttributesExtractor
  */
 public abstract class AttributesExtractor<REQUEST, RESPONSE> {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
@@ -18,7 +18,7 @@ import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.rpc.RpcAttributesExtractor;
 import java.util.ArrayList;
@@ -161,9 +161,9 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
    *
    * <ul>
    *   <li>CLIENT nested spans are suppressed depending on their type: {@linkplain
-   *       HttpAttributesExtractor HTTP}, {@linkplain RpcAttributesExtractor RPC} or {@linkplain
-   *       DbAttributesExtractor database} clients. If a span with the same type is present in the
-   *       parent context object, new span of the same type will not be started.
+   *       HttpClientAttributesExtractor HTTP}, {@linkplain RpcAttributesExtractor RPC} or
+   *       {@linkplain DbAttributesExtractor database} clients. If a span with the same type is
+   *       present in the parent context object, new span of the same type will not be started.
    * </ul>
    *
    * <p><strong>When disabled:</strong>

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/ServerInstrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/ServerInstrumenter.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapGetter;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.ContextPropagationDebug;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -36,11 +36,11 @@ final class ServerInstrumenter<REQUEST, RESPONSE> extends Instrumenter<REQUEST, 
 
   private static <REQUEST, RESPONSE> InstrumenterBuilder<REQUEST, RESPONSE> addClientIpExtractor(
       InstrumenterBuilder<REQUEST, RESPONSE> builder, TextMapGetter<REQUEST> getter) {
-    HttpAttributesExtractor<REQUEST, RESPONSE> httpAttributesExtractor = null;
+    HttpServerAttributesExtractor<REQUEST, RESPONSE> httpAttributesExtractor = null;
     for (AttributesExtractor<? super REQUEST, ? super RESPONSE> extractor :
         builder.attributesExtractors) {
-      if (extractor instanceof HttpAttributesExtractor) {
-        httpAttributesExtractor = (HttpAttributesExtractor<REQUEST, RESPONSE>) extractor;
+      if (extractor instanceof HttpServerAttributesExtractor) {
+        httpAttributesExtractor = (HttpServerAttributesExtractor<REQUEST, RESPONSE>) extractor;
       }
     }
     if (httpAttributesExtractor == null) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanKeyExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanKeyExtractor.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.instrumentation.api.instrumenter;
 
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.rpc.RpcAttributesExtractor;
 import java.util.HashSet;
@@ -23,7 +23,7 @@ final class SpanKeyExtractor {
       List<? extends AttributesExtractor<?, ?>> attributesExtractors) {
     Set<SpanKey> spanKeys = new HashSet<>();
     for (AttributesExtractor<?, ?> attributeExtractor : attributesExtractors) {
-      if (attributeExtractor instanceof HttpAttributesExtractor) {
+      if (attributeExtractor instanceof HttpClientAttributesExtractor) {
         spanKeys.add(SpanKey.HTTP_CLIENT);
       } else if (attributeExtractor instanceof RpcAttributesExtractor) {
         spanKeys.add(SpanKey.RPC_CLIENT);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.http;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Extractor of <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-client">HTTP
+ * client attributes</a>. Instrumentation of HTTP client frameworks should extend this class,
+ * defining {@link REQUEST} and {@link RESPONSE} with the actual request / response types of the
+ * instrumented library. If an attribute is not available in this library, it is appropriate to
+ * return {@code null} from the protected attribute methods, but implement as many as possible for
+ * best compliance with the OpenTelemetry specification.
+ */
+public abstract class HttpClientAttributesExtractor<REQUEST, RESPONSE>
+    extends HttpCommonAttributesExtractor<REQUEST, RESPONSE> {
+
+  @Override
+  protected final void onStart(AttributesBuilder attributes, REQUEST request) {
+    super.onStart(attributes, request);
+    set(attributes, SemanticAttributes.HTTP_URL, url(request));
+
+    // TODO: these are specific to servers, should we remove those?
+    set(attributes, SemanticAttributes.HTTP_TARGET, target(request));
+    set(attributes, SemanticAttributes.HTTP_HOST, host(request));
+    set(attributes, SemanticAttributes.HTTP_SCHEME, scheme(request));
+  }
+
+  @Override
+  protected final void onEnd(
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
+    super.onEnd(attributes, request, response, error);
+  }
+
+  // Attributes that always exist in a request
+
+  @Nullable
+  protected abstract String url(REQUEST request);
+
+  // TODO: this is specific to servers, should we remove this?
+  @Nullable
+  protected abstract String target(REQUEST request);
+
+  // TODO: this is specific to servers, should we remove this?
+  @Nullable
+  protected abstract String host(REQUEST request);
+
+  // TODO: this is specific to servers, should we remove this?
+  @Nullable
+  protected abstract String scheme(REQUEST request);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
@@ -14,33 +14,28 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Extractor of <a
- * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md">HTTP
- * attributes</a>. Instrumentation of HTTP server or client frameworks should extend this class,
- * defining {@link REQUEST} and {@link RESPONSE} with the actual request / response types of the
- * instrumented library. If an attribute is not available in this library, it is appropriate to
- * return {@code null} from the protected attribute methods, but implement as many as possible for
- * best compliance with the OpenTelemetry specification.
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes">HTTP
+ * attributes</a> that are common to client and server instrumentations.
  */
-public abstract class HttpAttributesExtractor<REQUEST, RESPONSE>
+public abstract class HttpCommonAttributesExtractor<REQUEST, RESPONSE>
     extends AttributesExtractor<REQUEST, RESPONSE> {
 
+  // directly extending this class should not be possible outside of this package
+  HttpCommonAttributesExtractor() {}
+
   @Override
-  protected final void onStart(AttributesBuilder attributes, REQUEST request) {
+  protected void onStart(AttributesBuilder attributes, REQUEST request) {
     set(attributes, SemanticAttributes.HTTP_METHOD, method(request));
-    set(attributes, SemanticAttributes.HTTP_URL, url(request));
-    set(attributes, SemanticAttributes.HTTP_TARGET, target(request));
-    set(attributes, SemanticAttributes.HTTP_HOST, host(request));
-    set(attributes, SemanticAttributes.HTTP_ROUTE, route(request));
-    set(attributes, SemanticAttributes.HTTP_SCHEME, scheme(request));
     set(attributes, SemanticAttributes.HTTP_USER_AGENT, userAgent(request));
   }
 
   @Override
-  protected final void onEnd(
+  protected void onEnd(
       AttributesBuilder attributes,
       REQUEST request,
       @Nullable RESPONSE response,
       @Nullable Throwable error) {
+
     set(
         attributes,
         SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH,
@@ -50,7 +45,6 @@ public abstract class HttpAttributesExtractor<REQUEST, RESPONSE>
         SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
         requestContentLengthUncompressed(request, response));
     set(attributes, SemanticAttributes.HTTP_FLAVOR, flavor(request, response));
-    set(attributes, SemanticAttributes.HTTP_SERVER_NAME, serverName(request, response));
     if (response != null) {
       Integer statusCode = statusCode(request, response);
       if (statusCode != null) {
@@ -71,21 +65,6 @@ public abstract class HttpAttributesExtractor<REQUEST, RESPONSE>
 
   @Nullable
   protected abstract String method(REQUEST request);
-
-  @Nullable
-  protected abstract String url(REQUEST request);
-
-  @Nullable
-  protected abstract String target(REQUEST request);
-
-  @Nullable
-  protected abstract String host(REQUEST request);
-
-  @Nullable
-  protected abstract String route(REQUEST request);
-
-  @Nullable
-  protected abstract String scheme(REQUEST request);
 
   @Nullable
   protected abstract String userAgent(REQUEST request);
@@ -119,15 +98,6 @@ public abstract class HttpAttributesExtractor<REQUEST, RESPONSE>
    */
   @Nullable
   protected abstract String flavor(REQUEST request, @Nullable RESPONSE response);
-
-  /**
-   * Extracts the {@code http.server_name} span attribute.
-   *
-   * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, whether
-   * {@code response} is {@code null} or not.
-   */
-  @Nullable
-  protected abstract String serverName(REQUEST request, @Nullable RESPONSE response);
 
   /**
    * Extracts the {@code http.status_code} span attribute.

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.http;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Extractor of <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server">HTTP
+ * server attributes</a>. Instrumentation of HTTP server frameworks should extend this class,
+ * defining {@link REQUEST} and {@link RESPONSE} with the actual request / response types of the
+ * instrumented library. If an attribute is not available in this library, it is appropriate to
+ * return {@code null} from the protected attribute methods, but implement as many as possible for
+ * best compliance with the OpenTelemetry specification.
+ */
+public abstract class HttpServerAttributesExtractor<REQUEST, RESPONSE>
+    extends HttpCommonAttributesExtractor<REQUEST, RESPONSE> {
+
+  @Override
+  protected final void onStart(AttributesBuilder attributes, REQUEST request) {
+    super.onStart(attributes, request);
+
+    set(attributes, SemanticAttributes.HTTP_SCHEME, scheme(request));
+    set(attributes, SemanticAttributes.HTTP_HOST, host(request));
+    set(attributes, SemanticAttributes.HTTP_TARGET, target(request));
+    set(attributes, SemanticAttributes.HTTP_ROUTE, route(request));
+
+    // TODO: this is specific to clients, should we remove this?
+    set(attributes, SemanticAttributes.HTTP_URL, url(request));
+  }
+
+  @Override
+  protected final void onEnd(
+      AttributesBuilder attributes,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
+
+    super.onEnd(attributes, request, response, error);
+    set(attributes, SemanticAttributes.HTTP_SERVER_NAME, serverName(request, response));
+  }
+
+  // Attributes that always exist in a request
+
+  // TODO: this is specific to clients, should we remove this?
+  @Nullable
+  protected abstract String url(REQUEST request);
+
+  @Nullable
+  protected abstract String target(REQUEST request);
+
+  @Nullable
+  protected abstract String host(REQUEST request);
+
+  @Nullable
+  protected abstract String route(REQUEST request);
+
+  @Nullable
+  protected abstract String scheme(REQUEST request);
+
+  // Attributes which are not always available when the request is ready.
+
+  /**
+   * Extracts the {@code http.server_name} span attribute.
+   *
+   * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, whether
+   * {@code response} is {@code null} or not.
+   */
+  @Nullable
+  protected abstract String serverName(REQUEST request, @Nullable RESPONSE response);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanNameExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanNameExtractor.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Extractor of the <a
@@ -20,19 +21,19 @@ public final class HttpSpanNameExtractor<REQUEST> implements SpanNameExtractor<R
    * will be examined to determine the name of the span.
    */
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
-      HttpAttributesExtractor<REQUEST, ?> attributesExtractor) {
+      HttpCommonAttributesExtractor<REQUEST, ?> attributesExtractor) {
     return new HttpSpanNameExtractor<>(attributesExtractor);
   }
 
-  private final HttpAttributesExtractor<REQUEST, ?> attributesExtractor;
+  private final HttpCommonAttributesExtractor<REQUEST, ?> attributesExtractor;
 
-  private HttpSpanNameExtractor(HttpAttributesExtractor<REQUEST, ?> attributesExtractor) {
+  private HttpSpanNameExtractor(HttpCommonAttributesExtractor<REQUEST, ?> attributesExtractor) {
     this.attributesExtractor = attributesExtractor;
   }
 
   @Override
   public String extract(REQUEST request) {
-    String route = attributesExtractor.route(request);
+    String route = extractRoute(request);
     if (route != null) {
       return route;
     }
@@ -41,5 +42,13 @@ public final class HttpSpanNameExtractor<REQUEST> implements SpanNameExtractor<R
       return "HTTP " + method;
     }
     return "HTTP request";
+  }
+
+  @Nullable
+  private String extractRoute(REQUEST request) {
+    if (attributesExtractor instanceof HttpServerAttributesExtractor) {
+      return ((HttpServerAttributesExtractor<REQUEST, ?>) attributesExtractor).route(request);
+    }
+    return null;
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractor.java
@@ -25,13 +25,15 @@ public final class HttpSpanStatusExtractor<REQUEST, RESPONSE>
    * default status} otherwise.
    */
   public static <REQUEST, RESPONSE> SpanStatusExtractor<REQUEST, RESPONSE> create(
-      HttpAttributesExtractor<REQUEST, RESPONSE> attributesExtractor) {
+      HttpCommonAttributesExtractor<? super REQUEST, ? super RESPONSE> attributesExtractor) {
     return new HttpSpanStatusExtractor<>(attributesExtractor);
   }
 
-  private final HttpAttributesExtractor<REQUEST, RESPONSE> attributesExtractor;
+  private final HttpCommonAttributesExtractor<? super REQUEST, ? super RESPONSE>
+      attributesExtractor;
 
-  private HttpSpanStatusExtractor(HttpAttributesExtractor<REQUEST, RESPONSE> attributesExtractor) {
+  private HttpSpanStatusExtractor(
+      HttpCommonAttributesExtractor<? super REQUEST, ? super RESPONSE> attributesExtractor) {
     this.attributesExtractor = attributesExtractor;
   }
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -23,7 +23,8 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetAttributesExtractor;
@@ -142,7 +143,12 @@ class InstrumenterTest {
   @RegisterExtension
   static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
 
-  @Mock HttpAttributesExtractor<Map<String, String>, Map<String, String>> mockHttpAttributes;
+  @Mock
+  HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> mockHttpClientAttributes;
+
+  @Mock
+  HttpServerAttributesExtractor<Map<String, String>, Map<String, String>> mockHttpServerAttributes;
+
   @Mock DbAttributesExtractor<Map<String, String>, Map<String, String>> mockDbAttributes;
 
   @Mock
@@ -266,7 +272,7 @@ class InstrumenterTest {
         Instrumenter.<Map<String, String>, Map<String, String>>newBuilder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addAttributesExtractors(
-                mockHttpAttributes,
+                mockHttpServerAttributes,
                 mockNetAttributes,
                 new AttributesExtractor1(),
                 new AttributesExtractor2())
@@ -305,7 +311,7 @@ class InstrumenterTest {
         Instrumenter.<Map<String, String>, Map<String, String>>newBuilder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addAttributesExtractors(
-                mockHttpAttributes,
+                mockHttpServerAttributes,
                 mockNetAttributes,
                 new AttributesExtractor1(),
                 new AttributesExtractor2())
@@ -751,7 +757,7 @@ class InstrumenterTest {
     Instrumenter<Map<String, String>, Map<String, String>> instrumenterOuter =
         getInstrumenterWithType(false, mockDbAttributes);
     Instrumenter<Map<String, String>, Map<String, String>> instrumenterInner =
-        getInstrumenterWithType(false, mockHttpAttributes);
+        getInstrumenterWithType(false, mockHttpClientAttributes);
 
     Map<String, String> request = new HashMap<>(REQUEST);
 
@@ -780,7 +786,7 @@ class InstrumenterTest {
     Instrumenter<Map<String, String>, Map<String, String>> instrumenterOuter =
         getInstrumenterWithType(true, mockDbAttributes);
     Instrumenter<Map<String, String>, Map<String, String>> instrumenterInner =
-        getInstrumenterWithType(true, mockHttpAttributes);
+        getInstrumenterWithType(true, mockHttpClientAttributes);
 
     Map<String, String> request = new HashMap<>(REQUEST);
 
@@ -818,7 +824,7 @@ class InstrumenterTest {
   @Test
   void instrumentationTypeDetected_http() {
     Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
-        getInstrumenterWithType(true, mockHttpAttributes, new AttributesExtractor1());
+        getInstrumenterWithType(true, mockHttpClientAttributes, new AttributesExtractor1());
 
     Map<String, String> request = new HashMap<>(REQUEST);
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/SpanKeyExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/SpanKeyExtractorTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.rpc.RpcAttributesExtractor;
@@ -41,7 +41,7 @@ class SpanKeyExtractorTest {
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
       return Stream.of(
           Arguments.of(mock(DbAttributesExtractor.class), SpanKey.DB_CLIENT),
-          Arguments.of(mock(HttpAttributesExtractor.class), SpanKey.HTTP_CLIENT),
+          Arguments.of(mock(HttpClientAttributesExtractor.class), SpanKey.HTTP_CLIENT),
           Arguments.of(mock(RpcAttributesExtractor.class), SpanKey.RPC_CLIENT));
     }
   }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -15,10 +15,10 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class HttpAttributesExtractorTest {
+class HttpClientAttributesExtractorTest {
 
-  static class TestHttpAttributesExtractor
-      extends HttpAttributesExtractor<Map<String, String>, Map<String, String>> {
+  static class TestHttpClientAttributesExtractor
+      extends HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> {
 
     @Override
     protected String method(Map<String, String> request) {
@@ -38,11 +38,6 @@ class HttpAttributesExtractorTest {
     @Override
     protected String host(Map<String, String> request) {
       return request.get("host");
-    }
-
-    @Override
-    protected String route(Map<String, String> request) {
-      return request.get("route");
     }
 
     @Override
@@ -87,11 +82,6 @@ class HttpAttributesExtractorTest {
         Map<String, String> request, Map<String, String> response) {
       return Long.parseLong(response.get("responseContentLengthUncompressed"));
     }
-
-    @Override
-    protected String serverName(Map<String, String> request, Map<String, String> response) {
-      return request.get("serverName");
-    }
   }
 
   @Test
@@ -101,20 +91,18 @@ class HttpAttributesExtractorTest {
     request.put("url", "http://github.com");
     request.put("target", "github.com");
     request.put("host", "github.com:80");
-    request.put("route", "/repositories/{id}");
     request.put("scheme", "https");
     request.put("userAgent", "okhttp 3.x");
     request.put("requestContentLength", "10");
     request.put("requestContentLengthUncompressed", "11");
     request.put("flavor", "http/2");
-    request.put("serverName", "server");
 
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");
     response.put("responseContentLength", "20");
     response.put("responseContentLengthUncompressed", "21");
 
-    TestHttpAttributesExtractor extractor = new TestHttpAttributesExtractor();
+    TestHttpClientAttributesExtractor extractor = new TestHttpClientAttributesExtractor();
     AttributesBuilder attributes = Attributes.builder();
     extractor.onStart(attributes, request);
     assertThat(attributes.build())
@@ -123,7 +111,6 @@ class HttpAttributesExtractorTest {
             entry(SemanticAttributes.HTTP_URL, "http://github.com"),
             entry(SemanticAttributes.HTTP_TARGET, "github.com"),
             entry(SemanticAttributes.HTTP_HOST, "github.com:80"),
-            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
             entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"));
 
@@ -134,13 +121,11 @@ class HttpAttributesExtractorTest {
             entry(SemanticAttributes.HTTP_URL, "http://github.com"),
             entry(SemanticAttributes.HTTP_TARGET, "github.com"),
             entry(SemanticAttributes.HTTP_HOST, "github.com:80"),
-            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
             entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, 11L),
             entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
-            entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
             entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
             entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, 21L));

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.http;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class HttpServerAttributesExtractorTest {
+
+  static class TestHttpServerAttributesExtractor
+      extends HttpServerAttributesExtractor<Map<String, String>, Map<String, String>> {
+
+    @Override
+    protected String method(Map<String, String> request) {
+      return request.get("method");
+    }
+
+    @Override
+    protected String url(Map<String, String> request) {
+      return request.get("url");
+    }
+
+    @Override
+    protected String target(Map<String, String> request) {
+      return request.get("target");
+    }
+
+    @Override
+    protected String host(Map<String, String> request) {
+      return request.get("host");
+    }
+
+    @Override
+    protected String route(Map<String, String> request) {
+      return request.get("route");
+    }
+
+    @Override
+    protected String scheme(Map<String, String> request) {
+      return request.get("scheme");
+    }
+
+    @Override
+    protected String serverName(Map<String, String> request, Map<String, String> response) {
+      return request.get("serverName");
+    }
+
+    @Override
+    protected String userAgent(Map<String, String> request) {
+      return request.get("userAgent");
+    }
+
+    @Override
+    protected Long requestContentLength(Map<String, String> request, Map<String, String> response) {
+      return Long.parseLong(request.get("requestContentLength"));
+    }
+
+    @Override
+    protected Long requestContentLengthUncompressed(
+        Map<String, String> request, Map<String, String> response) {
+      return Long.parseLong(request.get("requestContentLengthUncompressed"));
+    }
+
+    @Override
+    protected Integer statusCode(Map<String, String> request, Map<String, String> response) {
+      return Integer.parseInt(response.get("statusCode"));
+    }
+
+    @Override
+    protected String flavor(Map<String, String> request, Map<String, String> response) {
+      return request.get("flavor");
+    }
+
+    @Override
+    protected Long responseContentLength(
+        Map<String, String> request, Map<String, String> response) {
+      return Long.parseLong(response.get("responseContentLength"));
+    }
+
+    @Override
+    protected Long responseContentLengthUncompressed(
+        Map<String, String> request, Map<String, String> response) {
+      return Long.parseLong(response.get("responseContentLengthUncompressed"));
+    }
+  }
+
+  @Test
+  void normal() {
+    Map<String, String> request = new HashMap<>();
+    request.put("method", "POST");
+    request.put("url", "http://github.com");
+    request.put("target", "github.com");
+    request.put("host", "github.com:80");
+    request.put("scheme", "https");
+    request.put("userAgent", "okhttp 3.x");
+    request.put("requestContentLength", "10");
+    request.put("requestContentLengthUncompressed", "11");
+    request.put("flavor", "http/2");
+    request.put("route", "/repositories/{id}");
+    request.put("serverName", "server");
+
+    Map<String, String> response = new HashMap<>();
+    response.put("statusCode", "202");
+    response.put("responseContentLength", "20");
+    response.put("responseContentLengthUncompressed", "21");
+
+    TestHttpServerAttributesExtractor extractor = new TestHttpServerAttributesExtractor();
+    AttributesBuilder attributes = Attributes.builder();
+    extractor.onStart(attributes, request);
+    assertThat(attributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.HTTP_METHOD, "POST"),
+            entry(SemanticAttributes.HTTP_URL, "http://github.com"),
+            entry(SemanticAttributes.HTTP_TARGET, "github.com"),
+            entry(SemanticAttributes.HTTP_HOST, "github.com:80"),
+            entry(SemanticAttributes.HTTP_SCHEME, "https"),
+            entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
+            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"));
+
+    extractor.onEnd(attributes, request, response, null);
+    assertThat(attributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.HTTP_METHOD, "POST"),
+            entry(SemanticAttributes.HTTP_URL, "http://github.com"),
+            entry(SemanticAttributes.HTTP_TARGET, "github.com"),
+            entry(SemanticAttributes.HTTP_HOST, "github.com:80"),
+            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
+            entry(SemanticAttributes.HTTP_SCHEME, "https"),
+            entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
+            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
+            entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
+            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
+            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, 11L),
+            entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
+            entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
+            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
+            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, 21L));
+  }
+}

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanNameExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanNameExtractorTest.java
@@ -22,26 +22,30 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class HttpSpanNameExtractorTest {
 
-  @Mock private HttpAttributesExtractor<Map<String, String>, Map<String, String>> extractor;
+  @Mock
+  private HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> clientExtractor;
+
+  @Mock
+  private HttpServerAttributesExtractor<Map<String, String>, Map<String, String>> serverExtractor;
 
   @Test
   void routeAndMethod() {
-    when(extractor.route(anyMap())).thenReturn("/cats/{id}");
-    when(extractor.method(anyMap())).thenReturn("GET");
-    assertThat(HttpSpanNameExtractor.create(extractor).extract(Collections.emptyMap()))
+    when(serverExtractor.route(anyMap())).thenReturn("/cats/{id}");
+    when(serverExtractor.method(anyMap())).thenReturn("GET");
+    assertThat(HttpSpanNameExtractor.create(serverExtractor).extract(Collections.emptyMap()))
         .isEqualTo("/cats/{id}");
   }
 
   @Test
   void method() {
-    when(extractor.method(anyMap())).thenReturn("GET");
-    assertThat(HttpSpanNameExtractor.create(extractor).extract(Collections.emptyMap()))
+    when(clientExtractor.method(anyMap())).thenReturn("GET");
+    assertThat(HttpSpanNameExtractor.create(clientExtractor).extract(Collections.emptyMap()))
         .isEqualTo("HTTP GET");
   }
 
   @Test
   void nothing() {
-    assertThat(HttpSpanNameExtractor.create(extractor).extract(Collections.emptyMap()))
+    assertThat(HttpSpanNameExtractor.create(clientExtractor).extract(Collections.emptyMap()))
         .isEqualTo("HTTP request");
   }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractorTest.java
@@ -22,7 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class HttpSpanStatusExtractorTest {
-  @Mock private HttpAttributesExtractor<Map<String, String>, Map<String, String>> extractor;
+  @Mock private HttpCommonAttributesExtractor<Map<String, String>, Map<String, String>> extractor;
 
   @ParameterizedTest
   @ValueSource(ints = {1, 100, 101, 200, 201, 300, 301, 400, 401, 500, 501, 600, 601})

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesExtractor.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ApacheHttpAsyncClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
+    extends HttpClientAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
   protected String method(ApacheHttpClientRequest request) {
@@ -83,18 +83,6 @@ final class ApacheHttpAsyncClientHttpAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(
       ApacheHttpClientRequest request, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String serverName(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String route(ApacheHttpClientRequest request) {
     return null;
   }
 }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientSingletons.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientSingletons.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -22,7 +22,7 @@ public final class ApacheHttpAsyncClientSingletons {
   private static final Instrumenter<ApacheHttpClientRequest, HttpResponse> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<ApacheHttpClientRequest, HttpResponse> httpAttributesExtractor =
+    HttpClientAttributesExtractor<ApacheHttpClientRequest, HttpResponse> httpAttributesExtractor =
         new ApacheHttpAsyncClientHttpAttributesExtractor();
     SpanNameExtractor<? super ApacheHttpClientRequest> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v2_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HostConfiguration;
@@ -15,7 +15,7 @@ import org.apache.commons.httpclient.StatusLine;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ApacheHttpClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<HttpMethod, HttpMethod> {
+    extends HttpClientAttributesExtractor<HttpMethod, HttpMethod> {
 
   @Override
   protected String method(HttpMethod request) {
@@ -101,18 +101,6 @@ final class ApacheHttpClientHttpAttributesExtractor
   @Override
   @Nullable
   protected Long responseContentLengthUncompressed(HttpMethod request, HttpMethod response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String serverName(HttpMethod request, @Nullable HttpMethod response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String route(HttpMethod request) {
     return null;
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientSingletons.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientSingletons.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -22,7 +22,7 @@ public final class ApacheHttpClientSingletons {
   private static final Instrumenter<HttpMethod, HttpMethod> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<HttpMethod, HttpMethod> httpAttributesExtractor =
+    HttpClientAttributesExtractor<HttpMethod, HttpMethod> httpAttributesExtractor =
         new ApacheHttpClientHttpAttributesExtractor();
     SpanNameExtractor<? super HttpMethod> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v4_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import org.apache.http.HttpResponse;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ApacheHttpClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
+    extends HttpClientAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
   protected String method(ApacheHttpClientRequest request) {
@@ -80,18 +80,6 @@ final class ApacheHttpClientHttpAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(
       ApacheHttpClientRequest request, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String serverName(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String route(ApacheHttpClientRequest request) {
     return null;
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientSingletons.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientSingletons.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -22,7 +22,7 @@ public final class ApacheHttpClientSingletons {
   private static final Instrumenter<ApacheHttpClientRequest, HttpResponse> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<ApacheHttpClientRequest, HttpResponse> httpAttributesExtractor =
+    HttpClientAttributesExtractor<ApacheHttpClientRequest, HttpResponse> httpAttributesExtractor =
         new ApacheHttpClientHttpAttributesExtractor();
     SpanNameExtractor<? super ApacheHttpClientRequest> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesExtractor.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.instrumentation.apachehttpclient.v4_3;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import org.apache.http.HttpResponse;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ApacheHttpClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
+    extends HttpClientAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
   protected String method(ApacheHttpClientRequest request) {
@@ -82,18 +82,6 @@ final class ApacheHttpClientHttpAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(
       ApacheHttpClientRequest request, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String serverName(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String route(ApacheHttpClientRequest request) {
     return null;
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTracingBuilder.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTracingBuilder.java
@@ -11,7 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
 import java.util.ArrayList;
@@ -48,7 +48,7 @@ public final class ApacheHttpClientTracingBuilder {
    * ApacheHttpClientTracingBuilder}.
    */
   public ApacheHttpClientTracing build() {
-    HttpAttributesExtractor<ApacheHttpClientRequest, HttpResponse> httpAttributesExtractor =
+    HttpClientAttributesExtractor<ApacheHttpClientRequest, HttpResponse> httpAttributesExtractor =
         new ApacheHttpClientHttpAttributesExtractor();
     SpanNameExtractor<? super ApacheHttpClientRequest> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v5_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.Header;
@@ -17,7 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 final class ApacheHttpClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<ClassicHttpRequest, HttpResponse> {
+    extends HttpClientAttributesExtractor<ClassicHttpRequest, HttpResponse> {
 
   private static final Logger logger =
       LoggerFactory.getLogger(ApacheHttpClientHttpAttributesExtractor.class);
@@ -142,18 +142,6 @@ final class ApacheHttpClientHttpAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(
       ClassicHttpRequest request, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String serverName(ClassicHttpRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String route(ClassicHttpRequest request) {
     return null;
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientSingletons.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientSingletons.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -23,7 +23,7 @@ public final class ApacheHttpClientSingletons {
   private static final Instrumenter<ClassicHttpRequest, HttpResponse> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<ClassicHttpRequest, HttpResponse> httpAttributesExtractor =
+    HttpClientAttributesExtractor<ClassicHttpRequest, HttpResponse> httpAttributesExtractor =
         new ApacheHttpClientHttpAttributesExtractor();
     SpanNameExtractor<? super ClassicHttpRequest> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesExtractor.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.armeria.v1_3;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.logging.RequestLog;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+final class ArmeriaHttpClientAttributesExtractor
+    extends HttpClientAttributesExtractor<RequestContext, RequestLog> {
+
+  @Override
+  protected String method(RequestContext ctx) {
+    return ctx.method().name();
+  }
+
+  @Override
+  protected String url(RequestContext ctx) {
+    return request(ctx).uri().toString();
+  }
+
+  @Override
+  protected String target(RequestContext ctx) {
+    return request(ctx).path();
+  }
+
+  @Override
+  @Nullable
+  protected String host(RequestContext ctx) {
+    return request(ctx).authority();
+  }
+
+  @Override
+  @Nullable
+  protected String scheme(RequestContext ctx) {
+    return request(ctx).scheme();
+  }
+
+  @Override
+  @Nullable
+  protected String userAgent(RequestContext ctx) {
+    return request(ctx).headers().get(HttpHeaderNames.USER_AGENT);
+  }
+
+  @Override
+  @Nullable
+  protected Long requestContentLength(RequestContext ctx, @Nullable RequestLog requestLog) {
+    if (requestLog == null) {
+      return null;
+    }
+    return requestLog.requestLength();
+  }
+
+  @Override
+  @Nullable
+  protected Long requestContentLengthUncompressed(
+      RequestContext ctx, @Nullable RequestLog requestLog) {
+    return null;
+  }
+
+  @Override
+  @Nullable
+  protected Integer statusCode(RequestContext ctx, RequestLog requestLog) {
+    HttpStatus status = requestLog.responseHeaders().status();
+    if (!status.equals(HttpStatus.UNKNOWN)) {
+      return status.code();
+    }
+    return null;
+  }
+
+  @Override
+  protected String flavor(RequestContext ctx, @Nullable RequestLog requestLog) {
+    SessionProtocol protocol = ctx.sessionProtocol();
+    if (protocol.isMultiplex()) {
+      return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
+    } else {
+      return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
+    }
+  }
+
+  @Override
+  protected Long responseContentLength(RequestContext ctx, RequestLog requestLog) {
+    return requestLog.responseLength();
+  }
+
+  @Override
+  @Nullable
+  protected Long responseContentLengthUncompressed(RequestContext ctx, RequestLog requestLog) {
+    return null;
+  }
+
+  private static HttpRequest request(RequestContext ctx) {
+    HttpRequest request = ctx.request();
+    if (request == null) {
+      throw new IllegalStateException(
+          "Context always has a request in decorators, this exception indicates a programming bug.");
+    }
+    return request;
+  }
+}

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesExtractor.java
@@ -12,12 +12,12 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class ArmeriaHttpAttributesExtractor
-    extends HttpAttributesExtractor<RequestContext, RequestLog> {
+final class ArmeriaHttpServerAttributesExtractor
+    extends HttpServerAttributesExtractor<RequestContext, RequestLog> {
 
   @Override
   protected String method(RequestContext ctx) {

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesExtractor.java
@@ -8,12 +8,12 @@ package io.opentelemetry.javaagent.instrumentation.asynchttpclient.v1_9;
 import com.ning.http.client.Request;
 import com.ning.http.client.Response;
 import com.ning.http.client.uri.Uri;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class AsyncHttpClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<Request, Response> {
+    extends HttpClientAttributesExtractor<Request, Response> {
 
   @Override
   protected String method(Request request) {
@@ -85,18 +85,6 @@ final class AsyncHttpClientHttpAttributesExtractor
   @Override
   @Nullable
   protected Long responseContentLengthUncompressed(Request request, Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String serverName(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String route(Request request) {
     return null;
   }
 }

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientSingletons.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientSingletons.java
@@ -11,7 +11,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -23,7 +23,7 @@ public final class AsyncHttpClientSingletons {
   private static final Instrumenter<Request, Response> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<Request, Response> httpAttributesExtractor =
+    HttpClientAttributesExtractor<Request, Response> httpAttributesExtractor =
         new AsyncHttpClientHttpAttributesExtractor();
     SpanNameExtractor<? super Request> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesExtractor.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.asynchttpclient.v2_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.Response;
@@ -14,7 +14,7 @@ import org.asynchttpclient.uri.Uri;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class AsyncHttpClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<RequestContext, Response> {
+    extends HttpClientAttributesExtractor<RequestContext, Response> {
 
   @Override
   protected String method(RequestContext requestContext) {
@@ -108,18 +108,6 @@ final class AsyncHttpClientHttpAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(
       RequestContext requestContext, Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String serverName(RequestContext requestContext, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String route(RequestContext requestContext) {
     return null;
   }
 }

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientSingletons.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientSingletons.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -23,7 +23,7 @@ public final class AsyncHttpClientSingletons {
   private static final Instrumenter<RequestContext, Response> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<RequestContext, Response> httpAttributesExtractor =
+    HttpClientAttributesExtractor<RequestContext, Response> httpAttributesExtractor =
         new AsyncHttpClientHttpAttributesExtractor();
     SpanNameExtractor<RequestContext> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesExtractor.java
@@ -7,12 +7,12 @@ package io.opentelemetry.javaagent.instrumentation.googlehttpclient;
 
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class GoogleHttpClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<HttpRequest, HttpResponse> {
+    extends HttpClientAttributesExtractor<HttpRequest, HttpResponse> {
 
   @Override
   protected @Nullable String method(HttpRequest httpRequest) {
@@ -75,17 +75,6 @@ final class GoogleHttpClientHttpAttributesExtractor
   @Override
   protected @Nullable Long responseContentLengthUncompressed(
       HttpRequest httpRequest, HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String route(HttpRequest httpRequest) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String serverName(
-      HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
     return null;
   }
 }

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientSingletons.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientSingletons.java
@@ -11,7 +11,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -23,7 +23,7 @@ public class GoogleHttpClientSingletons {
   private static final Instrumenter<HttpRequest, HttpResponse> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<HttpRequest, HttpResponse> httpAttributesExtractor =
+    HttpClientAttributesExtractor<HttpRequest, HttpResponse> httpAttributesExtractor =
         new GoogleHttpClientHttpAttributesExtractor();
     SpanNameExtractor<? super HttpRequest> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesExtractor.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesExtractor.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.httpurlconnection;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.HttpURLConnection;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-class HttpUrlHttpAttributesExtractor extends HttpAttributesExtractor<HttpURLConnection, Integer> {
+class HttpUrlHttpAttributesExtractor
+    extends HttpClientAttributesExtractor<HttpURLConnection, Integer> {
   @Override
   protected String method(HttpURLConnection connection) {
     return connection.getRequestMethod();
@@ -28,11 +29,6 @@ class HttpUrlHttpAttributesExtractor extends HttpAttributesExtractor<HttpURLConn
 
   @Override
   protected @Nullable String host(HttpURLConnection connection) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String route(HttpURLConnection connection) {
     return null;
   }
 
@@ -61,12 +57,6 @@ class HttpUrlHttpAttributesExtractor extends HttpAttributesExtractor<HttpURLConn
   @Override
   protected String flavor(HttpURLConnection connection, @Nullable Integer statusCode) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
-  }
-
-  @Override
-  protected @Nullable String serverName(
-      HttpURLConnection connection, @Nullable Integer statusCode) {
-    return null;
   }
 
   @Override

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesExtractor.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesExtractor.java
@@ -5,14 +5,15 @@
 
 package io.opentelemetry.javaagent.instrumentation.httpclient;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-class JdkHttpAttributesExtractor extends HttpAttributesExtractor<HttpRequest, HttpResponse<?>> {
+class JdkHttpAttributesExtractor
+    extends HttpClientAttributesExtractor<HttpRequest, HttpResponse<?>> {
 
   @Override
   protected String method(HttpRequest httpRequest) {
@@ -78,17 +79,6 @@ class JdkHttpAttributesExtractor extends HttpAttributesExtractor<HttpRequest, Ht
   @Override
   protected @Nullable Long responseContentLengthUncompressed(
       HttpRequest httpRequest, HttpResponse<?> httpResponse) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String serverName(
-      HttpRequest httpRequest, @Nullable HttpResponse<?> httpResponse) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String route(HttpRequest httpRequest) {
     return null;
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesExtractor.java
@@ -7,12 +7,12 @@ package io.opentelemetry.javaagent.instrumentation.jaxrsclient.v1_1;
 
 import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class JaxRsClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<ClientRequest, ClientResponse> {
+    extends HttpClientAttributesExtractor<ClientRequest, ClientResponse> {
 
   @Override
   protected @Nullable String method(ClientRequest httpRequest) {
@@ -92,17 +92,6 @@ final class JaxRsClientHttpAttributesExtractor
   @Override
   protected @Nullable Long responseContentLengthUncompressed(
       ClientRequest httpRequest, ClientResponse httpResponse) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String route(ClientRequest httpRequest) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String serverName(
-      ClientRequest httpRequest, @Nullable ClientResponse httpResponse) {
     return null;
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientSingletons.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientSingletons.java
@@ -11,7 +11,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -23,7 +23,7 @@ public class JaxRsClientSingletons {
   private static final Instrumenter<ClientRequest, ClientResponse> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<ClientRequest, ClientResponse> httpAttributesExtractor =
+    HttpClientAttributesExtractor<ClientRequest, ClientResponse> httpAttributesExtractor =
         new JaxRsClientHttpAttributesExtractor();
     SpanNameExtractor<? super ClientRequest> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientHttpAttributesExtractor.java
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrsclient.v2_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class JaxRsClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<ClientRequestContext, ClientResponseContext> {
+    extends HttpClientAttributesExtractor<ClientRequestContext, ClientResponseContext> {
 
   @Override
   protected @Nullable String method(ClientRequestContext httpRequest) {
@@ -93,17 +93,6 @@ final class JaxRsClientHttpAttributesExtractor
   @Override
   protected @Nullable Long responseContentLengthUncompressed(
       ClientRequestContext httpRequest, ClientResponseContext httpResponse) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String route(ClientRequestContext httpRequest) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String serverName(
-      ClientRequestContext httpRequest, @Nullable ClientResponseContext httpResponse) {
     return null;
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientSingletons.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientSingletons.java
@@ -10,7 +10,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -25,8 +25,8 @@ public class JaxRsClientSingletons {
   private static final Instrumenter<ClientRequestContext, ClientResponseContext> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<ClientRequestContext, ClientResponseContext> httpAttributesExtractor =
-        new JaxRsClientHttpAttributesExtractor();
+    HttpClientAttributesExtractor<ClientRequestContext, ClientResponseContext>
+        httpAttributesExtractor = new JaxRsClientHttpAttributesExtractor();
     SpanNameExtractor<? super ClientRequestContext> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);
     SpanStatusExtractor<? super ClientRequestContext, ? super ClientResponseContext>

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientHttpAttributesExtractor.java
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrsclient.v2_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.ws.rs.core.Response;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 
 final class ResteasyClientHttpAttributesExtractor
-    extends HttpAttributesExtractor<ClientInvocation, Response> {
+    extends HttpClientAttributesExtractor<ClientInvocation, Response> {
 
   @Override
   protected @Nullable String method(ClientInvocation httpRequest) {
@@ -91,17 +91,6 @@ final class ResteasyClientHttpAttributesExtractor
   @Override
   protected @Nullable Long responseContentLengthUncompressed(
       ClientInvocation httpRequest, Response httpResponse) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String route(ClientInvocation httpRequest) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String serverName(
-      ClientInvocation httpRequest, @Nullable Response httpResponse) {
     return null;
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientSingletons.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientSingletons.java
@@ -10,7 +10,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -26,7 +26,7 @@ public class ResteasyClientSingletons {
   private static final Instrumenter<ClientInvocation, Response> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<ClientInvocation, Response> httpAttributesExtractor =
+    HttpClientAttributesExtractor<ClientInvocation, Response> httpAttributesExtractor =
         new ResteasyClientHttpAttributesExtractor();
     SpanNameExtractor<? super ClientInvocation> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesExtractor.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesExtractor.java
@@ -9,7 +9,7 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpF
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_1_1;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_2_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
@@ -19,7 +19,8 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class JettyClientHttpAttributesExtractor extends HttpAttributesExtractor<Request, Response> {
+final class JettyClientHttpAttributesExtractor
+    extends HttpClientAttributesExtractor<Request, Response> {
   private static final Logger logger =
       LoggerFactory.getLogger(JettyClientHttpAttributesExtractor.class);
 
@@ -46,12 +47,6 @@ final class JettyClientHttpAttributesExtractor extends HttpAttributesExtractor<R
   @Nullable
   protected String host(Request request) {
     return request.getHost();
-  }
-
-  @Override
-  @Nullable
-  protected String route(Request request) {
-    return null;
   }
 
   @Override
@@ -103,12 +98,6 @@ final class JettyClientHttpAttributesExtractor extends HttpAttributesExtractor<R
 
         return HTTP_1_1;
     }
-  }
-
-  @Override
-  @Nullable
-  protected String serverName(Request request, @Nullable Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientInstrumenterBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientInstrumenterBuilder.java
@@ -10,7 +10,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -39,7 +39,7 @@ public final class JettyClientInstrumenterBuilder {
   }
 
   public Instrumenter<Request, Response> build() {
-    HttpAttributesExtractor<Request, Response> httpAttributesExtractor =
+    HttpClientAttributesExtractor<Request, Response> httpAttributesExtractor =
         new JettyClientHttpAttributesExtractor();
     SpanNameExtractor<Request> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesExtractor.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesExtractor.java
@@ -6,12 +6,13 @@
 package io.opentelemetry.javaagent.instrumentation.kubernetesclient;
 
 import io.kubernetes.client.openapi.ApiResponse;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import okhttp3.Request;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-class KubernetesHttpAttributesExtractor extends HttpAttributesExtractor<Request, ApiResponse<?>> {
+class KubernetesHttpAttributesExtractor
+    extends HttpClientAttributesExtractor<Request, ApiResponse<?>> {
   @Override
   protected String method(Request request) {
     return request.method();
@@ -29,11 +30,6 @@ class KubernetesHttpAttributesExtractor extends HttpAttributesExtractor<Request,
 
   @Override
   protected @Nullable String host(Request request) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String route(Request request) {
     return null;
   }
 
@@ -62,11 +58,6 @@ class KubernetesHttpAttributesExtractor extends HttpAttributesExtractor<Request,
   @Override
   protected String flavor(Request request, @Nullable ApiResponse<?> apiResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
-  }
-
-  @Override
-  protected @Nullable String serverName(Request request, @Nullable ApiResponse<?> apiResponse) {
-    return null;
   }
 
   @Override

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesExtractor.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesExtractor.java
@@ -7,11 +7,12 @@ package io.opentelemetry.javaagent.instrumentation.okhttp.v2_2;
 
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class OkHttp2HttpAttributesExtractor extends HttpAttributesExtractor<Request, Response> {
+final class OkHttp2HttpAttributesExtractor
+    extends HttpClientAttributesExtractor<Request, Response> {
 
   @Override
   protected String method(Request request) {
@@ -92,18 +93,6 @@ final class OkHttp2HttpAttributesExtractor extends HttpAttributesExtractor<Reque
   @Override
   @Nullable
   protected Long responseContentLengthUncompressed(Request request, Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String serverName(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String route(Request request) {
     return null;
   }
 }

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2Singletons.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2Singletons.java
@@ -15,7 +15,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -29,7 +29,7 @@ public final class OkHttp2Singletons {
   private static final TracingInterceptor TRACING_INTERCEPTOR;
 
   static {
-    HttpAttributesExtractor<Request, Response> httpAttributesExtractor =
+    HttpClientAttributesExtractor<Request, Response> httpAttributesExtractor =
         new OkHttp2HttpAttributesExtractor();
     SpanNameExtractor<Request> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesExtractor.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesExtractor.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.instrumentation.okhttp.v3_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class OkHttpAttributesExtractor extends HttpAttributesExtractor<Request, Response> {
+final class OkHttpAttributesExtractor extends HttpClientAttributesExtractor<Request, Response> {
   @Override
   protected String method(Request request) {
     return request.method();
@@ -30,11 +30,6 @@ final class OkHttpAttributesExtractor extends HttpAttributesExtractor<Request, R
   @Override
   protected String host(Request request) {
     return request.url().host();
-  }
-
-  @Override
-  protected @Nullable String route(Request request) {
-    return null;
   }
 
   @Override
@@ -78,11 +73,6 @@ final class OkHttpAttributesExtractor extends HttpAttributesExtractor<Request, R
       default:
         return null;
     }
-  }
-
-  @Override
-  protected @Nullable String serverName(Request request, @Nullable Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesExtractor.java
+++ b/instrumentation/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesExtractor.java
@@ -5,14 +5,15 @@
 
 package io.opentelemetry.javaagent.instrumentation.playws;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import play.shaded.ahc.org.asynchttpclient.Request;
 import play.shaded.ahc.org.asynchttpclient.Response;
 import play.shaded.ahc.org.asynchttpclient.uri.Uri;
 
-final class PlayWsClientHttpAttributesExtractor extends HttpAttributesExtractor<Request, Response> {
+final class PlayWsClientHttpAttributesExtractor
+    extends HttpClientAttributesExtractor<Request, Response> {
 
   @Override
   protected String method(Request request) {
@@ -84,18 +85,6 @@ final class PlayWsClientHttpAttributesExtractor extends HttpAttributesExtractor<
   @Override
   @Nullable
   protected Long responseContentLengthUncompressed(Request request, Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String serverName(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  protected String route(Request request) {
     return null;
   }
 }

--- a/instrumentation/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientSingletons.java
+++ b/instrumentation/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientSingletons.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -23,7 +23,7 @@ public class PlayWsClientSingletons {
   private static final Instrumenter<Request, Response> INSTRUMENTER;
 
   static {
-    HttpAttributesExtractor<Request, Response> httpAttributesExtractor =
+    HttpClientAttributesExtractor<Request, Response> httpAttributesExtractor =
         new PlayWsClientHttpAttributesExtractor();
     SpanNameExtractor<? super Request> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesExtractor.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesExtractor.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.ratpack;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import ratpack.handling.Context;
@@ -13,7 +13,8 @@ import ratpack.http.Request;
 import ratpack.http.Response;
 import ratpack.server.PublicAddress;
 
-final class RatpackHttpAttributesExtractor extends HttpAttributesExtractor<Request, Response> {
+final class RatpackHttpAttributesExtractor
+    extends HttpServerAttributesExtractor<Request, Response> {
   @Override
   protected String method(Request request) {
     return request.getMethod().getName();

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesExtractor.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesExtractor.java
@@ -5,14 +5,16 @@
 
 package io.opentelemetry.instrumentation.restlet.v1_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.restlet.data.Reference;
 import org.restlet.data.Request;
 import org.restlet.data.Response;
 
-final class RestletHttpAttributesExtractor extends HttpAttributesExtractor<Request, Response> {
+final class RestletHttpAttributesExtractor
+    extends HttpServerAttributesExtractor<Request, Response> {
+
   @Override
   protected String method(Request request) {
     return request.getMethod().toString();

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletTracingBuilder.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletTracingBuilder.java
@@ -10,7 +10,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetAttributesExtractor;
@@ -46,8 +45,7 @@ public final class RestletTracingBuilder {
    * Returns a new {@link RestletTracing} with the settings of this {@link RestletTracingBuilder}.
    */
   public RestletTracing build() {
-    HttpAttributesExtractor<Request, Response> httpAttributesExtractor =
-        new RestletHttpAttributesExtractor();
+    RestletHttpAttributesExtractor httpAttributesExtractor = new RestletHttpAttributesExtractor();
     SpanNameExtractor<Request> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);
     SpanStatusExtractor<Request, Response> spanStatusExtractor =

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Singletons.java
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Singletons.java
@@ -9,7 +9,7 @@ import static io.opentelemetry.instrumentation.api.servlet.ServerSpanNaming.Sour
 
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.servlet.ServerSpanNaming;
 import io.opentelemetry.javaagent.instrumentation.servlet.ServletInstrumenterBuilder;
 import io.opentelemetry.javaagent.instrumentation.servlet.ServletRequestContext;
@@ -23,7 +23,7 @@ public final class Servlet2Singletons {
   private static final Servlet2Helper HELPER;
 
   static {
-    HttpAttributesExtractor<
+    HttpServerAttributesExtractor<
             ServletRequestContext<HttpServletRequest>, ServletResponseContext<HttpServletResponse>>
         httpAttributesExtractor = new Servlet2HttpAttributesExtractor(Servlet2Accessor.INSTANCE);
     SpanNameExtractor<ServletRequestContext<HttpServletRequest>> spanNameExtractor =

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesExtractor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesExtractor.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.UriBuilder;
 import io.opentelemetry.instrumentation.servlet.ServletAccessor;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ServletHttpAttributesExtractor<REQUEST, RESPONSE>
-    extends HttpAttributesExtractor<
+    extends HttpServerAttributesExtractor<
         ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>> {
   protected final ServletAccessor<REQUEST, RESPONSE> accessor;
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletInstrumenterBuilder.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletInstrumenterBuilder.java
@@ -12,7 +12,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
 import io.opentelemetry.instrumentation.api.servlet.MappingResolver;
@@ -53,8 +53,10 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
       String instrumentationName,
       ServletAccessor<REQUEST, RESPONSE> accessor,
       SpanNameExtractor<ServletRequestContext<REQUEST>> spanNameExtractor,
-      HttpAttributesExtractor<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
+      HttpServerAttributesExtractor<
+              ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
           httpAttributesExtractor) {
+
     SpanStatusExtractor<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
         spanStatusExtractor = HttpSpanStatusExtractor.create(httpAttributesExtractor);
     ServletNetAttributesExtractor<REQUEST, RESPONSE> netAttributesExtractor =
@@ -83,7 +85,7 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
 
   public Instrumenter<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>> build(
       String instrumentationName, ServletAccessor<REQUEST, RESPONSE> accessor) {
-    HttpAttributesExtractor<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
+    HttpServerAttributesExtractor<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
         httpAttributesExtractor = new ServletHttpAttributesExtractor<>(accessor);
     SpanNameExtractor<ServletRequestContext<REQUEST>> spanNameExtractor =
         new ServletSpanNameExtractor<>(accessor, mappingResolverFunction);

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebHttpAttributesExtractor.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebHttpAttributesExtractor.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.spring.web;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import java.io.IOException;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.http.HttpRequest;
@@ -13,7 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 
 final class SpringWebHttpAttributesExtractor
-    extends HttpAttributesExtractor<HttpRequest, ClientHttpResponse> {
+    extends HttpClientAttributesExtractor<HttpRequest, ClientHttpResponse> {
   @Override
   protected String method(HttpRequest httpRequest) {
     return httpRequest.getMethod().name();
@@ -32,11 +32,6 @@ final class SpringWebHttpAttributesExtractor
   @Override
   protected @Nullable String host(HttpRequest httpRequest) {
     return httpRequest.getHeaders().getFirst("host");
-  }
-
-  @Override
-  protected @Nullable String route(HttpRequest httpRequest) {
-    return null;
   }
 
   @Override
@@ -64,12 +59,6 @@ final class SpringWebHttpAttributesExtractor
 
   @Override
   protected @Nullable String flavor(
-      HttpRequest httpRequest, @Nullable ClientHttpResponse clientHttpResponse) {
-    return null;
-  }
-
-  @Override
-  protected @Nullable String serverName(
       HttpRequest httpRequest, @Nullable ClientHttpResponse clientHttpResponse) {
     return null;
   }

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesExtractor.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesExtractor.java
@@ -5,14 +5,15 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.common;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.UriBuilder;
 import org.apache.coyote.Request;
 import org.apache.coyote.Response;
 import org.apache.tomcat.util.buf.MessageBytes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class TomcatHttpAttributesExtractor extends HttpAttributesExtractor<Request, Response> {
+public class TomcatHttpAttributesExtractor
+    extends HttpServerAttributesExtractor<Request, Response> {
 
   @Override
   protected String method(Request request) {

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatInstrumenterBuilder.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatInstrumenterBuilder.java
@@ -12,7 +12,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -33,7 +33,7 @@ public final class TomcatInstrumenterBuilder {
       String instrumentationName,
       ServletAccessor<REQUEST, RESPONSE> accessor,
       TomcatServletEntityProvider<REQUEST, RESPONSE> servletEntityProvider) {
-    HttpAttributesExtractor<Request, Response> httpAttributesExtractor =
+    HttpServerAttributesExtractor<Request, Response> httpAttributesExtractor =
         new TomcatHttpAttributesExtractor();
     SpanNameExtractor<Request> spanNameExtractor =
         HttpSpanNameExtractor.create(httpAttributesExtractor);


### PR DESCRIPTION
This PR splits `HttpAttributesExtractor` into `HttpClientAttributesExtractor` and `HttpServerAttributesExtractor` - I need to do that before I implement the [http headers semantic attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers) that were recently added to the spec (because we'll want separate configurations for clients/servers).

And maybe, if we decide on a solution here we'll be able to get https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/3700 done