### PR TITLE
Remove restriction on vaadin latest dep tests

### DIFF
--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -63,9 +63,5 @@ dependencies {
   testInstrumentation(project(":instrumentation:tomcat:tomcat-7.0:javaagent"))
 
   add("vaadin14LatestTestImplementation", "com.vaadin:vaadin-spring-boot-starter:14.+")
-  // Pin latest tested vaadin version to 19
-  // https://github.com/vaadin/flow/issues/11524
-  // Update to workbox-build node module broke building javascript, remove this restriction after
-  // new version of vaadin is released.
-  add("latestDepTestImplementation", "com.vaadin:vaadin-spring-boot-starter:19.+")
+  add("latestDepTestImplementation", "com.vaadin:vaadin-spring-boot-starter:+")
 }

--- a/instrumentation/vaadin-14.2/testing/src/main/groovy/test/vaadin/AbstractVaadin16Test.groovy
+++ b/instrumentation/vaadin-14.2/testing/src/main/groovy/test/vaadin/AbstractVaadin16Test.groovy
@@ -12,20 +12,25 @@ import io.opentelemetry.api.trace.SpanKind
 abstract class AbstractVaadin16Test extends AbstractVaadinTest {
   static final boolean VAADIN_17 = Version.majorVersion >= 4
   static final boolean VAADIN_19 = Version.majorVersion >= 6
+  static final boolean VAADIN_21 = Version.majorVersion >= 8
 
   @Override
   List<String> getRequestHandlers() {
-    List<String> handlers = [
-      "PushRequestHandler"
-    ]
+    List<String> handlers = []
+    if (VAADIN_21) {
+      handlers.add("DevModeHandlerImpl")
+    }
+    handlers.add("PushRequestHandler")
     if (VAADIN_19) {
       handlers.addAll("WebComponentBootstrapHandler", "WebComponentProvider", "PwaHandler")
     }
     handlers.addAll([
       "StreamRequestHandler", "UnsupportedBrowserHandler", "UidlRequestHandler",
-      "HeartbeatHandler", "SessionRequestHandler", "JavaScriptBootstrapHandler", "FaviconHandler",
-      "DevModeHandler", "IndexHtmlRequestHandler"
-    ])
+      "HeartbeatHandler", "SessionRequestHandler", "JavaScriptBootstrapHandler", "FaviconHandler"])
+    if (!VAADIN_21) {
+      handlers.add("DevModeHandler")
+    }
+    handlers.add("IndexHtmlRequestHandler")
 
     return handlers
   }


### PR DESCRIPTION
We restricted latest dep tests to vaadin 19 because of an issue in vaadin 20 which has been resolved.