### PR TITLE
Remove problem files from META-INF

### DIFF
--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -266,6 +266,9 @@ fun CopySpec.isolateClasses(jars: Iterable<File>) {
       rename("(^.*)\\.class\$", "\$1.classdata")
       // Rename LICENSE file since it clashes with license dir on non-case sensitive FSs (i.e. Mac)
       rename("""^LICENSE$""", "LICENSE.renamed")
+      exclude("META-INF/INDEX.LIST")
+      exclude("META-INF/*.DSA")
+      exclude("META-INF/*.SF")
     }
   }
 }


### PR DESCRIPTION
These are only creating a problem because while building native image I'm writing out the `inst` directory to a real jar file.

* `INDEX.LIST` is from shadow'd dependency and subverts normal class lookup (I wonder if generating this correctly could speed up class loading?)
* `*.DSA` and `*.SF` are signature files from shadow'd dependencies