### PR TITLE
Improve muzzle check for constructors

### DIFF
--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceMatcher.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceMatcher.java
@@ -278,6 +278,7 @@ public final class ReferenceMatcher {
 
   private static MethodDescription.InDefinedShape findMethod(
       MethodRef methodRef, TypeDescription typeOnClasspath) {
+
     for (MethodDescription.InDefinedShape methodDescription :
         typeOnClasspath.getDeclaredMethods()) {
       if (methodDescription.getInternalName().equals(methodRef.getName())
@@ -285,6 +286,13 @@ public final class ReferenceMatcher {
         return methodDescription;
       }
     }
+
+    // if the method we're looking for is a constructor, we're only checking the direct super type;
+    // and skipping all the interfaces and indirect superclasses
+    if (methodRef.isConstructor()) {
+      return null;
+    }
+
     if (typeOnClasspath.getSuperClass() != null) {
       MethodDescription.InDefinedShape methodOnSupertype =
           findMethod(methodRef, typeOnClasspath.getSuperClass().asErasure());

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/references/MethodRef.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/references/MethodRef.java
@@ -54,6 +54,10 @@ public final class MethodRef {
     return descriptor;
   }
 
+  public boolean isConstructor() {
+    return "<init>".equals(name);
+  }
+
   MethodRef merge(MethodRef anotherMethod) {
     if (!equals(anotherMethod)) {
       throw new IllegalStateException("illegal merge " + this + " != " + anotherMethod);

--- a/muzzle/src/test/java/muzzle/TestClasses.java
+++ b/muzzle/src/test/java/muzzle/TestClasses.java
@@ -84,6 +84,10 @@ public class TestClasses {
     public interface AnotherInterface extends SomeInterface {}
   }
 
+  public abstract static class BaseClassWithConstructor {
+    protected BaseClassWithConstructor(long l) {}
+  }
+
   public static class LdcAdvice {
     public static void ldcMethod() {
       MethodBodyAdvice.A.class.getName();


### PR DESCRIPTION
Muzzle should fail if our helper class references a library base class constructor that's absent on the classpath. For example imagine that muzzle codegen has captured references to the following class hierarchy: `Helper extends LibraryBaseClass extends Object`, all with default no-arg constructors. Now, if the actual `LibraryBaseClass` on the application classpath had a constructor that requires a `long` the muzzle check would still pass - because it would find the default constructor in the `Object` class. This PR fixes muzzle so that it recognizes this situation.
