### PR TITLE
Hide virtual field accessor interface methods from reflection

### DIFF
--- a/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/test/groovy/ReflectionTest.groovy
+++ b/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/test/groovy/ReflectionTest.groovy
@@ -35,5 +35,18 @@ class ReflectionTest extends AgentInstrumentationSpecification {
       }
     }
     methodFound == false
+
+    and:
+    def interfaceClass = TestClass.getInterfaces().find {
+      it.getName().contains("VirtualFieldAccessor\$")
+    }
+    interfaceClass != null
+    def interfaceMethodFound = false
+    for (Method method : interfaceClass.getDeclaredMethods()) {
+      if (method.getName().contains("__opentelemetry")) {
+        interfaceMethodFound = true
+      }
+    }
+    interfaceMethodFound == false
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfacesGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfacesGenerator.java
@@ -54,10 +54,17 @@ final class FieldAccessorInterfacesGenerator {
         .makeInterface()
         .merge(SyntheticState.SYNTHETIC)
         .name(getFieldAccessorInterfaceName(typeName, fieldTypeName))
-        .defineMethod(getRealGetterName(typeName, fieldTypeName), fieldTypeDesc, Visibility.PUBLIC)
+        .defineMethod(
+            getRealGetterName(typeName, fieldTypeName),
+            fieldTypeDesc,
+            Visibility.PUBLIC,
+            SyntheticState.SYNTHETIC)
         .withoutCode()
         .defineMethod(
-            getRealSetterName(typeName, fieldTypeName), TypeDescription.VOID, Visibility.PUBLIC)
+            getRealSetterName(typeName, fieldTypeName),
+            TypeDescription.VOID,
+            Visibility.PUBLIC,
+            SyntheticState.SYNTHETIC)
         .withParameter(fieldTypeDesc, "value")
         .withoutCode()
         .make();


### PR DESCRIPTION
Alternative to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4385. Ideally application should not be able to reflectively observe virtual fields and accessor methods associated with them. Currently it is possible to see methods defined in virtual field accessor interfaces, which this pr corrects.