### PR TITLE
Add code attributes to quartz spans

### DIFF
--- a/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzCodeAttributesExtractor.java
+++ b/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzCodeAttributesExtractor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.quartz.v2_0;
+
+import io.opentelemetry.instrumentation.api.instrumenter.code.CodeAttributesExtractor;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.quartz.JobExecutionContext;
+
+public class QuartzCodeAttributesExtractor
+    extends CodeAttributesExtractor<JobExecutionContext, Void> {
+  @Override
+  protected Class<?> codeClass(JobExecutionContext jobExecutionContext) {
+    return jobExecutionContext.getJobDetail().getJobClass();
+  }
+
+  @Override
+  protected String methodName(JobExecutionContext jobExecutionContext) {
+    return "execute";
+  }
+
+  @Override
+  @Nullable
+  protected String filePath(JobExecutionContext jobExecutionContext) {
+    return null;
+  }
+
+  @Override
+  @Nullable
+  protected Long lineNumber(JobExecutionContext jobExecutionContext) {
+    return null;
+  }
+}

--- a/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzTracingBuilder.java
+++ b/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzTracingBuilder.java
@@ -43,6 +43,7 @@ public final class QuartzTracingBuilder {
         Instrumenter.newBuilder(openTelemetry, INSTRUMENTATION_NAME, new QuartzSpanNameExtractor());
 
     instrumenter.setErrorCauseExtractor(new QuartzErrorCauseExtractor());
+    instrumenter.addAttributesExtractor(new QuartzCodeAttributesExtractor());
     instrumenter.addAttributesExtractors(additionalExtractors);
 
     return new QuartzTracing(new TracingJobListener(instrumenter.newInstrumenter()));

--- a/instrumentation/quartz-2.0/testing/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/AbstractQuartzTest.java
+++ b/instrumentation/quartz-2.0/testing/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/AbstractQuartzTest.java
@@ -13,6 +13,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -67,8 +68,10 @@ public abstract class AbstractQuartzTest {
                                 attrs ->
                                     assertThat(attrs)
                                         .containsEntry(
-                                            "code.namespace", SuccessfulJob.class.getName())
-                                        .containsEntry("code.function", "execute")),
+                                            SemanticAttributes.CODE_NAMESPACE,
+                                            SuccessfulJob.class.getName())
+                                        .containsEntry(
+                                            SemanticAttributes.CODE_FUNCTION, "execute")),
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)
@@ -96,8 +99,11 @@ public abstract class AbstractQuartzTest {
                             .hasAttributesSatisfying(
                                 attrs ->
                                     assertThat(attrs)
-                                        .containsEntry("code.namespace", FailingJob.class.getName())
-                                        .containsEntry("code.function", "execute"))));
+                                        .containsEntry(
+                                            SemanticAttributes.CODE_NAMESPACE,
+                                            FailingJob.class.getName())
+                                        .containsEntry(
+                                            SemanticAttributes.CODE_FUNCTION, "execute"))));
   }
 
   private static Scheduler createScheduler(String name) throws Exception {


### PR DESCRIPTION
Motivation is that these spans currently have no attributes, so there's no way to suppress them via an attribute-based sampler.