### PR TITLE
Small renames for clarification

### DIFF
--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/muzzle/HelperClassPredicateTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/muzzle/HelperClassPredicateTest.groovy
@@ -8,14 +8,14 @@ package io.opentelemetry.javaagent.tooling.muzzle
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class InstrumentationClassPredicateTest extends Specification {
+class HelperClassPredicateTest extends Specification {
   @Unroll
   def "should collect references for #desc"() {
     setup:
-    def predicate = new InstrumentationClassPredicate({ it.startsWith("com.example.instrumentation.library") })
+    def predicate = new HelperClassPredicate({ it.startsWith("com.example.instrumentation.library") })
 
     expect:
-    predicate.isInstrumentationClass(className)
+    predicate.isHelperClass(className)
 
     where:
     desc                                       | className
@@ -27,10 +27,10 @@ class InstrumentationClassPredicateTest extends Specification {
   @Unroll
   def "should not collect references for #desc"() {
     setup:
-    def predicate = new InstrumentationClassPredicate({ false })
+    def predicate = new HelperClassPredicate({ false })
 
     expect:
-    !predicate.isInstrumentationClass(className)
+    !predicate.isHelperClass(className)
 
     where:
     desc                                  | className

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/HelperClassPredicate.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/HelperClassPredicate.java
@@ -7,7 +7,7 @@ package io.opentelemetry.javaagent.tooling.muzzle;
 
 import java.util.function.Predicate;
 
-public final class InstrumentationClassPredicate {
+public final class HelperClassPredicate {
   // javaagent instrumentation packages
   private static final String JAVAAGENT_INSTRUMENTATION_PACKAGE =
       "io.opentelemetry.javaagent.instrumentation.";
@@ -18,11 +18,10 @@ public final class InstrumentationClassPredicate {
   private static final String LIBRARY_INSTRUMENTATION_PACKAGE = "io.opentelemetry.instrumentation.";
   private static final String INSTRUMENTATION_API_PACKAGE = "io.opentelemetry.instrumentation.api.";
 
-  private final Predicate<String> additionalLibraryInstrumentationPredicate;
+  private final Predicate<String> additionalLibraryHelperClassPredicate;
 
-  public InstrumentationClassPredicate(
-      Predicate<String> additionalLibraryInstrumentationPredicate) {
-    this.additionalLibraryInstrumentationPredicate = additionalLibraryInstrumentationPredicate;
+  public HelperClassPredicate(Predicate<String> additionalLibraryHelperClassPredicate) {
+    this.additionalLibraryHelperClassPredicate = additionalLibraryHelperClassPredicate;
   }
 
   /**
@@ -37,17 +36,17 @@ public final class InstrumentationClassPredicate {
    * <p>Aside from "standard" instrumentation helper class packages, instrumentation modules can
    * pass an additional predicate to include instrumentation helper classes from 3rd party packages.
    */
-  public boolean isInstrumentationClass(String className) {
-    return isJavaagentInstrumentationClass(className)
-        || isLibraryInstrumentationClass(className)
-        || additionalLibraryInstrumentationPredicate.test(className);
+  public boolean isHelperClass(String className) {
+    return isJavaagentHelperClass(className)
+        || isLibraryHelperClass(className)
+        || additionalLibraryHelperClassPredicate.test(className);
   }
 
-  public boolean isProvidedByLibrary(String className) {
-    return !isInstrumentationClass(className) && !isProvidedByJavaagent(className);
+  public boolean isLibraryClass(String className) {
+    return !isHelperClass(className) && !isBootstrapClass(className);
   }
 
-  private static boolean isProvidedByJavaagent(String className) {
+  private static boolean isBootstrapClass(String className) {
     return className.startsWith(JAVAAGENT_API_PACKAGE)
         || className.startsWith(INSTRUMENTATION_API_PACKAGE)
         || className.startsWith("io.opentelemetry.javaagent.bootstrap.")
@@ -57,12 +56,12 @@ public final class InstrumentationClassPredicate {
         || className.startsWith("org.slf4j.");
   }
 
-  private static boolean isJavaagentInstrumentationClass(String className) {
+  private static boolean isJavaagentHelperClass(String className) {
     return className.startsWith(JAVAAGENT_INSTRUMENTATION_PACKAGE)
         && !className.startsWith(JAVAAGENT_API_PACKAGE);
   }
 
-  private static boolean isLibraryInstrumentationClass(String className) {
+  private static boolean isLibraryHelperClass(String className) {
     return className.startsWith(LIBRARY_INSTRUMENTATION_PACKAGE)
         && !className.startsWith(INSTRUMENTATION_API_PACKAGE);
   }

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCollectingClassVisitor.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCollectingClassVisitor.java
@@ -105,7 +105,7 @@ final class ReferenceCollectingClassVisitor extends ClassVisitor {
     return type;
   }
 
-  private final InstrumentationClassPredicate instrumentationClassPredicate;
+  private final HelperClassPredicate helperClassPredicate;
   private final boolean isAdviceClass;
 
   private final Map<String, ClassRef> references = new LinkedHashMap<>();
@@ -119,9 +119,9 @@ final class ReferenceCollectingClassVisitor extends ClassVisitor {
   private Type refSourceType;
 
   ReferenceCollectingClassVisitor(
-      InstrumentationClassPredicate instrumentationClassPredicate, boolean isAdviceClass) {
+      HelperClassPredicate helperClassPredicate, boolean isAdviceClass) {
     super(Opcodes.ASM7);
-    this.instrumentationClassPredicate = instrumentationClassPredicate;
+    this.helperClassPredicate = helperClassPredicate;
     this.isAdviceClass = isAdviceClass;
   }
 
@@ -143,7 +143,7 @@ final class ReferenceCollectingClassVisitor extends ClassVisitor {
 
   private void addExtendsReference(ClassRef ref) {
     addReference(ref);
-    if (instrumentationClassPredicate.isInstrumentationClass(ref.getClassName())) {
+    if (helperClassPredicate.isHelperClass(ref.getClassName())) {
       helperSuperClasses.add(ref.getClassName());
     }
   }
@@ -157,7 +157,7 @@ final class ReferenceCollectingClassVisitor extends ClassVisitor {
         references.put(ref.getClassName(), reference.merge(ref));
       }
     }
-    if (instrumentationClassPredicate.isInstrumentationClass(ref.getClassName())) {
+    if (helperClassPredicate.isHelperClass(ref.getClassName())) {
       helperClasses.add(ref.getClassName());
     }
   }

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceMatcher.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceMatcher.java
@@ -35,7 +35,7 @@ public final class ReferenceMatcher {
       Cache.newBuilder().setWeakKeys().build();
   private final Map<String, ClassRef> references;
   private final Set<String> helperClassNames;
-  private final InstrumentationClassPredicate instrumentationClassPredicate;
+  private final HelperClassPredicate helperClassPredicate;
 
   public static ReferenceMatcher of(InstrumentationModule instrumentationModule) {
     return new ReferenceMatcher(
@@ -50,8 +50,7 @@ public final class ReferenceMatcher {
       Predicate<String> libraryInstrumentationPredicate) {
     this.references = references;
     this.helperClassNames = new HashSet<>(helperClassNames);
-    this.instrumentationClassPredicate =
-        new InstrumentationClassPredicate(libraryInstrumentationPredicate);
+    this.helperClassPredicate = new HelperClassPredicate(libraryInstrumentationPredicate);
   }
 
   /**
@@ -109,7 +108,7 @@ public final class ReferenceMatcher {
    */
   private List<Mismatch> checkMatch(ClassRef reference, TypePool typePool, ClassLoader loader) {
     try {
-      if (instrumentationClassPredicate.isInstrumentationClass(reference.getClassName())) {
+      if (helperClassPredicate.isHelperClass(reference.getClassName())) {
         // make sure helper class is registered
         if (!helperClassNames.contains(reference.getClassName())) {
           return singletonList(new Mismatch.MissingClass(reference));


### PR DESCRIPTION
A couple of renames for a bit more clarity:
* `InstrumentationClassPredicate` --> `HelperClassPredicate`
* `isInstrumentationClass` --> `isHelperClass`