### PR TITLE
Remove dynamo db.name attribute

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRequestType.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.awssdk.v2_2;
 
 import static io.opentelemetry.instrumentation.awssdk.v2_2.FieldMapping.request;
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -16,9 +15,7 @@ enum AwsSdkRequestType {
   S3(request("aws.bucket.name", "Bucket")),
   SQS(request("aws.queue.url", "QueueUrl"), request("aws.queue.name", "QueueName")),
   Kinesis(request("aws.stream.name", "StreamName")),
-  DynamoDB(
-      request("aws.table.name", "TableName"),
-      request(SemanticAttributes.DB_NAME.getKey(), "TableName"));
+  DynamoDB(request("aws.table.name", "TableName"));
 
   // Wrapping in unmodifiableMap
   @SuppressWarnings("ImmutableEnumChecker")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -170,7 +170,6 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
             "aws.requestId" "$requestId"
             "aws.table.name" "sometable"
             "${SemanticAttributes.DB_SYSTEM.key}" "dynamodb"
-            "${SemanticAttributes.DB_NAME.key}" "sometable"
             "${SemanticAttributes.DB_OPERATION.key}" "CreateTable"
             "aws.dynamodb.global_secondary_indexes" "[{\"IndexName\":\"globalIndex\",\"KeySchema\":[{\"AttributeName\":\"attribute\"}],\"ProvisionedThroughput\":{\"ReadCapacityUnits\":10,\"WriteCapacityUnits\":12}},{\"IndexName\":\"globalIndexSecondary\",\"KeySchema\":[{\"AttributeName\":\"attributeSecondary\"}],\"ProvisionedThroughput\":{\"ReadCapacityUnits\":7,\"WriteCapacityUnits\":8}}]"
             "aws.dynamodb.provisioned_throughput.read_capacity_units" "1"
@@ -206,7 +205,6 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
             "aws.requestId" "$requestId"
             "aws.table.name" "sometable"
             "${SemanticAttributes.DB_SYSTEM.key}" "dynamodb"
-            "${SemanticAttributes.DB_NAME.key}" "sometable"
             "${SemanticAttributes.DB_OPERATION.key}" "Query"
             "aws.dynamodb.limit" "10"
             "aws.dynamodb.select" "ALL_ATTRIBUTES"
@@ -241,7 +239,6 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
             "aws.requestId" "$requestId"
             "aws.table.name" "sometable"
             "${SemanticAttributes.DB_SYSTEM.key}" "dynamodb"
-            "${SemanticAttributes.DB_NAME.key}" "sometable"
             "${SemanticAttributes.DB_OPERATION.key}" "${operation}"
           }
         }


### PR DESCRIPTION
Resolves #3828

This does seem like a case where `db.name` may not make sense (or at least I think it should probably be something bigger than table name, maybe falling back to `db.system`, though that falling back could be done in backend as well).

cc: @Oberon00