### PR TITLE
Run selenium tests with chrome

### DIFF
--- a/instrumentation/gwt-2.0/javaagent/src/test/groovy/GwtTest.groovy
+++ b/instrumentation/gwt-2.0/javaagent/src/test/groovy/GwtTest.groovy
@@ -11,7 +11,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.util.resource.Resource
 import org.eclipse.jetty.webapp.WebAppContext
-import org.openqa.selenium.firefox.FirefoxOptions
+import org.openqa.selenium.chrome.ChromeOptions
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.testcontainers.Testcontainers
@@ -54,7 +54,7 @@ class GwtTest extends AgentInstrumentationSpecification implements HttpServerTes
     Testcontainers.exposeHostPorts(port)
 
     browser = new BrowserWebDriverContainer<>()
-      .withCapabilities(new FirefoxOptions())
+      .withCapabilities(new ChromeOptions())
       .withLogConsumer(new Slf4jLogConsumer(logger))
     browser.start()
 

--- a/instrumentation/vaadin-14.2/testing/src/main/groovy/test/vaadin/AbstractVaadinTest.groovy
+++ b/instrumentation/vaadin-14.2/testing/src/main/groovy/test/vaadin/AbstractVaadinTest.groovy
@@ -11,7 +11,7 @@ import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
-import org.openqa.selenium.firefox.FirefoxOptions
+import org.openqa.selenium.chrome.ChromeOptions
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.boot.SpringApplication
@@ -48,7 +48,7 @@ abstract class AbstractVaadinTest extends AgentInstrumentationSpecification impl
     Testcontainers.exposeHostPorts(port)
 
     browser = new BrowserWebDriverContainer<>()
-      .withCapabilities(new FirefoxOptions())
+      .withCapabilities(new ChromeOptions())
       .withLogConsumer(new Slf4jLogConsumer(logger))
     browser.start()
 


### PR DESCRIPTION
A while back in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/3732 we changed selenium tests from chrome to firefox, because tests started failing in CI. We were never able to figure out why exactly this happened, debugging was complicated because it didn't reproduce locally. This pr attempts changing back to chrome in the hope that whatever broke it previously is fixed by now.
The main motivation for attempting changing back to chrome is that vaadin tests occasionally fail with 
```
06:20:26.532 [docker-java-stream--230040152] INFO  test.vaadin.AbstractVaadinTest - STDOUT: Marionette threw an error: AbortError: Actor 'MarionetteCommands' destroyed before query 'MarionetteCommandsParent:findElement' was resolved |  
06:20:26.532 [docker-java-stream--230040152] INFO  test.vaadin.AbstractVaadinTest - STDOUT: |  
06:20:26.604 [docker-java-stream--230040152] INFO  test.vaadin.AbstractVaadinTest - STDOUT: 1634278826602	Marionette	INFO	Stopped listening on port 40181 |  
06:20:27.087 [docker-java-stream--230040152] INFO  test.vaadin.AbstractVaadinTest - STDOUT: JavaScript error: resource:///modules/Interactions.jsm, line 230: NS_ERROR_FAILURE: Component returned failure code: 0x80004005 (NS_ERROR_FAILURE) [nsIUserIdleService.removeIdleObserver] |  
06:20:27.685 [docker-java-stream--230040152] INFO  test.vaadin.AbstractVaadinTest - STDOUT: |  
06:20:27.685 [docker-java-stream--230040152] INFO  test.vaadin.AbstractVaadinTest - STDOUT: ###!!! [Parent][RunMessage] Error: Channel closing: too late to send/recv, messages will be lost |  
06:20:27.685 [docker-java-stream--230040152] INFO  test.vaadin.AbstractVaadinTest - STDOUT:
```
like in https://scans.gradle.com/s/rsf7ofeovtrcs/tests/:instrumentation:vaadin-14.2:javaagent:latestDepTest/test.vaadin.VaadinLatestTest/test%20vaadin?top-execution=1
As we retry failed tests it eventually passes but it would be best if it always passed on the first try.