### PR TITLE
Suppress snapshot publishing on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,7 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     needs: [ build, test, testLatestDeps, smoke-test, examples, muzzle ]
+    if: github.repository == 'open-telemetry/opentelemetry-java-instrumentation'
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
this will avoid build failures on forks when pushing to `main`