### PR TITLE
Remove implementations of host() and userAgent() in HTTP extractors

### DIFF
--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/InstrumenterBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/InstrumenterBenchmark.java
@@ -76,12 +76,10 @@ public class InstrumenterBenchmark {
     }
 
     @Override
-    protected @Nullable String userAgent(Void unused) {
-      return "OpenTelemetryBot";
-    }
-
-    @Override
     protected List<String> requestHeader(Void unused, String name) {
+      if (name.equalsIgnoreCase("user-agent")) {
+        return Collections.singletonList("OpenTelemetryBot");
+      }
       return Collections.emptyList();
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
@@ -87,9 +87,8 @@ public abstract class HttpCommonAttributesExtractor<REQUEST, RESPONSE>
   @Nullable
   protected abstract String method(REQUEST request);
 
-  // TODO: remove implementations?
   @Nullable
-  protected String userAgent(REQUEST request) {
+  private String userAgent(REQUEST request) {
     List<String> values = requestHeader(request, "user-agent");
     return values.isEmpty() ? null : values.get(0);
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -64,9 +64,8 @@ public abstract class HttpServerAttributesExtractor<REQUEST, RESPONSE>
   @Nullable
   protected abstract String target(REQUEST request);
 
-  // TODO: remove implementations?
   @Nullable
-  protected String host(REQUEST request) {
+  private String host(REQUEST request) {
     List<String> values = requestHeader(request, "host");
     return values.isEmpty() ? null : values.get(0);
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -37,13 +37,6 @@ final class ApacheHttpClientHttpAttributesExtractor
   }
 
   @Override
-  @Nullable
-  protected String userAgent(HttpMethod request) {
-    Header header = request.getRequestHeader("User-Agent");
-    return header != null ? header.getValue() : null;
-  }
-
-  @Override
   protected List<String> requestHeader(HttpMethod request, String name) {
     Header header = request.getRequestHeader(name);
     return header == null ? emptyList() : singletonList(header.getValue());

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesExtractor.java
@@ -69,13 +69,6 @@ final class ApacheHttpClientHttpAttributesExtractor
   }
 
   @Override
-  @Nullable
-  protected String userAgent(ClassicHttpRequest request) {
-    Header header = request.getFirstHeader("User-Agent");
-    return header != null ? header.getValue() : null;
-  }
-
-  @Override
   protected List<String> requestHeader(ClassicHttpRequest request, String name) {
     return headersToList(request.getHeaders(name));
   }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesExtractor.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.armeria.v1_3;
 
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
@@ -33,12 +32,6 @@ final class ArmeriaHttpClientAttributesExtractor
   @Override
   protected String url(RequestContext ctx) {
     return request(ctx).uri().toString();
-  }
-
-  @Override
-  @Nullable
-  protected String userAgent(RequestContext ctx) {
-    return request(ctx).headers().get(HttpHeaderNames.USER_AGENT);
   }
 
   @Override

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesExtractor.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.armeria.v1_3;
 
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
@@ -38,20 +37,8 @@ final class ArmeriaHttpServerAttributesExtractor
 
   @Override
   @Nullable
-  protected String host(RequestContext ctx) {
-    return request(ctx).authority();
-  }
-
-  @Override
-  @Nullable
   protected String scheme(RequestContext ctx) {
     return request(ctx).scheme();
-  }
-
-  @Override
-  @Nullable
-  protected String userAgent(RequestContext ctx) {
-    return request(ctx).headers().get(HttpHeaderNames.USER_AGENT);
   }
 
   @Override

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesExtractor.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesExtractor.java
@@ -31,11 +31,6 @@ final class GoogleHttpClientHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(HttpRequest httpRequest) {
-    return httpRequest.getHeaders().getUserAgent();
-  }
-
-  @Override
   protected List<String> requestHeader(HttpRequest httpRequest, String name) {
     return httpRequest.getHeaders().getHeaderStringValues(name);
   }

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesExtractor.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesExtractor.java
@@ -33,11 +33,6 @@ class HttpUrlHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(HttpURLConnection connection) {
-    return connection.getRequestProperty("User-Agent");
-  }
-
-  @Override
   protected List<String> requestHeader(HttpURLConnection connection, String name) {
     String value = connection.getRequestProperty(name);
     return value == null ? emptyList() : singletonList(value);

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesExtractor.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesExtractor.java
@@ -32,11 +32,6 @@ class JdkHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(HttpRequest httpRequest) {
-    return httpRequest.headers().firstValue("User-Agent").orElse(null);
-  }
-
-  @Override
   protected List<String> requestHeader(HttpRequest httpRequest, String name) {
     return httpRequest.headers().allValues(name);
   }

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesExtractor.java
@@ -34,12 +34,6 @@ final class JaxRsClientHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(ClientRequest httpRequest) {
-    Object header = httpRequest.getHeaders().getFirst("User-Agent");
-    return header != null ? header.toString() : null;
-  }
-
-  @Override
   protected List<String> requestHeader(ClientRequest httpRequest, String name) {
     List<Object> rawHeaders = httpRequest.getHeaders().getOrDefault(name, emptyList());
     if (rawHeaders.isEmpty()) {

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesExtractor.java
@@ -40,9 +40,8 @@ final class JaxRsClientHttpAttributesExtractor
       return emptyList();
     }
     List<String> stringHeaders = new ArrayList<>(rawHeaders.size());
-    int i = 0;
     for (Object headerValue : rawHeaders) {
-      stringHeaders.set(i++, String.valueOf(headerValue));
+      stringHeaders.add(String.valueOf(headerValue));
     }
     return stringHeaders;
   }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/JaxRsClientHttpAttributesExtractor.java
@@ -33,11 +33,6 @@ final class JaxRsClientHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(ClientRequestContext httpRequest) {
-    return httpRequest.getHeaderString("User-Agent");
-  }
-
-  @Override
   protected List<String> requestHeader(ClientRequestContext httpRequest, String name) {
     return httpRequest.getStringHeaders().getOrDefault(name, emptyList());
   }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientHttpAttributesExtractor.java
@@ -40,9 +40,8 @@ final class ResteasyClientHttpAttributesExtractor
       return emptyList();
     }
     List<String> stringHeaders = new ArrayList<>(rawHeaders.size());
-    int i = 0;
     for (Object headerValue : rawHeaders) {
-      stringHeaders.set(i++, String.valueOf(headerValue));
+      stringHeaders.add(String.valueOf(headerValue));
     }
     return stringHeaders;
   }

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientHttpAttributesExtractor.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v2_0/ResteasyClientHttpAttributesExtractor.java
@@ -34,11 +34,6 @@ final class ResteasyClientHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(ClientInvocation httpRequest) {
-    return httpRequest.getHeaders().getHeader("User-Agent");
-  }
-
-  @Override
   protected List<String> requestHeader(ClientInvocation httpRequest, String name) {
     List<Object> rawHeaders = httpRequest.getHeaders().getHeaders().getOrDefault(name, emptyList());
     if (rawHeaders.isEmpty()) {

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesExtractor.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesExtractor.java
@@ -44,13 +44,6 @@ final class JettyClientHttpAttributesExtractor
   }
 
   @Override
-  @Nullable
-  protected String userAgent(Request request) {
-    HttpField agentField = request.getHeaders().getField(HttpHeader.USER_AGENT);
-    return agentField != null ? agentField.getValue() : null;
-  }
-
-  @Override
   protected List<String> requestHeader(Request request, String name) {
     return request.getHeaders().getValuesList(name);
   }

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesExtractor.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesExtractor.java
@@ -33,11 +33,6 @@ class KubernetesHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(Request request) {
-    return request.header("user-agent");
-  }
-
-  @Override
   protected List<String> requestHeader(Request request, String name) {
     return request.headers(name);
   }

--- a/instrumentation/liberty/compile-stub/src/main/java/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/instrumentation/liberty/compile-stub/src/main/java/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -22,10 +22,6 @@ public class HttpDispatcherLink {
     throw new UnsupportedOperationException();
   }
 
-  public String getRequestedHost() {
-    throw new UnsupportedOperationException();
-  }
-
   public int getRequestedPort() {
     throw new UnsupportedOperationException();
   }

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesExtractor.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesExtractor.java
@@ -23,11 +23,6 @@ public class LibertyDispatcherHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(LibertyRequest libertyRequest) {
-    return libertyRequest.getHeaderValue("User-Agent");
-  }
-
-  @Override
   protected List<String> requestHeader(LibertyRequest libertyRequest, String name) {
     return libertyRequest.getHeaderValues(name);
   }
@@ -88,11 +83,6 @@ public class LibertyDispatcherHttpAttributesExtractor
       return requestUri + "?" + queryString;
     }
     return requestUri;
-  }
-
-  @Override
-  protected String host(LibertyRequest libertyRequest) {
-    return libertyRequest.getServerName() + ":" + libertyRequest.getServerPort();
   }
 
   @Override

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
@@ -58,9 +58,8 @@ public class LibertyRequest {
       return Collections.emptyList();
     }
     List<String> stringHeaders = new ArrayList<>(headers.size());
-    int i = 0;
     for (HeaderField header : headers) {
-      stringHeaders.set(i++, header.asString());
+      stringHeaders.add(header.asString());
     }
     return stringHeaders;
   }

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
@@ -39,10 +39,6 @@ public class LibertyRequest {
     return httpRequestMessage.getQueryString();
   }
 
-  public String getServerName() {
-    return httpDispatcherLink.getRequestedHost();
-  }
-
   public int getServerPort() {
     return httpDispatcherLink.getRequestedPort();
   }

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesExtractor.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesExtractor.java
@@ -31,12 +31,6 @@ final class OkHttp2HttpAttributesExtractor
   }
 
   @Override
