### PR TITLE
Check if span name is null before use

### DIFF
--- a/instrumentation/jaxws/jaxws-2.0-cxf-3.0/library/build.gradle.kts
+++ b/instrumentation/jaxws/jaxws-2.0-cxf-3.0/library/build.gradle.kts
@@ -5,4 +5,6 @@ plugins {
 dependencies {
   compileOnly("javax.servlet:javax.servlet-api:3.0.1")
   compileOnly("org.apache.cxf:cxf-rt-frontend-jaxws:3.0.0")
+
+  testImplementation("org.apache.cxf:cxf-rt-frontend-jaxws:3.0.0")
 }

--- a/instrumentation/jaxws/jaxws-2.0-cxf-3.0/library/src/main/java/io/opentelemetry/javaagent/instrumentation/cxf/CxfHelper.java
+++ b/instrumentation/jaxws/jaxws-2.0-cxf-3.0/library/src/main/java/io/opentelemetry/javaagent/instrumentation/cxf/CxfHelper.java
@@ -26,10 +26,15 @@ public final class CxfHelper {
     Context parentContext = Context.current();
 
     CxfRequest request = new CxfRequest(message);
+
+    if (!request.shouldCreateSpan()) {
+      return;
+    }
+
     ServerSpanNaming.updateServerSpanName(
         parentContext, CONTROLLER, CxfServerSpanNaming.SERVER_SPAN_NAME, request);
 
-    if (!request.shouldCreateSpan() || !instrumenter().shouldStart(parentContext, request)) {
+    if (!instrumenter().shouldStart(parentContext, request)) {
       return;
     }
 

--- a/instrumentation/jaxws/jaxws-2.0-cxf-3.0/library/src/test/java/io/opentelemetry/javaagent/instrumentation/cxf/TracingStartInInterceptorTest.java
+++ b/instrumentation/jaxws/jaxws-2.0-cxf-3.0/library/src/test/java/io/opentelemetry/javaagent/instrumentation/cxf/TracingStartInInterceptorTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.cxf;
+
+import org.apache.cxf.message.ExchangeImpl;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.jupiter.api.Test;
+
+class TracingStartInInterceptorTest {
+
+  @Test
+  void shouldNotThrowExceptionIfSpanNameIsNull() {
+    // given Exchange without BindingOperationInfo.class -> spanName eq null
+    Message message = new MessageImpl();
+    message.setExchange(new ExchangeImpl());
+
+    // when interceptor handling message
+    TracingStartInInterceptor tracingStartInInterceptor = new TracingStartInInterceptor();
+    tracingStartInInterceptor.handleMessage(message);
+
+    // then no NPE
+  }
+}


### PR DESCRIPTION
Because of getSpanName can return null, we should check this before SERVER_SPAN_NAME uses spanName() which has requireNonNull. Otherwise we receive NPE in main app, when spanName is NULL. 