### PR TITLE
Extract HTTP request/response headers as span attributes

### DIFF
--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/InstrumenterBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/InstrumenterBenchmark.java
@@ -8,11 +8,14 @@ package io.opentelemetry.benchmark;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -58,6 +61,10 @@ public class InstrumenterBenchmark {
     static final HttpClientAttributesExtractor<Void, Void> INSTANCE =
         new ConstantHttpAttributesExtractor();
 
+    public ConstantHttpAttributesExtractor() {
+      super(CapturedHttpHeaders.empty());
+    }
+
     @Override
     protected @Nullable String method(Void unused) {
       return "GET";
@@ -71,6 +78,11 @@ public class InstrumenterBenchmark {
     @Override
     protected @Nullable String userAgent(Void unused) {
       return "OpenTelemetryBot";
+    }
+
+    @Override
+    protected List<String> requestHeader(Void unused, String name) {
+      return Collections.emptyList();
     }
 
     @Override
@@ -101,6 +113,11 @@ public class InstrumenterBenchmark {
     @Override
     protected @Nullable Long responseContentLengthUncompressed(Void unused, Void unused2) {
       return null;
+    }
+
+    @Override
+    protected List<String> responseHeader(Void unused, Void unused2, String name) {
+      return Collections.emptyList();
     }
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/ServerInstrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/ServerInstrumenter.java
@@ -34,6 +34,8 @@ final class ServerInstrumenter<REQUEST, RESPONSE> extends Instrumenter<REQUEST, 
     return super.start(extracted, request);
   }
 
+  // TODO: move that to HttpServerAttributesExtractor, now that we have a method for extracting
+  // header values there
   private static <REQUEST, RESPONSE> InstrumenterBuilder<REQUEST, RESPONSE> addClientIpExtractor(
       InstrumenterBuilder<REQUEST, RESPONSE> builder, TextMapGetter<REQUEST> getter) {
     HttpServerAttributesExtractor<REQUEST, RESPONSE> httpAttributesExtractor = null;

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/CapturedHttpHeaders.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/CapturedHttpHeaders.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.http;
+
+import static java.util.Collections.emptyList;
+
+import com.google.auto.value.AutoValue;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+/**
+ * Represents the configuration that specifies which HTTP request/response headers should be
+ * captured as span attributes.
+ */
+@AutoValue
+public abstract class CapturedHttpHeaders {
+
+  private static final CapturedHttpHeaders EMPTY = create(emptyList(), emptyList());
+
+  /** Don't capture any HTTP headers as span attributes. */
+  public static CapturedHttpHeaders empty() {
+    return EMPTY;
+  }
+
+  /**
+   * Captures the configured HTTP request and response headers as span attributes as described in <a
+   * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers">HTTP
+   * semantic conventions</a>.
+   *
+   * <p>The HTTP request header values will be captured under the {@code http.request.header.<name>}
+   * attribute key. The HTTP response header values will be captured under the {@code
+   * http.response.header.<name>} attribute key. The {@code <name>} part in the attribute key is the
+   * normalized header name: lowercase, with dashes replaced by underscores.
+   *
+   * @param capturedRequestHeaders A list of HTTP request header names that are to be captured as
+   *     span attributes.
+   * @param capturedResponseHeaders A list of HTTP response header names that are to be captured as
+   *     span attributes.
+   */
+  public static CapturedHttpHeaders create(
+      List<String> capturedRequestHeaders, List<String> capturedResponseHeaders) {
+    return new AutoValue_CapturedHttpHeaders(
+        lowercase(capturedRequestHeaders), lowercase(capturedResponseHeaders));
+  }
+
+  private static List<String> lowercase(List<String> names) {
+    return names.stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(Collectors.toList());
+  }
+
+  /** Returns the list of HTTP request header names that are to be captured as span attributes. */
+  public abstract List<String> requestHeaders();
+
+  /** Returns the list of HTTP response header names that are to be captured as span attributes. */
+  public abstract List<String> responseHeaders();
+
+  CapturedHttpHeaders() {}
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
@@ -23,6 +23,16 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public abstract class HttpClientAttributesExtractor<REQUEST, RESPONSE>
     extends HttpCommonAttributesExtractor<REQUEST, RESPONSE> {
 
+  /**
+   * Create the HTTP client attributes extractor.
+   *
+   * @param capturedHttpHeaders A configuration object specifying which HTTP request and response
+   *     headers should be captured as span attributes.
+   */
+  protected HttpClientAttributesExtractor(CapturedHttpHeaders capturedHttpHeaders) {
+    super(capturedHttpHeaders);
+  }
+
   @Override
   protected final void onStart(AttributesBuilder attributes, REQUEST request) {
     super.onStart(attributes, request);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
@@ -97,6 +97,9 @@ public abstract class HttpCommonAttributesExtractor<REQUEST, RESPONSE>
   /**
    * Extracts all values of header named {@code name} from the request, or an empty list if there
    * were none.
+   *
+   * <p>Implementations of this method <b>must not</b> return a null value; an empty list should be
+   * returned instead.
    */
   protected abstract List<String> requestHeader(REQUEST request, String name);
 
@@ -154,6 +157,9 @@ public abstract class HttpCommonAttributesExtractor<REQUEST, RESPONSE>
    *
    * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, only when
    * {@code response} is non-{@code null}.
+   *
+   * <p>Implementations of this method <b>must not</b> return a null value; an empty list should be
+   * returned instead.
    */
   protected abstract List<String> responseHeader(REQUEST request, RESPONSE response, String name);
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpHeaderAttributes.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpHeaderAttributes.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.http;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.caching.Cache;
+import java.util.List;
+
+final class HttpHeaderAttributes {
+
+  private static final Cache<String, AttributeKey<List<String>>> requestKeysCache =
+      Cache.newBuilder().setMaximumSize(32).build();
+  private static final Cache<String, AttributeKey<List<String>>> responseKeysCache =
+      Cache.newBuilder().setMaximumSize(32).build();
+
+  static AttributeKey<List<String>> requestAttributeKey(String headerName) {
+    return requestKeysCache.computeIfAbsent(headerName, n -> createKey("request", n));
+  }
+
+  static AttributeKey<List<String>> responseAttributeKey(String headerName) {
+    return responseKeysCache.computeIfAbsent(headerName, n -> createKey("response", n));
+  }
+
+  private static AttributeKey<List<String>> createKey(String type, String headerName) {
+    // headerName is always lowercase, see CapturedHttpHeaders
+    String key = "http." + type + ".header." + headerName.replace('-', '_');
+    return AttributeKey.stringArrayKey(key);
+  }
+
+  private HttpHeaderAttributes() {}
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -22,6 +23,16 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public abstract class HttpServerAttributesExtractor<REQUEST, RESPONSE>
     extends HttpCommonAttributesExtractor<REQUEST, RESPONSE> {
+
+  /**
+   * Create the HTTP server attributes extractor.
+   *
+   * @param capturedHttpHeaders A configuration object specifying which HTTP request and response
+   *     headers should be captured as span attributes.
+   */
+  protected HttpServerAttributesExtractor(CapturedHttpHeaders capturedHttpHeaders) {
+    super(capturedHttpHeaders);
+  }
 
   @Override
   protected final void onStart(AttributesBuilder attributes, REQUEST request) {
@@ -53,8 +64,12 @@ public abstract class HttpServerAttributesExtractor<REQUEST, RESPONSE>
   @Nullable
   protected abstract String target(REQUEST request);
 
+  // TODO: remove implementations?
   @Nullable
-  protected abstract String host(REQUEST request);
+  protected String host(REQUEST request) {
+    List<String> values = requestHeader(request, "host");
+    return values.isEmpty() ? null : values.get(0);
+  }
 
   @Nullable
   protected abstract String route(REQUEST request);

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbSpanNameExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbSpanNameExtractorTest.java
@@ -24,9 +24,9 @@ class DbSpanNameExtractorTest {
     // given
     DbRequest dbRequest = new DbRequest();
 
-    // cannot stub dbOperation() and dbTable() because they're final
-    given(sqlAttributesExtractor.rawStatement(dbRequest)).willReturn("SELECT * FROM table");
+    given(sqlAttributesExtractor.operation(dbRequest)).willReturn("SELECT");
     given(sqlAttributesExtractor.name(dbRequest)).willReturn("database");
+    given(sqlAttributesExtractor.table(dbRequest)).willReturn("table");
 
     SpanNameExtractor<DbRequest> underTest = DbSpanNameExtractor.create(sqlAttributesExtractor);
 
@@ -42,9 +42,9 @@ class DbSpanNameExtractorTest {
     // given
     DbRequest dbRequest = new DbRequest();
 
-    // cannot stub dbOperation() and dbTable() because they're final
-    given(sqlAttributesExtractor.rawStatement(dbRequest)).willReturn("SELECT * FROM another.table");
+    given(sqlAttributesExtractor.operation(dbRequest)).willReturn("SELECT");
     given(sqlAttributesExtractor.name(dbRequest)).willReturn("database");
+    given(sqlAttributesExtractor.table(dbRequest)).willReturn("another.table");
 
     SpanNameExtractor<DbRequest> underTest = DbSpanNameExtractor.create(sqlAttributesExtractor);
 
@@ -60,8 +60,8 @@ class DbSpanNameExtractorTest {
     // given
     DbRequest dbRequest = new DbRequest();
 
-    // cannot stub dbOperation() and dbTable() because they're final
-    given(sqlAttributesExtractor.rawStatement(dbRequest)).willReturn("SELECT * FROM table");
+    given(sqlAttributesExtractor.operation(dbRequest)).willReturn("SELECT");
+    given(sqlAttributesExtractor.table(dbRequest)).willReturn("table");
 
     SpanNameExtractor<DbRequest> underTest = DbSpanNameExtractor.create(sqlAttributesExtractor);
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -6,12 +6,16 @@
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.entry;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +23,10 @@ class HttpClientAttributesExtractorTest {
 
   static class TestHttpClientAttributesExtractor
       extends HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> {
+
+    TestHttpClientAttributesExtractor(CapturedHttpHeaders capturedHttpHeaders) {
+      super(capturedHttpHeaders);
+    }
 
     @Override
     protected String method(Map<String, String> request) {
@@ -31,8 +39,8 @@ class HttpClientAttributesExtractorTest {
     }
 
     @Override
-    protected String userAgent(Map<String, String> request) {
-      return request.get("userAgent");
+    protected List<String> requestHeader(Map<String, String> request, String name) {
+      return asList(request.get("header." + name).split(","));
     }
 
     @Override
@@ -67,6 +75,12 @@ class HttpClientAttributesExtractorTest {
         Map<String, String> request, Map<String, String> response) {
       return Long.parseLong(response.get("responseContentLengthUncompressed"));
     }
+
+    @Override
+    protected List<String> responseHeader(
+        Map<String, String> request, Map<String, String> response, String name) {
+      return asList(response.get("header." + name).split(","));
+    }
   }
 
   @Test
@@ -74,24 +88,33 @@ class HttpClientAttributesExtractorTest {
     Map<String, String> request = new HashMap<>();
     request.put("method", "POST");
     request.put("url", "http://github.com");
-    request.put("userAgent", "okhttp 3.x");
     request.put("requestContentLength", "10");
     request.put("requestContentLengthUncompressed", "11");
     request.put("flavor", "http/2");
+    request.put("header.user-agent", "okhttp 3.x");
+    request.put("header.custom-request-header", "123,456");
 
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");
     response.put("responseContentLength", "20");
     response.put("responseContentLengthUncompressed", "21");
+    response.put("header.custom-response-header", "654,321");
 
-    TestHttpClientAttributesExtractor extractor = new TestHttpClientAttributesExtractor();
+    TestHttpClientAttributesExtractor extractor =
+        new TestHttpClientAttributesExtractor(
+            CapturedHttpHeaders.create(
+                singletonList("Custom-Request-Header"), singletonList("Custom-Response-Header")));
+
     AttributesBuilder attributes = Attributes.builder();
     extractor.onStart(attributes, request);
     assertThat(attributes.build())
         .containsOnly(
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_URL, "http://github.com"),
-            entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"));
+            entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
+            entry(
+                AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
+                asList("123", "456")));
 
     extractor.onEnd(attributes, request, response, null);
     assertThat(attributes.build())
@@ -99,11 +122,17 @@ class HttpClientAttributesExtractorTest {
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_URL, "http://github.com"),
             entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
+            entry(
+                AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
+                asList("123", "456")),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, 11L),
             entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
             entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
-            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, 21L));
+            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, 21L),
+            entry(
+                AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
+                asList("654", "321")));
   }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -6,12 +6,16 @@
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.entry;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +23,10 @@ class HttpServerAttributesExtractorTest {
 
   static class TestHttpServerAttributesExtractor
       extends HttpServerAttributesExtractor<Map<String, String>, Map<String, String>> {
+
+    TestHttpServerAttributesExtractor(CapturedHttpHeaders capturedHttpHeaders) {
+      super(capturedHttpHeaders);
+    }
 
     @Override
     protected String method(Map<String, String> request) {
@@ -28,11 +36,6 @@ class HttpServerAttributesExtractorTest {
     @Override
     protected String target(Map<String, String> request) {
       return request.get("target");
-    }
-
-    @Override
-    protected String host(Map<String, String> request) {
-      return request.get("host");
     }
 
     @Override
@@ -51,8 +54,8 @@ class HttpServerAttributesExtractorTest {
     }
 
     @Override
-    protected String userAgent(Map<String, String> request) {
-      return request.get("userAgent");
+    protected List<String> requestHeader(Map<String, String> request, String name) {
+      return asList(request.get("header." + name).split(","));
     }
 
     @Override
@@ -87,6 +90,12 @@ class HttpServerAttributesExtractorTest {
         Map<String, String> request, Map<String, String> response) {
       return Long.parseLong(response.get("responseContentLengthUncompressed"));
     }
+
+    @Override
+    protected List<String> responseHeader(
+        Map<String, String> request, Map<String, String> response, String name) {
+      return asList(response.get("header." + name).split(","));
+    }
   }
 
   @Test
@@ -95,49 +104,63 @@ class HttpServerAttributesExtractorTest {
     request.put("method", "POST");
     request.put("url", "http://github.com");
     request.put("target", "/repositories/1");
-    request.put("host", "github.com:80");
     request.put("scheme", "https");
-    request.put("userAgent", "okhttp 3.x");
     request.put("requestContentLength", "10");
     request.put("requestContentLengthUncompressed", "11");
     request.put("flavor", "http/2");
     request.put("route", "/repositories/{id}");
     request.put("serverName", "server");
+    request.put("header.user-agent", "okhttp 3.x");
+    request.put("header.host", "github.com");
+    request.put("header.custom-request-header", "123,456");
 
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");
     response.put("responseContentLength", "20");
     response.put("responseContentLengthUncompressed", "21");
+    response.put("header.custom-response-header", "654,321");
 
-    TestHttpServerAttributesExtractor extractor = new TestHttpServerAttributesExtractor();
+    TestHttpServerAttributesExtractor extractor =
+        new TestHttpServerAttributesExtractor(
+            CapturedHttpHeaders.create(
+                singletonList("Custom-Request-Header"), singletonList("Custom-Response-Header")));
+
     AttributesBuilder attributes = Attributes.builder();
     extractor.onStart(attributes, request);
     assertThat(attributes.build())
         .containsOnly(
             entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
-            entry(SemanticAttributes.HTTP_TARGET, "/repositories/1"),
-            entry(SemanticAttributes.HTTP_HOST, "github.com:80"),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
+            entry(SemanticAttributes.HTTP_HOST, "github.com"),
+            entry(SemanticAttributes.HTTP_TARGET, "/repositories/1"),
             entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
-            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"));
+            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
+            entry(
+                AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
+                asList("123", "456")));
 
     extractor.onEnd(attributes, request, response, null);
     assertThat(attributes.build())
         .containsOnly(
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
-            entry(SemanticAttributes.HTTP_TARGET, "/repositories/1"),
-            entry(SemanticAttributes.HTTP_HOST, "github.com:80"),
-            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
+            entry(SemanticAttributes.HTTP_HOST, "github.com"),
+            entry(SemanticAttributes.HTTP_TARGET, "/repositories/1"),
             entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
             entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
+            entry(
+                AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
+                asList("123", "456")),
             entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, 11L),
             entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
             entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
-            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, 21L));
+            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, 21L),
+            entry(
+                AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
+                asList("654", "321")));
   }
 }

--- a/instrumentation-api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/instrumentation-api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesExtractor.java
@@ -6,12 +6,21 @@
 package io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ApacheHttpAsyncClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
+
+  ApacheHttpAsyncClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected String method(ApacheHttpClientRequest request) {
@@ -24,9 +33,8 @@ final class ApacheHttpAsyncClientHttpAttributesExtractor
   }
 
   @Override
-  @Nullable
-  protected String userAgent(ApacheHttpClientRequest request) {
-    return request.getHeader("User-Agent");
+  protected List<String> requestHeader(ApacheHttpClientRequest request, String name) {
+    return request.getHeader(name);
   }
 
   @Override
@@ -67,5 +75,13 @@ final class ApacheHttpAsyncClientHttpAttributesExtractor
   protected Long responseContentLengthUncompressed(
       ApacheHttpClientRequest request, HttpResponse response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      ApacheHttpClientRequest request, HttpResponse response, String name) {
+    return Arrays.stream(response.getHeaders(name))
+        .map(Header::getValue)
+        .collect(Collectors.toList());
   }
 }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesExtractor.java
@@ -5,12 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient;
 
+import static io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient.ApacheHttpClientRequest.headersToList;
+
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -80,8 +79,6 @@ final class ApacheHttpAsyncClientHttpAttributesExtractor
   @Override
   protected List<String> responseHeader(
       ApacheHttpClientRequest request, HttpResponse response, String name) {
-    return Arrays.stream(response.getHeaders(name))
-        .map(Header::getValue)
-        .collect(Collectors.toList());
+    return headersToList(response.getHeaders(name));
   }
 }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -34,9 +37,10 @@ public final class ApacheHttpClientRequest {
     delegate = httpRequest;
   }
 
-  public String getHeader(String name) {
-    Header header = delegate.getFirstHeader(name);
-    return header != null ? header.getValue() : null;
+  public List<String> getHeader(String name) {
+    return Arrays.stream(delegate.getHeaders(name))
+        .map(Header::getValue)
+        .collect(Collectors.toList());
   }
 
   public void setHeader(String name, String value) {

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
@@ -8,9 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -38,9 +38,19 @@ public final class ApacheHttpClientRequest {
   }
 
   public List<String> getHeader(String name) {
-    return Arrays.stream(delegate.getHeaders(name))
-        .map(Header::getValue)
-        .collect(Collectors.toList());
+    return headersToList(delegate.getHeaders(name));
+  }
+
+  // minimize memory overhead by not using streams
+  static List<String> headersToList(Header[] headers) {
+    if (headers.length == 0) {
+      return Collections.emptyList();
+    }
+    List<String> headersList = new ArrayList<>(headers.length);
+    for (int i = 0; i < headers.length; ++i) {
+      headersList.set(i, headers[i].getValue());
+    }
+    return headersList;
   }
 
   public void setHeader(String name, String value) {

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -5,8 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v2_0;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HostConfiguration;
 import org.apache.commons.httpclient.HttpMethod;
@@ -16,6 +21,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ApacheHttpClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<HttpMethod, HttpMethod> {
+
+  ApacheHttpClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected String method(HttpMethod request) {
@@ -32,6 +41,12 @@ final class ApacheHttpClientHttpAttributesExtractor
   protected String userAgent(HttpMethod request) {
     Header header = request.getRequestHeader("User-Agent");
     return header != null ? header.getValue() : null;
+  }
+
+  @Override
+  protected List<String> requestHeader(HttpMethod request, String name) {
+    Header header = request.getRequestHeader(name);
+    return header == null ? emptyList() : singletonList(header.getValue());
   }
 
   @Override
@@ -75,6 +90,12 @@ final class ApacheHttpClientHttpAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(HttpMethod request, HttpMethod response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(HttpMethod request, HttpMethod response, String name) {
+    Header header = response.getResponseHeader(name);
+    return header == null ? emptyList() : singletonList(header.getValue());
   }
 
   // mirroring implementation HttpMethodBase.getURI(), to avoid converting to URI and back to String

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -6,11 +6,20 @@
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v4_0;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ApacheHttpClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
+
+  ApacheHttpClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected String method(ApacheHttpClientRequest request) {
@@ -23,9 +32,8 @@ final class ApacheHttpClientHttpAttributesExtractor
   }
 
   @Override
-  @Nullable
-  protected String userAgent(ApacheHttpClientRequest request) {
-    return request.getHeader("User-Agent");
+  protected List<String> requestHeader(ApacheHttpClientRequest request, String name) {
+    return request.getHeader(name);
   }
 
   @Override
@@ -64,5 +72,13 @@ final class ApacheHttpClientHttpAttributesExtractor
   protected Long responseContentLengthUncompressed(
       ApacheHttpClientRequest request, HttpResponse response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      ApacheHttpClientRequest request, HttpResponse response, String name) {
+    return Arrays.stream(response.getHeaders(name))
+        .map(Header::getValue)
+        .collect(Collectors.toList());
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -5,12 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v4_0;
 
+import static io.opentelemetry.javaagent.instrumentation.apachehttpclient.v4_0.ApacheHttpClientRequest.headersToList;
+
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -77,8 +76,6 @@ final class ApacheHttpClientHttpAttributesExtractor
   @Override
   protected List<String> responseHeader(
       ApacheHttpClientRequest request, HttpResponse response, String name) {
-    return Arrays.stream(response.getHeaders(name))
-        .map(Header::getValue)
-        .collect(Collectors.toList());
+    return headersToList(response.getHeaders(name));
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v4_0;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -40,9 +43,10 @@ public final class ApacheHttpClientRequest {
     delegate = httpRequest;
   }
 
-  public String getHeader(String name) {
-    Header header = delegate.getFirstHeader(name);
-    return header != null ? header.getValue() : null;
+  public List<String> getHeader(String name) {
+    return Arrays.stream(delegate.getHeaders(name))
+        .map(Header::getValue)
+        .collect(Collectors.toList());
   }
 
   public void setHeader(String name, String value) {

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
@@ -8,9 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v4_0;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -44,9 +44,19 @@ public final class ApacheHttpClientRequest {
   }
 
   public List<String> getHeader(String name) {
-    return Arrays.stream(delegate.getHeaders(name))
-        .map(Header::getValue)
-        .collect(Collectors.toList());
+    return headersToList(delegate.getHeaders(name));
+  }
+
+  // minimize memory overhead by not using streams
+  static List<String> headersToList(Header[] headers) {
+    if (headers.length == 0) {
+      return Collections.emptyList();
+    }
+    List<String> headersList = new ArrayList<>(headers.length);
+    for (int i = 0; i < headers.length; ++i) {
+      headersList.set(i, headers[i].getValue());
+    }
+    return headersList;
   }
 
   public void setHeader(String name, String value) {

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesExtractor.java
@@ -5,12 +5,22 @@
 
 package io.opentelemetry.instrumentation.apachehttpclient.v4_3;
 
+import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ApacheHttpClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
+
+  // TODO: add support for capturing HTTP headers in library instrumentations
+  ApacheHttpClientHttpAttributesExtractor() {
+    super(CapturedHttpHeaders.empty());
+  }
 
   @Override
   protected String method(ApacheHttpClientRequest request) {
@@ -24,9 +34,8 @@ final class ApacheHttpClientHttpAttributesExtractor
   }
 
   @Override
-  @Nullable
-  protected String userAgent(ApacheHttpClientRequest request) {
-    return request.getHeader("User-Agent");
+  protected List<String> requestHeader(ApacheHttpClientRequest request, String name) {
+    return request.getHeader(name);
   }
 
   @Override
@@ -65,5 +74,13 @@ final class ApacheHttpClientHttpAttributesExtractor
   protected Long responseContentLengthUncompressed(
       ApacheHttpClientRequest request, HttpResponse response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      ApacheHttpClientRequest request, HttpResponse response, String name) {
+    return Arrays.stream(response.getHeaders(name))
+        .map(Header::getValue)
+        .collect(Collectors.toList());
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesExtractor.java
@@ -5,12 +5,11 @@
 
 package io.opentelemetry.instrumentation.apachehttpclient.v4_3;
 
+import static io.opentelemetry.instrumentation.apachehttpclient.v4_3.ApacheHttpClientRequest.headersToList;
+
 import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -79,8 +78,6 @@ final class ApacheHttpClientHttpAttributesExtractor
   @Override
   protected List<String> responseHeader(
       ApacheHttpClientRequest request, HttpResponse response, String name) {
-    return Arrays.stream(response.getHeaders(name))
-        .map(Header::getValue)
-        .collect(Collectors.toList());
+    return headersToList(response.getHeaders(name));
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.instrumentation.apachehttpclient.v4_3;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -39,10 +42,10 @@ public final class ApacheHttpClientRequest {
     return delegate;
   }
 
-  @Nullable
-  String getHeader(String name) {
-    Header header = delegate.getFirstHeader(name);
-    return header != null ? header.getValue() : null;
+  List<String> getHeader(String name) {
+    return Arrays.stream(delegate.getHeaders(name))
+        .map(Header::getValue)
+        .collect(Collectors.toList());
   }
 
   void setHeader(String name, String value) {

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
@@ -8,9 +8,9 @@ package io.opentelemetry.instrumentation.apachehttpclient.v4_3;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -43,9 +43,19 @@ public final class ApacheHttpClientRequest {
   }
 
   List<String> getHeader(String name) {
-    return Arrays.stream(delegate.getHeaders(name))
-        .map(Header::getValue)
-        .collect(Collectors.toList());
+    return headersToList(delegate.getHeaders(name));
+  }
+
+  // minimize memory overhead by not using streams
+  static List<String> headersToList(Header[] headers) {
+    if (headers.length == 0) {
+      return Collections.emptyList();
+    }
+    List<String> headersList = new ArrayList<>(headers.length);
+    for (int i = 0; i < headers.length; ++i) {
+      headersList.set(i, headers[i].getValue());
+    }
+    return headersList;
   }
 
   void setHeader(String name, String value) {

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -6,7 +6,11 @@
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v5_0;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpResponse;
@@ -21,6 +25,10 @@ final class ApacheHttpClientHttpAttributesExtractor
 
   private static final Logger logger =
       LoggerFactory.getLogger(ApacheHttpClientHttpAttributesExtractor.class);
+
+  ApacheHttpClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected String method(ClassicHttpRequest request) {
@@ -65,6 +73,13 @@ final class ApacheHttpClientHttpAttributesExtractor
   protected String userAgent(ClassicHttpRequest request) {
     Header header = request.getFirstHeader("User-Agent");
     return header != null ? header.getValue() : null;
+  }
+
+  @Override
+  protected List<String> requestHeader(ClassicHttpRequest request, String name) {
+    return Arrays.stream(request.getHeaders(name))
+        .map(Header::getValue)
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -122,5 +137,13 @@ final class ApacheHttpClientHttpAttributesExtractor
   protected Long responseContentLengthUncompressed(
       ClassicHttpRequest request, HttpResponse response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      ClassicHttpRequest request, HttpResponse response, String name) {
+    return Arrays.stream(response.getHeaders(name))
+        .map(Header::getValue)
+        .collect(Collectors.toList());
   }
 }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesExtractor.java
@@ -11,12 +11,19 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
+import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ArmeriaHttpClientAttributesExtractor
     extends HttpClientAttributesExtractor<RequestContext, RequestLog> {
+
+  // TODO: add support for capturing HTTP headers in library instrumentations
+  ArmeriaHttpClientAttributesExtractor() {
+    super(CapturedHttpHeaders.empty());
+  }
 
   @Override
   protected String method(RequestContext ctx) {
@@ -32,6 +39,11 @@ final class ArmeriaHttpClientAttributesExtractor
   @Nullable
   protected String userAgent(RequestContext ctx) {
     return request(ctx).headers().get(HttpHeaderNames.USER_AGENT);
+  }
+
+  @Override
+  protected List<String> requestHeader(RequestContext ctx, String name) {
+    return request(ctx).headers().getAll(name);
   }
 
   @Override
@@ -79,6 +91,11 @@ final class ArmeriaHttpClientAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(RequestContext ctx, RequestLog requestLog) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(RequestContext ctx, RequestLog requestLog, String name) {
+    return requestLog.responseHeaders().getAll(name);
   }
 
   private static HttpRequest request(RequestContext ctx) {

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesExtractor.java
@@ -12,12 +12,19 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ArmeriaHttpServerAttributesExtractor
     extends HttpServerAttributesExtractor<RequestContext, RequestLog> {
+
+  // TODO: add support for capturing HTTP headers in library instrumentations
+  ArmeriaHttpServerAttributesExtractor() {
+    super(CapturedHttpHeaders.empty());
+  }
 
   @Override
   protected String method(RequestContext ctx) {
@@ -45,6 +52,11 @@ final class ArmeriaHttpServerAttributesExtractor
   @Nullable
   protected String userAgent(RequestContext ctx) {
     return request(ctx).headers().get(HttpHeaderNames.USER_AGENT);
+  }
+
+  @Override
+  protected List<String> requestHeader(RequestContext ctx, String name) {
+    return request(ctx).headers().getAll(name);
   }
 
   @Override
@@ -92,6 +104,11 @@ final class ArmeriaHttpServerAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(RequestContext ctx, RequestLog requestLog) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(RequestContext ctx, RequestLog requestLog, String name) {
+    return requestLog.responseHeaders().getAll(name);
   }
 
   @Override

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesExtractor.java
@@ -8,11 +8,18 @@ package io.opentelemetry.javaagent.instrumentation.asynchttpclient.v1_9;
 import com.ning.http.client.Request;
 import com.ning.http.client.Response;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.Collections;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class AsyncHttpClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<Request, Response> {
+
+  AsyncHttpClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected String method(Request request) {
@@ -25,9 +32,8 @@ final class AsyncHttpClientHttpAttributesExtractor
   }
 
   @Override
-  @Nullable
-  protected String userAgent(Request request) {
-    return null;
+  protected List<String> requestHeader(Request request, String name) {
+    return request.getHeaders().getOrDefault(name, Collections.emptyList());
   }
 
   @Override
@@ -62,5 +68,10 @@ final class AsyncHttpClientHttpAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(Request request, Response response, String name) {
+    return response.getHeaders().getOrDefault(name, Collections.emptyList());
   }
 }

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesExtractor.java
@@ -6,13 +6,19 @@
 package io.opentelemetry.javaagent.instrumentation.asynchttpclient.v2_0;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import org.asynchttpclient.Response;
 import org.asynchttpclient.netty.request.NettyRequest;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class AsyncHttpClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<RequestContext, Response> {
+
+  AsyncHttpClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected String method(RequestContext requestContext) {
@@ -25,9 +31,8 @@ final class AsyncHttpClientHttpAttributesExtractor
   }
 
   @Override
-  @Nullable
-  protected String userAgent(RequestContext requestContext) {
-    return null;
+  protected List<String> requestHeader(RequestContext requestContext, String name) {
+    return requestContext.getRequest().getHeaders().getAll(name);
   }
 
   @Override
@@ -83,5 +88,11 @@ final class AsyncHttpClientHttpAttributesExtractor
   protected Long responseContentLengthUncompressed(
       RequestContext requestContext, Response response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      RequestContext requestContext, Response response, String name) {
+    return response.getHeaders(name);
   }
 }

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesExtractor.java
@@ -93,6 +93,6 @@ final class AsyncHttpClientHttpAttributesExtractor
   @Override
   protected List<String> responseHeader(
       RequestContext requestContext, Response response, String name) {
-    return response.getHeaders(name);
+    return response.getHeaders().getAll(name);
   }
 }

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesExtractor.java
@@ -8,11 +8,17 @@ package io.opentelemetry.javaagent.instrumentation.googlehttpclient;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class GoogleHttpClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<HttpRequest, HttpResponse> {
+
+  GoogleHttpClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected @Nullable String method(HttpRequest httpRequest) {
@@ -27,6 +33,11 @@ final class GoogleHttpClientHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(HttpRequest httpRequest) {
     return httpRequest.getHeaders().getUserAgent();
+  }
+
+  @Override
+  protected List<String> requestHeader(HttpRequest httpRequest, String name) {
+    return httpRequest.getHeaders().getHeaderStringValues(name);
   }
 
   @Override
@@ -61,5 +72,11 @@ final class GoogleHttpClientHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       HttpRequest httpRequest, HttpResponse httpResponse) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      HttpRequest httpRequest, HttpResponse httpResponse, String name) {
+    return httpResponse.getHeaders().getHeaderStringValues(name);
   }
 }

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesExtractor.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesExtractor.java
@@ -5,13 +5,23 @@
 
 package io.opentelemetry.javaagent.instrumentation.httpurlconnection;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.HttpURLConnection;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 class HttpUrlHttpAttributesExtractor
     extends HttpClientAttributesExtractor<HttpURLConnection, Integer> {
+
+  HttpUrlHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
+
   @Override
   protected String method(HttpURLConnection connection) {
     return connection.getRequestMethod();
@@ -25,6 +35,12 @@ class HttpUrlHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(HttpURLConnection connection) {
     return connection.getRequestProperty("User-Agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(HttpURLConnection connection, String name) {
+    String value = connection.getRequestProperty(name);
+    return value == null ? emptyList() : singletonList(value);
   }
 
   @Override
@@ -58,5 +74,11 @@ class HttpUrlHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       HttpURLConnection connection, Integer statusCode) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      HttpURLConnection connection, Integer statusCode, String name) {
+    return emptyList();
   }
 }

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesExtractor.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesExtractor.java
@@ -6,14 +6,20 @@
 package io.opentelemetry.javaagent.instrumentation.httpclient;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 class JdkHttpAttributesExtractor
     extends HttpClientAttributesExtractor<HttpRequest, HttpResponse<?>> {
+
+  JdkHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected String method(HttpRequest httpRequest) {
@@ -28,6 +34,11 @@ class JdkHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(HttpRequest httpRequest) {
     return httpRequest.headers().firstValue("User-Agent").orElse(null);
+  }
+
+  @Override
+  protected List<String> requestHeader(HttpRequest httpRequest, String name) {
+    return httpRequest.headers().allValues(name);
   }
 
   @Override
@@ -65,5 +76,11 @@ class JdkHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       HttpRequest httpRequest, HttpResponse<?> httpResponse) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      HttpRequest httpRequest, HttpResponse<?> httpResponse, String name) {
+    return httpResponse.headers().allValues(name);
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesExtractor.java
@@ -12,8 +12,8 @@ import com.sun.jersey.api.client.ClientResponse;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class JaxRsClientHttpAttributesExtractor
@@ -41,9 +41,16 @@ final class JaxRsClientHttpAttributesExtractor
 
   @Override
   protected List<String> requestHeader(ClientRequest httpRequest, String name) {
-    return httpRequest.getHeaders().getOrDefault(name, emptyList()).stream()
-        .map(String::valueOf)
-        .collect(Collectors.toList());
+    List<Object> rawHeaders = httpRequest.getHeaders().getOrDefault(name, emptyList());
+    if (rawHeaders.isEmpty()) {
+      return emptyList();
+    }
+    List<String> stringHeaders = new ArrayList<>(rawHeaders.size());
+    int i = 0;
+    for (Object headerValue : rawHeaders) {
+      stringHeaders.set(i++, String.valueOf(headerValue));
+    }
+    return stringHeaders;
   }
 
   @Override

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesExtractor.java
@@ -5,14 +5,23 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrsclient.v1_1;
 
+import static java.util.Collections.emptyList;
+
 import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class JaxRsClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<ClientRequest, ClientResponse> {
+
+  JaxRsClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected @Nullable String method(ClientRequest httpRequest) {
@@ -28,6 +37,13 @@ final class JaxRsClientHttpAttributesExtractor
   protected @Nullable String userAgent(ClientRequest httpRequest) {
     Object header = httpRequest.getHeaders().getFirst("User-Agent");
     return header != null ? header.toString() : null;
+  }
+
+  @Override
+  protected List<String> requestHeader(ClientRequest httpRequest, String name) {
+    return httpRequest.getHeaders().getOrDefault(name, emptyList()).stream()
+        .map(String::valueOf)
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -63,5 +79,11 @@ final class JaxRsClientHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       ClientRequest httpRequest, ClientResponse httpResponse) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      ClientRequest httpRequest, ClientResponse httpResponse, String name) {
+    return httpResponse.getHeaders().getOrDefault(name, emptyList());
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientHttpAttributesExtractor.java
@@ -5,14 +5,22 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrsclient.v2_0;
 
+import static java.util.Collections.emptyList;
+
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class JaxRsClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<ClientRequestContext, ClientResponseContext> {
+
+  JaxRsClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected @Nullable String method(ClientRequestContext httpRequest) {
@@ -27,6 +35,11 @@ final class JaxRsClientHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(ClientRequestContext httpRequest) {
     return httpRequest.getHeaderString("User-Agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(ClientRequestContext httpRequest, String name) {
+    return httpRequest.getStringHeaders().getOrDefault(name, emptyList());
   }
 
   @Override
@@ -48,7 +61,7 @@ final class JaxRsClientHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable Integer statusCode(
+  protected Integer statusCode(
       ClientRequestContext httpRequest, ClientResponseContext httpResponse) {
     return httpResponse.getStatus();
   }
@@ -64,5 +77,11 @@ final class JaxRsClientHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       ClientRequestContext httpRequest, ClientResponseContext httpResponse) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      ClientRequestContext httpRequest, ClientResponseContext httpResponse, String name) {
+    return httpResponse.getHeaders().getOrDefault(name, emptyList());
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientHttpAttributesExtractor.java
@@ -10,8 +10,8 @@ import static java.util.Collections.emptyList;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
@@ -40,9 +40,16 @@ final class ResteasyClientHttpAttributesExtractor
 
   @Override
   protected List<String> requestHeader(ClientInvocation httpRequest, String name) {
-    return httpRequest.getHeaders().getHeaders().getOrDefault(name, emptyList()).stream()
-        .map(String::valueOf)
-        .collect(Collectors.toList());
+    List<Object> rawHeaders = httpRequest.getHeaders().getHeaders().getOrDefault(name, emptyList());
+    if (rawHeaders.isEmpty()) {
+      return emptyList();
+    }
+    List<String> stringHeaders = new ArrayList<>(rawHeaders.size());
+    int i = 0;
+    for (Object headerValue : rawHeaders) {
+      stringHeaders.set(i++, String.valueOf(headerValue));
+    }
+    return stringHeaders;
   }
 
   @Override

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientHttpAttributesExtractor.java
@@ -5,14 +5,23 @@
 
 package io.opentelemetry.javaagent.instrumentation.jaxrsclient.v2_0;
 
+import static java.util.Collections.emptyList;
+
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 
 final class ResteasyClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<ClientInvocation, Response> {
+
+  ResteasyClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected @Nullable String method(ClientInvocation httpRequest) {
@@ -27,6 +36,13 @@ final class ResteasyClientHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(ClientInvocation httpRequest) {
     return httpRequest.getHeaders().getHeader("User-Agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(ClientInvocation httpRequest, String name) {
+    return httpRequest.getHeaders().getHeaders().getOrDefault(name, emptyList()).stream()
+        .map(String::valueOf)
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -62,5 +78,11 @@ final class ResteasyClientHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       ClientInvocation httpRequest, Response httpResponse) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      ClientInvocation clientInvocation, Response response, String name) {
+    return response.getStringHeaders().getOrDefault(name, emptyList());
   }
 }

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesExtractor.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesExtractor.java
@@ -5,14 +5,23 @@
 
 package io.opentelemetry.javaagent.instrumentation.kubernetesclient;
 
+import static java.util.Collections.emptyList;
+
 import io.kubernetes.client.openapi.ApiResponse;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import okhttp3.Request;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 class KubernetesHttpAttributesExtractor
     extends HttpClientAttributesExtractor<Request, ApiResponse<?>> {
+
+  KubernetesHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
+
   @Override
   protected String method(Request request) {
     return request.method();
@@ -26,6 +35,11 @@ class KubernetesHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(Request request) {
     return request.header("user-agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(Request request, String name) {
+    return request.headers(name);
   }
 
   @Override
@@ -59,5 +73,10 @@ class KubernetesHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       Request request, ApiResponse<?> apiResponse) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(Request request, ApiResponse<?> apiResponse, String name) {
+    return apiResponse.getHeaders().getOrDefault(name, emptyList());
   }
 }

--- a/instrumentation/liberty/compile-stub/src/main/java/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/instrumentation/liberty/compile-stub/src/main/java/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -5,6 +5,8 @@
 
 package com.ibm.ws.http.dispatcher.internal.channel;
 
+import com.ibm.wsspi.http.HttpResponse;
+
 // https://github.com/OpenLiberty/open-liberty/blob/master/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
 public class HttpDispatcherLink {
 
@@ -25,6 +27,10 @@ public class HttpDispatcherLink {
   }
 
   public int getRequestedPort() {
+    throw new UnsupportedOperationException();
+  }
+
+  public HttpResponse getResponse() {
     throw new UnsupportedOperationException();
   }
 }

--- a/instrumentation/liberty/compile-stub/src/main/java/com/ibm/wsspi/http/HttpResponse.java
+++ b/instrumentation/liberty/compile-stub/src/main/java/com/ibm/wsspi/http/HttpResponse.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.wsspi.http;
+
+import java.util.List;
+
+// https://github.com/OpenLiberty/open-liberty/blob/integration/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/HttpResponse.java
+public interface HttpResponse {
+
+  List<String> getHeaders(String name);
+}

--- a/instrumentation/liberty/compile-stub/src/main/java/com/ibm/wsspi/http/channel/HttpRequestMessage.java
+++ b/instrumentation/liberty/compile-stub/src/main/java/com/ibm/wsspi/http/channel/HttpRequestMessage.java
@@ -15,6 +15,8 @@ public interface HttpRequestMessage {
 
   HeaderField getHeader(String paramString);
 
+  List<HeaderField> getHeaders(String name);
+
   String getScheme();
 
   String getRequestURI();

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesExtractor.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesExtractor.java
@@ -6,14 +6,16 @@
 package io.opentelemetry.javaagent.instrumentation.liberty.dispatcher;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class LibertyDispatcherHttpAttributesExtractor
     extends HttpServerAttributesExtractor<LibertyRequest, LibertyResponse> {
-  private static final Logger logger =
-      LoggerFactory.getLogger(LibertyDispatcherHttpAttributesExtractor.class);
+
+  public LibertyDispatcherHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedServerHeaders());
+  }
 
   @Override
   protected @Nullable String method(LibertyRequest libertyRequest) {
@@ -23,6 +25,11 @@ public class LibertyDispatcherHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(LibertyRequest libertyRequest) {
     return libertyRequest.getHeaderValue("User-Agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(LibertyRequest libertyRequest, String name) {
+    return libertyRequest.getHeaderValues(name);
   }
 
   @Override
@@ -65,6 +72,12 @@ public class LibertyDispatcherHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       LibertyRequest libertyRequest, LibertyResponse libertyResponse) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      LibertyRequest libertyRequest, LibertyResponse libertyResponse, String name) {
+    return libertyResponse.getHeaderValues(name);
   }
 
   @Override

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherLinkInstrumentation.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherLinkInstrumentation.java
@@ -68,6 +68,7 @@ public class LibertyDispatcherLinkInstrumentation implements TypeInstrumentation
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
+        @Advice.This HttpDispatcherLink httpDispatcherLink,
         @Advice.Thrown Throwable throwable,
         @Advice.Argument(value = 0) StatusCodes statusCode,
         @Advice.Argument(value = 2) Exception failure,
@@ -79,7 +80,7 @@ public class LibertyDispatcherLinkInstrumentation implements TypeInstrumentation
       }
       scope.close();
 
-      LibertyResponse response = new LibertyResponse(statusCode);
+      LibertyResponse response = new LibertyResponse(httpDispatcherLink, statusCode);
       request.setCompleted();
 
       Throwable t = failure != null ? failure : throwable;

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.javaagent.instrumentation.liberty.dispatcher;
 import com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink;
 import com.ibm.wsspi.genericbnf.HeaderField;
 import com.ibm.wsspi.http.channel.HttpRequestMessage;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class LibertyRequest {
@@ -52,6 +54,19 @@ public class LibertyRequest {
   public String getHeaderValue(String name) {
     HeaderField hf = httpRequestMessage.getHeader(name);
     return hf != null ? hf.asString() : null;
+  }
+
+  public List<String> getHeaderValues(String name) {
+    List<HeaderField> headers = httpRequestMessage.getHeaders(name);
+    if (headers.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<String> stringHeaders = new ArrayList<>(headers.size());
+    int i = 0;
+    for (HeaderField header : headers) {
+      stringHeaders.set(i++, header.asString());
+    }
+    return stringHeaders;
   }
 
   public int peerPort() {

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyResponse.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyResponse.java
@@ -5,16 +5,29 @@
 
 package io.opentelemetry.javaagent.instrumentation.liberty.dispatcher;
 
+import com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink;
+import com.ibm.wsspi.http.HttpResponse;
 import com.ibm.wsspi.http.channel.values.StatusCodes;
+import java.util.Collections;
+import java.util.List;
 
 public class LibertyResponse {
+  private final HttpDispatcherLink httpDispatcherLink;
   private final StatusCodes code;
 
-  public LibertyResponse(StatusCodes code) {
+  public LibertyResponse(HttpDispatcherLink httpDispatcherLink, StatusCodes code) {
+    this.httpDispatcherLink = httpDispatcherLink;
     this.code = code;
   }
 
   public int getStatus() {
     return code.getIntCode();
+  }
+
+  public List<String> getHeaderValues(String name) {
+    HttpResponse response = httpDispatcherLink.getResponse();
+    // response is set to null on destroy(), so it shouldn't really ever be null in the middle of
+    // request processing, but just to be safe let's check it
+    return response == null ? Collections.emptyList() : response.getHeaders(name);
   }
 }

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesExtractor.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesExtractor.java
@@ -8,11 +8,17 @@ package io.opentelemetry.javaagent.instrumentation.okhttp.v2_2;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class OkHttp2HttpAttributesExtractor
     extends HttpClientAttributesExtractor<Request, Response> {
+
+  OkHttp2HttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected String method(Request request) {
@@ -28,6 +34,11 @@ final class OkHttp2HttpAttributesExtractor
   @Nullable
   protected String userAgent(Request request) {
     return request.header("User-Agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(Request request, String name) {
+    return request.headers(name);
   }
 
   @Override
@@ -77,5 +88,10 @@ final class OkHttp2HttpAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(Request request, Response response, String name) {
+    return response.headers(name);
   }
 }

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesExtractor.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesExtractor.java
@@ -5,13 +5,21 @@
 
 package io.opentelemetry.instrumentation.okhttp.v3_0;
 
+import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class OkHttpAttributesExtractor extends HttpClientAttributesExtractor<Request, Response> {
+
+  // TODO: add support for capturing HTTP headers in library instrumentations
+  OkHttpAttributesExtractor() {
+    super(CapturedHttpHeaders.empty());
+  }
+
   @Override
   protected String method(Request request) {
     return request.method();
@@ -26,6 +34,11 @@ final class OkHttpAttributesExtractor extends HttpClientAttributesExtractor<Requ
   protected @Nullable String userAgent(Request request) {
     // using lowercase header name intentionally to ensure extraction is not case-sensitive
     return request.header("user-agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(Request request, String name) {
+    return request.headers(name);
   }
 
   @Override
@@ -73,5 +86,10 @@ final class OkHttpAttributesExtractor extends HttpClientAttributesExtractor<Requ
   @Override
   protected @Nullable Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(Request request, Response response, String name) {
+    return response.headers(name);
   }
 }

--- a/instrumentation/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesExtractor.java
+++ b/instrumentation/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesExtractor.java
@@ -6,13 +6,19 @@
 package io.opentelemetry.javaagent.instrumentation.playws;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import play.shaded.ahc.org.asynchttpclient.Request;
 import play.shaded.ahc.org.asynchttpclient.Response;
 
 final class PlayWsClientHttpAttributesExtractor
     extends HttpClientAttributesExtractor<Request, Response> {
+
+  PlayWsClientHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedClientHeaders());
+  }
 
   @Override
   protected String method(Request request) {
@@ -28,6 +34,11 @@ final class PlayWsClientHttpAttributesExtractor
   @Nullable
   protected String userAgent(Request request) {
     return null;
+  }
+
+  @Override
+  protected List<String> requestHeader(Request request, String name) {
+    return request.getHeaders().getAll(name);
   }
 
   @Override
@@ -62,5 +73,10 @@ final class PlayWsClientHttpAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(Request request, Response response, String name) {
+    return response.getHeaders().getAll(name);
   }
 }

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesExtractor.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesExtractor.java
@@ -5,9 +5,11 @@
 
 package io.opentelemetry.instrumentation.ratpack;
 
+import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import ratpack.handling.Context;
 import ratpack.http.Request;
@@ -16,6 +18,12 @@ import ratpack.server.PublicAddress;
 
 final class RatpackHttpAttributesExtractor
     extends HttpServerAttributesExtractor<Request, Response> {
+
+  // TODO: add support for capturing HTTP headers in library instrumentations
+  RatpackHttpAttributesExtractor() {
+    super(CapturedHttpHeaders.empty());
+  }
+
   @Override
   protected String method(Request request) {
     return request.getMethod().getName();
@@ -70,6 +78,11 @@ final class RatpackHttpAttributesExtractor
   }
 
   @Override
+  protected List<String> requestHeader(Request request, String name) {
+    return request.getHeaders().getAll(name);
+  }
+
+  @Override
   @Nullable
   protected Long requestContentLength(Request request, @Nullable Response response) {
     return null;
@@ -118,5 +131,10 @@ final class RatpackHttpAttributesExtractor
   @Nullable
   protected Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(Request request, Response response, String name) {
+    return response.getHeaders().getAll(name);
   }
 }

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHeadersGetter.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHeadersGetter.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.restlet.v1_0;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import java.util.Locale;
 import org.restlet.data.Form;
+import org.restlet.data.Message;
 import org.restlet.data.Request;
 
 final class RestletHeadersGetter implements TextMapGetter<Request> {
@@ -29,7 +30,7 @@ final class RestletHeadersGetter implements TextMapGetter<Request> {
     return headers.getFirstValue(key.toLowerCase(Locale.ROOT));
   }
 
-  private static Form getHeaders(Request carrier) {
+  static Form getHeaders(Message carrier) {
     return (Form) carrier.getAttributes().get("org.restlet.http.headers");
   }
 }

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesExtractor.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesExtractor.java
@@ -5,15 +5,26 @@
 
 package io.opentelemetry.instrumentation.restlet.v1_0;
 
+import static io.opentelemetry.instrumentation.restlet.v1_0.RestletHeadersGetter.getHeaders;
+
+import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.restlet.data.Parameter;
 import org.restlet.data.Reference;
 import org.restlet.data.Request;
 import org.restlet.data.Response;
 
 final class RestletHttpAttributesExtractor
     extends HttpServerAttributesExtractor<Request, Response> {
+
+  // TODO: add support for capturing HTTP headers in library instrumentations
+  RestletHttpAttributesExtractor() {
+    super(CapturedHttpHeaders.empty());
+  }
 
   @Override
   protected String method(Request request) {
@@ -46,6 +57,13 @@ final class RestletHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(Request request) {
     return request.getClientInfo().getAgent();
+  }
+
+  @Override
+  protected List<String> requestHeader(Request request, String name) {
+    return getHeaders(request).subList(name, /* ignoreCase = */ true).stream()
+        .map(Parameter::getValue)
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -93,5 +111,12 @@ final class RestletHttpAttributesExtractor
   @Override
   protected @Nullable Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(Request request, Response response, String name) {
+    return getHeaders(response).subList(name, /* ignoreCase = */ true).stream()
+        .map(Parameter::getValue)
+        .collect(Collectors.toList());
   }
 }

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Accessor.java
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Accessor.java
@@ -7,6 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.servlet.v2_2;
 
 import io.opentelemetry.instrumentation.servlet.ServletAsyncListener;
 import io.opentelemetry.instrumentation.servlet.javax.JavaxServletAccessor;
+import java.util.Collections;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -36,6 +38,12 @@ public class Servlet2Accessor extends JavaxServletAccessor<HttpServletResponse> 
   @Override
   public String getResponseHeader(HttpServletResponse httpServletResponse, String name) {
     return null;
+  }
+
+  @Override
+  public List<String> getResponseHeaderValues(
+      HttpServletResponse httpServletResponse, String name) {
+    return Collections.emptyList();
   }
 
   @Override

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Accessor.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Accessor.java
@@ -7,6 +7,10 @@ package io.opentelemetry.javaagent.instrumentation.servlet.v3_0;
 
 import io.opentelemetry.instrumentation.servlet.ServletAsyncListener;
 import io.opentelemetry.instrumentation.servlet.javax.JavaxServletAccessor;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
 import javax.servlet.http.HttpServletRequest;
@@ -42,6 +46,18 @@ public class Servlet3Accessor extends JavaxServletAccessor<HttpServletResponse> 
   @Override
   public String getResponseHeader(HttpServletResponse response, String name) {
     return response.getHeader(name);
+  }
+
+  @Override
+  public List<String> getResponseHeaderValues(HttpServletResponse response, String name) {
+    Collection<String> values = response.getHeaders(name);
+    if (values == null) {
+      return Collections.emptyList();
+    }
+    if (values instanceof List) {
+      return (List<String>) values;
+    }
+    return new ArrayList<>(values);
   }
 
   @Override

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
@@ -13,7 +13,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
 
 public class Servlet5Accessor implements ServletAccessor<HttpServletRequest, HttpServletResponse> {
   public static final Servlet5Accessor INSTANCE = new Servlet5Accessor();
@@ -81,6 +85,12 @@ public class Servlet5Accessor implements ServletAccessor<HttpServletRequest, Htt
   }
 
   @Override
+  public List<String> getRequestHeaderValues(HttpServletRequest request, String name) {
+    Enumeration<String> values = request.getHeaders(name);
+    return values == null ? Collections.emptyList() : Collections.list(values);
+  }
+
+  @Override
   public Iterable<String> getRequestHeaderNames(HttpServletRequest httpServletRequest) {
     return Collections.list(httpServletRequest.getHeaderNames());
   }
@@ -135,6 +145,18 @@ public class Servlet5Accessor implements ServletAccessor<HttpServletRequest, Htt
   @Override
   public String getResponseHeader(HttpServletResponse response, String name) {
     return response.getHeader(name);
+  }
+
+  @Override
+  public List<String> getResponseHeaderValues(HttpServletResponse response, String name) {
+    Collection<String> values = response.getHeaders(name);
+    if (values == null) {
+      return Collections.emptyList();
+    }
+    if (values instanceof List) {
+      return (List<String>) values;
+    }
+    return new ArrayList<>(values);
   }
 
   @Override

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesExtractor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesExtractor.java
@@ -7,6 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.servlet;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.servlet.ServletAccessor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ServletHttpAttributesExtractor<REQUEST, RESPONSE>
@@ -15,6 +17,7 @@ public class ServletHttpAttributesExtractor<REQUEST, RESPONSE>
   protected final ServletAccessor<REQUEST, RESPONSE> accessor;
 
   public ServletHttpAttributesExtractor(ServletAccessor<REQUEST, RESPONSE> accessor) {
+    super(HttpHeadersConfig.capturedServerHeaders());
     this.accessor = accessor;
   }
 
@@ -48,6 +51,11 @@ public class ServletHttpAttributesExtractor<REQUEST, RESPONSE>
   @Override
   protected @Nullable String userAgent(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestHeader(requestContext.request(), "User-Agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(ServletRequestContext<REQUEST> requestContext, String name) {
+    return accessor.getRequestHeaderValues(requestContext.request(), name);
   }
 
   @Override
@@ -121,6 +129,14 @@ public class ServletHttpAttributesExtractor<REQUEST, RESPONSE>
       ServletRequestContext<REQUEST> requestContext,
       ServletResponseContext<RESPONSE> responseContext) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      ServletRequestContext<REQUEST> requestContext,
+      ServletResponseContext<RESPONSE> responseContext,
+      String name) {
+    return accessor.getResponseHeaderValues(responseContext.response(), name);
   }
 
   @Override

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/ServletAccessor.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/ServletAccessor.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.servlet;
 
 import java.security.Principal;
+import java.util.List;
 
 /**
  * This interface is used to access methods of ServletContext, HttpServletRequest and
@@ -42,6 +43,8 @@ public interface ServletAccessor<REQUEST, RESPONSE> {
 
   String getRequestHeader(REQUEST request, String name);
 
+  List<String> getRequestHeaderValues(REQUEST request, String name);
+
   Iterable<String> getRequestHeaderNames(REQUEST request);
 
   String getRequestServletPath(REQUEST request);
@@ -62,6 +65,8 @@ public interface ServletAccessor<REQUEST, RESPONSE> {
   int getResponseStatus(RESPONSE response);
 
   String getResponseHeader(RESPONSE response, String name);
+
+  List<String> getResponseHeaderValues(RESPONSE response, String name);
 
   boolean isResponseCommitted(RESPONSE response);
 

--- a/instrumentation/servlet/servlet-javax-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/javax/JavaxServletAccessor.java
+++ b/instrumentation/servlet/servlet-javax-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/javax/JavaxServletAccessor.java
@@ -8,6 +8,8 @@ package io.opentelemetry.instrumentation.servlet.javax;
 import io.opentelemetry.instrumentation.servlet.ServletAccessor;
 import java.security.Principal;
 import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
@@ -75,6 +77,12 @@ public abstract class JavaxServletAccessor<R> implements ServletAccessor<HttpSer
   @Override
   public String getRequestHeader(HttpServletRequest request, String name) {
     return request.getHeader(name);
+  }
+
+  @Override
+  public List<String> getRequestHeaderValues(HttpServletRequest request, String name) {
+    Enumeration<String> values = request.getHeaders(name);
+    return values == null ? Collections.emptyList() : Collections.list(values);
   }
 
   @Override

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebHttpAttributesExtractor.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebHttpAttributesExtractor.java
@@ -5,8 +5,12 @@
 
 package io.opentelemetry.instrumentation.spring.web;
 
+import static java.util.Collections.emptyList;
+
+import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import java.io.IOException;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpStatus;
@@ -14,6 +18,12 @@ import org.springframework.http.client.ClientHttpResponse;
 
 final class SpringWebHttpAttributesExtractor
     extends HttpClientAttributesExtractor<HttpRequest, ClientHttpResponse> {
+
+  // TODO: add support for capturing HTTP headers in library instrumentations
+  SpringWebHttpAttributesExtractor() {
+    super(CapturedHttpHeaders.empty());
+  }
+
   @Override
   protected String method(HttpRequest httpRequest) {
     return httpRequest.getMethod().name();
@@ -28,6 +38,11 @@ final class SpringWebHttpAttributesExtractor
   protected @Nullable String userAgent(HttpRequest httpRequest) {
     // using lowercase header name intentionally to ensure extraction is not case-sensitive
     return httpRequest.getHeaders().getFirst("user-agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(HttpRequest httpRequest, String name) {
+    return httpRequest.getHeaders().getOrDefault(name, emptyList());
   }
 
   @Override
@@ -67,5 +82,11 @@ final class SpringWebHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       HttpRequest httpRequest, ClientHttpResponse clientHttpResponse) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      HttpRequest httpRequest, ClientHttpResponse clientHttpResponse, String name) {
+    return clientHttpResponse.getHeaders().getOrDefault(name, emptyList());
   }
 }

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcHttpAttributesExtractor.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcHttpAttributesExtractor.java
@@ -5,13 +5,25 @@
 
 package io.opentelemetry.instrumentation.spring.webmvc;
 
+import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class SpringWebMvcHttpAttributesExtractor
     extends HttpServerAttributesExtractor<HttpServletRequest, HttpServletResponse> {
+
+  // TODO: add support for capturing HTTP headers in library instrumentations
+  SpringWebMvcHttpAttributesExtractor() {
+    super(CapturedHttpHeaders.empty());
+  }
+
   @Override
   protected @Nullable String method(HttpServletRequest request) {
     return request.getMethod();
@@ -20,6 +32,12 @@ final class SpringWebMvcHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(HttpServletRequest request) {
     return request.getHeader("user-agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(HttpServletRequest request, String name) {
+    Enumeration<String> headers = request.getHeaders(name);
+    return headers == null ? Collections.emptyList() : Collections.list(headers);
   }
 
   @Override
@@ -55,6 +73,19 @@ final class SpringWebMvcHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       HttpServletRequest request, HttpServletResponse response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      HttpServletRequest request, HttpServletResponse response, String name) {
+    Collection<String> headers = response.getHeaders(name);
+    if (headers == null) {
+      return Collections.emptyList();
+    }
+    if (headers instanceof List) {
+      return (List<String>) headers;
+    }
+    return new ArrayList<>(headers);
   }
 
   @Override

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesExtractor.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesExtractor.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.javaagent.instrumentation.tomcat.common;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
+import java.util.Collections;
+import java.util.List;
 import org.apache.coyote.Request;
 import org.apache.coyote.Response;
 import org.apache.tomcat.util.buf.MessageBytes;
@@ -13,6 +16,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TomcatHttpAttributesExtractor
     extends HttpServerAttributesExtractor<Request, Response> {
+
+  public TomcatHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedServerHeaders());
+  }
 
   @Override
   protected String method(Request request) {
@@ -43,6 +50,11 @@ public class TomcatHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(Request request) {
     return request.getHeader("User-Agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(Request request, String name) {
+    return Collections.list(request.getMimeHeaders().values(name));
   }
 
   @Override
@@ -89,6 +101,11 @@ public class TomcatHttpAttributesExtractor
   @Override
   protected @Nullable Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(Request request, Response response, String name) {
+    return Collections.list(response.getMimeHeaders().values(name));
   }
 
   @Override

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesExtractor.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesExtractor.java
@@ -6,11 +6,19 @@
 package io.opentelemetry.javaagent.instrumentation.undertow;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.api.config.HttpHeadersConfig;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderValues;
+import java.util.Collections;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class UndertowHttpAttributesExtractor
     extends HttpServerAttributesExtractor<HttpServerExchange, HttpServerExchange> {
+
+  public UndertowHttpAttributesExtractor() {
+    super(HttpHeadersConfig.capturedServerHeaders());
+  }
 
   @Override
   protected String method(HttpServerExchange exchange) {
@@ -20,6 +28,12 @@ public class UndertowHttpAttributesExtractor
   @Override
   protected @Nullable String userAgent(HttpServerExchange exchange) {
     return exchange.getRequestHeaders().getFirst("User-Agent");
+  }
+
+  @Override
+  protected List<String> requestHeader(HttpServerExchange exchange, String name) {
+    HeaderValues values = exchange.getRequestHeaders().get(name);
+    return values == null ? Collections.emptyList() : values;
   }
 
   @Override
@@ -61,6 +75,13 @@ public class UndertowHttpAttributesExtractor
   protected @Nullable Long responseContentLengthUncompressed(
       HttpServerExchange exchange, HttpServerExchange unused) {
     return null;
+  }
+
+  @Override
+  protected List<String> responseHeader(
+      HttpServerExchange exchange, HttpServerExchange unused, String name) {
+    HeaderValues values = exchange.getResponseHeaders().get(name);
+    return values == null ? Collections.emptyList() : values;
   }
 
   @Override

--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/config/HttpHeadersConfig.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/config/HttpHeadersConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.api.config;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
+
+/** Javaagent configuration of captured HTTP request/response headers. */
+public final class HttpHeadersConfig {
+
+  private static final CapturedHttpHeaders CLIENT;
+  private static final CapturedHttpHeaders SERVER;
+
+  static {
+    Config config = Config.get();
+    CLIENT =
+        CapturedHttpHeaders.create(
+            config.getList(
+                "otel.instrumentation.common.experimental.capture-http-headers.client.request"),
+            config.getList(
+                "otel.instrumentation.common.experimental.capture-http-headers.client.response"));
+    SERVER =
+        CapturedHttpHeaders.create(
+            config.getList(
+                "otel.instrumentation.common.experimental.capture-http-headers.server.request"),
+            config.getList(
+                "otel.instrumentation.common.experimental.capture-http-headers.server.response"));
+  }
+
+  public static CapturedHttpHeaders capturedClientHeaders() {
+    return CLIENT;
+  }
+
+  public static CapturedHttpHeaders capturedServerHeaders() {
+    return SERVER;
+  }
+
+  private HttpHeadersConfig() {}
+}


### PR DESCRIPTION
This PR implements the [HTTP request/response headers as span attributes semantic convention](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md).

It includes:
* new methods added in the HTTP extractors, and a new "configuration" class that needs to be passed to HTTP extractors
* 4 new javaagent config properties (see `HttpHeadersConfig`)
* implementations of the new methods in all HTTP instrumentations that we have

Things that will be done in the followings PRs:
* remove `userAgent()` and `host()` implementations from all instrumentations, they're not needed anymore
* implement captured headers configuration for library instrumentations
* add tests that verify that headers were captured to `HttpClientTest` and `HttpServerTest`
* move client IP extraction from `ServerInstrumenter` to `HttpServerAttributesExtractor`
* maybe introduce a universal `HttpHeadersGetter` for all HTTP instrumentations? since we already have a method that returns values of any header in the extractor (it could implement https://github.com/open-telemetry/opentelemetry-specification/pull/1884 properly too, for all HTTP instrumentations at the same time)
* some documentation for the new config properties (other than Javadocs 😅 )