### PR TITLE
Add Spring Extension tests to Restlet instrumentation

### DIFF
--- a/instrumentation/restlet/restlet-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/restlet/v1_0/spring/SpringBeanRouterTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/restlet/v1_0/spring/SpringBeanRouterTest.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.restlet.v1_0.spring
+
+import io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest
+import io.opentelemetry.instrumentation.test.AgentTestTrait
+
+class SpringBeanRouterTest extends AbstractSpringServerTest implements AgentTestTrait {
+  @Override
+  String getConfigurationName() {
+    return "springBeanRouterConf.xml"
+  }
+  
+}

--- a/instrumentation/restlet/restlet-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/restlet/v1_0/spring/SpringRouterTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/restlet/v1_0/spring/SpringRouterTest.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.restlet.v1_0.spring
+
+import io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest
+import io.opentelemetry.instrumentation.test.AgentTestTrait
+
+class SpringRouterTest extends AbstractSpringServerTest implements AgentTestTrait {
+  @Override
+  String getConfigurationName() {
+    return "springRouterConf.xml"
+  }
+  
+}

--- a/instrumentation/restlet/restlet-1.0/library/build.gradle.kts
+++ b/instrumentation/restlet/restlet-1.0/library/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
   library("com.noelios.restlet:com.noelios.restlet:1.1.5")
 
   testImplementation(project(":instrumentation:restlet:restlet-1.0:testing"))
+  testImplementation("org.restlet:org.restlet.ext.spring:1.1.5")
+  testImplementation("org.springframework:spring:2.5.6")
 
   latestDepTestLibrary("org.restlet:org.restlet:1.1.+")
   latestDepTestLibrary("com.noelios.restlet:com.noelios.restlet:1.1.+")

