### PR TITLE
Enable read timeout tests in OkHTTP instrumentation

### DIFF
--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/test/groovy/OkHttp2Test.groovy
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/test/groovy/OkHttp2Test.groovy
@@ -25,6 +25,7 @@ class OkHttp2Test extends HttpClientTest<Request> implements AgentTestTrait {
 
   def setupSpec() {
     client.setConnectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    client.setReadTimeout(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
   }
 
   @Override
@@ -69,6 +70,7 @@ class OkHttp2Test extends HttpClientTest<Request> implements AgentTestTrait {
     switch (uri.toString()) {
       case "http://localhost:61/":
       case "https://192.0.2.1/":
+      case resolveAddress("/read-timeout").toString():
         attributes.remove(SemanticAttributes.HTTP_FLAVOR)
     }
 
@@ -78,5 +80,10 @@ class OkHttp2Test extends HttpClientTest<Request> implements AgentTestTrait {
   @Override
   boolean testRedirects() {
     false
+  }
+
+  @Override
+  boolean testReadTimeout() {
+    true
   }
 }

--- a/instrumentation/okhttp/okhttp-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/okhttp/v3_0/AbstractOkHttp3Test.groovy
+++ b/instrumentation/okhttp/okhttp-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/okhttp/v3_0/AbstractOkHttp3Test.groovy
@@ -31,6 +31,7 @@ abstract class AbstractOkHttp3Test extends HttpClientTest<Request> {
   Call.Factory client = createCallFactory(
     new OkHttpClient.Builder()
       .connectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+      .readTimeout(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
       .protocols(Arrays.asList(Protocol.HTTP_1_1))
       .retryOnConnectionFailure(false))
 
@@ -74,6 +75,11 @@ abstract class AbstractOkHttp3Test extends HttpClientTest<Request> {
   }
 
   @Override
+  boolean testReadTimeout() {
+    true
+  }
+
+  @Override
   Set<AttributeKey<?>> httpAttributes(URI uri) {
     Set<AttributeKey<?>> extra = [
       SemanticAttributes.HTTP_HOST,
@@ -85,6 +91,7 @@ abstract class AbstractOkHttp3Test extends HttpClientTest<Request> {
     switch (uri.toString()) {
       case "http://localhost:61/":
       case "https://192.0.2.1/":
+      case resolveAddress("/read-timeout").toString():
         attributes.remove(SemanticAttributes.HTTP_FLAVOR)
     }
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4421