### PR TITLE
Move servlet images to repo-scoped ghcr packages (part 1)

### DIFF
--- a/smoke-tests/matrix/build.gradle
+++ b/smoke-tests/matrix/build.gradle
@@ -123,7 +123,7 @@ def configureImage(Task parentTask, server, dockerfile, version, vm, jdk, warPro
 
   def extraTag = findProperty("extraTag") ?: new Date().format("yyyyMMdd.HHmmSS")
   def vmSuffix = vm == "hotspot" ? "" : "-$vm"
-  def image = "ghcr.io/open-telemetry/java-test-containers:$server-$version-jdk$jdk$vmSuffix$platformSuffix-$extraTag"
+  def image = "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-servlet-$server:$version-jdk$jdk$vmSuffix$platformSuffix-$extraTag"
 
   def jdkImage
   if (vm == "hotspot") {


### PR DESCRIPTION
hm, for some reason i thought it was going to be (a little) harder than this 😂

still need to follow-up with updating the tests once these new packages are published

see #3693