### PR TITLE
Fix jedis muzzle failure

### DIFF
--- a/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-3.0/javaagent/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
   // ensures jedis-1.4 instrumentation does not load with jedis 3.0+ by failing
   // the tests in the event it does. The tests will end up with double spans
   testInstrumentation(project(":instrumentation:jedis:jedis-1.4:javaagent"))
+  testInstrumentation(project(":instrumentation:jedis:jedis-4.0:javaagent"))
 
   latestDepTestLibrary("redis.clients:jedis:3.+")
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisInstrumentationModule.java
@@ -24,7 +24,10 @@ public class JedisInstrumentationModule extends InstrumentationModule {
 
   @Override
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    return not(hasClassesNamed("redis.clients.jedis.CommandArguments"));
+    // missing in 2.x
+    return hasClassesNamed("redis.clients.jedis.commands.BasicCommands")
+        // added in 4.0
+        .and(not(hasClassesNamed("redis.clients.jedis.CommandArguments")));
   }
 
   @Override


### PR DESCRIPTION
Improve jedis-3.0 class loader matcher so that it would not run on jedis-1.4 to avoid muzzle failure.