### PR TITLE
Fix issue creation on build failure

### DIFF
--- a/.github/templates/workflow-failed.md
+++ b/.github/templates/workflow-failed.md
@@ -1,6 +1,5 @@
 ---
 title: "{{ env.GITHUB_WORKFLOW }} #{{ env.GITHUB_RUN_NUMBER }} failed"
-assignees: open-telemetry/java-instrumentation-maintainers
 labels: bug, area:build, priority:p1
 ---
 <a href="https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}">


### PR DESCRIPTION
#4373 got further, new error is:

```
HttpError: Validation Failed: {"value":"open-telemetry/java-instrumentation-maintainers","resource":"Issue","field":"assignees","code":"invalid"} 
```

guessing this means we can't assign to a group