### PR TITLE
Don't include caffeine3 in instrumentation-api

### DIFF
--- a/instrumentation-api-caching/build.gradle.kts
+++ b/instrumentation-api-caching/build.gradle.kts
@@ -8,9 +8,6 @@ sourceSets {
   main {
     val caffeine2ShadedDeps = project(":instrumentation-api-caching:caffeine2")
     output.dir(caffeine2ShadedDeps.file("build/extracted/shadow"), "builtBy" to ":instrumentation-api-caching:caffeine2:extractShadowJar")
-
-    val caffeine3ShadedDeps = project(":instrumentation-api-caching:caffeine3")
-    output.dir(caffeine3ShadedDeps.file("build/extracted/shadow"), "builtBy" to ":instrumentation-api-caching:caffeine3:extractShadowJar")
   }
 }
 

--- a/instrumentation-api-caching/caffeine3/build.gradle.kts
+++ b/instrumentation-api-caching/caffeine3/build.gradle.kts
@@ -36,21 +36,4 @@ tasks {
   javadoc {
     enabled = false
   }
-
-  val extractShadowJar by registering(Copy::class) {
-    dependsOn(shadowJar)
-
-    // replace caffeine class with our patched version
-    from(zipTree(shadowJar.get().archiveFile)) {
-      exclude("io/opentelemetry/instrumentation/api/internal/shaded/caffeine3/cache/BoundedLocalCache\$PerformCleanupTask.class")
-      exclude("META-INF/**")
-    }
-    from(patch.output) {
-      include("io/opentelemetry/instrumentation/api/internal/shaded/caffeine3/cache/BoundedLocalCache\$PerformCleanupTask.class")
-    }
-
-    into("build/extracted/shadow")
-    // prevents empty com/github/benmanes/caffeine/cache path from ending up in instrumentation-api
-    includeEmptyDirs = false
-  }
 }

--- a/instrumentation-api-caching/src/main/java/io/opentelemetry/instrumentation/api/caching/Caffeine3Cache.java
+++ b/instrumentation-api-caching/src/main/java/io/opentelemetry/instrumentation/api/caching/Caffeine3Cache.java
@@ -26,7 +26,7 @@ final class Caffeine3Cache<K, V> implements CaffeineCache<K, V> {
     try {
       Caffeine.class.getName();
       return true;
-    } catch (UnsupportedClassVersionError exception) {
+    } catch (UnsupportedClassVersionError | NoClassDefFoundError exception) {
       // caffeine 3 requires jdk 11
       return false;
     }

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -58,6 +58,7 @@ val licenseReportDependencies by configurations.creating {
 dependencies {
   bootstrapLibs(project(":instrumentation-api"))
   bootstrapLibs(project(":instrumentation-api-annotation-support"))
+  bootstrapLibs(project(":instrumentation-api-caching:caffeine3", configuration = "shadow"))
   bootstrapLibs(project(":javaagent-bootstrap"))
   bootstrapLibs(project(":javaagent-instrumentation-api"))
   bootstrapLibs("org.slf4j:slf4j-simple")


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4452
Instead of putting caffeine3 inside instrumentation-api include it only inside javaagent. This way agent still has caffeine3 classes but instrumentation-api doesn't.
As `:instrumentation-api-caching:caffeine3` isn't published this might not work for vendors who build their distro from published modules. Is that an issue? Would adding `id("otel.publish-conventions")` be enough to fix it?