### PR TITLE
Fix flaky okhttp read timeout tests

### DIFF
--- a/instrumentation/okhttp/okhttp-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/okhttp/v3_0/AbstractOkHttp3Test.groovy
+++ b/instrumentation/okhttp/okhttp-3.0/testing/src/main/groovy/io/opentelemetry/instrumentation/okhttp/v3_0/AbstractOkHttp3Test.groovy
@@ -28,12 +28,20 @@ abstract class AbstractOkHttp3Test extends HttpClientTest<Request> {
   abstract Call.Factory createCallFactory(OkHttpClient.Builder clientBuilder)
 
   @Shared
-  Call.Factory client = createCallFactory(
-    new OkHttpClient.Builder()
+  Call.Factory client = createCallFactory(getClientBuilder(false))
+  @Shared
+  Call.Factory clientWithReadTimeout = createCallFactory(getClientBuilder(true))
+
+  OkHttpClient.Builder getClientBuilder(boolean withReadTimeout) {
+    OkHttpClient.Builder builder = new OkHttpClient.Builder()
       .connectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-      .readTimeout(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
       .protocols(Arrays.asList(Protocol.HTTP_1_1))
-      .retryOnConnectionFailure(false))
+      .retryOnConnectionFailure(false)
+    if (withReadTimeout) {
+      builder.readTimeout(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    }
+    return builder
+  }
 
   @Override
   Request buildRequest(String method, URI uri, Map<String, String> headers) {
@@ -46,7 +54,7 @@ abstract class AbstractOkHttp3Test extends HttpClientTest<Request> {
 
   @Override
   int sendRequest(Request request, String method, URI uri, Map<String, String> headers) {
-    def response = client.newCall(request).execute()
+    def response = getClient(uri).newCall(request).execute()
     response.body().withCloseable {
       return response.code()
     }
@@ -54,7 +62,7 @@ abstract class AbstractOkHttp3Test extends HttpClientTest<Request> {
 
   @Override
   void sendRequestWithCallback(Request request, String method, URI uri, Map<String, String> headers, AbstractHttpClientTest.RequestResult requestResult) {
-    client.newCall(request).enqueue(new Callback() {
+    getClient(uri).newCall(request).enqueue(new Callback() {
       @Override
       void onFailure(Call call, IOException e) {
         requestResult.complete(e)
@@ -67,6 +75,13 @@ abstract class AbstractOkHttp3Test extends HttpClientTest<Request> {
         }
       }
     })
+  }
+
+  Call.Factory getClient(URI uri) {
+    if (uri.toString().contains("/read-timeout")) {
+      return clientWithReadTimeout
+    }
+    return client
   }
 
   @Override


### PR DESCRIPTION
On my machine okhttp tests sometimes fail with read timeout. To prevent this set read timeout only for read timeout test.