### PR TITLE
AWS lambda - improvements in custom type handling in wrappers, SQS ev…

### DIFF
--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/LambdaParameters.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/LambdaParameters.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awslambda.v1_0;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import java.lang.reflect.Method;
+import java.util.function.BiFunction;
+
+class LambdaParameters {
+
+  static <T> Object[] toArray(
+      Method targetMethod, T input, Context context, BiFunction<T, Class, Object> mapper) {
+    Class<?>[] parameterTypes = targetMethod.getParameterTypes();
+    Object[] parameters = new Object[parameterTypes.length];
+    for (int i = 0; i < parameterTypes.length; i++) {
+      Class clazz = parameterTypes[i];
+      boolean isContext = clazz.equals(Context.class);
+      if (isContext) {
+        parameters[i] = context;
+      } else if (i == 0) {
+        parameters[0] = (clazz.isInstance(input) ? input : mapper.apply(input, clazz));
+      }
+    }
+    return parameters;
+  }
+}

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestApiGatewayWrapper.java
@@ -5,23 +5,58 @@
 
 package io.opentelemetry.instrumentation.awslambda.v1_0;
 
+import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import java.util.function.BiFunction;
 
 /**
  * Wrapper for {@link TracingRequestHandler}. Allows for wrapping a lambda proxied through API
  * Gateway, enabling single span tracing and HTTP context propagation.
  */
 public class TracingRequestApiGatewayWrapper
-    extends TracingRequestWrapperBase<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    extends TracingRequestWrapperBase<APIGatewayProxyRequestEvent, Object> {
 
   public TracingRequestApiGatewayWrapper() {
-    super();
+    super(TracingRequestApiGatewayWrapper::map);
   }
 
   // Visible for testing
-  TracingRequestApiGatewayWrapper(OpenTelemetrySdk openTelemetrySdk, WrappedLambda wrappedLambda) {
-    super(openTelemetrySdk, wrappedLambda);
+  TracingRequestApiGatewayWrapper(
+      OpenTelemetrySdk openTelemetrySdk,
+      WrappedLambda wrappedLambda,
+      BiFunction<APIGatewayProxyRequestEvent, Class, Object> mapper) {
+    super(openTelemetrySdk, wrappedLambda, mapper);
+  }
+
+  // Visible for testing
+  static Object map(APIGatewayProxyRequestEvent event, Class clazz) {
+    try {
+      return OBJECT_MAPPER.readValue(event.getBody(), clazz);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(
+          "Could not map API Gateway event body to requested parameter type: " + clazz, e);
+    }
+  }
+
+  @Override
+  protected APIGatewayProxyResponseEvent doHandleRequest(
+      APIGatewayProxyRequestEvent input, Context context) {
+    Object result = super.doHandleRequest(input, context);
+    APIGatewayProxyResponseEvent event = null;
+    // map to response event if needed
+    if (result instanceof APIGatewayProxyResponseEvent) {
+      event = (APIGatewayProxyResponseEvent) result;
+    } else {
+      try {
+        event = new APIGatewayProxyResponseEvent();
+        event.setBody(OBJECT_MAPPER.writeValueAsString(result));
+      } catch (JsonProcessingException e) {
+        throw new IllegalStateException("Could not serialize return value.", e);
+      }
+    }
+    return event;
   }
 }

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapper.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awslambda.v1_0;
 
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import java.util.function.BiFunction;
 
 /**
  * Wrapper for {@link TracingRequestHandler}. Allows for wrapping a regular lambda, not proxied
@@ -13,11 +14,24 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
  */
 public class TracingRequestWrapper extends TracingRequestWrapperBase<Object, Object> {
   public TracingRequestWrapper() {
-    super();
+    super(TracingRequestWrapper::map);
   }
 
   // Visible for testing
-  TracingRequestWrapper(OpenTelemetrySdk openTelemetrySdk, WrappedLambda wrappedLambda) {
-    super(openTelemetrySdk, wrappedLambda);
+  TracingRequestWrapper(
+      OpenTelemetrySdk openTelemetrySdk,
+      WrappedLambda wrappedLambda,
+      BiFunction<Object, Class, Object> mapper) {
+    super(openTelemetrySdk, wrappedLambda, mapper);
+  }
+
+  // Visible for testing
+  static Object map(Object jsonMap, Class clazz) {
+    try {
+      return OBJECT_MAPPER.convertValue(jsonMap, clazz);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalStateException(
+          "Could not map input to requested parameter type: " + clazz, e);
+    }
   }
 }

--- a/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsEventWrapper.java
+++ b/instrumentation/aws-lambda-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambda/v1_0/TracingSqsEventWrapper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awslambda.v1_0;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class TracingSqsEventWrapper extends TracingSqsEventHandler {
+
+  private final WrappedLambda wrappedLambda;
+
+  public TracingSqsEventWrapper() {
+    this(OpenTelemetrySdkAutoConfiguration.initialize(), WrappedLambda.fromConfiguration());
+  }
+
+  // Visible for testing
+  TracingSqsEventWrapper(OpenTelemetrySdk openTelemetrySdk, WrappedLambda wrappedLambda) {
+    super(openTelemetrySdk, WrapperConfiguration.flushTimeout());
+    this.wrappedLambda = wrappedLambda;
+  }
+
+  @Override
+  protected void handleEvent(SQSEvent sqsEvent, Context context) {
+    Method targetMethod = wrappedLambda.getRequestTargetMethod();
+    Object[] parameters =
+        LambdaParameters.toArray(targetMethod, sqsEvent, context, (event, clazz) -> event);
+    try {
+      targetMethod.invoke(wrappedLambda.getTargetObject(), parameters);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("Method is inaccessible", e);
+    } catch (InvocationTargetException e) {
+      throw (e.getCause() instanceof RuntimeException
+          ? (RuntimeException) e.getCause()
+          : new IllegalStateException(e.getTargetException()));
+    }
+  }
+}

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTest.groovy
@@ -26,9 +26,35 @@ class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
     }
   }
 
