### PR TITLE
Simplify gradle files

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -179,7 +179,7 @@ class TestcontainersBuildService : BuildService<BuildServiceParameters.None?> {
 }
 // To limit number of concurrently running resource intensive tests add
 // tasks {
-//   named<Test>("test") {
+//   test {
 //     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
 //   }
 // }

--- a/instrumentation-api/build.gradle.kts
+++ b/instrumentation-api/build.gradle.kts
@@ -57,7 +57,7 @@ tasks {
     jvmArgs("-Dotel.instrumentation.common.db-statement-sanitizer.enabled=false")
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(testStatementSanitizerConfig)
 
     filter {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
@@ -102,7 +102,7 @@ tasks {
     }
   }
 
-  named<Test>("test") {
+  test {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     systemProperty("otel.instrumentation.aws-sdk.experimental-span-attributes", true)
   }
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
 configurations.testRuntimeClasspath.resolutionStrategy.force("com.google.guava:guava:19.0")
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/couchbase/couchbase-3.1.6/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.1.6/javaagent/build.gradle.kts
@@ -16,12 +16,20 @@ muzzle {
 sourceSets {
   main {
     val shadedDep = project(":instrumentation:couchbase:couchbase-3.1.6:tracing-opentelemetry-shaded")
-    output.dir(shadedDep.file("build/extracted/shadow"), "builtBy" to ":instrumentation:couchbase:couchbase-3.1.6:tracing-opentelemetry-shaded:extractShadowJar")
+    output.dir(
+      shadedDep.file("build/extracted/shadow"),
+      "builtBy" to ":instrumentation:couchbase:couchbase-3.1.6:tracing-opentelemetry-shaded:extractShadowJar"
+    )
   }
 }
 
 dependencies {
-  compileOnly(project(path = ":instrumentation:couchbase:couchbase-3.1.6:tracing-opentelemetry-shaded", configuration = "shadow"))
+  compileOnly(
+    project(
+      path = ":instrumentation:couchbase:couchbase-3.1.6:tracing-opentelemetry-shaded",
+      configuration = "shadow"
+    )
+  )
 
   library("com.couchbase.client:core-io:2.1.6")
 
@@ -34,7 +42,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/build.gradle.kts
@@ -16,12 +16,20 @@ muzzle {
 sourceSets {
   main {
     val shadedDep = project(":instrumentation:couchbase:couchbase-3.1:tracing-opentelemetry-shaded")
-    output.dir(shadedDep.file("build/extracted/shadow"), "builtBy" to ":instrumentation:couchbase:couchbase-3.1:tracing-opentelemetry-shaded:extractShadowJar")
+    output.dir(
+      shadedDep.file("build/extracted/shadow"),
+      "builtBy" to ":instrumentation:couchbase:couchbase-3.1:tracing-opentelemetry-shaded:extractShadowJar"
+    )
   }
 }
 
 dependencies {
-  compileOnly(project(path = ":instrumentation:couchbase:couchbase-3.1:tracing-opentelemetry-shaded", configuration = "shadow"))
+  compileOnly(
+    project(
+      path = ":instrumentation:couchbase:couchbase-3.1:tracing-opentelemetry-shaded",
+      configuration = "shadow"
+    )
+  )
 
   library("com.couchbase.client:core-io:2.1.0")
 
@@ -34,7 +42,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/couchbase/couchbase-3.2/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-3.2/javaagent/build.gradle.kts
@@ -16,12 +16,20 @@ muzzle {
 sourceSets {
   main {
     val shadedDep = project(":instrumentation:couchbase:couchbase-3.2:tracing-opentelemetry-shaded")
-    output.dir(shadedDep.file("build/extracted/shadow"), "builtBy" to ":instrumentation:couchbase:couchbase-3.2:tracing-opentelemetry-shaded:extractShadowJar")
+    output.dir(
+      shadedDep.file("build/extracted/shadow"),
+      "builtBy" to ":instrumentation:couchbase:couchbase-3.2:tracing-opentelemetry-shaded:extractShadowJar"
+    )
   }
 }
 
 dependencies {
-  compileOnly(project(path = ":instrumentation:couchbase:couchbase-3.2:tracing-opentelemetry-shaded", configuration = "shadow"))
+  compileOnly(
+    project(
+      path = ":instrumentation:couchbase:couchbase-3.2:tracing-opentelemetry-shaded",
+      configuration = "shadow"
+    )
+  )
 
   library("com.couchbase.client:core-io:2.1.6")
 
@@ -31,7 +39,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/external-annotations/javaagent/build.gradle.kts
+++ b/instrumentation/external-annotations/javaagent/build.gradle.kts
@@ -47,7 +47,7 @@ tasks {
     jvmArgs("-Dotel.instrumentation.external-annotations.exclude-methods=TracedMethodsExclusionTest\$TestClass[excluded,annotatedButExcluded]")
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(testIncludeProperty)
     dependsOn(testExcludeMethodsProperty)
     filter {

--- a/instrumentation/grpc-1.6/javaagent/build.gradle.kts
+++ b/instrumentation/grpc-1.6/javaagent/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     // The agent context debug mechanism isn't compatible with the bridge approach which may add a
     // gRPC context to the root.
     jvmArgs("-Dotel.javaagent.experimental.thread-propagation-debugger.enabled=false")

--- a/instrumentation/gwt-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/gwt-2.0/javaagent/build.gradle.kts
@@ -88,7 +88,7 @@ tasks {
     into(file("$buildDir/testapp/web"))
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(sourceSets["testapp"].output)
     dependsOn(copyTestWebapp)
 

--- a/instrumentation/hibernate/hibernate-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/build.gradle.kts
@@ -26,7 +26,7 @@ testSets {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     dependsOn("version5Test")
     dependsOn("version6Test")
   }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/javaagent/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-wildfly-testing/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-wildfly-testing/build.gradle.kts
@@ -42,7 +42,7 @@ tasks {
     }
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(modifyLogbackJar)
     dependsOn(setupServer)
 

--- a/instrumentation/jaxws/jaxws-2.0-wildfly-testing/build.gradle.kts
+++ b/instrumentation/jaxws/jaxws-2.0-wildfly-testing/build.gradle.kts
@@ -43,7 +43,7 @@ tasks {
     }
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(modifyLogbackJar)
     dependsOn(setupServer)
 

--- a/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-1.4/javaagent/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/jsf/mojarra-1.2/javaagent/build.gradle.kts
+++ b/instrumentation/jsf/mojarra-1.2/javaagent/build.gradle.kts
@@ -55,7 +55,7 @@ testSets {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     dependsOn("mojarra12Test")
     dependsOn("mojarra2Test")
   }

--- a/instrumentation/jsf/myfaces-1.2/javaagent/build.gradle.kts
+++ b/instrumentation/jsf/myfaces-1.2/javaagent/build.gradle.kts
@@ -23,7 +23,7 @@ testSets {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     dependsOn("myfaces12Test")
     dependsOn("myfaces2Test")
   }

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }

--- a/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/library/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }

--- a/instrumentation/log4j/log4j-2.13.2/javaagent/build.gradle.kts
+++ b/instrumentation/log4j/log4j-2.13.2/javaagent/build.gradle.kts
@@ -36,7 +36,7 @@ tasks {
 
   // Threadlocals are always false if is.webapp is true, so we make sure to override it because as of
   // now testing-common includes jetty / servlet.
-  named<Test>("test") {
+  test {
     jvmArgs("-Dlog4j2.is.webapp=false")
     jvmArgs("-Dlog4j2.enable.threadlocals=true")
   }

--- a/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/mongo/mongo-3.1/library/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/library/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/netty/netty-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/netty/netty-4.0/javaagent/build.gradle.kts
@@ -39,7 +39,7 @@ tasks {
     jvmArgs("-Dotel.instrumentation.netty.always-create-connect-span=true")
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(testConnectionSpan)
     filter {
       excludeTestsMatching("Netty40ConnectionSpanTest")

--- a/instrumentation/netty/netty-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/netty/netty-4.1/javaagent/build.gradle.kts
@@ -52,7 +52,7 @@ tasks {
     jvmArgs("-Dotel.instrumentation.netty.always-create-connect-span=true")
   }
 
-  named<Test>("test") {
+  test {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
 
     dependsOn(testConnectionSpan)

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/build.gradle.kts
@@ -26,7 +26,7 @@ tasks {
   compileTestJava {
     options.compilerArgs.add("-parameters")
   }
-  named<Test>("test") {
+  test {
     jvmArgs("-Dotel.instrumentation.opentelemetry-annotations.exclude-methods=io.opentelemetry.test.annotation.TracedWithSpan[ignored]")
   }
 }

--- a/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/build.gradle.kts
+++ b/instrumentation/reactor-netty/reactor-netty-0.9/javaagent/build.gradle.kts
@@ -36,7 +36,7 @@ tasks {
     jvmArgs("-Dotel.instrumentation.netty.always-create-connect-span=true")
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(testConnectionSpan)
     filter {
       excludeTestsMatching("ReactorNettyConnectionSpanTest")

--- a/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/build.gradle.kts
@@ -35,7 +35,7 @@ tasks {
     jvmArgs("-Dotel.instrumentation.reactor-netty.always-create-connect-span=true")
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(testConnectionSpan)
     filter {
       excludeTestsMatching("ReactorNettyConnectionSpanTest")

--- a/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
+++ b/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/redisson-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/redisson-3.0/javaagent/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   annotationProcessor("com.google.auto.value:auto-value")
 }
 
-tasks.named<Test>("test") {
+tasks.test {
   systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
 }

--- a/instrumentation/rmi/javaagent/build.gradle.kts
+++ b/instrumentation/rmi/javaagent/build.gradle.kts
@@ -22,10 +22,19 @@ tasks {
       File(System.getProperty("java.home"), it).absoluteFile
     }.find { it.isFile() }?.let(File::toString) ?: "rmic"
 
-    commandLine(rmicBinaryPath, "-g", "-keep", "-classpath", sourceSets.test.get().output.classesDirs.asPath, "-d", "$buildDir/classes/java/test", clazz)
+    commandLine(
+      rmicBinaryPath,
+      "-g",
+      "-keep",
+      "-classpath",
+      sourceSets.test.get().output.classesDirs.asPath,
+      "-d",
+      "$buildDir/classes/java/test",
+      clazz
+    )
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(rmic)
   }
 }
@@ -52,7 +61,9 @@ tasks {
     jvmArgs("-Djava.rmi.server.hostname=127.0.0.1")
 
     // Can only export on Java 9+
-    val testJavaVersion = gradle.startParameter.projectProperties.get("testJavaVersion")?.let(JavaVersion::toVersion) ?: JavaVersion.current()
+    val testJavaVersion =
+      gradle.startParameter.projectProperties.get("testJavaVersion")?.let(JavaVersion::toVersion)
+        ?: JavaVersion.current()
     if (testJavaVersion.isJava9Compatible) {
       jvmArgs("--add-exports=java.rmi/sun.rmi.server=ALL-UNNAMED")
       jvmArgs("--add-exports=java.rmi/sun.rmi.transport=ALL-UNNAMED")

--- a/instrumentation/scala-executors/javaagent/build.gradle.kts
+++ b/instrumentation/scala-executors/javaagent/build.gradle.kts
@@ -44,7 +44,7 @@ tasks {
     classpath = classpath.plus(files(sourceSets["slickTest"].scala.classesDirectory))
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(slickTest)
   }
 }

--- a/instrumentation/spring/spring-batch-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/build.gradle.kts
@@ -39,7 +39,7 @@ tasks {
     jvmArgs("-Dotel.instrumentation.spring-batch.item.enabled=true")
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(testChunkRootSpan)
     dependsOn(testItemLevelSpan)
     filter {

--- a/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
@@ -45,7 +45,7 @@ tasks {
     jvmArgs("-Dotel.instrumentation.spring-rabbit.enabled=true")
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(testWithRabbitInstrumentation)
 
     filter {

--- a/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
 
     // TODO run tests both with and without experimental span attributes

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
   }
 }

--- a/instrumentation/spring/spring-webmvc-3.1/wildfly-testing/build.gradle.kts
+++ b/instrumentation/spring/spring-webmvc-3.1/wildfly-testing/build.gradle.kts
@@ -58,7 +58,7 @@ tasks {
     from(appLibrary).into("$buildDir/app-libs")
   }
 
-  named<Test>("test") {
+  test {
     dependsOn(modifyLogbackJar)
     dependsOn(setupServer)
     dependsOn(copyDependencies)

--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -40,7 +40,7 @@ tasks {
   val vaadin16Test by existing
   val vaadin14LatestTest by existing
 
-  named<Test>("test") {
+  test {
     dependsOn(vaadin142Test)
     dependsOn(vaadin16Test)
     if (findProperty("testLatestDeps") as Boolean) {

--- a/instrumentation/vertx-http-client/vertx-http-client-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx-http-client/vertx-http-client-3.0/javaagent/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
   }
 }

--- a/instrumentation/vertx-reactive-3.5/javaagent/build.gradle.kts
+++ b/instrumentation/vertx-reactive-3.5/javaagent/build.gradle.kts
@@ -17,7 +17,7 @@ testSets {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     dependsOn("version35Test")
   }
 }

--- a/instrumentation/vertx-web-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx-web-3.0/javaagent/build.gradle.kts
@@ -18,7 +18,7 @@ testSets {
 }
 
 tasks {
-  named<Test>("test") {
+  test {
     dependsOn("version3Test")
   }
 }


### PR DESCRIPTION
Replaces `named<Test>("test") {` by `test {`.

This PR also includes auto-format of gradle files because my search/replace always converts from 2-space to 4-space indent 😞.