-  @Nullable
-  protected String userAgent(Request request) {
-    return request.header("User-Agent");
-  }
-
-  @Override
   protected List<String> requestHeader(Request request, String name) {
     return request.headers(name);
   }

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesExtractor.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesExtractor.java
@@ -31,12 +31,6 @@ final class OkHttpAttributesExtractor extends HttpClientAttributesExtractor<Requ
   }
 
   @Override
-  protected @Nullable String userAgent(Request request) {
-    // using lowercase header name intentionally to ensure extraction is not case-sensitive
-    return request.header("user-agent");
-  }
-
-  @Override
   protected List<String> requestHeader(Request request, String name) {
     return request.headers(name);
   }

--- a/instrumentation/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesExtractor.java
+++ b/instrumentation/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesExtractor.java
@@ -31,12 +31,6 @@ final class PlayWsClientHttpAttributesExtractor
   }
 
   @Override
-  @Nullable
-  protected String userAgent(Request request) {
-    return null;
-  }
-
-  @Override
   protected List<String> requestHeader(Request request, String name) {
     return request.getHeaders().getAll(name);
   }

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesExtractor.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesExtractor.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.ratpack;
 import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import java.net.URI;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import ratpack.handling.Context;
@@ -37,21 +36,6 @@ final class RatpackHttpAttributesExtractor
 
   @Override
   @Nullable