--- a/instrumentation/restlet/restlet-1.0/library/build.gradle.kts
+++ b/instrumentation/restlet/restlet-1.0/library/build.gradle.kts
@@ -10,15 +10,10 @@ repositories {
 
 dependencies {
 
-  compileOnly("com.google.auto.value:auto-value-annotations")
-  annotationProcessor("com.google.auto.value:auto-value")
-
   library("org.restlet:org.restlet:1.1.5")
   library("com.noelios.restlet:com.noelios.restlet:1.1.5")
 
   testImplementation(project(":instrumentation:restlet:restlet-1.0:testing"))
-  testImplementation("org.restlet:org.restlet.ext.spring:1.1.5")
-  testImplementation("org.springframework:spring:2.5.6")
 
   latestDepTestLibrary("org.restlet:org.restlet:1.1.+")
   latestDepTestLibrary("com.noelios.restlet:com.noelios.restlet:1.1.+")

--- a/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/AbstractSpringServerLibraryTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/AbstractSpringServerLibraryTest.groovy
@@ -14,7 +14,7 @@ import org.restlet.Route
 import org.restlet.Router
 import org.restlet.util.RouteList
 
-abstract class AbstractSpringTest extends AbstractSpringServerTest implements LibraryTestTrait {
+abstract class AbstractSpringServerLibraryTest extends AbstractSpringServerTest implements LibraryTestTrait {
   @Override
   Restlet wrapRestlet(Restlet restlet, String path) {
 

--- a/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/AbstractSpringTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/AbstractSpringTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opententelemetry.instrumentation.restlet.v1_0.spring
+
+import com.noelios.restlet.StatusFilter
+import io.opentelemetry.instrumentation.restlet.v1_0.RestletTracing
+import io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import org.restlet.Restlet
+import org.restlet.Route
+import org.restlet.Router
+import org.restlet.util.RouteList
+
+abstract class AbstractSpringTest extends AbstractSpringServerTest implements LibraryTestTrait {
+  @Override
+  Restlet wrapRestlet(Restlet restlet, String path) {
+
+    RestletTracing tracing = RestletTracing.newBuilder(openTelemetry)
+      .captureHttpHeaders(capturedHttpHeadersForTesting())
+      .build()
+
+    def tracingFilter = tracing.newFilter(path)
+    def statusFilter = new StatusFilter(component.getContext(), false, null, null)
+
+    tracingFilter.setNext(statusFilter)
+    statusFilter.setNext(restlet)
+
+    return tracingFilter
+  }
+
+  @Override
+  void setupRouting() {
+    List<Route> routes = []
+    for (Route route : router.getRoutes()) {
+      def pattern = route.getTemplate().getPattern()
+      routes.add(new Route(router, pattern, wrapRestlet(route.getNext(), pattern)))
+    }
+    router.setRoutes(new RouteList(routes))
+    router.setDefaultRoute(new Route(router, "/", wrapRestlet(new Router(host.getContext()), "/*")))
+    host.attach(router)
+  }
+}

--- a/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/SpringBeanRouterTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/SpringBeanRouterTest.groovy
@@ -1,0 +1,14 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opententelemetry.instrumentation.restlet.v1_0.spring
+
+class SpringBeanRouterTest extends AbstractSpringTest {
+  @Override
+  String getConfigurationName() {
+    return "springBeanRouterConf.xml"
+  }
+
+}

--- a/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/SpringBeanRouterTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/SpringBeanRouterTest.groovy
@@ -5,7 +5,7 @@
 
 package io.opententelemetry.instrumentation.restlet.v1_0.spring
 
-class SpringBeanRouterTest extends AbstractSpringTest {
+class SpringBeanRouterTest extends AbstractSpringServerLibraryTest {
   @Override
   String getConfigurationName() {
     return "springBeanRouterConf.xml"

--- a/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/SpringRouterTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/SpringRouterTest.groovy
@@ -5,7 +5,7 @@
 
 package io.opententelemetry.instrumentation.restlet.v1_0.spring
 
-class SpringRouterTest extends AbstractSpringTest {
+class SpringRouterTest extends AbstractSpringServerLibraryTest {
 
   @Override
   String getConfigurationName() {

--- a/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/SpringRouterTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/library/src/test/groovy/io/opententelemetry/instrumentation/restlet/v1_0/spring/SpringRouterTest.groovy
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opententelemetry.instrumentation.restlet.v1_0.spring
+
+class SpringRouterTest extends AbstractSpringTest {
+
+  @Override
+  String getConfigurationName() {
+    return "springRouterConf.xml"
+  }
+
+}

--- a/instrumentation/restlet/restlet-1.0/testing/build.gradle.kts
+++ b/instrumentation/restlet/restlet-1.0/testing/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
 
   implementation("org.restlet:org.restlet:1.1.5")
   implementation("com.noelios.restlet:com.noelios.restlet:1.1.5")
+  implementation("org.restlet:org.restlet.ext.spring:1.1.5")
+  implementation("org.springframework:spring:2.5.6")
 
   implementation("org.codehaus.groovy:groovy-all")
   implementation("io.opentelemetry:opentelemetry-api")

--- a/instrumentation/restlet/restlet-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v1_0/AbstractRestletServerTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v1_0/AbstractRestletServerTest.groovy
@@ -42,10 +42,9 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
   Server startServer(int port) {
 
     component = new Component()
-    def server = component.getServers().add(Protocol.HTTP, port)
-
     host = component.getDefaultHost()
-    attachRestlets()
+    def server = setupServer(component)
+    setupRouting()
 
     component.start()
 
@@ -61,7 +60,11 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
     host.attach(path, wrapRestlet(restlet, path))
   }
 
-  def attachRestlets() {
+  Server setupServer(Component component) {
+    return component.getServers().add(Protocol.HTTP, port)
+  }
+
+  void setupRouting() {
 
     def defaultRouter = wrapRestlet(new Router(host.getContext()), "/*")
     host.attach("/", defaultRouter).setMatchingMode(Template.MODE_STARTS_WITH)
@@ -178,6 +181,8 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
     }
   }
 
-  abstract Restlet wrapRestlet(Restlet restlet, String path)
+  Restlet wrapRestlet(Restlet restlet, String path) {
+    return restlet
+  }
 
 }

--- a/instrumentation/restlet/restlet-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v1_0/spring/AbstractSpringServerTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v1_0/spring/AbstractSpringServerTest.groovy
@@ -1,0 +1,190 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.restlet.v1_0.spring
+
+import io.opentelemetry.instrumentation.restlet.v1_0.AbstractRestletServerTest
+import org.restlet.Component
+import org.restlet.Context
+import org.restlet.Router
+import org.restlet.Server
+import org.restlet.data.Form
+import org.restlet.data.MediaType
+import org.restlet.data.Reference
+import org.restlet.data.Request
+import org.restlet.data.Response
+import org.restlet.data.Status
+import org.restlet.resource.Representation
+import org.restlet.resource.Resource
+import org.restlet.resource.StringRepresentation
+import org.restlet.resource.Variant
+import org.springframework.context.support.ClassPathXmlApplicationContext
+
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_HEADERS
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+
+abstract class AbstractSpringServerTest extends AbstractRestletServerTest {
+
+  Router router
+
+  abstract String getConfigurationName()
+
+  @Override
+  Server setupServer(Component component) {
+    def context = new ClassPathXmlApplicationContext(getConfigurationName())
+    router = (Router) context.getBean("testRouter")
+    def server = (Server) context.getBean("testServer", "http", port)
+    component.getServers().add(server)
+    return server
+  }
+
+  @Override
+  void setupRouting() {
+    host.attach(router)
+  }
+
+  static class SuccessResource extends Resource {
+
+    @Override
+    void init(Context context, Request request, Response response) {
+      super.init(context, request, response)
+      getVariants().add(new Variant(MediaType.TEXT_PLAIN))
+    }
+
+    @Override
+    Representation represent(Variant variant) {
+      controller(SUCCESS) {
+        return new StringRepresentation(SUCCESS.body)
+      }
+    }
+  }
+
+  static class ErrorResource extends Resource {
+
+    @Override
+    void init(Context context, Request request, Response response) {
+      super.init(context, request, response)
+      getVariants().add(new Variant(MediaType.TEXT_PLAIN))
+    }
+
+    @Override
+    Representation represent(Variant variant) {
+      controller(ERROR) {
+        getResponse().setStatus(Status.valueOf(ERROR.getStatus()), ERROR.getBody())
+        return new StringRepresentation(ERROR.body)
+      }
+    }
+  }
+
+  static class ExceptionResource extends Resource {
+
+    @Override
+    void init(Context context, Request request, Response response) {
+      super.init(context, request, response)
+      getVariants().add(new Variant(MediaType.TEXT_PLAIN))
+    }
+
+    @Override
+    Representation represent(Variant variant) {
+      controller(ERROR) {
+        throw new Exception(EXCEPTION.body)
+      }
+    }
+  }
+
+  static class QueryParamResource extends Resource {
+
+    @Override
+    void init(Context context, Request request, Response response) {
+      super.init(context, request, response)
+      getVariants().add(new Variant(MediaType.TEXT_PLAIN))
+    }
+
+    @Override
+    Representation represent(Variant variant) {
+      controller(QUERY_PARAM) {
+        return new StringRepresentation(QUERY_PARAM.getBody())
+      }
+    }
+  }
+
+  static class PathParamResource extends Resource {
+
+    @Override
+    void init(Context context, Request request, Response response) {
+      super.init(context, request, response)
+      getVariants().add(new Variant(MediaType.TEXT_PLAIN))
+    }
+
+    @Override
+    Representation represent(Variant variant) {
+      controller(PATH_PARAM) {
+        return new StringRepresentation(PATH_PARAM.getBody())
+      }
+    }
+  }
+
+  static class RedirectResource extends Resource {
+
+    @Override
+    void init(Context context, Request request, Response response) {
+      super.init(context, request, response)
+      getVariants().add(new Variant(MediaType.TEXT_PLAIN))
+    }
+
+    @Override
+    Representation represent(Variant variant) {
+      controller(REDIRECT) {
+        response.setLocationRef(new Reference(REDIRECT.getBody()))
+        response.setStatus(Status.REDIRECTION_FOUND)
+        return new StringRepresentation(REDIRECT.getBody())
+      }
+    }
+  }
+
+  static class CaptureHeadersResource extends Resource {
+    @Override
+    void init(Context context, Request request, Response response) {
+      super.init(context, request, response)
+      getVariants().add(new Variant(MediaType.TEXT_PLAIN))
+    }
+
+    @Override
+    Representation represent(Variant variant) {
+      controller(CAPTURE_HEADERS) {
+        Form requestHeaders = request.getAttributes().get("org.restlet.http.headers")
+        Form responseHeaders = response.getAttributes().computeIfAbsent("org.restlet.http.headers", { new Form() })
+        responseHeaders.add("X-Test-Response", requestHeaders.getValues("X-Test-Request"))
+
+        return new StringRepresentation(CAPTURE_HEADERS.getBody())
+      }
+    }
+  }
+
+  static class IndexedChildResource extends Resource {
+
+    @Override
+    void init(Context context, Request request, Response response) {
+      super.init(context, request, response)
+      getVariants().add(new Variant(MediaType.TEXT_PLAIN))
+    }
+
+    @Override
+    Representation represent(Variant variant) {
+      controller(INDEXED_CHILD) {
+        INDEXED_CHILD.collectSpanAttributes { request.getOriginalRef().getQueryAsForm().getFirst(it).getValue() }
+        return new StringRepresentation(INDEXED_CHILD.getBody())
+      }
+    }
+  }
+
+
+}

--- a/instrumentation/restlet/restlet-1.0/testing/src/main/resources/springBeanRouterConf.xml
+++ b/instrumentation/restlet/restlet-1.0/testing/src/main/resources/springBeanRouterConf.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="testServer" class="org.restlet.ext.spring.SpringServer" scope="prototype">
+    <constructor-arg value="http"/>
+  </bean>
+
+  <bean name="testRouter" class="org.restlet.ext.spring.SpringBeanRouter"/>
+
+  <bean name="/success" scope="prototype" id="successResource"
+    class="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$SuccessResource"/>
+  <bean name="/error-status" scope="prototype" id="errorResource"
+    class="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$ErrorResource"/>
+  <bean name="/exception" scope="prototype" id="exceptionResource"
+    class="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$ExceptionResource"/>
+  <bean name="/query" scope="prototype" id="queryParamResource"
+    class="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$QueryParamResource"/>
+  <bean name="/path/{id}/param" scope="prototype" id="pathParamResource"
+    class="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$PathParamResource"/>
+  <bean name="/redirect" scope="prototype" id="redirectResource"
+    class="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$RedirectResource"/>
+  <bean name="/captureHeaders" scope="prototype" id="captureHeadersResource"
+    class="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$CaptureHeadersResource"/>
+  <bean name="/child" scope="prototype" id="indexedChildResource"
+    class="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$IndexedChildResource"/>
+
+</beans>

--- a/instrumentation/restlet/restlet-1.0/testing/src/main/resources/springRouterConf.xml
+++ b/instrumentation/restlet/restlet-1.0/testing/src/main/resources/springRouterConf.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="testServer" class="org.restlet.ext.spring.SpringServer" scope="prototype">
+    <constructor-arg value="http"/>
+  </bean>
+
+  <bean name="testRouter" class="org.restlet.ext.spring.SpringRouter">
+
+    <property name="attachments">
+      <map>
+        <entry key="/success"
+          value="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$SuccessResource"/>
+        <entry key="/error-status"
+          value="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$ErrorResource"/>
+        <entry key="/exception"
+          value="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$ExceptionResource"/>
+        <entry key="/query"
+          value="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$QueryParamResource"/>
+        <entry key="/path/{id}/param"
+          value="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$PathParamResource"/>
+        <entry key="/redirect"
+          value="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$RedirectResource"/>
+        <entry key="/captureHeaders"
+          value="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$CaptureHeadersResource"/>
+        <entry key="/child"
+          value="io.opentelemetry.instrumentation.restlet.v1_0.spring.AbstractSpringServerTest$IndexedChildResource"/>
+      </map>
+    </property>
+  </bean>
+
+</beans>


### PR DESCRIPTION
Related to #3662
Added tests for `org.restlet.ext.spring` components configured in .xml files