### PR TITLE
Remove unnecessary VirtualField#setIfNull() method

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/field/VirtualField.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/field/VirtualField.java
@@ -48,9 +48,6 @@ public abstract class VirtualField<T, F> {
   /** Sets the new value of this virtual field. */
   public abstract void set(T object, @Nullable F fieldValue);
 
-  /** Sets the new value of this virtual field if the current value is {@code null}. */
-  public abstract void setIfNull(T object, F fieldValue);
-
   /**
    * Sets the new value of this virtual field if the current value is {@code null}.
    *

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
@@ -73,11 +73,6 @@ public final class RuntimeVirtualFieldSupplier {
     }
 
     @Override
-    public void setIfNull(T object, F fieldValue) {
-      cache.computeIfAbsent(object, k -> fieldValue);
-    }
-
-    @Override
     public F computeIfNull(T object, Supplier<F> fieldValueSupplier) {
       return cache.computeIfAbsent(object, k -> fieldValueSupplier.get());
     }

--- a/instrumentation/hibernate/hibernate-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/SessionFactoryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v3_3/SessionFactoryInstrumentation.java
@@ -62,11 +62,11 @@ public class SessionFactoryInstrumentation implements TypeInstrumentation {
       if (session instanceof Session) {
         VirtualField<Session, Context> virtualField =
             VirtualField.find(Session.class, Context.class);
-        virtualField.setIfNull((Session) session, context);
+        virtualField.set((Session) session, context);
       } else if (session instanceof StatelessSession) {
         VirtualField<StatelessSession, Context> virtualField =
             VirtualField.find(StatelessSession.class, Context.class);
-        virtualField.setIfNull((StatelessSession) session, context);
+        virtualField.set((StatelessSession) session, context);
       }
     }
   }

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionFactoryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/SessionFactoryInstrumentation.java
@@ -58,7 +58,7 @@ public class SessionFactoryInstrumentation implements TypeInstrumentation {
 
       VirtualField<SharedSessionContract, Context> virtualField =
           VirtualField.find(SharedSessionContract.class, Context.class);
-      virtualField.setIfNull(session, context);
+      virtualField.set(session, context);
     }
   }
 }

--- a/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/SessionMethodUtils.java
+++ b/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/SessionMethodUtils.java
@@ -90,7 +90,7 @@ public final class SessionMethodUtils {
       return;
     }
 
-    targetVirtualField.setIfNull(target, sessionContext);
+    targetVirtualField.set(target, sessionContext);
   }
 
   public static String getSessionMethodSpanName(String methodName) {

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
@@ -81,6 +81,14 @@ public class NettyChannelPipelineInstrumentation
         return;
       }
 
+      VirtualField<ChannelHandler, ChannelHandler> instrumentationHandlerField =
+          VirtualField.find(ChannelHandler.class, ChannelHandler.class);
+
+      // don't add another instrumentation handler if there already is one attached
+      if (instrumentationHandlerField.get(handler) != null) {
+        return;
+      }
+
       String name = handlerName;
       if (name == null) {
         ChannelHandlerContext context = pipeline.context(handler);
@@ -113,8 +121,7 @@ public class NettyChannelPipelineInstrumentation
         try {
           pipeline.addAfter(name, ourHandler.getClass().getName(), ourHandler);
           // associate our handle with original handler so they could be removed together
-          VirtualField.find(ChannelHandler.class, ChannelHandler.class)
-              .setIfNull(handler, ourHandler);
+          instrumentationHandlerField.set(handler, ourHandler);
         } catch (IllegalArgumentException e) {
           // Prevented adding duplicate handlers.
         }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3FilterInitAdvice.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3FilterInitAdvice.java
@@ -21,6 +21,6 @@ public class Servlet3FilterInitAdvice {
       return;
     }
     VirtualField.find(Filter.class, MappingResolver.Factory.class)
-        .setIfNull(filter, new Servlet3FilterMappingResolverFactory(filterConfig));
+        .set(filter, new Servlet3FilterMappingResolverFactory(filterConfig));
   }
 }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3InitAdvice.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3InitAdvice.java
@@ -21,6 +21,6 @@ public class Servlet3InitAdvice {
       return;
     }
     VirtualField.find(Servlet.class, MappingResolver.Factory.class)
-        .setIfNull(servlet, new Servlet3MappingResolverFactory(servletConfig));
+        .set(servlet, new Servlet3MappingResolverFactory(servletConfig));
   }
 }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/service/JakartaServletFilterInitAdvice.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/service/JakartaServletFilterInitAdvice.java
@@ -21,6 +21,6 @@ public class JakartaServletFilterInitAdvice {
       return;
     }
     VirtualField.find(Filter.class, MappingResolver.Factory.class)
-        .setIfNull(filter, new JakartaServletFilterMappingResolverFactory(filterConfig));
+        .set(filter, new JakartaServletFilterMappingResolverFactory(filterConfig));
   }
 }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/service/JakartaServletInitAdvice.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/service/JakartaServletInitAdvice.java
@@ -21,6 +21,6 @@ public class JakartaServletInitAdvice {
       return;
     }
     VirtualField.find(Servlet.class, MappingResolver.Factory.class)
-        .setIfNull(servlet, new JakartaServletMappingResolverFactory(servletConfig));
+        .set(servlet, new JakartaServletMappingResolverFactory(servletConfig));
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/context/FieldBackedProvider.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/context/FieldBackedProvider.java
@@ -882,21 +882,6 @@ public class FieldBackedProvider implements InstrumentationContextProvider {
     }
 
     @Override
-    public void setIfNull(Object object, Object fieldValue) {
-      Object oldFieldValue = realGet(object);
-      if (oldFieldValue != null) {
-        return;
-      }
-      synchronized (realSynchronizeInstance(object)) {
-        oldFieldValue = realGet(object);
-        if (oldFieldValue != null) {
-          return;
-        }
-        realPut(object, fieldValue);
-      }
-    }
-
-    @Override
     public Object computeIfNull(Object object, Supplier<Object> fieldValueSupplier) {
       Object existingContext = realGet(object);
       if (null != existingContext) {

--- a/testing-common/integration-tests/src/main/java/context/ContextTestInstrumentation.java
+++ b/testing-common/integration-tests/src/main/java/context/ContextTestInstrumentation.java
@@ -52,19 +52,6 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
         @Advice.This KeyClass thiz, @Advice.Return(readOnly = false) int contextCount) {
       VirtualField<KeyClass, Context> virtualField =
           VirtualField.find(KeyClass.class, Context.class);
-      virtualField.setIfNull(thiz, new Context());
-      Context context = virtualField.get(thiz);
-      contextCount = ++context.count;
-    }
-  }
-
-  @SuppressWarnings("unused")
-  public static class StoreAndIncrementWithFactoryApiUsageAdvice {
-    @Advice.OnMethodExit
-    public static void methodExit(
-        @Advice.This KeyClass thiz, @Advice.Return(readOnly = false) int contextCount) {
-      VirtualField<KeyClass, Context> virtualField =
-          VirtualField.find(KeyClass.class, Context.class);
       Context context = virtualField.computeIfNull(thiz, Context.FACTORY);
       contextCount = ++context.count;
     }

--- a/testing-common/library-for-integration-tests/src/main/java/library/KeyClass.java
+++ b/testing-common/library-for-integration-tests/src/main/java/library/KeyClass.java
@@ -16,11 +16,6 @@ public class KeyClass {
     return -1;
   }
 
-  public int incrementContextCountWithFactory() {
-    // implementation replaced with test instrumentation
-    return -1;
-  }
-
   public int getContextCount() {
     // implementation replaced with test instrumentation
     return -1;


### PR DESCRIPTION
I was used in 3 instrumentations:
* Hibernate -- the field value was set for freshly constructed objects (`@Advice.Return` instrumentation), there couldn't have been any value other than null
* Netty -- I replaced it with a much safer alternative that skips adding the handler altogether if there's a non-null value attached
* Servlet -- only used in `(Filter|Servlet).init()` calls, I doubt that a servlet instance will have its `init()` method called more than once (and even if it somehow does get called again, it's probably safer to construct the mappings again based on the most recent `ServletConfig` value)