-  protected String host(Request request) {
-    Context ratpackContext = request.get(Context.class);
-    if (ratpackContext == null) {
-      return null;
-    }
-    PublicAddress publicAddress = ratpackContext.get(PublicAddress.class);
-    if (publicAddress == null) {
-      return null;
-    }
-    URI uri = publicAddress.get();
-    return uri.getHost() + ":" + uri.getPort();
-  }
-
-  @Override
-  @Nullable
   protected String route(Request request) {
     // Ratpack route not available at the beginning of request.
     return null;
@@ -69,12 +53,6 @@ final class RatpackHttpAttributesExtractor
       return null;
     }
     return publicAddress.get().getScheme();
-  }
-
-  @Override
-  @Nullable
-  protected String userAgent(Request request) {
-    return request.getHeaders().get("user-agent");
   }
 
   @Override

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesExtractor.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesExtractor.java
@@ -41,12 +41,6 @@ final class RestletHttpAttributesExtractor
   }
 
   @Override
-  protected String host(Request request) {
-    Reference originalRef = request.getOriginalRef();
-    return originalRef.getHostDomain() + ":" + originalRef.getHostPort();
-  }
-
-  @Override
   protected @Nullable String route(Request request) {
     return null;
   }
@@ -54,11 +48,6 @@ final class RestletHttpAttributesExtractor
   @Override
   protected @Nullable String scheme(Request request) {
     return request.getOriginalRef().getScheme();
-  }
-
-  @Override
-  protected @Nullable String userAgent(Request request) {
-    return request.getClientInfo().getAgent();
   }
 
   @Override

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesExtractor.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesExtractor.java
@@ -113,9 +113,8 @@ final class RestletHttpAttributesExtractor
       return Collections.emptyList();
     }
     List<String> stringHeaders = new ArrayList<>(headers.size());
