### PR TITLE
Jax-rs async cancel handling

### DIFF
--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsAsyncResponseInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsAsyncResponseInstrumentation.java
@@ -85,7 +85,7 @@ public class JaxrsAsyncResponseInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class AsyncResponseCancelAdvice {
 
-    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void stopSpan(@Advice.This AsyncResponse asyncResponse) {
 
       VirtualField<AsyncResponse, AsyncResponseData> virtualField =


### PR DESCRIPTION
Make `AsyncResponse.cancel` handling use `OnMethodEnter` advice instead of `OnMethodExit` because span is already finished by the time of `OnMethodExit` and it might be already sent out without the `jaxrs.canceled` attribute.
Should reproduce when `JerseyHttpServerTest` is run with strict context stressor.