### PR TITLE
Prototype Log4j2 Appender

### DIFF
--- a/instrumentation/log4j/log4j-2-testing/build.gradle.kts
+++ b/instrumentation/log4j/log4j-2-testing/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
   api(project(":testing-common"))
 
+  api("io.opentelemetry:opentelemetry-sdk-extension-logging")
+
   api("org.apache.logging.log4j:log4j-core:2.7")
 
   implementation("com.google.guava:guava")

--- a/instrumentation/log4j/log4j-2-testing/src/main/groovy/Log4j2Test.groovy
+++ b/instrumentation/log4j/log4j-2-testing/src/main/groovy/Log4j2Test.groovy
@@ -9,7 +9,7 @@ import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import org.apache.logging.log4j.LogManager
 
 abstract class Log4j2Test extends InstrumentationSpecification {
-  def cleanup() {
+  def setup() {
     ListAppender.get().clearEvents()
   }
 

--- a/instrumentation/log4j/log4j-2-testing/src/main/resources/log4j2-test.xml
+++ b/instrumentation/log4j/log4j-2-testing/src/main/resources/log4j2-test.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="com.example.appender">
+<Configuration status="WARN" packages="com.example.appender,io.opentelemetry.instrumentation.log4j.v2_13_2">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} traceId: %X{trace_id} spanId: %X{span_id} flags: %X{trace_flags} - %msg%n" />
     </Console>
     <ListAppender name="ListAppender" />
+    <OpenTelemetry name="OpenTelemetryAppender" />
   </Appenders>
   <Loggers>
     <Logger name="TestLogger" level="All">
+      <AppenderRef ref="OpenTelemetryAppender" leve="All" />
       <AppenderRef ref="ListAppender" level="All" />
       <AppenderRef ref="Console" level="All" />
     </Logger>

--- a/instrumentation/log4j/log4j-2.13.2/library/build.gradle.kts
+++ b/instrumentation/log4j/log4j-2.13.2/library/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+  api("io.opentelemetry:opentelemetry-sdk-extension-logging")
+
   library("org.apache.logging.log4j:log4j-core:2.13.2")
 
   // Library instrumentation cannot be applied to 2.13.2 due to a bug in Log4J. The agent works

--- a/instrumentation/log4j/log4j-2.13.2/library/src/main/java/io/opentelemetry/instrumentation/log4j/v2_13_2/InMemoryLogExporter.java
+++ b/instrumentation/log4j/log4j-2.13.2/library/src/main/java/io/opentelemetry/instrumentation/log4j/v2_13_2/InMemoryLogExporter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.log4j.v2_13_2;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.export.LogExporter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public final class InMemoryLogExporter implements LogExporter {
+
+  // using LinkedBlockingQueue to avoid manual locks for thread-safe operations
+  private final Queue<LogRecord> finishedLogItems = new LinkedBlockingQueue<>();
+  private boolean isStopped = false;
+
+  private InMemoryLogExporter() {}
+
+  /**
+   * Returns a new instance of the {@code InMemoryLogExporter}.
+   *
+   * @return a new instance of the {@code InMemoryLogExporter}.
+   */
+  public static InMemoryLogExporter create() {
+    return new InMemoryLogExporter();
+  }
+
+  /**
+   * Returns a {@code List} of the finished {@code Log}s, represented by {@code LogRecord}.
+   *
+   * @return a {@code List} of the finished {@code Log}s.
+   */
+  public List<LogRecord> getFinishedLogItems() {
+    return Collections.unmodifiableList(new ArrayList<>(finishedLogItems));
+  }
+
+  /**
+   * Clears the internal {@code List} of finished {@code Log}s.
+   *
+   * <p>Does not reset the state of this exporter if already shutdown.
+   */
+  public void reset() {
+    finishedLogItems.clear();
+  }
+
+  /**
+   * Exports the collection of {@code Log}s into the inmemory queue.
+   *
+   * <p>If this is called after {@code shutdown}, this will return {@code ResultCode.FAILURE}.
+   */
+  @Override
+  public CompletableResultCode export(Collection<LogRecord> logs) {
+    if (isStopped) {
+      return CompletableResultCode.ofFailure();
+    }
+    finishedLogItems.addAll(logs);
+    return CompletableResultCode.ofSuccess();
+  }
+
+  /**
+   * Clears the internal {@code List} of finished {@code Log}s.
+   *
+   * <p>Any subsequent call to export() function on this LogExporter, will return {@code
+   * CompletableResultCode.ofFailure()}
+   */
+  @Override
+  public CompletableResultCode shutdown() {
+    isStopped = true;
+    finishedLogItems.clear();
+    return CompletableResultCode.ofSuccess();
+  }
+}

--- a/instrumentation/log4j/log4j-2.13.2/library/src/main/java/io/opentelemetry/instrumentation/log4j/v2_13_2/LogEventMapper.java
+++ b/instrumentation/log4j/log4j-2.13.2/library/src/main/java/io/opentelemetry/instrumentation/log4j/v2_13_2/LogEventMapper.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.log4j.v2_13_2;
+
+import static io.opentelemetry.instrumentation.api.log.LoggingContextConstants.SPAN_ID;
+import static io.opentelemetry.instrumentation.api.log.LoggingContextConstants.TRACE_ID;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.logging.data.Body;
+import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.data.LogRecord.Severity;
+import io.opentelemetry.sdk.logging.data.LogRecordBuilder;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+
+final class LogEventMapper {
+
+  private static final Map<Level, Severity> LEVEL_SEVERITY_MAP;
+
+  static {
+    Map<Level, Severity> levelSeverityMap = new HashMap<>();
+    levelSeverityMap.put(Level.ALL, Severity.TRACE);
+    levelSeverityMap.put(Level.TRACE, Severity.TRACE2);
+    levelSeverityMap.put(Level.DEBUG, Severity.DEBUG);
+    levelSeverityMap.put(Level.INFO, Severity.INFO);
+    levelSeverityMap.put(Level.WARN, Severity.WARN);
+    levelSeverityMap.put(Level.ERROR, Severity.ERROR);
+    levelSeverityMap.put(Level.FATAL, Severity.FATAL);
+    LEVEL_SEVERITY_MAP = Collections.unmodifiableMap(levelSeverityMap);
+  }
+
+  static LogRecord toLogRecord(
+      LogEvent logEvent, Resource resource, InstrumentationLibraryInfo instrumentationLibraryInfo) {
+    LogRecordBuilder builder =
+        LogRecord.builder(resource, instrumentationLibraryInfo)
+            .setBody(Body.stringBody(logEvent.getMessage().getFormattedMessage()))
+            .setSeverity(
+                LEVEL_SEVERITY_MAP.getOrDefault(
+                    logEvent.getLevel(), Severity.UNDEFINED_SEVERITY_NUMBER))
+            .setSeverityText(logEvent.getLevel().name())
+            .setUnixTimeNano(logEvent.getNanoTime());
+
+    AttributesBuilder attributes = Attributes.builder();
+    attributes.put("logger.name", logEvent.getLoggerName());
+    attributes.put("thread.name", logEvent.getThreadName());
+
+    Map<String, String> contextMap = logEvent.getContextData().toMap();
+    if (!contextMap.isEmpty()) {
+      if (contextMap.containsKey(TRACE_ID)) {
+        builder.setTraceId(contextMap.remove(TRACE_ID));
+      }
+      if (contextMap.containsKey(SPAN_ID)) {
+        builder.setSpanId(contextMap.remove(SPAN_ID));
+      }
+      contextMap.forEach(attributes::put);
+    }
+
+    builder.setAttributes(attributes.build());
+
+    return builder.build();
+  }
+
+  private LogEventMapper() {}
+}

--- a/instrumentation/log4j/log4j-2.13.2/library/src/main/java/io/opentelemetry/instrumentation/log4j/v2_13_2/OpenTelemetryAppender.java
+++ b/instrumentation/log4j/log4j-2.13.2/library/src/main/java/io/opentelemetry/instrumentation/log4j/v2_13_2/OpenTelemetryAppender.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.log4j.v2_13_2;
+
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.logging.LogSink;
+import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.resources.Resource;
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Core;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+
+@Plugin(
+    name = OpenTelemetryAppender.PLUGIN_NAME,
+    category = Core.CATEGORY_NAME,
+    elementType = Appender.ELEMENT_TYPE)
+public class OpenTelemetryAppender extends AbstractAppender {
+
+  static final String PLUGIN_NAME = "OpenTelemetry";
+
+  @PluginBuilderFactory
+  public static <B extends Builder<B>> B newBuilder() {
+    return new Builder<B>().asBuilder();
+  }
+
+  public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
+      implements org.apache.logging.log4j.core.util.Builder<OpenTelemetryAppender> {
+
+    @Override
+    public OpenTelemetryAppender build() {
+      OpenTelemetryAppender appender =
+          new OpenTelemetryAppender(
+              getName(), getLayout(), getFilter(), isIgnoreExceptions(), getPropertyArray());
+      OpenTelemetryLog4j.registerInstance(appender);
+      return appender;
+    }
+  }
+
+  private final AtomicReference<SinkAndResource> sinkAndResourceRef = new AtomicReference<>();
+  private final InstrumentationLibraryInfo instrumentationLibraryInfo;
+
+  private OpenTelemetryAppender(
+      String name,
+      Layout<? extends Serializable> layout,
+      Filter filter,
+      boolean ignoreExceptions,
+      Property[] properties) {
+    super(name, filter, layout, ignoreExceptions, properties);
+    instrumentationLibraryInfo =
+        InstrumentationLibraryInfo.create(OpenTelemetryAppender.class.getName(), null);
+  }
+
+  @Override
+  public void append(LogEvent event) {
+    SinkAndResource sinkAndResource = sinkAndResourceRef.get();
+    if (sinkAndResource == null) {
+      // appender hasn't been initialized
+      return;
+    }
+    LogRecord logRecord =
+        LogEventMapper.toLogRecord(event, sinkAndResource.resource, instrumentationLibraryInfo);
+    sinkAndResource.logSink.offer(logRecord);
+  }
+
+  void initialize(LogSink logSink, Resource resource) {
+    if (!sinkAndResourceRef.compareAndSet(null, new SinkAndResource(logSink, resource))) {
+      throw new IllegalStateException("OpenTelemetryAppender has already been initialized.");
+    }
+  }
+
+  private static class SinkAndResource {
+    private final LogSink logSink;
+    private final Resource resource;
+
+    private SinkAndResource(LogSink logSink, Resource resource) {
+      this.logSink = logSink;
+      this.resource = resource;
+    }
+  }
+}

--- a/instrumentation/log4j/log4j-2.13.2/library/src/main/java/io/opentelemetry/instrumentation/log4j/v2_13_2/OpenTelemetryLog4j.java
+++ b/instrumentation/log4j/log4j-2.13.2/library/src/main/java/io/opentelemetry/instrumentation/log4j/v2_13_2/OpenTelemetryLog4j.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.log4j.v2_13_2;
+
+import io.opentelemetry.sdk.logging.LogSink;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.concurrent.GuardedBy;
+
+public final class OpenTelemetryLog4j {
+
+  private static final Object LOCK = new Object();
+
+  @GuardedBy("LOCK")
+  private static LogSink logSink;
+
+  @GuardedBy("LOCK")
+  private static Resource resource;
+
+  @GuardedBy("LOCK")
+  private static final List<OpenTelemetryAppender> APPENDERS = new ArrayList<>();
+
+  public static void initialize(LogSink logSink, Resource resource) {
+    List<OpenTelemetryAppender> instances;
+    synchronized (LOCK) {
+      if (OpenTelemetryLog4j.logSink != null) {
+        throw new IllegalStateException("LogSinkSdkProvider has already been set.");
+      }
+      OpenTelemetryLog4j.logSink = logSink;
+      OpenTelemetryLog4j.resource = resource;
+      instances = new ArrayList<>(APPENDERS);
+    }
+    for (OpenTelemetryAppender instance : instances) {
+      instance.initialize(logSink, resource);
+    }
+  }
+
+  static void registerInstance(OpenTelemetryAppender appender) {
+    synchronized (LOCK) {
+      if (logSink != null) {
+        appender.initialize(logSink, resource);
+      }
+      APPENDERS.add(appender);
+    }
+  }
+
+  private OpenTelemetryLog4j() {}
+}

--- a/instrumentation/log4j/log4j-2.13.2/library/src/main/java/io/opentelemetry/instrumentation/log4j/v2_13_2/SimpleLogProcessor.java
+++ b/instrumentation/log4j/log4j-2.13.2/library/src/main/java/io/opentelemetry/instrumentation/log4j/v2_13_2/SimpleLogProcessor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.log4j.v2_13_2;
+
+import static java.util.Objects.requireNonNull;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logging.LogProcessor;
+import io.opentelemetry.sdk.logging.data.LogRecord;
+import io.opentelemetry.sdk.logging.export.BatchLogProcessor;
+import io.opentelemetry.sdk.logging.export.LogExporter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class SimpleLogProcessor implements LogProcessor {
+
+  private static final Logger logger = Logger.getLogger(SimpleLogProcessor.class.getName());
+
+  private final LogExporter logExporter;
+  private final Set<CompletableResultCode> pendingExports =
+      Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private final AtomicBoolean isShutdown = new AtomicBoolean(false);
+
+  /**
+   * Returns a new {@link SimpleLogProcessor} which exports spans to the {@link LogExporter}
+   * synchronously.
+   *
+   * <p>This processor will cause all logs to be exported directly as they finish, meaning each
+   * export request will have a single log. Most backends will not perform well with a single log
+   * per request so unless you know what you're doing, strongly consider using {@link
+   * BatchLogProcessor} instead, including in special environments such as serverless runtimes.
+   * {@link SimpleLogProcessor} is generally meant to for logging exporters only.
+   */
+  public static LogProcessor create(LogExporter exporter) {
+    requireNonNull(exporter, "exporter");
+    return new SimpleLogProcessor(exporter, /* sampled= */ true);
+  }
+
+  SimpleLogProcessor(LogExporter logExporter, boolean sampled) {
+    this.logExporter = requireNonNull(logExporter, "logExporter");
+  }
+
+  @Override
+  public void addLogRecord(LogRecord logRecord) {
+    try {
+      List<LogRecord> spans = Collections.singletonList(logRecord);
+      final CompletableResultCode result = logExporter.export(spans);
+      pendingExports.add(result);
+      result.whenComplete(
+          () -> {
+            pendingExports.remove(result);
+            if (!result.isSuccess()) {
+              logger.log(Level.FINE, "Exporter failed");
+            }
+          });
+    } catch (RuntimeException e) {
+      logger.log(Level.WARNING, "Exporter threw an Exception", e);
+    }
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    if (isShutdown.getAndSet(true)) {
+      return CompletableResultCode.ofSuccess();
+    }
+    final CompletableResultCode result = new CompletableResultCode();
+
+    final CompletableResultCode flushResult = forceFlush();
+    flushResult.whenComplete(
+        () -> {
+          final CompletableResultCode shutdownResult = logExporter.shutdown();
+          shutdownResult.whenComplete(
+              () -> {
+                if (!flushResult.isSuccess() || !shutdownResult.isSuccess()) {
+                  result.fail();
+                } else {
+                  result.succeed();
+                }
+              });
+        });
+
+    return result;
+  }
+
+  @Override
+  public CompletableResultCode forceFlush() {
+    return CompletableResultCode.ofAll(pendingExports);
+  }
+}

--- a/instrumentation/log4j/log4j-2.13.2/library/src/test/groovy/OpenTelemetryAppenderTest.groovy
+++ b/instrumentation/log4j/log4j-2.13.2/library/src/test/groovy/OpenTelemetryAppenderTest.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.log4j.v2_13_2.InMemoryLogExporter
+import io.opentelemetry.instrumentation.log4j.v2_13_2.OpenTelemetryAppender
+import io.opentelemetry.instrumentation.log4j.v2_13_2.OpenTelemetryLog4j
+import io.opentelemetry.instrumentation.log4j.v2_13_2.SimpleLogProcessor
+import io.opentelemetry.instrumentation.test.InstrumentationSpecification
+import io.opentelemetry.instrumentation.test.LibraryTestTrait
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
+import io.opentelemetry.sdk.logging.LogSinkSdkProvider
+import io.opentelemetry.sdk.resources.Resource
+import org.apache.logging.log4j.LogManager
+
+class OpenTelemetryAppenderTest extends InstrumentationSpecification implements LibraryTestTrait {
+
+  private static InMemoryLogExporter logExporter
+  private static Resource resource
+  private static InstrumentationLibraryInfo instrumentationLibraryInfo
+  private static Attributes attributes
+
+  def setupSpec() {
+    logExporter = InMemoryLogExporter.create()
+    resource = Resource.getDefault()
+    instrumentationLibraryInfo = InstrumentationLibraryInfo.create(OpenTelemetryAppender.getName(), null)
+    attributes = Attributes.builder().put("logger.name", "TestLogger").put("thread.name", "Time-limited test").build()
+
+    def sdkSinkProvider = LogSinkSdkProvider.builder().build()
+    sdkSinkProvider.addLogProcessor(SimpleLogProcessor.create(logExporter))
+    def logSink = sdkSinkProvider.get(null, null)
+    OpenTelemetryLog4j.initialize(logSink, resource)
+  }
+
+  def cleanup() {
+    logExporter.reset()
+  }
+
+  def "no span"() {
+    given:
+    def logger = LogManager.getLogger("TestLogger")
+
+    when:
+    logger.info("log message 1")
+    logger.info("log message 2")
+
+    def logRecords = logExporter.getFinishedLogItems()
+
+    then:
+    logRecords.size() == 2
+    logRecords[0].getBody().asString() == "log message 1"
+    logRecords[0].getResource() == resource
+    logRecords[0].getInstrumentationLibraryInfo() == instrumentationLibraryInfo
+    logRecords[0].getTraceId() == ""
+    logRecords[0].getSpanId() == ""
+    logRecords[0].getAttributes() == attributes
+
+    logRecords[1].getBody().asString() == "log message 2"
+    logRecords[1].getResource() == resource
+    logRecords[1].getInstrumentationLibraryInfo() == instrumentationLibraryInfo
+    logRecords[1].getTraceId() == ""
+    logRecords[1].getSpanId() == ""
+    logRecords[1].getAttributes() == attributes
+  }
+
+  def "with span"() {
+    given:
+    def logger = LogManager.getLogger("TestLogger")
+
+    when:
+    def span1 = runWithSpan("test") {
+      logger.info("log message 1")
+      Span.current()
+    }
+
+    logger.info("log message 2")
+
+    def span2 = runWithSpan("test 2") {
+      logger.info("log message 3")
+      Span.current()
+    }
+
+    def logRecords = logExporter.getFinishedLogItems()
+
+    then:
+    logRecords.size() == 3
+    logRecords[0].getBody().asString() == "log message 1"
+    logRecords[0].getResource() == resource
+    logRecords[0].getInstrumentationLibraryInfo() == instrumentationLibraryInfo
+    logRecords[0].getTraceId() == span1.spanContext.traceId
+    logRecords[0].getSpanId() == span1.spanContext.spanId
+    logRecords[0].getAttributes() == attributes.toBuilder().put("trace_flags", "01").build()
+
+    logRecords[1].getBody().asString() == "log message 2"
+    logRecords[1].getResource() == resource
+    logRecords[1].getInstrumentationLibraryInfo() == instrumentationLibraryInfo
+    logRecords[1].getTraceId() == ""
+    logRecords[1].getSpanId() == ""
+    logRecords[1].getAttributes() == attributes
+
+    logRecords[2].getBody().asString() == "log message 3"
+    logRecords[2].getResource() == resource
+    logRecords[2].getInstrumentationLibraryInfo() == instrumentationLibraryInfo
+    logRecords[2].getTraceId() == span2.spanContext.traceId
+    logRecords[2].getSpanId() == span2.spanContext.spanId
+    logRecords[2].getAttributes() == attributes.toBuilder().put("trace_flags", "01").build()
+  }
+
+}


### PR DESCRIPTION
This is meant to prompt discussion. Proves out what an `OpenTelemetryAppender` might look like for log4j2. The idea behind this appender is that it delivers log records to a opentelemetry `LogSink`, where they can be batched and shipped out of process via an exporter, such as the recently added OTLP grpc and http log exporters. 

One of the main problems I had to address was that log appenders are instantiated before the opentelemetry log sdk is available. To get around this, each `OpenTelemetryAppender` instance is statically registered after initialization. Once the otel log sdk is available, it is passed to each `OpnTelemetryAppender` instance via a static method, upon which log records start flowing.

Learnings so far:
- LogRecord trace id and span id need to be nullable. And potentially other properties too. The otlp grpc and http exporters currently fail to serialize if span id and trace id are left as their default `""` values.
- We need a `InMemoryLoggingExporter` for testing. Mocked it out in this code, and will contribute back to `opentelemetry-java`. 
- We need a `SimpleLogProcessor` for testing. Mocked it out in this code, and will contribute back to `opentelemetry-java`. 
- `LogSinkSdkProvider.builder()` is not public but needs to be for it to be useful. I'll make it so.
- `LogSinkSdkProvider` should be immutable after its created. Log processors should be registered with the builder, not with the instance. I'll make it so. 
- Thought needs to be put into how resource and instrumentation library get attached to the log records. Right now and producer to `LogSink` is responsible for creating `LogRecord`s with resource and instrumenation library attached. This means that components like the `OpenTelemetryAppender` need to maintain fields for these. Should `LogSink` accept `LogRecords` without resource and instrumenation library, and let the pipeline attach those? 