### PR TITLE
Fix a bug in the field backed VirtualField implementation

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -26,7 +26,6 @@ import io.opentelemetry.javaagent.instrumentation.api.internal.InstrumentedTaskC
 import io.opentelemetry.javaagent.tooling.asyncannotationsupport.WeakRefAsyncOperationEndStrategies;
 import io.opentelemetry.javaagent.tooling.bootstrap.BootstrapPackagesBuilderImpl;
 import io.opentelemetry.javaagent.tooling.config.ConfigInitializer;
-import io.opentelemetry.javaagent.tooling.field.FieldBackedImplementationInstaller;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredClassLoadersMatcher;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesBuilderImpl;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesMatcher;
@@ -132,8 +131,6 @@ public class AgentInstaller {
     setBootstrapPackages(config);
 
     runBeforeAgentListeners(agentListeners, config);
-
-    FieldBackedImplementationInstaller.resetContextMatchers();
 
     AgentBuilder agentBuilder =
         new AgentBuilder.Default()

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfacesGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfacesGenerator.java
@@ -49,14 +49,14 @@ final class FieldAccessorInterfacesGenerator {
       String typeName, String fieldTypeName) {
     // We are using Object class name instead of fieldTypeName here because this gets injected
     // onto Bootstrap classloader where context class may be unavailable
-    TypeDescription fieldTypeDesc = new TypeDescription.ForLoadedType(Object.class);
+    TypeDescription fieldTypeDesc = TypeDescription.OBJECT;
     return byteBuddy
         .makeInterface()
         .merge(SyntheticState.SYNTHETIC)
         .name(getFieldAccessorInterfaceName(typeName, fieldTypeName))
-        .defineMethod(getRealGetterName(typeName), fieldTypeDesc, Visibility.PUBLIC)
+        .defineMethod(getRealGetterName(fieldTypeName), fieldTypeDesc, Visibility.PUBLIC)
         .withoutCode()
-        .defineMethod(getRealSetterName(typeName), TypeDescription.VOID, Visibility.PUBLIC)
+        .defineMethod(getRealSetterName(fieldTypeName), TypeDescription.VOID, Visibility.PUBLIC)
         .withParameter(fieldTypeDesc, "value")
         .withoutCode()
         .make();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfacesGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfacesGenerator.java
@@ -54,9 +54,10 @@ final class FieldAccessorInterfacesGenerator {
         .makeInterface()
         .merge(SyntheticState.SYNTHETIC)
         .name(getFieldAccessorInterfaceName(typeName, fieldTypeName))
-        .defineMethod(getRealGetterName(fieldTypeName), fieldTypeDesc, Visibility.PUBLIC)
+        .defineMethod(getRealGetterName(typeName, fieldTypeName), fieldTypeDesc, Visibility.PUBLIC)
         .withoutCode()
-        .defineMethod(getRealSetterName(fieldTypeName), TypeDescription.VOID, Visibility.PUBLIC)
+        .defineMethod(
+            getRealSetterName(typeName, fieldTypeName), TypeDescription.VOID, Visibility.PUBLIC)
         .withParameter(fieldTypeDesc, "value")
         .withoutCode()
         .make();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationInstaller.java
@@ -53,8 +53,7 @@ import net.bytebuddy.utility.JavaModule;
  * <em>FieldBackedImplementation$VirtualField$Runnable$RunnableState12345.getVirtualField(Runnable.class,
  * RunnableState.class)</em>
  */
-public final class FieldBackedImplementationInstaller
-    implements VirtualFieldImplementationInstaller {
+final class FieldBackedImplementationInstaller implements VirtualFieldImplementationInstaller {
 
   private static final TransformSafeLogger logger =
       TransformSafeLogger.getLogger(FieldBackedImplementationInstaller.class);
@@ -160,13 +159,6 @@ public final class FieldBackedImplementationInstaller
    */
   private static final Set<Map.Entry<String, String>> INSTALLED_VIRTUAL_FIELD_MATCHERS =
       new HashSet<>();
-
-  /** Clear set that prevents multiple matchers for same context class. */
-  public static void resetContextMatchers() {
-    synchronized (INSTALLED_VIRTUAL_FIELD_MATCHERS) {
-      INSTALLED_VIRTUAL_FIELD_MATCHERS.clear();
-    }
-  }
 
   @Override
   public AgentBuilder.Identified.Extendable injectFields(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/GeneratedVirtualFieldNames.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/GeneratedVirtualFieldNames.java
@@ -38,15 +38,15 @@ final class GeneratedVirtualFieldNames {
         + Utils.convertToInnerClassName(fieldTypeName);
   }
 
-  static String getRealFieldName(String typeName) {
-    return "__opentelemetryVirtualField$" + Utils.convertToInnerClassName(typeName);
+  static String getRealFieldName(String fieldTypeName) {
+    return "__opentelemetryVirtualField$" + Utils.convertToInnerClassName(fieldTypeName);
   }
 
-  static String getRealGetterName(String typeName) {
-    return "get" + getRealFieldName(typeName);
+  static String getRealGetterName(String fieldTypeName) {
+    return "get" + getRealFieldName(fieldTypeName);
   }
 
-  static String getRealSetterName(String typeName) {
-    return "set" + getRealFieldName(typeName);
+  static String getRealSetterName(String fieldTypeName) {
+    return "set" + getRealFieldName(fieldTypeName);
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/GeneratedVirtualFieldNames.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/GeneratedVirtualFieldNames.java
@@ -38,15 +38,18 @@ final class GeneratedVirtualFieldNames {
         + Utils.convertToInnerClassName(fieldTypeName);
   }
 
-  static String getRealFieldName(String fieldTypeName) {
-    return "__opentelemetryVirtualField$" + Utils.convertToInnerClassName(fieldTypeName);
+  static String getRealFieldName(String typeName, String fieldTypeName) {
+    return "__opentelemetryVirtualField$"
+        + Utils.convertToInnerClassName(typeName)
+        + "$"
+        + Utils.convertToInnerClassName(fieldTypeName);
   }
 
-  static String getRealGetterName(String fieldTypeName) {
-    return "get" + getRealFieldName(fieldTypeName);
+  static String getRealGetterName(String typeName, String fieldTypeName) {
+    return "get" + getRealFieldName(typeName, fieldTypeName);
   }
 
-  static String getRealSetterName(String fieldTypeName) {
-    return "set" + getRealFieldName(fieldTypeName);
+  static String getRealSetterName(String typeName, String fieldTypeName) {
+    return "set" + getRealFieldName(typeName, fieldTypeName);
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/RealFieldInjector.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/RealFieldInjector.java
@@ -67,10 +67,10 @@ final class RealFieldInjector implements AsmVisitorWrapper {
     return new ClassVisitor(Opcodes.ASM7, classVisitor) {
       // We are using Object class name instead of fieldTypeName here because this gets
       // injected onto Bootstrap classloader where context class may be unavailable
-      private final TypeDescription fieldType = new TypeDescription.ForLoadedType(Object.class);
-      private final String fieldName = getRealFieldName(typeName);
-      private final String getterMethodName = getRealGetterName(typeName);
-      private final String setterMethodName = getRealSetterName(typeName);
+      private final TypeDescription fieldType = TypeDescription.OBJECT;
+      private final String fieldName = getRealFieldName(fieldTypeName);
+      private final String getterMethodName = getRealGetterName(fieldTypeName);
+      private final String setterMethodName = getRealSetterName(fieldTypeName);
       private final TypeDescription interfaceType =
           fieldAccessorInterfaces.find(typeName, fieldTypeName);
       private boolean foundField = false;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/RealFieldInjector.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/RealFieldInjector.java
@@ -68,9 +68,9 @@ final class RealFieldInjector implements AsmVisitorWrapper {
       // We are using Object class name instead of fieldTypeName here because this gets
       // injected onto Bootstrap classloader where context class may be unavailable
       private final TypeDescription fieldType = TypeDescription.OBJECT;
-      private final String fieldName = getRealFieldName(fieldTypeName);
-      private final String getterMethodName = getRealGetterName(fieldTypeName);
-      private final String setterMethodName = getRealSetterName(fieldTypeName);
+      private final String fieldName = getRealFieldName(typeName, fieldTypeName);
+      private final String getterMethodName = getRealGetterName(typeName, fieldTypeName);
+      private final String setterMethodName = getRealSetterName(typeName, fieldTypeName);
       private final TypeDescription interfaceType =
           fieldAccessorInterfaces.find(typeName, fieldTypeName);
       private boolean foundField = false;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
@@ -154,7 +154,7 @@ final class VirtualFieldImplementationsGenerator {
            * @param name name of the method being visited
            */
           private void generateRealGetMethod(String name) {
-            String getterName = getRealGetterName(fieldTypeName);
+            String getterName = getRealGetterName(typeName, fieldTypeName);
             Label elseLabel = new Label();
             MethodVisitor mv = getMethodVisitor(name);
             mv.visitCode();
@@ -207,7 +207,7 @@ final class VirtualFieldImplementationsGenerator {
            * @param name name of the method being visited
            */
           private void generateRealPutMethod(String name) {
-            String setterName = getRealSetterName(fieldTypeName);
+            String setterName = getRealSetterName(typeName, fieldTypeName);
             Label elseLabel = new Label();
             Label endLabel = new Label();
             MethodVisitor mv = getMethodVisitor(name);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
@@ -154,7 +154,7 @@ final class VirtualFieldImplementationsGenerator {
            * @param name name of the method being visited
            */
           private void generateRealGetMethod(String name) {
-            String getterName = getRealGetterName(typeName);
+            String getterName = getRealGetterName(fieldTypeName);
             Label elseLabel = new Label();
             MethodVisitor mv = getMethodVisitor(name);
             mv.visitCode();
@@ -207,7 +207,7 @@ final class VirtualFieldImplementationsGenerator {
            * @param name name of the method being visited
            */
           private void generateRealPutMethod(String name) {
-            String setterName = getRealSetterName(typeName);
+            String setterName = getRealSetterName(fieldTypeName);
             Label elseLabel = new Label();
             Label endLabel = new Label();
             MethodVisitor mv = getMethodVisitor(name);

--- a/testing-common/integration-tests/src/main/java/context/ContextTestInstrumentation.java
+++ b/testing-common/integration-tests/src/main/java/context/ContextTestInstrumentation.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.field.VirtualField;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import library.KeyClass;
+import library.KeyInterface;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -36,7 +37,7 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
     transformer.applyAdviceToMethod(
         named("removeContextCount"), this.getClass().getName() + "$RemoveApiUsageAdvice");
     transformer.applyAdviceToMethod(
-        named("useTwoFields"), this.getClass().getName() + "$UseTwoFieldsAdvice");
+        named("useMultipleFields"), this.getClass().getName() + "$UseMultipleFieldsAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -94,15 +95,18 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
   }
 
   @SuppressWarnings("unused")
-  public static class UseTwoFieldsAdvice {
+  public static class UseMultipleFieldsAdvice {
     @Advice.OnMethodExit
     public static void methodExit(@Advice.This KeyClass thiz) {
       VirtualField<KeyClass, Context> field1 = VirtualField.find(KeyClass.class, Context.class);
       VirtualField<KeyClass, Integer> field2 = VirtualField.find(KeyClass.class, Integer.class);
+      VirtualField<KeyInterface, Integer> interfaceField =
+          VirtualField.find(KeyInterface.class, Integer.class);
 
       Context context = field1.get(thiz);
       int count = context == null ? 0 : context.count;
       field2.set(thiz, count);
+      interfaceField.set(thiz, count);
     }
   }
 }

--- a/testing-common/integration-tests/src/main/java/context/ContextTestInstrumentation.java
+++ b/testing-common/integration-tests/src/main/java/context/ContextTestInstrumentation.java
@@ -35,6 +35,8 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
         named("putContextCount"), this.getClass().getName() + "$PutApiUsageAdvice");
     transformer.applyAdviceToMethod(
         named("removeContextCount"), this.getClass().getName() + "$RemoveApiUsageAdvice");
+    transformer.applyAdviceToMethod(
+        named("useTwoFields"), this.getClass().getName() + "$UseTwoFieldsAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -88,6 +90,19 @@ public class ContextTestInstrumentation implements TypeInstrumentation {
       VirtualField<KeyClass, Context> virtualField =
           VirtualField.find(KeyClass.class, Context.class);
       virtualField.set(thiz, null);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class UseTwoFieldsAdvice {
+    @Advice.OnMethodExit
+    public static void methodExit(@Advice.This KeyClass thiz) {
+      VirtualField<KeyClass, Context> field1 = VirtualField.find(KeyClass.class, Context.class);
+      VirtualField<KeyClass, Integer> field2 = VirtualField.find(KeyClass.class, Integer.class);
+
+      Context context = field1.get(thiz);
+      int count = context == null ? 0 : context.count;
+      field2.set(thiz, count);
     }
   }
 }

--- a/testing-common/integration-tests/src/test/groovy/context/FieldBackedImplementationTest.groovy
+++ b/testing-common/integration-tests/src/test/groovy/context/FieldBackedImplementationTest.groovy
@@ -102,14 +102,14 @@ class FieldBackedImplementationTest extends AgentInstrumentationSpecification {
     }
 
     expect:
-    fields.size() == 2
+    fields.size() == 3
     fields.forEach { field ->
       assert Modifier.isPrivate(field.modifiers)
       assert Modifier.isTransient(field.modifiers)
       assert field.synthetic
     }
 
-    interfaces.size() == 2
+    interfaces.size() == 3
     interfaces.forEach { iface ->
       assert iface.synthetic
     }

--- a/testing-common/library-for-integration-tests/src/main/java/library/KeyClass.java
+++ b/testing-common/library-for-integration-tests/src/main/java/library/KeyClass.java
@@ -5,7 +5,7 @@
 
 package library;
 
-public class KeyClass {
+public class KeyClass implements KeyInterface {
   public boolean isInstrumented() {
     // implementation replaced with test instrumentation
     return false;
@@ -29,7 +29,7 @@ public class KeyClass {
     // implementation replaced with test instrumentation
   }
 
-  public void useTwoFields() {
+  public void useMultipleFields() {
     // implementation replaced with test instrumentation
   }
 }

--- a/testing-common/library-for-integration-tests/src/main/java/library/KeyClass.java
+++ b/testing-common/library-for-integration-tests/src/main/java/library/KeyClass.java
@@ -28,4 +28,8 @@ public class KeyClass {
   public void removeContextCount() {
     // implementation replaced with test instrumentation
   }
+
+  public void useTwoFields() {
+    // implementation replaced with test instrumentation
+  }
 }

--- a/testing-common/library-for-integration-tests/src/main/java/library/KeyInterface.java
+++ b/testing-common/library-for-integration-tests/src/main/java/library/KeyInterface.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package library;
+
+public interface KeyInterface {}


### PR DESCRIPTION
When refactoring these classes I've noticed that generated fields (and getters and setters) are not named correctly; thus making it impossible to actually inject more than one field. It turned out to be a bug: when more than one `VirtualField` was used for a single class, only the first field would "really" be injected; the rest of them used the cache-based fallback implementation.