### PR TITLE
Remove more usages of checker's Nullable

### DIFF
--- a/instrumentation-api-caching/src/main/java/io/opentelemetry/instrumentation/api/caching/Caffeine2Cache.java
+++ b/instrumentation-api-caching/src/main/java/io/opentelemetry/instrumentation/api/caching/Caffeine2Cache.java
@@ -9,8 +9,8 @@ import io.opentelemetry.instrumentation.api.internal.shaded.caffeine2.cache.Caff
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
-import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
 
 final class Caffeine2Cache<K, V> implements CaffeineCache<K, V> {
 
@@ -68,12 +68,12 @@ final class Caffeine2Cache<K, V> implements CaffeineCache<K, V> {
     }
 
     @Override
-    public void maximumSize(@NonNegative long maximumSize) {
+    public void maximumSize(@Nonnegative long maximumSize) {
       caffeine.maximumSize(maximumSize);
     }
 
     @Override
-    public void executor(@NonNull Executor executor) {
+    public void executor(@Nonnull Executor executor) {
       caffeine.executor(executor);
     }
 

--- a/instrumentation-api-caching/src/main/java/io/opentelemetry/instrumentation/api/caching/Caffeine3Cache.java
+++ b/instrumentation-api-caching/src/main/java/io/opentelemetry/instrumentation/api/caching/Caffeine3Cache.java
@@ -9,8 +9,8 @@ import io.opentelemetry.instrumentation.api.internal.shaded.caffeine3.cache.Caff
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
-import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
 
 final class Caffeine3Cache<K, V> implements CaffeineCache<K, V> {
 
@@ -78,12 +78,12 @@ final class Caffeine3Cache<K, V> implements CaffeineCache<K, V> {
     }
 
     @Override
-    public void maximumSize(@NonNegative long maximumSize) {
+    public void maximumSize(@Nonnegative long maximumSize) {
       caffeine.maximumSize(maximumSize);
     }
 
     @Override
-    public void executor(@NonNull Executor executor) {
+    public void executor(@Nonnull Executor executor) {
       caffeine.executor(executor);
     }
 

--- a/instrumentation-api-caching/src/main/java/io/opentelemetry/instrumentation/api/caching/CaffeineCache.java
+++ b/instrumentation-api-caching/src/main/java/io/opentelemetry/instrumentation/api/caching/CaffeineCache.java
@@ -7,8 +7,8 @@ package io.opentelemetry.instrumentation.api.caching;
 
 import java.util.Set;
 import java.util.concurrent.Executor;
-import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
 
 interface CaffeineCache<K, V> extends Cache<K, V> {
 
@@ -18,9 +18,9 @@ interface CaffeineCache<K, V> extends Cache<K, V> {
 
     void weakValues();
 
-    void maximumSize(@NonNegative long maximumSize);
+    void maximumSize(@Nonnegative long maximumSize);
 
-    void executor(@NonNull Executor executor);
+    void executor(@Nonnull Executor executor);
 
     Cache<K, V> build();
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/package-info.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/package-info.java
@@ -1,8 +1,4 @@
-@DefaultQualifier(
-    value = NonNull.class,
-    locations = {TypeUseLocation.FIELD, TypeUseLocation.PARAMETER, TypeUseLocation.RETURN})
+@ParametersAreNonnullByDefault
 package io.opentelemetry.instrumentation.api;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.checkerframework.framework.qual.TypeUseLocation;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoDbAttributesExtractor.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoDbAttributesExtractor.java
@@ -16,12 +16,12 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.json.JsonWriter;
 import org.bson.json.JsonWriterSettings;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 class MongoDbAttributesExtractor extends DbAttributesExtractor<CommandStartedEvent, Void> {
 
@@ -50,17 +50,20 @@ class MongoDbAttributesExtractor extends DbAttributesExtractor<CommandStartedEve
   }
 
   @Override
-  protected @Nullable String user(CommandStartedEvent event) {
+  @Nullable
+  protected String user(CommandStartedEvent event) {
     return null;
   }
 
   @Override
-  protected @Nullable String name(CommandStartedEvent event) {
+  @Nullable
+  protected String name(CommandStartedEvent event) {
     return event.getDatabaseName();
   }
 
   @Override
-  protected @Nullable String connectionString(CommandStartedEvent event) {
+  @Nullable
+  protected String connectionString(CommandStartedEvent event) {
     ConnectionDescription connectionDescription = event.getConnectionDescription();
     if (connectionDescription != null) {
       ServerAddress sa = connectionDescription.getServerAddress();
@@ -82,7 +85,8 @@ class MongoDbAttributesExtractor extends DbAttributesExtractor<CommandStartedEve
   }
 
   @Override
-  protected @Nullable String operation(CommandStartedEvent event) {
+  @Nullable
+  protected String operation(CommandStartedEvent event) {
     return event.getCommandName();
   }
 


### PR DESCRIPTION
Part of #4291

I tried to remove checkerframework dependency as well, but then got this error:

```
> Task :instrumentation-api-caching:compileJava FAILED
warning: unknown enum constant TypeUseLocation.FIELD
  reason: class file for org.checkerframework.framework.qual.TypeUseLocation not found
warning: unknown enum constant TypeUseLocation.PARAMETER
warning: unknown enum constant TypeUseLocation.RETURN
error: warnings found and -Werror specified
1 error
3 warnings
```