### PR TITLE
NetAttributesExtractor optimization

### DIFF
--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/InstrumenterBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/InstrumenterBenchmark.java
@@ -110,6 +110,10 @@ public class InstrumenterBenchmark {
     private static final InetSocketAddress ADDRESS =
         InetSocketAddress.createUnresolved("localhost", 8080);
 
+    protected ConstantNetAttributesExtractor() {
+      super(NetPeerAttributeExtraction.ON_START);
+    }
+
     @Override
     public @Nullable InetSocketAddress getAddress(Void unused, @Nullable Void unused2) {
       return ADDRESS;

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetAttributesExtractor.java
@@ -19,6 +19,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public abstract class InetSocketAddressNetAttributesExtractor<REQUEST, RESPONSE>
     extends NetAttributesExtractor<REQUEST, RESPONSE> {
 
+  protected InetSocketAddressNetAttributesExtractor() {
+    this(NetPeerAttributeExtraction.ON_BOTH);
+  }
+
+  protected InetSocketAddressNetAttributesExtractor(
+      NetPeerAttributeExtraction netPeerAttributeExtraction) {
+    super(netPeerAttributeExtraction);
+  }
+
   /**
    * This method will be called twice: both when the request starts ({@code response} is always null
    * then) and when the response ends. This way it is possible to capture net attributes in both

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetAttributesExtractor.java
@@ -19,9 +19,23 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public abstract class NetAttributesExtractor<REQUEST, RESPONSE>
     extends AttributesExtractor<REQUEST, RESPONSE> {
 
+  private final NetPeerAttributeExtraction netPeerAttributeExtraction;
+
+  protected NetAttributesExtractor() {
+    this(NetPeerAttributeExtraction.ON_BOTH);
+  }
+
+  protected NetAttributesExtractor(NetPeerAttributeExtraction netPeerAttributeExtraction) {
+    this.netPeerAttributeExtraction = netPeerAttributeExtraction;
+  }
+
   @Override
   protected final void onStart(AttributesBuilder attributes, REQUEST request) {
     set(attributes, SemanticAttributes.NET_TRANSPORT, transport(request));
+
+    if (netPeerAttributeExtraction == NetPeerAttributeExtraction.ON_END) {
+      return;
+    }
 
     String peerIp = peerIp(request, null);
     String peerName = peerName(request, null);
@@ -43,6 +57,10 @@ public abstract class NetAttributesExtractor<REQUEST, RESPONSE>
       REQUEST request,
       @Nullable RESPONSE response,
       @Nullable Throwable error) {
+
+    if (netPeerAttributeExtraction == NetPeerAttributeExtraction.ON_START) {
+      return;
+    }
 
     String peerIp = peerIp(request, response);
     String peerName = peerName(request, response);
@@ -84,4 +102,10 @@ public abstract class NetAttributesExtractor<REQUEST, RESPONSE>
    */
   @Nullable
   public abstract String peerIp(REQUEST request, @Nullable RESPONSE response);
+
+  public enum NetPeerAttributeExtraction {
+    ON_START,
+    ON_END,
+    ON_BOTH
+  }
 }

--- a/instrumentation/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetAttributesExtractor.java
+++ b/instrumentation/apache-dubbo-2.7/library/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class DubboNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<DubboRequest, Result> {
 
+  public DubboNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public @Nullable InetSocketAddress getAddress(DubboRequest request, @Nullable Result result) {
     return request.context().getRemoteAddress();

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesExtractor.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesExtractor.java
@@ -13,6 +13,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class ApacheHttpAsyncClientNetAttributesExtractor
     extends NetAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
 
+  ApacheHttpAsyncClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(ApacheHttpClientRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class ApacheHttpClientNetAttributesExtractor
     extends NetAttributesExtractor<HttpMethod, HttpMethod> {
 
+  ApacheHttpClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(HttpMethod request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientNetAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientNetAttributesExtractor.java
@@ -13,6 +13,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class ApacheHttpClientNetAttributesExtractor
     extends NetAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
 
+  ApacheHttpClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(ApacheHttpClientRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesExtractor.java
@@ -13,6 +13,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class ApacheHttpClientNetAttributesExtractor
     extends NetAttributesExtractor<ApacheHttpClientRequest, HttpResponse> {
 
+  ApacheHttpClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(ApacheHttpClientRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesExtractor.java
@@ -19,6 +19,10 @@ final class ApacheHttpClientNetAttributesExtractor
   private static final Logger logger =
       LoggerFactory.getLogger(ApacheHttpClientNetAttributesExtractor.class);
 
+  ApacheHttpClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(ClassicHttpRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetAttributesExtractor.java
@@ -16,6 +16,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ArmeriaNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<RequestContext, RequestLog> {
 
+  public ArmeriaNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_END);
+  }
+
   @Override
   public String transport(RequestContext ctx) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientNetAttributesExtractor.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class AsyncHttpClientNetAttributesExtractor
     extends NetAttributesExtractor<Request, Response> {
 
+  AsyncHttpClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesExtractor.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class AsyncHttpClientNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<RequestContext, Response> {
 
+  AsyncHttpClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_END);
+  }
+
   @Override
   public String transport(RequestContext requestContext) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetAttributesExtractor.java
@@ -13,6 +13,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class CassandraNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<CassandraRequest, ExecutionInfo> {
 
+  CassandraNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_END);
+  }
+
   @Override
   @Nullable
   public String transport(CassandraRequest request) {

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetAttributesExtractor.java
@@ -15,6 +15,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class CassandraNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<CassandraRequest, ExecutionInfo> {
 
+  CassandraNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_END);
+  }
+
   @Override
   @Nullable
   public String transport(CassandraRequest request) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestNetAttributesExtractor.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestNetAttributesExtractor.java
@@ -12,6 +12,10 @@ import org.elasticsearch.client.Response;
 
 final class ElasticsearchRestNetAttributesExtractor
     extends NetAttributesExtractor<String, Response> {
+  ElasticsearchRestNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_END);
+  }
+
   @Override
   public String transport(String s) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportNetAttributesExtractor.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportNetAttributesExtractor.java
@@ -13,6 +13,11 @@ import org.elasticsearch.action.ActionResponse;
 
 public class Elasticsearch6TransportNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<ElasticTransportRequest, ActionResponse> {
+
+  public Elasticsearch6TransportNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_END);
+  }
+
   @Override
   public @Nullable String transport(ElasticTransportRequest elasticTransportRequest) {
     return null;

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/library/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticTransportNetAttributesExtractor.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/library/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticTransportNetAttributesExtractor.java
@@ -11,6 +11,10 @@ import org.elasticsearch.action.ActionResponse;
 
 public class ElasticTransportNetAttributesExtractor
     extends NetAttributesExtractor<ElasticTransportRequest, ActionResponse> {
+  public ElasticTransportNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_END);
+  }
+
   @Override
   public @Nullable String transport(ElasticTransportRequest elasticTransportRequest) {
     return null;

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientNetAttributesExtractor.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class GoogleHttpClientNetAttributesExtractor
     extends NetAttributesExtractor<HttpRequest, HttpResponse> {
 
+  GoogleHttpClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(HttpRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetAttributesExtractor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetAttributesExtractor.java
@@ -15,6 +15,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class GrpcNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<GrpcRequest, Status> {
+
+  public GrpcNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   @Nullable
   public InetSocketAddress getAddress(GrpcRequest request, @Nullable Status status) {

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlNetAttributesExtractor.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlNetAttributesExtractor.java
@@ -11,6 +11,10 @@ import java.net.HttpURLConnection;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 class HttpUrlNetAttributesExtractor extends NetAttributesExtractor<HttpURLConnection, Integer> {
+  HttpUrlNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public @Nullable String transport(HttpURLConnection connection) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesExtractor.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesExtractor.java
@@ -18,6 +18,10 @@ public class JdkHttpNetAttributesExtractor
 
   private static final Logger logger = LoggerFactory.getLogger(JdkHttpNetAttributesExtractor.class);
 
+  public JdkHttpNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(HttpRequest httpRequest) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientNetAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class JaxRsClientNetAttributesExtractor
     extends NetAttributesExtractor<ClientRequest, ClientResponse> {
 
+  JaxRsClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(ClientRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientNetAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class JaxRsClientNetAttributesExtractor
     extends NetAttributesExtractor<ClientRequestContext, ClientResponseContext> {
 
+  JaxRsClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(ClientRequestContext request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientNetAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 final class ResteasyClientNetAttributesExtractor
     extends NetAttributesExtractor<ClientInvocation, Response> {
 
+  ResteasyClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(ClientInvocation request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcNetAttributesExtractor.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcNetAttributesExtractor.java
@@ -10,6 +10,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class JdbcNetAttributesExtractor extends NetAttributesExtractor<DbRequest, Void> {
 
+  public JdbcNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Nullable
   @Override
   public String transport(DbRequest request) {

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetAttributesExtractor.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetAttributesExtractor.java
@@ -10,6 +10,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class JedisNetAttributesExtractor extends NetAttributesExtractor<JedisRequest, Void> {
 
+  JedisNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   @Nullable
   public String transport(JedisRequest request) {

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetAttributesExtractor.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class JedisNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<JedisRequest, Void> {
 
+  JedisNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public @Nullable InetSocketAddress getAddress(JedisRequest jedisRequest, @Nullable Void unused) {
     Socket socket = jedisRequest.getConnection().getSocket();

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClientNetAttributesExtractor.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClientNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.eclipse.jetty.client.api.Response;
 public class JettyHttpClientNetAttributesExtractor
     extends NetAttributesExtractor<Request, Response> {
 
+  public JettyHttpClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesNetAttributesExtractor.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesNetAttributesExtractor.java
@@ -12,6 +12,10 @@ import okhttp3.Request;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 class KubernetesNetAttributesExtractor extends NetAttributesExtractor<Request, ApiResponse<?>> {
+  KubernetesNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetAttributesExtractor.java
@@ -11,6 +11,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class LettuceConnectNetAttributesExtractor extends NetAttributesExtractor<RedisURI, Void> {
 
+  LettuceConnectNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   @Nullable
   public String transport(RedisURI redisUri) {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetAttributesExtractor.java
@@ -11,6 +11,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class LettuceConnectNetAttributesExtractor extends NetAttributesExtractor<RedisURI, Void> {
 
+  LettuceConnectNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   @Nullable
   public String transport(RedisURI redisUri) {

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherLinkInstrumentation.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherLinkInstrumentation.java
@@ -80,7 +80,6 @@ public class LibertyDispatcherLinkInstrumentation implements TypeInstrumentation
       scope.close();
 
       LibertyResponse response = new LibertyResponse(statusCode);
-      request.setCompleted();
 
       Throwable t = failure != null ? failure : throwable;
       instrumenter().end(context, request, response, t);

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesExtractor.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesExtractor.java
@@ -12,6 +12,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class LibertyDispatcherNetAttributesExtractor
     extends NetAttributesExtractor<LibertyRequest, LibertyResponse> {
 
+  public LibertyDispatcherNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(LibertyRequest libertyRequest) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
@@ -20,30 +24,18 @@ public class LibertyDispatcherNetAttributesExtractor
   @Override
   public @Nullable String peerName(
       LibertyRequest libertyRequest, @Nullable LibertyResponse libertyResponse) {
-    // condition limits calling peerName to onStart because in onEnd it may throw a NPE
-    if (!libertyRequest.isCompleted()) {
-      return libertyRequest.peerName();
-    }
-    return null;
+    return libertyRequest.peerName();
   }
 
   @Override
   public @Nullable Integer peerPort(
       LibertyRequest libertyRequest, @Nullable LibertyResponse libertyResponse) {
-    // condition limits calling getServerPort to onStart because in onEnd it may throw a NPE
-    if (!libertyRequest.isCompleted()) {
-      return libertyRequest.getServerPort();
-    }
-    return null;
+    return libertyRequest.getServerPort();
   }
 
   @Override
   public @Nullable String peerIp(
       LibertyRequest libertyRequest, @Nullable LibertyResponse libertyResponse) {
-    // condition limits calling peerIp to onStart because in onEnd it may throw a NPE
-    if (!libertyRequest.isCompleted()) {
-      return libertyRequest.peerIp();
-    }
-    return null;
+    return libertyRequest.peerIp();
   }
 }

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
@@ -13,7 +13,6 @@ import java.util.List;
 public class LibertyRequest {
   private final HttpDispatcherLink httpDispatcherLink;
   private final HttpRequestMessage httpRequestMessage;
-  private boolean completed;
 
   public LibertyRequest(
       HttpDispatcherLink httpDispatcherLink, HttpRequestMessage httpRequestMessage) {
@@ -68,13 +67,5 @@ public class LibertyRequest {
 
   public String getProtocol() {
     return httpRequestMessage.getVersion();
-  }
-
-  public boolean isCompleted() {
-    return completed;
-  }
-
-  public void setCompleted() {
-    completed = true;
   }
 }

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2NetAttributesExtractor.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2NetAttributesExtractor.java
@@ -12,6 +12,10 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class OkHttp2NetAttributesExtractor extends NetAttributesExtractor<Request, Response> {
+  public OkHttp2NetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpNetAttributesExtractor.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpNetAttributesExtractor.java
@@ -12,6 +12,10 @@ import okhttp3.Response;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class OkHttpNetAttributesExtractor extends NetAttributesExtractor<Request, Response> {
+  public OkHttpNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientNetAttributesExtractor.java
+++ b/instrumentation/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientNetAttributesExtractor.java
@@ -15,6 +15,10 @@ import play.shaded.ahc.org.asynchttpclient.Response;
 final class PlayWsClientNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<Request, Response> {
 
+  PlayWsClientNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_END);
+  }
+
   @Override
   public String transport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/internal/RatpackNetAttributesExtractor.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/internal/RatpackNetAttributesExtractor.java
@@ -12,6 +12,10 @@ import ratpack.http.Request;
 import ratpack.http.Response;
 
 public final class RatpackNetAttributesExtractor extends NetAttributesExtractor<Request, Response> {
+  public RatpackNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   @Nullable
   public String transport(Request request) {

--- a/instrumentation/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonNetAttributesExtractor.java
+++ b/instrumentation/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonNetAttributesExtractor.java
@@ -12,6 +12,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class RedissonNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<RedissonRequest, Void> {
 
+  RedissonNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public InetSocketAddress getAddress(RedissonRequest request, @Nullable Void unused) {
     return request.getAddress();

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletNetAttributesExtractor.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletNetAttributesExtractor.java
@@ -12,6 +12,10 @@ import org.restlet.data.Request;
 import org.restlet.data.Response;
 
 final class RestletNetAttributesExtractor extends NetAttributesExtractor<Request, Response> {
+  RestletNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesExtractor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesExtractor.java
@@ -15,6 +15,7 @@ public class ServletNetAttributesExtractor<REQUEST, RESPONSE>
   private final ServletAccessor<REQUEST, RESPONSE> accessor;
 
   public ServletNetAttributesExtractor(ServletAccessor<REQUEST, RESPONSE> accessor) {
+    super(NetPeerAttributeExtraction.ON_START);
     this.accessor = accessor;
   }
 

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebNetAttributesExtractor.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebNetAttributesExtractor.java
@@ -13,6 +13,10 @@ import org.springframework.http.client.ClientHttpResponse;
 
 final class SpringWebNetAttributesExtractor
     extends NetAttributesExtractor<HttpRequest, ClientHttpResponse> {
+  SpringWebNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(HttpRequest httpRequest) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcNetAttributesExtractor.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcNetAttributesExtractor.java
@@ -13,6 +13,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class SpringWebMvcNetAttributesExtractor
     extends NetAttributesExtractor<HttpServletRequest, HttpServletResponse> {
+  SpringWebMvcNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public String transport(HttpServletRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesExtractor.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesExtractor.java
@@ -13,6 +13,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TomcatNetAttributesExtractor extends NetAttributesExtractor<Request, Response> {
 
+  public TomcatNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public @Nullable String transport(Request request) {
     // return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesExtractor.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesExtractor.java
@@ -14,6 +14,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class UndertowNetAttributesExtractor
     extends InetSocketAddressNetAttributesExtractor<HttpServerExchange, HttpServerExchange> {
 
+  protected UndertowNetAttributesExtractor() {
+    super(NetPeerAttributeExtraction.ON_START);
+  }
+
   @Override
   public @Nullable InetSocketAddress getAddress(
       HttpServerExchange exchange, @Nullable HttpServerExchange unused) {


### PR DESCRIPTION
NetAttributesExtractor is currently often collecting net attributes twice.

Even if the underlying collection methods are fast, we are still allocating memory to store them in AttributesBuilders twice.

Also motivated by the issue where extracting from request can throw exception during onEnd: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4256#discussion_r720723396

Initially I tried to split it into two AttributesExtractors, one that just captures from request onStart, and one that just captures from response onEnd. This almost worked except for armeria instrumentation which captures from request onEnd (and there may be others, this was just the first one that failed tests after I split them up).

The duplicative hierarchy wasn't lovely either since it led to separate NetAttributesExtractors and separate InetSocketAddressNetAttributesExtractors.

I think this is a fairly low impact change to the extractors, and provides a good value.

This PR currently preserves the existing behavior by providing default NetAttributesExtractor and InetSocketAddressNetAttributesExtractor constructors which default to `ON_BOTH`. An option is to remove those so that users are more likely to think about which behavior they want. I'm not even sure if `ON_BOTH` is ever really needed, so could likely even remove that option.