### PR TITLE
Fail tests on muzzle failure

### DIFF
--- a/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/HibernateInstrumentationModule.java
+++ b/instrumentation/hibernate/hibernate-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_0/HibernateInstrumentationModule.java
@@ -5,18 +5,29 @@
 
 package io.opentelemetry.javaagent.instrumentation.hibernate.v4_0;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class HibernateInstrumentationModule extends InstrumentationModule {
 
   public HibernateInstrumentationModule() {
     super("hibernate", "hibernate-4.0");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed(
+        // not present before 4.0
+        "org.hibernate.internal.SessionFactoryImpl",
+        // missing in 6.0
+        "org.hibernate.Criteria");
   }
 
   @Override

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/HibernateInstrumentationModule.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/v4_3/HibernateInstrumentationModule.java
@@ -5,17 +5,24 @@
 
 package io.opentelemetry.javaagent.instrumentation.hibernate.v4_3;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class HibernateInstrumentationModule extends InstrumentationModule {
   public HibernateInstrumentationModule() {
     super("hibernate", "hibernate-4.3");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("org.hibernate.procedure.ProcedureCall");
   }
 
   @Override

--- a/instrumentation/jetty/jetty-11.0/javaagent/build.gradle.kts
+++ b/instrumentation/jetty/jetty-11.0/javaagent/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
   implementation(project(":instrumentation:servlet:servlet-5.0:javaagent"))
   implementation(project(":instrumentation:jetty:jetty-common:javaagent"))
 
+  testInstrumentation(project(":instrumentation:jetty:jetty-8.0:javaagent"))
+
   testLibrary("org.eclipse.jetty:jetty-servlet:11.0.0")
 }
 

--- a/instrumentation/jetty/jetty-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/v11_0/Jetty11InstrumentationModule.java
+++ b/instrumentation/jetty/jetty-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/v11_0/Jetty11InstrumentationModule.java
@@ -5,18 +5,26 @@
 
 package io.opentelemetry.javaagent.instrumentation.jetty.v11_0;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.instrumentation.jetty.common.JettyHandlerInstrumentation;
 import java.util.Collections;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class Jetty11InstrumentationModule extends InstrumentationModule {
 
   public Jetty11InstrumentationModule() {
     super("jetty", "jetty-11.0");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("jakarta.servlet.Servlet");
   }
 
   @Override

--- a/instrumentation/jetty/jetty-8.0/javaagent/build.gradle.kts
+++ b/instrumentation/jetty/jetty-8.0/javaagent/build.gradle.kts
@@ -16,7 +16,9 @@ dependencies {
   library("org.eclipse.jetty:jetty-server:8.0.0.v20110901")
   implementation(project(":instrumentation:servlet:servlet-3.0:javaagent"))
   implementation(project(":instrumentation:jetty:jetty-common:javaagent"))
+
   testInstrumentation(project(":instrumentation:servlet:servlet-javax-common:javaagent"))
+  testInstrumentation(project(":instrumentation:jetty:jetty-11.0:javaagent"))
 
   testLibrary("org.eclipse.jetty:jetty-servlet:8.0.0.v20110901")
   testLibrary("org.eclipse.jetty:jetty-continuation:8.0.0.v20110901")

--- a/instrumentation/jetty/jetty-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/v8_0/Jetty8InstrumentationModule.java
+++ b/instrumentation/jetty/jetty-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/v8_0/Jetty8InstrumentationModule.java
@@ -5,18 +5,26 @@
 
 package io.opentelemetry.javaagent.instrumentation.jetty.v8_0;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.instrumentation.jetty.common.JettyHandlerInstrumentation;
 import java.util.Arrays;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class Jetty8InstrumentationModule extends InstrumentationModule {
 
   public Jetty8InstrumentationModule() {
     super("jetty", "jetty-8.0");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("javax.servlet.Servlet");
   }
 
   @Override

--- a/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
@@ -17,6 +17,10 @@ dependencies {
   library("org.mongodb:mongo-java-driver:3.1.0")
 
   testImplementation(project(":instrumentation:mongo:mongo-3.1:testing"))
+
+  testInstrumentation(project(":instrumentation:mongo:mongo-async-3.3:javaagent"))
+  testInstrumentation(project(":instrumentation:mongo:mongo-3.7:javaagent"))
+  testInstrumentation(project(":instrumentation:mongo:mongo-4.0:javaagent"))
 }
 
 tasks {

--- a/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.7/javaagent/build.gradle.kts
@@ -27,6 +27,10 @@ dependencies {
   library("org.mongodb:mongo-java-driver:3.8.0")
 
   testImplementation(project(":instrumentation:mongo:mongo-common:testing"))
+
+  testInstrumentation(project(":instrumentation:mongo:mongo-async-3.3:javaagent"))
+  testInstrumentation(project(":instrumentation:mongo:mongo-3.1:javaagent"))
+  testInstrumentation(project(":instrumentation:mongo:mongo-4.0:javaagent"))
 }
 
 tasks {

--- a/instrumentation/mongo/mongo-3.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v3_7/MongoClientInstrumentationModule.java
+++ b/instrumentation/mongo/mongo-3.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v3_7/MongoClientInstrumentationModule.java
@@ -5,18 +5,26 @@
 
 package io.opentelemetry.javaagent.instrumentation.mongo.v3_7;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class MongoClientInstrumentationModule extends InstrumentationModule {
 
   public MongoClientInstrumentationModule() {
     super("mongo", "mongo-3.7");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed(
+        "com.mongodb.MongoClientSettings$Builder", "com.mongodb.async.SingleResultCallback");
   }
 
   @Override

--- a/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-4.0/javaagent/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
 
   testImplementation(project(":instrumentation:mongo:mongo-common:testing"))
   testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.5")
+
+  testInstrumentation(project(":instrumentation:mongo:mongo-async-3.3:javaagent"))
+  testInstrumentation(project(":instrumentation:mongo:mongo-3.1:javaagent"))
+  testInstrumentation(project(":instrumentation:mongo:mongo-3.7:javaagent"))
 }
 
 tasks {

--- a/instrumentation/mongo/mongo-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v4_0/MongoClientInstrumentationModule.java
+++ b/instrumentation/mongo/mongo-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v4_0/MongoClientInstrumentationModule.java
@@ -5,18 +5,25 @@
 
 package io.opentelemetry.javaagent.instrumentation.mongo.v4_0;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class MongoClientInstrumentationModule extends InstrumentationModule {
 
   public MongoClientInstrumentationModule() {
     super("mongo", "mongo-4.0");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("com.mongodb.internal.async.SingleResultCallback");
   }
 
   @Override

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/build.gradle.kts
@@ -19,7 +19,9 @@ dependencies {
 
   testImplementation(project(":instrumentation:mongo:mongo-common:testing"))
 
+  testInstrumentation(project(":instrumentation:mongo:mongo-3.1:javaagent"))
   testInstrumentation(project(":instrumentation:mongo:mongo-3.7:javaagent"))
+  testInstrumentation(project(":instrumentation:mongo:mongo-4.0:javaagent"))
 }
 
 tasks {

--- a/instrumentation/mongo/mongo-async-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongoasync/v3_3/MongoAsyncClientInstrumentationModule.java
+++ b/instrumentation/mongo/mongo-async-3.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongoasync/v3_3/MongoAsyncClientInstrumentationModule.java
@@ -5,18 +5,25 @@
 
 package io.opentelemetry.javaagent.instrumentation.mongoasync.v3_3;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class MongoAsyncClientInstrumentationModule extends InstrumentationModule {
 
   public MongoAsyncClientInstrumentationModule() {
     super("mongo-async", "mongo-async-3.3", "mongo");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("com.mongodb.async.client.MongoClientSettings$Builder");
   }
 
   @Override

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
@@ -144,6 +144,7 @@ public final class InstrumentationModuleInstaller {
       boolean isMatch = muzzle.matches(classLoader);
 
       if (!isMatch) {
+        MuzzleFailureCounter.inc();
         if (muzzleLogger.isWarnEnabled()) {
           muzzleLogger.warn(
               "Instrumentation skipped, mismatched references were found: {} [class {}] on {}",

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/MuzzleFailureCounter.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/MuzzleFailureCounter.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.instrumentation;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class MuzzleFailureCounter {
+  private static final AtomicInteger counter = new AtomicInteger();
+
+  private MuzzleFailureCounter() {}
+
+  public static int getAndReset() {
+    return counter.getAndSet(0);
+  }
+
+  public static void inc() {
+    counter.incrementAndGet();
+  }
+}

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/AgentTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/AgentTestRunner.java
@@ -53,6 +53,8 @@ public final class AgentTestRunner implements InstrumentationTestRunner {
     assert TestAgentListenerAccess.getInstrumentationErrorCount() == 0
         : TestAgentListenerAccess.getInstrumentationErrorCount()
             + " Instrumentation errors during test";
+    int muzzleFailureCount = TestAgentListenerAccess.getAndResetMuzzleFailureCount();
+    assert muzzleFailureCount == 0 : muzzleFailureCount + " Muzzle failures during test";
     // additional library ignores are ignored during tests, because they can make it really
     // confusing for contributors wondering why their instrumentation is not applied
     //

--- a/testing-common/src/main/java/io/opentelemetry/javaagent/testing/common/TestAgentListenerAccess.java
+++ b/testing-common/src/main/java/io/opentelemetry/javaagent/testing/common/TestAgentListenerAccess.java
@@ -17,6 +17,7 @@ public final class TestAgentListenerAccess {
 
   private static final MethodHandle reset;
   private static final MethodHandle getInstrumentationErrorCount;
+  private static final MethodHandle getMuzzleFailureCount;
   private static final MethodHandle getIgnoredButTransformedClassNames;
   private static final MethodHandle addSkipTransformationCondition;
   private static final MethodHandle addSkipErrorCondition;
@@ -31,6 +32,9 @@ public final class TestAgentListenerAccess {
       getInstrumentationErrorCount =
           lookup.findStatic(
               testAgentListenerClass, "getInstrumentationErrorCount", methodType(int.class));
+      getMuzzleFailureCount =
+          lookup.findStatic(
+              testAgentListenerClass, "getAndResetMuzzleFailureCount", methodType(int.class));
       getIgnoredButTransformedClassNames =
           lookup.findStatic(
               testAgentListenerClass, "getIgnoredButTransformedClassNames", methodType(List.class));
@@ -63,6 +67,14 @@ public final class TestAgentListenerAccess {
     } catch (Throwable t) {
       throw new AssertionError(
           "Could not invoke TestAgentListener.getInstrumentationErrorCount", t);
+    }
+  }
+
+  public static int getAndResetMuzzleFailureCount() {
+    try {
+      return (int) getMuzzleFailureCount.invokeExact();
+    } catch (Throwable t) {
+      throw new AssertionError("Could not invoke TestAgentListener.getMuzzleFailureCount", t);
     }
   }
 

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
@@ -12,6 +12,7 @@ import io.opentelemetry.javaagent.tooling.ignore.AdditionalLibraryIgnoredTypesCo
 import io.opentelemetry.javaagent.tooling.ignore.GlobalIgnoredTypesConfigurer;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoreAllow;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesBuilderImpl;
+import io.opentelemetry.javaagent.tooling.instrumentation.MuzzleFailureCounter;
 import io.opentelemetry.javaagent.tooling.util.Trie;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -70,6 +71,10 @@ public class TestAgentListener implements AgentBuilder.Listener {
 
   public static int getInstrumentationErrorCount() {
     return INSTANCE.instrumentationErrorCount.get();
+  }
+
+  public static int getAndResetMuzzleFailureCount() {
+    return MuzzleFailureCounter.getAndReset();
   }
 
   public static List<String> getIgnoredButTransformedClassNames() {


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4477
Perhaps instead of trying to avoid muzzle failures by adding `hasClassesNamed` checks we should instead change muzzle failures from warn to info and accept them as a part of normal execution.