### PR TITLE
Remove micrometer from armeria-shaded-for-testing

### DIFF
--- a/testing/armeria-shaded-for-testing/build.gradle.kts
+++ b/testing/armeria-shaded-for-testing/build.gradle.kts
@@ -9,9 +9,6 @@ dependencies {
     // We don't use JSON features of Armeria but shading it in can cause version conflicts with
     // instrumentation tests that do.
     exclude("com.fasterxml.jackson.core")
-
-    // exclude micrometer so that it doesn't conflict with instrumentation tests
-    exclude("io.micrometer")
   }
 }
 
@@ -19,6 +16,7 @@ tasks {
   shadowJar {
     // Ensures tests are not affected by Armeria instrumentation
     relocate("com.linecorp.armeria", "io.opentelemetry.testing.internal.armeria")
+
     // Allows tests of Netty instrumentations which would otherwise conflict.
     // The relocation must end with io.netty to allow Netty to detect shaded native libraries.
     // https://github.com/netty/netty/blob/e69107ceaf247099ad9a198b8ef557bdff994a99/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java#L120
@@ -26,6 +24,12 @@ tasks {
     exclude("META-INF/maven/**")
     relocate("META-INF/native/libnetty", "META-INF/native/libio_opentelemetry_testing_internal_netty")
     relocate("META-INF/native/netty", "META-INF/native/io_opentelemetry_testing_internal_netty")
+
+    // relocate micrometer and its dependencies so that it doesn't conflict with instrumentation tests
+    relocate("io.micrometer", "io.opentelemetry.testing.internal.io.micrometer")
+    relocate("org.HdrHistogram", "io.opentelemetry.testing.internal.org.hdrhistogram")
+    relocate("org.LatencyUtils", "io.opentelemetry.testing.internal.org.latencyutils")
+
     mergeServiceFiles()
   }
 

--- a/testing/armeria-shaded-for-testing/build.gradle.kts
+++ b/testing/armeria-shaded-for-testing/build.gradle.kts
@@ -9,6 +9,9 @@ dependencies {
     // We don't use JSON features of Armeria but shading it in can cause version conflicts with
     // instrumentation tests that do.
     exclude("com.fasterxml.jackson.core")
+
+    // exclude micrometer so that it doesn't conflict with instrumentation tests
+    exclude("io.micrometer")
   }
 }
 


### PR DESCRIPTION
This will become really useful when we implement a micrometer->otel bridge instrumentation