### PR TITLE
Fix patch release build

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -282,9 +282,9 @@ jobs:
           asset_name: opentelemetry-javaagent.jar
           asset_content_type: application/java-archive
 
-        # TODO (trask) delete this after the 1.7.0 release (to make sure it is used for any 1.6.x patches)
+        # TODO (trask) delete this after the 1.8.0 release (to make sure it is used for any 1.7.x patches)
       - name: Upload Release Asset (backwards compatible "all" artifact)
-        id: upload-release-asset
+        id: upload-release-asset-backwards-compatible
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes patch release build failing with

```
The workflow is not valid. .github/workflows/patch-release-build.yml (Line: 287, Col: 13): The identifier 'upload-release-asset' may not be used more than once within the same scope.
```