### PR TITLE
Fix flaky StatementSanitizationConfigTest

### DIFF
--- a/instrumentation-api/build.gradle.kts
+++ b/instrumentation-api/build.gradle.kts
@@ -47,4 +47,22 @@ tasks {
   sourcesJar {
     dependsOn("generateJflex")
   }
+
+  val testStatementSanitizerConfig by registering(Test::class) {
+    filter {
+      includeTestsMatching("StatementSanitizationConfigTest")
+      isFailOnNoMatchingTests = false
+    }
+    include("**/StatementSanitizationConfigTest.*")
+    jvmArgs("-Dotel.instrumentation.common.db-statement-sanitizer.enabled=false")
+  }
+
+  named<Test>("test") {
+    dependsOn(testStatementSanitizerConfig)
+
+    filter {
+      excludeTestsMatching("StatementSanitizationConfigTest")
+      isFailOnNoMatchingTests = false
+    }
+  }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/db/StatementSanitizationConfigTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/db/StatementSanitizationConfigTest.java
@@ -7,18 +7,12 @@ package io.opentelemetry.instrumentation.api.db;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import io.opentelemetry.instrumentation.api.config.Config;
 import org.junit.jupiter.api.Test;
 
 public class StatementSanitizationConfigTest {
 
   @Test
   void shouldGetFalse() {
-    Config config =
-        Config.newBuilder()
-            .addProperty("otel.instrumentation.common.db-statement-sanitizer.enabled", "false")
-            .build();
-    Config.internalInitializeConfig(config);
     assertFalse(StatementSanitizationConfig.isStatementSanitizationEnabled());
   }
 }


### PR DESCRIPTION
As configuration is reused between tests either this or other statement sanitation tests will fail depending on which runs first. I guess it passes CI only because failing tests are retried.