-    int i = 0;
     for (Parameter header : headers) {
-      stringHeaders.set(i++, header.getValue());
+      stringHeaders.add(header.getValue());
     }
     return stringHeaders;
   }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesExtractor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesExtractor.java
@@ -38,19 +38,8 @@ public class ServletHttpAttributesExtractor<REQUEST, RESPONSE>
   }
 
   @Override
-  protected @Nullable String host(ServletRequestContext<REQUEST> requestContext) {
-    REQUEST request = requestContext.request();
-    return accessor.getRequestServerName(request) + ":" + accessor.getRequestServerPort(request);
-  }
-
-  @Override
   protected @Nullable String scheme(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestScheme(requestContext.request());
-  }
-
-  @Override
-  protected @Nullable String userAgent(ServletRequestContext<REQUEST> requestContext) {
-    return accessor.getRequestHeader(requestContext.request(), "User-Agent");
   }
 
   @Override

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebHttpAttributesExtractor.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebHttpAttributesExtractor.java
@@ -35,12 +35,6 @@ final class SpringWebHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(HttpRequest httpRequest) {
-    // using lowercase header name intentionally to ensure extraction is not case-sensitive
-    return httpRequest.getHeaders().getFirst("user-agent");
-  }
-
-  @Override
   protected List<String> requestHeader(HttpRequest httpRequest, String name) {
     return httpRequest.getHeaders().getOrDefault(name, emptyList());
   }

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcHttpAttributesExtractor.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcHttpAttributesExtractor.java
@@ -30,11 +30,6 @@ final class SpringWebMvcHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(HttpServletRequest request) {
-    return request.getHeader("user-agent");
-  }
-
-  @Override
   protected List<String> requestHeader(HttpServletRequest request, String name) {
     Enumeration<String> headers = request.getHeaders(name);
     return headers == null ? Collections.emptyList() : Collections.list(headers);
@@ -96,11 +91,6 @@ final class SpringWebMvcHttpAttributesExtractor
       target += "?" + queryString;
     }
     return target;
-  }
-
-  @Override
-  protected @Nullable String host(HttpServletRequest request) {
-    return request.getHeader("host");
   }
 
   @Override

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesExtractor.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesExtractor.java
@@ -37,19 +37,9 @@ public class TomcatHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String host(Request request) {
-    return request.serverName().toString() + ":" + request.getServerPort();
-  }
-
-  @Override
   protected @Nullable String scheme(Request request) {
     MessageBytes schemeMessageBytes = request.scheme();
     return schemeMessageBytes.isNull() ? "http" : schemeMessageBytes.toString();
-  }
-
-  @Override
-  protected @Nullable String userAgent(Request request) {
-    return request.getHeader("User-Agent");
   }
 
   @Override

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesExtractor.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesExtractor.java
@@ -26,11 +26,6 @@ public class UndertowHttpAttributesExtractor
   }
 
   @Override
-  protected @Nullable String userAgent(HttpServerExchange exchange) {
-    return exchange.getRequestHeaders().getFirst("User-Agent");
-  }
-
-  @Override
   protected List<String> requestHeader(HttpServerExchange exchange, String name) {
     HeaderValues values = exchange.getRequestHeaders().get(name);
     return values == null ? Collections.emptyList() : values;
@@ -92,11 +87,6 @@ public class UndertowHttpAttributesExtractor
       return requestPath + "?" + queryString;
     }
     return requestPath;
-  }
-
-  @Override
-  protected @Nullable String host(HttpServerExchange exchange) {
-    return exchange.getHostAndPort();
   }
 
   @Override

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpServerTest.groovy
@@ -578,8 +578,8 @@ abstract class HttpServerTest<SERVER> extends InstrumentationSpecification imple
           // netty instrumentation uses this
           "${SemanticAttributes.HTTP_URL.key}" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }
         } else {
-          "${SemanticAttributes.HTTP_HOST}" "localhost:${port}"
           "${SemanticAttributes.HTTP_SCHEME}" "http"
+          "${SemanticAttributes.HTTP_HOST}" { it == "localhost" || it == "localhost:${port}" }
           "${SemanticAttributes.HTTP_TARGET}" endpoint.resolvePath(address).getPath() + "${endpoint == QUERY_PARAM ? "?${endpoint.body}" : ""}"
         }
 


### PR DESCRIPTION
The common/server base classes extract them using the `requestHeader()` method