### PR TITLE
Fix CI snapshot build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-        run: ./gradlew snapshot
+        run: ./gradlew assemble publishToSonatype
 
       - name: Build and publish gradle plugin snapshots
         env:


### PR DESCRIPTION
```
* What went wrong:
Task 'snapshot' not found in root project 'opentelemetry-java-instrumentation'.
```