### PR TITLE
Intern db info

### DIFF
--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/DriverInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/DriverInstrumentation.java
@@ -58,7 +58,7 @@ public class DriverInstrumentation implements TypeInstrumentation {
         return;
       }
       DbInfo dbInfo = JdbcConnectionUrlParser.parse(url, props);
-      JdbcData.connectionInfo.set(connection, dbInfo);
+      JdbcData.connectionInfo.set(connection, JdbcData.intern(dbInfo));
     }
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcData.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcData.java
@@ -6,16 +6,42 @@
 package io.opentelemetry.instrumentation.jdbc.internal;
 
 import io.opentelemetry.instrumentation.api.field.VirtualField;
+import java.lang.ref.WeakReference;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /** Holds info associated with JDBC connections and prepared statements. */
 public final class JdbcData {
 
+  private static final Map<DbInfo, WeakReference<DbInfo>> dbInfos = new WeakHashMap<>();
   public static VirtualField<Connection, DbInfo> connectionInfo =
       VirtualField.find(Connection.class, DbInfo.class);
   public static VirtualField<PreparedStatement, String> preparedStatement =
       VirtualField.find(PreparedStatement.class, String.class);
 
   private JdbcData() {}
+
+  /**
+   * Returns canonical representation of db info.
+   *
+   * @param dbInfo db info to canonicalize
+   * @return db info with same content as input db info. If two equal inputs are given to this
+   *     method, both calls will return the same instance. This method may return one instance now
+   *     and a different instance later if the original interned instance was garbage collected.
+   */
+  public static DbInfo intern(DbInfo dbInfo) {
+    synchronized (dbInfos) {
+      WeakReference<DbInfo> reference = dbInfos.get(dbInfo);
+      if (reference != null) {
+        DbInfo result = reference.get();
+        if (result != null) {
+          return result;
+        }
+      }
+      dbInfos.put(dbInfo, new WeakReference<>(dbInfo));
+      return dbInfo;
+    }
+  }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcUtils.java
@@ -72,7 +72,7 @@ public final class JdbcUtils {
     DbInfo dbInfo = JdbcData.connectionInfo.get(connection);
     if (dbInfo == null) {
       dbInfo = computeDbInfo(connection);
-      JdbcData.connectionInfo.set(connection, dbInfo);
+      JdbcData.connectionInfo.set(connection, JdbcData.intern(dbInfo));
     }
     return dbInfo;
   }


### PR DESCRIPTION
Most applications should be using a connection pool that has a limited number of connections. The connections returned from that pool should be wrapped in a way that code in https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/bfeb482465ae66d9346cfadc6df807edcc41792a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcUtils.java#L24 can unwrap them to the original connection that was returned from jdbc driver. If that is the case then we'll have a small number of `DbInfo` instances. If application does not use a connection pool or we are unable to unwrap connection to get the original one that already has `DbInfo` attached we'll end up with a large number of `DbInfo` instances which all contain the same data. I have a heap dump that has a bit under a million `DbInfo` instances consuming slightly less than 500mb.