### PR TITLE
Make all methods on PropagatedContext package protected

### DIFF
--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
@@ -12,6 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import io.opentelemetry.instrumentation.api.field.VirtualField;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.api.concurrent.ExecutorAdviceHelper;
 import io.opentelemetry.javaagent.instrumentation.api.concurrent.PropagatedContext;
 import java.util.Arrays;
 import java.util.Collection;
@@ -103,10 +104,7 @@ public class FutureInstrumentation implements TypeInstrumentation {
       // is called, one way or another
       VirtualField<Future<?>, PropagatedContext> virtualField =
           VirtualField.find(Future.class, PropagatedContext.class);
-      PropagatedContext propagatedContext = virtualField.get(future);
-      if (propagatedContext != null) {
-        propagatedContext.clear();
-      }
+      ExecutorAdviceHelper.cleanPropagatedContext(virtualField, future);
     }
   }
 }

--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/ExecutorAdviceHelper.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/ExecutorAdviceHelper.java
@@ -72,5 +72,14 @@ public final class ExecutorAdviceHelper {
     }
   }
 
+  /** Clean context attached to the given task. */
+  public static <T> void cleanPropagatedContext(
+      VirtualField<T, PropagatedContext> virtualField, T task) {
+    PropagatedContext propagatedContext = virtualField.get(task);
+    if (propagatedContext != null) {
+      propagatedContext.clear();
+    }
+  }
+
   private ExecutorAdviceHelper() {}
 }

--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/PropagatedContext.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/PropagatedContext.java
@@ -44,7 +44,7 @@ public final class PropagatedContext {
     }
   }
 
-  public void clear() {
+  void clear() {
     contextUpdater.set(this, null);
   }
 


### PR DESCRIPTION
I am not sure if this is worth the trouble, but with this PR `PropagatedContext` class does not have any public methods anymore. `ExecutorAdviceHelper` gets one more public method, but that class is by nature meant for public API.