### PR TITLE
Fix issue on build failure

### DIFF
--- a/.github/templates/workflow-failed.md
+++ b/.github/templates/workflow-failed.md
@@ -1,7 +1,7 @@
 ---
-title: #{{ env.GITHUB_WORKFLOW }} #{{ env.GITHUB_RUN_NUMBER }} failed
+title: {{ env.GITHUB_WORKFLOW }} #{{ env.GITHUB_RUN_NUMBER }} failed
 assignees: open-telemetry/java-instrumentation-maintainers
 labels: bug, area:build, priority:p1
 ---
 <a href="https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}">
-#{{ env.GITHUB_WORKFLOW }} #{{ env.GITHUB_RUN_NUMBER }}</a> failed. Please take a look and fix it ASAP.
+{{ env.GITHUB_WORKFLOW }} #{{ env.GITHUB_RUN_NUMBER }}</a> failed. Please take a look and fix it ASAP.


### PR DESCRIPTION
Creating issue on build failure is failing: https://github.com/open-telemetry/opentelemetry-java-instrumentation/runs/3878191817?check_suite_focus=true

I'm not sure this will fix it (but this change is needed anyways, I mistook `#` earlier for part of the templating).

If this doesn't fix, next attempt will be to put title value into quotes.