### PR TITLE
Revert patch release workflow to 1.7.x version

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -248,7 +248,7 @@ jobs:
         with:
           job-id: jdk11
           remote-build-cache-proxy-enabled: false
-          arguments: assemble final closeAndReleaseSonatypeStagingRepository
+          arguments: assemble final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }}
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
@@ -256,14 +256,6 @@ jobs:
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-
-        # TODO (trask) cache gradle wrapper?
-      - name: Build and publish gradle plugins
-        env:
-          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
-          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-        run: ../gradlew build publishPlugins
-        working-directory: gradle-plugins
 
       - name: Push cherry-picked changes to the release branch
         run: git push


### PR DESCRIPTION
I think most CIs actually use the version of a workflow on the branch being released, annoying that GitHub seems to always use main branch