### PR TITLE
Set server span name only when needed

### DIFF
--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/org/springframework/web/servlet/OpenTelemetryHandlerMappingFilter.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/org/springframework/web/servlet/OpenTelemetryHandlerMappingFilter.java
@@ -53,13 +53,15 @@ public class OpenTelemetryHandlerMappingFilter implements Filter, Ordered {
       return;
     }
 
-    if (handlerMappings != null) {
-      Context context = Context.current();
-      ServerSpanNaming.updateServerSpanName(
-          context, CONTROLLER, serverSpanName, (HttpServletRequest) request);
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      if (handlerMappings != null) {
+        Context context = Context.current();
+        ServerSpanNaming.updateServerSpanName(
+            context, CONTROLLER, serverSpanName, (HttpServletRequest) request);
+      }
     }
-
-    filterChain.doFilter(request, response);
   }
 
   @Override


### PR DESCRIPTION
My understanding is that `OpenTelemetryHandlerMappingFilter` is useful when spring security rejects request, which happens before request reaches the place where we usually update server span name. For regular requests this filter just duplicates the effort of finding a handler that matches the request, the same needs to be done by spring also and we update server span name there too. This pr makes `OpenTelemetryHandlerMappingFilter` set server span name after the request is completed and only when server span name is not set.