### PR TITLE
Refine 404 handling in Restlet instrumentation

### DIFF
--- a/instrumentation/restlet/restlet-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/restlet/v1_0/ServerInstrumentation.java
+++ b/instrumentation/restlet/restlet-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/restlet/v1_0/ServerInstrumentation.java
@@ -75,8 +75,7 @@ public class ServerInstrumentation implements TypeInstrumentation {
 
       scope.close();
 
-      if (response.getStatus() != null
-          && response.getStatus().equals(Status.CLIENT_ERROR_NOT_FOUND)) {
+      if (Status.CLIENT_ERROR_NOT_FOUND.equals(response.getStatus())) {
         ServerSpanNaming.updateServerSpanName(
             context, CONTROLLER, RestletServerSpanNaming.SERVER_SPAN_NAME, "/*");
       }

--- a/instrumentation/restlet/restlet-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v1_0/AbstractRestletServerTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v1_0/AbstractRestletServerTest.groovy
@@ -12,6 +12,7 @@ import org.restlet.Component
 import org.restlet.Context
 import org.restlet.Redirector
 import org.restlet.Restlet
+import org.restlet.Router
 import org.restlet.Server
 import org.restlet.VirtualHost
 import org.restlet.data.MediaType
@@ -19,6 +20,7 @@ import org.restlet.data.Protocol
 import org.restlet.data.Request
 import org.restlet.data.Response
 import org.restlet.data.Status
+import org.restlet.util.Template
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -42,6 +44,7 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
 
     host = component.getDefaultHost()
     attachRestlets()
+
     component.start()
 
     return server
@@ -52,11 +55,15 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
     component.stop()
   }
 
-  def attachAndWrap(path, restlet){
+  def attachAndWrap(path, restlet) {
     host.attach(path, wrapRestlet(restlet, path))
   }
 
-  def attachRestlets(){
+  def attachRestlets() {
+
+    def defaultRouter = wrapRestlet(new Router(host.getContext()), "/*")
+    host.attach("/", defaultRouter).setMatchingMode(Template.MODE_STARTS_WITH)
+
     attachAndWrap(SUCCESS.path, new Restlet() {
       @Override
       void handle(Request request, Response response) {
@@ -69,26 +76,26 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
 
     attachAndWrap(REDIRECT.path, new Redirector(Context.getCurrent(), REDIRECT.body, Redirector.MODE_CLIENT_FOUND) {
       @Override
-      void handle(Request request, Response response){
+      void handle(Request request, Response response) {
         super.handle(request, response)
-        controller(REDIRECT){
+        controller(REDIRECT) {
         } //TODO: check why handle fails inside controller
       }
     })
 
-    attachAndWrap(ERROR.path, new Restlet(){
+    attachAndWrap(ERROR.path, new Restlet() {
       @Override
-      void handle(Request request, Response response){
-        controller(ERROR){
+      void handle(Request request, Response response) {
+        controller(ERROR) {
           response.setStatus(Status.valueOf(ERROR.getStatus()), ERROR.getBody())
         }
       }
     })
 
-    attachAndWrap(EXCEPTION.path, new Restlet(){
+    attachAndWrap(EXCEPTION.path, new Restlet() {
       @Override
-      void handle(Request request, Response response){
-        controller(EXCEPTION){
+      void handle(Request request, Response response) {
+        controller(EXCEPTION) {
           throw new Exception(EXCEPTION.getBody())
         }
       }
@@ -96,25 +103,15 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
 
     attachAndWrap(QUERY_PARAM.path, new Restlet() {
       @Override
-      void handle(Request request, Response response){
-        controller(QUERY_PARAM){
+      void handle(Request request, Response response) {
+        controller(QUERY_PARAM) {
           response.setEntity(QUERY_PARAM.getBody(), MediaType.TEXT_PLAIN)
           response.setStatus(Status.valueOf(QUERY_PARAM.getStatus()), QUERY_PARAM.getBody())
         }
       }
     })
 
-    attachAndWrap(NOT_FOUND.path, new Restlet() {
-      @Override
-      void handle(Request request, Response response){
-        controller(NOT_FOUND){
-          response.setEntity(NOT_FOUND.getBody(), MediaType.TEXT_PLAIN)
-          response.setStatus(Status.valueOf(NOT_FOUND.getStatus()), NOT_FOUND.getBody())
-        }
-      }
-    })
-
-    attachAndWrap("/path/{id}/param", new Restlet(){
+    attachAndWrap("/path/{id}/param", new Restlet() {
       @Override
       void handle(Request request, Response response) {
         controller(PATH_PARAM) {
@@ -128,7 +125,7 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
       @Override
       void handle(Request request, Response response) {
         controller(INDEXED_CHILD) {
-          INDEXED_CHILD.collectSpanAttributes {request.getOriginalRef().getQueryAsForm().getFirst(it).getValue() }
+          INDEXED_CHILD.collectSpanAttributes { request.getOriginalRef().getQueryAsForm().getFirst(it).getValue() }
           response.setStatus(Status.valueOf(INDEXED_CHILD.status))
         }
       }
@@ -142,7 +139,7 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
       SemanticAttributes.HTTP_TARGET,
       SemanticAttributes.HTTP_SCHEME,
       SemanticAttributes.NET_TRANSPORT,
-      ]
+    ]
   }
 
   @Override
@@ -161,7 +158,7 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
       case PATH_PARAM:
         return getContextPath() + "/path/{id}/param"
       case NOT_FOUND:
-        return getContextPath() + "/notFound"
+        return getContextPath() + "/*"
       default:
         return endpoint.resolvePath(address).path
     }


### PR DESCRIPTION
A small fix to the Restlet server instrumentation - if response code is 404, span name will be `/*`