+  static class TestRequestHandlerInteger implements RequestHandler<Integer, String> {
+
+    @Override
+    String handleRequest(Integer input, Context context) {
+      if (input == 1) {
+        return "world"
+      }
+      throw new IllegalArgumentException("bad argument")
+    }
+  }
+
+  static class CustomType {
+    String key, value
+  }
+
+  static class TestRequestHandlerCustomType implements RequestHandler<CustomType, String> {
+
+    @Override
+    String handleRequest(CustomType input, Context context) {
+      if (input.key == "hello there") {
+        return input.value
+      }
+      throw new IllegalArgumentException("bad argument")
+    }
+  }
+
   def "handler string traced"() {
     given:
-    setLambda(TestRequestHandlerString.getName() + "::handleRequest", TracingRequestWrapper.metaClass.&invokeConstructor)
+    setLambda(TestRequestHandlerString.getName() + "::handleRequest", TracingRequestWrapper.metaClass.&invokeConstructor, TracingRequestWrapper.&map)
 
     when:
     def result = wrapper.handleRequest("hello", context)
@@ -52,7 +78,7 @@ class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
 
   def "handler with exception"() {
     given:
-    setLambda(TestRequestHandlerString.getName() + "::handleRequest", TracingRequestWrapper.metaClass.&invokeConstructor)
+    setLambda(TestRequestHandlerString.getName() + "::handleRequest", TracingRequestWrapper.metaClass.&invokeConstructor, TracingRequestWrapper.&map)
 
     when:
     def thrown
@@ -71,6 +97,57 @@ class TracingRequestWrapperTest extends TracingRequestWrapperTestBase {
           kind SERVER
           status ERROR
           errorEvent(IllegalArgumentException, "bad argument")
+          attributes {
+            "$ResourceAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"
+            "$ResourceAttributes.CLOUD_ACCOUNT_ID.key" "123456789"
+            "${SemanticAttributes.FAAS_EXECUTION.key}" "1-22-333"
+          }
+        }
+      }
+    }
+  }
+
+  def "handler integer traced"() {
+    given:
+    setLambda(TestRequestHandlerInteger.getName() + "::handleRequest", TracingRequestWrapper.metaClass.&invokeConstructor, TracingRequestWrapper.&map)
+
+    when:
+    def result = wrapper.handleRequest(1, context)
+
+    then:
+    result == "world"
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name("my_function")
+          kind SERVER
+          attributes {
+            "$ResourceAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"
+            "$ResourceAttributes.CLOUD_ACCOUNT_ID.key" "123456789"
+            "${SemanticAttributes.FAAS_EXECUTION.key}" "1-22-333"
+          }
+        }
+      }
+    }
+  }
+
+  def "handler custom type traced"() {
+    given:
+    setLambda(TestRequestHandlerCustomType.getName() + "::handleRequest", TracingRequestWrapper.metaClass.&invokeConstructor, TracingRequestWrapper.&map)
+
+    when:
+    CustomType ct = new CustomType()
+    ct.key = "hello there"
+    ct.value = "General Kenobi"
+    def result = wrapper.handleRequest(ct, context)
+
+    then:
+    result == "General Kenobi"
+    assertTraces(1) {
+      trace(0, 1) {
+        span(0) {
+          name("my_function")
+          kind SERVER
           attributes {
             "$ResourceAttributes.FAAS_ID.key" "arn:aws:lambda:us-east-1:123456789:function:test"
             "$ResourceAttributes.CLOUD_ACCOUNT_ID.key" "123456789"

--- a/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
+++ b/instrumentation/aws-lambda-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/awslambda/v1_0/TracingRequestWrapperTestBase.groovy
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awslambda.v1_0
 
 import com.amazonaws.services.lambda.runtime.Context
 import io.opentelemetry.instrumentation.test.LibraryInstrumentationSpecification
+import java.util.function.BiFunction
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Shared
@@ -29,8 +30,8 @@ class TracingRequestWrapperTestBase extends LibraryInstrumentationSpecification 
     context.getInvokedFunctionArn() >> "arn:aws:lambda:us-east-1:123456789:function:test"
   }
 
-  def setLambda(handler, Closure<TracingRequestWrapperBase> wrapperConstructor) {
+  def setLambda(handler, Closure<TracingRequestWrapperBase> wrapperConstructor, BiFunction<?, Class, Object> mapper) {
     environmentVariables.set(WrappedLambda.OTEL_LAMBDA_HANDLER_ENV_KEY, handler)
-    wrapper = wrapperConstructor.call(testRunner().openTelemetrySdk, WrappedLambda.fromConfiguration())
+    wrapper = wrapperConstructor.call(testRunner().openTelemetrySdk, WrappedLambda.fromConfiguration(), mapper)
   }
 }

--- a/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/LambdaParametersTest.java
+++ b/instrumentation/aws-lambda-1.0/library/src/test/java/io/opentelemetry/instrumentation/awslambda/v1_0/LambdaParametersTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awslambda.v1_0;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+class LambdaParametersTest {
+
+  public void onlyContext(Context context) {}
+
+  public void contextOnThird(String one, String two, Context context) {}
+
+  @Test
+  public void shouldSetContextOnFirstPosition() throws NoSuchMethodException {
+    // given
+    Context context = mock(Context.class);
+    Method method = getClass().getMethod("onlyContext", Context.class);
+    // when
+    Object[] params = LambdaParameters.toArray(method, "", context, (o, c) -> o);
+    // then
+    assertThat(params).hasSize(1);
+    assertThat(params[0]).isEqualTo(context);
+  }
+
+  @Test
+  public void shouldSetContextOnTheLastPosition() throws NoSuchMethodException {
+    // given
+    Context context = mock(Context.class);
+    Method method =
+        getClass().getMethod("contextOnThird", String.class, String.class, Context.class);
+    // when
+    Object[] params = LambdaParameters.toArray(method, "", context, (o, c) -> o);
+    // then
+    assertThat(params).hasSize(3);
+    assertThat(params[0]).isEqualTo("");
+    assertThat(params[1]).isNull();
+    assertThat(params[2]).isEqualTo(context);
+  }
+}


### PR DESCRIPTION
…en wrapper added

Two goals with this PR:
- allow users of lambda wrappers to use custom types in their handlers (along with simple types and build-in events)
- add wrapper for SQS event handler 