### PR TITLE
Move Trie back to javaagent-tooling

### DIFF
--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/internal/InstrumentedTaskClasses.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/internal/InstrumentedTaskClasses.java
@@ -41,8 +41,8 @@ public final class InstrumentedTaskClasses {
   private static volatile Predicate<String> ignoredTaskClassesPredicate;
 
   /**
-   * Sets the configured ignored tasks predicate (that uses a trie to find the common prefix). This
-   * method is called internally from the agent classloader.
+   * Sets the configured ignored tasks predicate. This method is called internally from the agent
+   * classloader.
    */
   public static void setIgnoredTaskClassesPredicate(Predicate<String> ignoredTasksTriePredicate) {
     if (InstrumentedTaskClasses.ignoredTaskClassesPredicate != null) {

--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/internal/InstrumentedTaskClasses.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/internal/InstrumentedTaskClasses.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.api.internal;
 
 import io.opentelemetry.instrumentation.api.config.Config;
-import io.opentelemetry.javaagent.instrumentation.api.util.Trie;
+import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +22,7 @@ public final class InstrumentedTaskClasses {
         @Override
         protected Boolean computeValue(Class<?> taskClass) {
           // do not instrument ignored task classes
-          if (ignoredTaskClasses.getOrDefault(taskClass.getName(), false)) {
+          if (ignoredTaskClassesPredicate.test(taskClass.getName())) {
             return false;
           }
           // Don't trace runnables from libraries that are packaged inside the agent.
@@ -38,18 +38,18 @@ public final class InstrumentedTaskClasses {
         }
       };
 
-  private static volatile Trie<Boolean> ignoredTaskClasses;
+  private static volatile Predicate<String> ignoredTaskClassesPredicate;
 
   /**
-   * Sets the configured ignored tasks trie. This method is called internally from the agent
-   * classloader.
+   * Sets the configured ignored tasks predicate (that uses a trie to find the common prefix). This
+   * method is called internally from the agent classloader.
    */
-  public static void setIgnoredTaskClasses(Trie<Boolean> ignoredTasksTrie) {
-    if (InstrumentedTaskClasses.ignoredTaskClasses != null) {
+  public static void setIgnoredTaskClassesPredicate(Predicate<String> ignoredTasksTriePredicate) {
+    if (InstrumentedTaskClasses.ignoredTaskClassesPredicate != null) {
       logger.warn("Ignored task classes were already set earlier; returning.");
       return;
     }
-    InstrumentedTaskClasses.ignoredTaskClasses = ignoredTasksTrie;
+    InstrumentedTaskClasses.ignoredTaskClassesPredicate = ignoredTasksTriePredicate;
   }
 
   /**

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -31,6 +31,7 @@ import io.opentelemetry.javaagent.tooling.ignore.IgnoredClassLoadersMatcher;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesBuilderImpl;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesMatcher;
 import io.opentelemetry.javaagent.tooling.muzzle.AgentTooling;
+import io.opentelemetry.javaagent.tooling.util.Trie;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
@@ -209,7 +210,8 @@ public class AgentInstaller {
       configurer.configure(config, builder);
     }
 
-    InstrumentedTaskClasses.setIgnoredTaskClasses(builder.buildIgnoredTasksTrie());
+    Trie<Boolean> ignoredTasksTrie = builder.buildIgnoredTasksTrie();
+    InstrumentedTaskClasses.setIgnoredTaskClassesPredicate(ignoredTasksTrie::contains);
 
     return agentBuilder
         .ignore(any(), new IgnoredClassLoadersMatcher(builder.buildIgnoredClassLoadersTrie()))

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/IgnoredClassLoadersMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/IgnoredClassLoadersMatcher.java
@@ -7,7 +7,7 @@ package io.opentelemetry.javaagent.tooling.ignore;
 
 import io.opentelemetry.instrumentation.api.caching.Cache;
 import io.opentelemetry.javaagent.bootstrap.PatchLogger;
-import io.opentelemetry.javaagent.instrumentation.api.util.Trie;
+import io.opentelemetry.javaagent.tooling.util.Trie;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.slf4j.Logger;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/IgnoredTypesBuilderImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/IgnoredTypesBuilderImpl.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.tooling.ignore;
 
 import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesBuilder;
-import io.opentelemetry.javaagent.instrumentation.api.util.Trie;
+import io.opentelemetry.javaagent.tooling.util.Trie;
 
 public class IgnoredTypesBuilderImpl implements IgnoredTypesBuilder {
   private final Trie.Builder<IgnoreAllow> ignoredTypesTrie = Trie.newBuilder();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/IgnoredTypesMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/IgnoredTypesMatcher.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.tooling.ignore;
 
-import io.opentelemetry.javaagent.instrumentation.api.util.Trie;
+import io.opentelemetry.javaagent.tooling.util.Trie;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/Trie.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/Trie.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.api.util;
+package io.opentelemetry.javaagent.tooling.util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -31,6 +31,11 @@ public interface Trie<V> {
    * trie.getOrDefault("abcd", -1)} will return {@code 10}.
    */
   V getOrDefault(CharSequence str, V defaultValue);
+
+  /** Returns {@code true} if this trie contains the prefix {@code str}. */
+  default boolean contains(CharSequence str) {
+    return getOrNull(str) != null;
+  }
 
   interface Builder<V> {
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/TrieImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/util/TrieImpl.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.api.util;
+package io.opentelemetry.javaagent.tooling.util;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/util/TrieTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/util/TrieTest.java
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.api.util;
+package io.opentelemetry.javaagent.tooling.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,9 +19,11 @@ class TrieTest {
         Trie.<Integer>newBuilder().put("abc", 0).put("abcd", 10).put("abcde", 20).build();
 
     assertNull(trie.getOrNull("ab"));
+    assertFalse(trie.contains("ab"));
     assertEquals(0, trie.getOrNull("abc"));
     assertEquals(10, trie.getOrNull("abcd"));
     assertEquals(20, trie.getOrNull("abcde"));
+    assertTrue(trie.contains("abcde"));
   }
 
   @Test

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
@@ -7,12 +7,12 @@ package io.opentelemetry.javaagent.testing.bytebuddy;
 
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
-import io.opentelemetry.javaagent.instrumentation.api.util.Trie;
 import io.opentelemetry.javaagent.tooling.SafeServiceLoader;
 import io.opentelemetry.javaagent.tooling.ignore.AdditionalLibraryIgnoredTypesConfigurer;
 import io.opentelemetry.javaagent.tooling.ignore.GlobalIgnoredTypesConfigurer;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoreAllow;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesBuilderImpl;
+import io.opentelemetry.javaagent.tooling.util.Trie;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
As discussed in the SIG this morning - the trie class should not be exposed in any of our `*-api` modules, it should be kept in some internal javaagent module.