### PR TITLE
Verify example extension during release build

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -200,9 +200,17 @@ jobs:
           git fetch origin main
           git cherry-pick ${{ github.event.inputs.commits }}
 
-      - name: Build
-        run: ./gradlew build --stacktrace
+      - name: Local publish
+        # javadoc task fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
+        run: ./gradlew publishToMavenLocal -x javadoc
+
+      - name: Build distro
+        run: ./gradlew build --init-script ../../.github/scripts/local.init.gradle.kts
         working-directory: examples/distro
+
+      - name: Build extension
+        run: ./gradlew build --init-script ../../.github/scripts/local.init.gradle.kts
+        working-directory: examples/extension
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -122,9 +122,17 @@ jobs:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('examples/distro/gradle/wrapper/gradle-wrapper.properties') }}
 
-      - name: Build
-        run: ./gradlew build --stacktrace
+      - name: Local publish
+        # javadoc task fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
+        run: ./gradlew publishToMavenLocal -x javadoc
+
+      - name: Build distro
+        run: ./gradlew build --init-script ../../.github/scripts/local.init.gradle.kts
         working-directory: examples/distro
+
+      - name: Build extension
+        run: ./gradlew build --init-script ../../.github/scripts/local.init.gradle.kts
+        working-directory: examples/extension
 
   release:
     needs: [ test, smoke-test, examples ]


### PR DESCRIPTION
Unrelated to the 1.6.1 problem, but noticed when looking at that.