### PR TITLE
AWS 1.11 strict context check

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent-unit-tests/build.gradle.kts
@@ -11,7 +11,3 @@ dependencies {
 
   testImplementation("org.assertj:assertj-core")
 }
-
-tasks.withType<Test>().configureEach {
-  jvmArgs("-Dio.opentelemetry.context.enableStrictContext=false")
-}


### PR DESCRIPTION
Part of #3916
This is purely a test issue `shouldSetScopeIfClientSpanNotPresent` didn't close scope. `shouldNotSetScopeAndNotFailIfClientSpanAlreadyPresent` started failing when the scope was closed, this test didn't pass when it was run on its own.