### PR TITLE
Sync otlp exporter grpc-netty-shaded version with opentelemetry-java

### DIFF
--- a/javaagent-exporters/build.gradle.kts
+++ b/javaagent-exporters/build.gradle.kts
@@ -19,5 +19,5 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-exporter-zipkin")
 
   // TODO(anuraaga): Move version to dependency management
-  implementation("io.grpc:grpc-netty-shaded:1.38.0")
+  implementation("io.grpc:grpc-netty-shaded:1.40.1")
 }


### PR DESCRIPTION
`opentelemetry-java` uses [grpc version 1.40.1](https://github.com/open-telemetry/opentelemetry-java/blob/main/dependencyManagement/build.gradle.kts#L19). 

I know that its sometimes ok using different grpc api and implementation versions, but sometimes not. I think we ought to try to keep these in sync. 