### PR TITLE
Support suppress-messaging-receive-span in JMS

### DIFF
--- a/instrumentation/jms-1.1/javaagent/src/jms2TestReceiveSpansDisabled/groovy/SpringListenerJms2SuppressReceiveSpansTest.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2TestReceiveSpansDisabled/groovy/SpringListenerJms2SuppressReceiveSpansTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import listener.Config
 import org.springframework.context.annotation.AnnotationConfigApplicationContext

--- a/instrumentation/jms-1.1/javaagent/src/jms2TestReceiveSpansDisabled/groovy/SpringListenerJms2SuppressReceiveSpansTest.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2TestReceiveSpansDisabled/groovy/SpringListenerJms2SuppressReceiveSpansTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import listener.Config
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.jms.core.JmsTemplate
+
+import javax.jms.ConnectionFactory
+
+class SpringListenerJms2SuppressReceiveSpansTest extends AgentInstrumentationSpecification {
+  def "receiving message in spring listener generates spans"() {
+    setup:
+    def context = new AnnotationConfigApplicationContext(Config)
+    def factory = context.getBean(ConnectionFactory)
+    def template = new JmsTemplate(factory)
+
+    template.convertAndSend("SpringListenerJms2", "a message")
+
+    expect:
+    assertTraces(1) {
+      trace(0, 2) {
+        Jms2Test.producerSpan(it, 0, "queue", "SpringListenerJms2")
+        Jms2Test.consumerSpan(it, 1, "queue", "SpringListenerJms2", "", span(0), "process")
+      }
+    }
+
+    cleanup:
+    context.close()
+  }
+}

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.jms;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.config.ExperimentalConfig;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
@@ -46,6 +47,7 @@ public final class JmsSingletons {
         .addAttributesExtractor(attributesExtractor)
         .setTimeExtractors(
             MessageWithDestination::startTime, (request, response, error) -> request.endTime())
+        .setDisabled(ExperimentalConfig.get().suppressMessagingReceiveSpans())
         .newInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 

--- a/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringListenerJms1SuppressReceiveSpansTest.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/test/groovy/SpringListenerJms1SuppressReceiveSpansTest.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import listener.Config
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.jms.core.JmsTemplate
+
+import javax.jms.ConnectionFactory
+
+import static Jms1Test.consumerSpan
+import static Jms1Test.producerSpan
+
+class SpringListenerJms1SuppressReceiveSpansTest extends AgentInstrumentationSpecification {
+
+  def "receiving message in spring listener generates spans"() {
+    setup:
+    def context = new AnnotationConfigApplicationContext(Config)
+    def factory = context.getBean(ConnectionFactory)
+    def template = new JmsTemplate(factory)
+
+    template.convertAndSend("SpringListenerJms1", "a message")
+
+    expect:
+    assertTraces(1) {
+      trace(0, 2) {
+        producerSpan(it, 0, "queue", "SpringListenerJms1")
+        consumerSpan(it, 1, "queue", "SpringListenerJms1", "", span(0), "process")
+      }
+    }
+
+    cleanup:
+    context.stop()
+  }
+}


### PR DESCRIPTION
Applying `otel.instrumentation.common.experimental.suppress-messaging-receive-spans` from #4187 to JMS messaging as well.