### PR TITLE
Increase wait timeout in lettuce tests

### DIFF
--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -196,7 +196,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
@@ -259,7 +259,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
@@ -311,7 +311,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
@@ -373,7 +373,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     })
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
@@ -421,7 +421,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     redisFuture.get()
 
     then:
-    conds.await()
+    conds.await(10)
     completedExceptionally == true
     thrown Exception
     assertTraces(1) {
@@ -462,7 +462,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     asyncCommands.flushCommands()
 
     then:
-    conds.await()
+    conds.await(10)
     cancelSuccess == true
     assertTraces(1) {
       trace(0, 3) {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -202,7 +202,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
@@ -266,7 +266,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
@@ -319,7 +319,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
@@ -381,7 +381,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     })
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
@@ -431,7 +431,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     redisFuture.get()
 
     then:
-    conds.await()
+    conds.await(10)
     completedExceptionally == true
     thrown Exception
     assertTraces(1) {
@@ -473,7 +473,7 @@ class LettuceAsyncClientTest extends AgentInstrumentationSpecification {
     asyncCommands.flushCommands()
 
     then:
-    conds.await()
+    conds.await(10)
     cancelSuccess == true
     assertTraces(1) {
       trace(0, 3) {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -89,7 +89,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
@@ -124,7 +124,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
     reactiveCommands.get("TESTKEY").subscribe { res -> conds.evaluate { assert res == "TESTVAL" } }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -160,7 +160,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
@@ -201,7 +201,7 @@ class LettuceReactiveClientTest extends AgentInstrumentationSpecification {
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 1) {
         span(0) {

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.groovy
@@ -93,6 +93,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
 
   def cleanup() {
     connection.close()
+    redisClient.shutdown()
     redisServer.stop()
   }
 
@@ -124,6 +125,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
 
     cleanup:
     connection.close()
+    testConnectionClient.shutdown()
   }
 
   def "connect exception inside the connection future"() {
@@ -141,6 +143,9 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
     thrown ExecutionException
     // Lettuce tracing does not trace connect
     assertTraces(0) {}
+
+    cleanup:
+    testConnectionClient.shutdown()
   }
 
   def "set command using Future get with timeout"() {
@@ -194,7 +199,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 2 + (testCallback() ? 1 : 0)) {
         span(0) {
@@ -267,7 +272,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 2 + (testCallback() ? 2 : 0)) {
         span(0) {
@@ -330,7 +335,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 2 + (testCallback() ? 1 : 0)) {
         span(0) {
@@ -402,7 +407,7 @@ abstract class AbstractLettuceAsyncClientTest extends InstrumentationSpecificati
     })
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(2) {
       trace(0, 1) {
         span(0) {

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.groovy
@@ -90,7 +90,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
@@ -133,7 +133,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
     reactiveCommands.get("TESTKEY").subscribe { res -> conds.evaluate { assert res == "TESTVAL" } }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
@@ -177,7 +177,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
@@ -226,7 +226,7 @@ abstract class AbstractLettuceReactiveClientTest extends InstrumentationSpecific
     }
 
     then:
-    conds.await()
+    conds.await(10)
     assertTraces(1) {
       trace(0, 1) {
         span(0) {

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientAuthTest.groovy
@@ -52,6 +52,7 @@ abstract class AbstractLettuceSyncClientAuthTest extends InstrumentationSpecific
   }
 
   def cleanup() {
+    redisClient.shutdown()
     redisServer.stop()
   }
 

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/groovy/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.groovy
@@ -85,6 +85,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
 
   def cleanup() {
     connection.close()
+    redisClient.shutdown()
     redisServer.stop()
   }
 
@@ -102,6 +103,7 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
 
     cleanup:
     connection.close()
+    testConnectionClient.shutdown()
   }
 
   def "connect exception"() {
@@ -116,6 +118,9 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
     thrown RedisConnectionException
     // Lettuce tracing does not trace connect
     assertTraces(0) {}
+
+    cleanup:
+    testConnectionClient.shutdown()
   }
 
   def "set command"() {
@@ -178,6 +183,10 @@ abstract class AbstractLettuceSyncClientTest extends InstrumentationSpecificatio
         }
       }
     }
+
+    cleanup:
+    connection.close()
+    testConnectionClient.shutdown()
   }
 
   def "get command"() {


### PR DESCRIPTION
Noticed a flaky lettuce test in https://scans.gradle.com/s/zouw46gb5b2cu/tests/:instrumentation:lettuce:lettuce-5.1:javaagent:test/io.opentelemetry.javaagent.instrumentation.lettuce.v5_1.LettuceReactiveClientTest/set%20command%20with%20subscribe%20on%20a%20defined%20consumer?anchor=eyJvdXRwdXRMaW5lIjoiMS0zMDUifQ&focused-execution=2&top-execution=1#Lundefined
`Async conditions timed out after 1.00 seconds; 1 out of 1 evaluate blocks did not complete in time`
Also added some missing cleanup to avoid
```
06:26:53.697 [Finalizer] WARN  i.l.c.r.DefaultClientResources - io.lettuce.core.resource.DefaultClientResources was not shut down properly, shutdown() was not called before it's garbage-collected. Call shutdown() or shutdown(long,long,TimeUnit)
```