### PR TITLE
Add smoke test image for websphere and update other images

### DIFF
--- a/.github/workflows/pr-smoke-test-servlet-images.yml
+++ b/.github/workflows/pr-smoke-test-servlet-images.yml
@@ -21,6 +21,7 @@ jobs:
           - tomcat
           - tomee
           - wildfly
+          - websphere
       fail-fast: false
     steps:
       - name: Support longpaths
@@ -57,4 +58,4 @@ jobs:
       - name: Build Windows docker images
         working-directory: smoke-tests/images/servlet
         run: ./gradlew buildWindowsTestImages -PsmokeTestServer=${{ matrix.smoke-test-server }}
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-latest' && matrix.smoke-test-server != 'websphere'

--- a/.github/workflows/publish-smoke-test-servlet-images.yml
+++ b/.github/workflows/publish-smoke-test-servlet-images.yml
@@ -27,6 +27,7 @@ jobs:
           - tomcat
           - tomee
           - wildfly
+          - websphere
       fail-fast: false
     steps:
       - name: Support longpaths
@@ -76,7 +77,7 @@ jobs:
           TAG="$(date '+%Y%m%d').$GITHUB_RUN_ID"
           echo "Using extra tag $TAG"
           ./gradlew buildWindowsTestImages pushMatrix -PextraTag=$TAG -PsmokeTestServer=${{ matrix.smoke-test-server }}
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-latest' && matrix.smoke-test-server != 'websphere'
 
   issue:
     name: Open issue on failure

--- a/smoke-tests/images/servlet/build.gradle
+++ b/smoke-tests/images/servlet/build.gradle
@@ -65,7 +65,9 @@ def targets = [
   ],
   "liberty": [
     // running configure.sh is failing while building the image with Java 17
-    [version: ["20.0.0.12", "21.0.0.9"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "16"], args: [release: "2020-11-11_0736"]]
+    [version: ["20.0.0.12"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "16"], args: [release: "2020-11-11_0736"]],
+    [version: ["21.0.0.10"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [release: "2020-09-15_1100"]],
+    [version: ["21.0.0.10"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [release: "2020-09-15_1100"]]
   ],
   "websphere": [
     [version: ["8.5.5.20", "9.0.5.9"], vm: ["openj9"], jdk: ["8"]]

--- a/smoke-tests/images/servlet/build.gradle
+++ b/smoke-tests/images/servlet/build.gradle
@@ -66,8 +66,8 @@ def targets = [
   "liberty": [
     // running configure.sh is failing while building the image with Java 17
     [version: ["20.0.0.12"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "16"], args: [release: "2020-11-11_0736"]],
-    [version: ["21.0.0.10"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [release: "2020-09-15_1100"]],
-    [version: ["21.0.0.10"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [release: "2020-09-15_1100"]]
+    [version: ["21.0.0.10"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [release: "2021-09-20_1900"]],
+    [version: ["21.0.0.10"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [release: "2021-09-20_1900"]]
   ],
   "websphere": [
     [version: ["8.5.5.20", "9.0.5.9"], vm: ["openj9"], jdk: ["8"]]

--- a/smoke-tests/images/servlet/build.gradle
+++ b/smoke-tests/images/servlet/build.gradle
@@ -29,7 +29,7 @@ tasks.create("pushMatrix", DockerPushImage) {
 // Each line under appserver describes one matrix of (version x vm x jdk), dockerfile key overrides
 // Dockerfile name, args key passes raw arguments to docker build
 def targets = [
-  "jetty" : [
+  "jetty": [
     [version: ["9.4.39"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [sourceVersion: "9.4.39.v20210325"]],
     [version: ["9.4.39"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [sourceVersion: "9.4.39.v20210325"]],
     [version: ["10.0.7"], vm: ["hotspot"], jdk: ["11", "17"], args: [sourceVersion: "10.0.7"]],
@@ -37,16 +37,16 @@ def targets = [
     [version: ["11.0.7"], vm: ["hotspot"], jdk: ["11", "17"], args: [sourceVersion: "11.0.7"], war: "servlet-5.0"],
     [version: ["11.0.7"], vm: ["openj9"], jdk: ["11", "16"], args: [sourceVersion: "11.0.7"], war: "servlet-5.0"]
   ],
-  "tomcat" : [
+  "tomcat": [
     [version: ["7.0.109"], vm: ["hotspot", "openj9"], jdk: ["8"], args: [majorVersion: "7"]],
-    [version: ["8.5.71"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "8"]],
-    [version: ["8.5.71"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "8"]],
-    [version: ["9.0.53"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "9"]],
-    [version: ["9.0.53"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "9"]],
-    [version: ["10.0.11"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "10"], war: "servlet-5.0"],
-    [version: ["10.0.11"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "10"], war: "servlet-5.0"]
+    [version: ["8.5.72"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "8"]],
+    [version: ["8.5.72"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "8"]],
+    [version: ["9.0.54"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "9"]],
+    [version: ["9.0.54"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "9"]],
+    [version: ["10.0.12"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "10"], war: "servlet-5.0"],
+    [version: ["10.0.12"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "10"], war: "servlet-5.0"]
   ],
-  "tomee"  : [
+  "tomee": [
     [version: ["7.0.9"], vm: ["hotspot", "openj9"], jdk: ["8"]],
     [version: ["7.1.4"], vm: ["hotspot", "openj9"], jdk: ["8"]],
     [version: ["8.0.8"], vm: ["hotspot"], jdk: ["8", "11", "17"]],
@@ -54,17 +54,21 @@ def targets = [
     [version: ["9.0.0-M7"], vm: ["hotspot"], jdk: ["8", "11", "17"], war: "servlet-5.0"],
     [version: ["9.0.0-M7"], vm: ["openj9"], jdk: ["8", "11", "16"], war: "servlet-5.0"]
   ],
-  "payara" : [
-    [version: ["5.2020.6"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]]
+  "payara": [
+    [version: ["5.2020.6"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]],
+    [version: ["5.2021.8"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]]
   ],
   "wildfly": [
     [version: ["13.0.0.Final"], vm: ["hotspot", "openj9"], jdk: ["8"]],
-    [version: ["17.0.1.Final", "21.0.0.Final"], vm: ["hotspot"], jdk: ["8", "11", "17"]],
-    [version: ["17.0.1.Final", "21.0.0.Final"], vm: ["openj9"], jdk: ["8", "11", "16"]]
+    [version: ["17.0.1.Final", "21.0.0.Final", "25.0.1.Final"], vm: ["hotspot"], jdk: ["8", "11", "17"]],
+    [version: ["17.0.1.Final", "21.0.0.Final", "25.0.1.Final"], vm: ["openj9"], jdk: ["8", "11", "16"]]
   ],
   "liberty": [
     // running configure.sh is failing while building the image with Java 17
-    [version: ["20.0.0.12"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "16"], args: [release: "2020-11-11_0736"]]
+    [version: ["20.0.0.12", "21.0.0.9"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "16"], args: [release: "2020-11-11_0736"]]
+  ],
+  "websphere": [
+    [version: ["8.5.5.20", "9.0.5.9"], vm: ["openj9"], jdk: ["8"]]
   ]
 ]
 
@@ -96,10 +100,15 @@ createDockerTasks(buildLinuxTestImagesTask, targets, false)
 createDockerTasks(buildWindowsTestImagesTask, targets, true)
 
 def configureImage(Task parentTask, server, dockerfile, version, vm, jdk, warProject, Map<String, String> extraArgs, boolean isWindows, String extraTag) {
-  // Using separate build directory for different war files allows using the same app.war filename
-  def dockerWorkingDir = new File(project.buildDir, "docker-$warProject")
+  // Using separate build directory for different images
+  def dockerWorkingDir = new File(project.buildDir, "docker-$server-$version-jdk$jdk-$vm-$warProject")
   def dockerFileName = isWindows ? "${dockerfile}.windows.dockerfile" : "${dockerfile}.dockerfile"
   def platformSuffix = isWindows ? "-windows" : ""
+
+  if (!new File("src/${dockerFileName}").exists()) {
+    println "Skipping ${dockerFileName} as it doesn't exist"
+    return
+  }
 
   def prepareTask = tasks.register("${server}ImagePrepare-$version-jdk$jdk-$vm$platformSuffix", Copy) {
     def warTask = warProject != null ? project(":$warProject").tasks["war"] : project.tasks.war
@@ -122,6 +131,24 @@ def configureImage(Task parentTask, server, dockerfile, version, vm, jdk, warPro
     jdkImage = "adoptopenjdk:${jdk}-openj9"
   } else {
     throw new GradleException("Unexpected vm: $vm")
+  }
+
+  if (server == "wildfly") {
+    // wildfly url without .zip or .tar.gz suffix
+    def serverBaseUrl
+    int majorVersion = version.substring(0, version.indexOf(".")) as int
+    if (majorVersion >= 25) {
+      serverBaseUrl = "https://github.com/wildfly/wildfly/releases/download/${version}/wildfly-${version}"
+    } else {
+      serverBaseUrl = "https://download.jboss.org/wildfly/${version}/wildfly-${version}"
+    }
+    extraArgs = extraArgs + [baseDownloadUrl: serverBaseUrl]
+  } else if (server == "payara") {
+    if (version == "5.2020.6") {
+      extraArgs = extraArgs + [domainName: "production"]
+    } else {
+      extraArgs = extraArgs + [domainName: "domain1"]
+    }
   }
 
   def buildTask = tasks.register("${server}Image-$version-jdk$jdk$vmSuffix$platformSuffix", DockerBuildImage) {

--- a/smoke-tests/images/servlet/build.gradle
+++ b/smoke-tests/images/servlet/build.gradle
@@ -70,7 +70,7 @@ def targets = [
     [version: ["21.0.0.10"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [release: "2021-09-20_1900"]]
   ],
   "websphere": [
-    [version: ["8.5.5.20", "9.0.5.9"], vm: ["openj9"], jdk: ["8"]]
+    [version: ["8.5.5.20", "9.0.5.9"], vm: ["openj9"], jdk: ["8"], windows: false]
   ]
 ]
 
@@ -106,11 +106,6 @@ def configureImage(Task parentTask, server, dockerfile, version, vm, jdk, warPro
   def dockerWorkingDir = new File(project.buildDir, "docker-$server-$version-jdk$jdk-$vm-$warProject")
   def dockerFileName = isWindows ? "${dockerfile}.windows.dockerfile" : "${dockerfile}.dockerfile"
   def platformSuffix = isWindows ? "-windows" : ""
-
-  if (!new File("src/${dockerFileName}").exists()) {
-    println "Skipping ${dockerFileName} as it doesn't exist"
-    return
-  }
 
   def prepareTask = tasks.register("${server}ImagePrepare-$version-jdk$jdk-$vm$platformSuffix", Copy) {
     def warTask = warProject != null ? project(":$warProject").tasks["war"] : project.tasks.war
@@ -183,11 +178,14 @@ def createDockerTasks(Task parentTask, targets, isWindows) {
       def dockerfile = entry["dockerfile"]?.toString() ?: server
       def extraArgs = (entry["args"] ?: [:]) as Map<String, String>
       def warProject = entry["war"] ?: "servlet-3.0"
+      def supportsWindows = entry["windows"] != null ? entry["windows"] : true
 
       entry.version.forEach { version ->
         entry.vm.forEach { vm ->
           entry.jdk.forEach { jdk ->
-            resultImages.add(configureImage(parentTask, server, dockerfile, version, vm, jdk, warProject, extraArgs, isWindows, extraTag))
+            if (supportsWindows || !isWindows) {
+              resultImages.add(configureImage(parentTask, server, dockerfile, version, vm, jdk, warProject, extraArgs, isWindows, extraTag))
+            }
           }
         }
       }

--- a/smoke-tests/images/servlet/src/main/docker/websphere/changePort.py
+++ b/smoke-tests/images/servlet/src/main/docker/websphere/changePort.py
@@ -1,4 +1,4 @@
-# change port from 9080 to 88080
+# change port from 9080 to 8080
 AdminTask.modifyServerPort('server1', '[-nodeName ' + AdminControl.getNode() + ' -endPointName WC_defaulthost -host * -port 8080 -modifyShared true]')
 # add new port to default virtual host
 AdminConfig.create('HostAlias', AdminConfig.getid('/Cell:' + AdminControl.getCell() + '/VirtualHost:default_host/'), '[[port "8080"] [hostname "*"]]')

--- a/smoke-tests/images/servlet/src/main/docker/websphere/changePort.py
+++ b/smoke-tests/images/servlet/src/main/docker/websphere/changePort.py
@@ -1,0 +1,5 @@
+# change port from 9080 to 88080
+AdminTask.modifyServerPort('server1', '[-nodeName ' + AdminControl.getNode() + ' -endPointName WC_defaulthost -host * -port 8080 -modifyShared true]')
+# add new port to default virtual host
+AdminConfig.create('HostAlias', AdminConfig.getid('/Cell:' + AdminControl.getCell() + '/VirtualHost:default_host/'), '[[port "8080"] [hostname "*"]]')
+AdminConfig.save()

--- a/smoke-tests/images/servlet/src/main/docker/websphere/installApp.py
+++ b/smoke-tests/images/servlet/src/main/docker/websphere/installApp.py
@@ -1,0 +1,7 @@
+fileName = '/work/app/app.war'
+appName = 'app'
+contextRoot = '/app'
+serverName = 'server1'
+
+AdminApp.install(fileName,'[-appname ' + appName + ' -contextroot ' + contextRoot + ' -server ' + serverName + ' -usedefaultbindings ]')
+AdminConfig.save()

--- a/smoke-tests/images/servlet/src/payara.dockerfile
+++ b/smoke-tests/images/servlet/src/payara.dockerfile
@@ -4,6 +4,7 @@ ARG version
 FROM payara/server-full:${version} as builder
 
 FROM ${jdkImage}
+ARG domainName
 
 # These environment variables have been confirmed to work with 5.2020.6 only
 ENV HOME_DIR=/opt/payara
@@ -16,9 +17,11 @@ ENV PAYARA_DIR="${HOME_DIR}/appserver" \
     ADMIN_PASSWORD="admin" \
     MEM_MAX_RAM_PERCENTAGE=70.0 \
     MEM_XSS=512k \
-    DOMAIN_NAME="production" \
+    DOMAIN_NAME=${domainName} \
     PREBOOT_COMMANDS="${HOME_DIR}/config/pre-boot-commands.asadmin" \
+    PREBOOT_COMMANDS_FINAL="${HOME_DIR}/config/pre-boot-commands-final.asadmin" \
     POSTBOOT_COMMANDS="${HOME_DIR}/config/post-boot-commands.asadmin" \
+    POSTBOOT_COMMANDS_FINAL="${HOME_DIR}/config/post-boot-commands-final.asadmin" \
     PATH="${PATH}:${HOME_DIR}/scripts"
 
 COPY --from=builder $HOME_DIR $HOME_DIR

--- a/smoke-tests/images/servlet/src/websphere.dockerfile
+++ b/smoke-tests/images/servlet/src/websphere.dockerfile
@@ -1,0 +1,10 @@
+ARG version
+
+FROM ibmcom/websphere-traditional:${version}
+ENV ENABLE_BASIC_LOGGING=true
+COPY --chown=was:root app.war /work/app/
+COPY --chown=was:root installApp.py /work/config/
+COPY --chown=was:root changePort.py /work/config/
+RUN /work/configure.sh
+
+ENV EXTRACT_PORT_FROM_HOST_HEADER=false

--- a/smoke-tests/images/servlet/src/wildfly.dockerfile
+++ b/smoke-tests/images/servlet/src/wildfly.dockerfile
@@ -2,6 +2,7 @@ ARG jdkImage
 
 FROM ${jdkImage}
 ARG version
+ARG baseDownloadUrl
 
 # Create a user and group used to launch processes
 # The user ID 1000 is the default for the first "regular" user on Fedora/RHEL,
@@ -18,14 +19,15 @@ USER jboss
 
 # Set the WILDFLY_VERSION env variable
 ENV WILDFLY_VERSION=${version}
+ENV DOWNLOAD_URL=${baseDownloadUrl}.tar.gz
 ENV JBOSS_HOME /opt/jboss/wildfly
 
 USER root
-RUN echo curl -O https://download.jboss.org/wildfly/$WILDFLY_VERSION/wildfly-$WILDFLY_VERSION.tar.gz
+RUN echo curl -O -L $DOWNLOAD_URL
 # Add the WildFly distribution to /opt, and make wildfly the owner of the extracted tar content
 # Make sure the distribution is available from a well-known place
 RUN cd $HOME \
-    && curl -O https://download.jboss.org/wildfly/$WILDFLY_VERSION/wildfly-$WILDFLY_VERSION.tar.gz \
+    && curl -O -L $DOWNLOAD_URL \
     && tar xf wildfly-$WILDFLY_VERSION.tar.gz \
     && mv $HOME/wildfly-$WILDFLY_VERSION $JBOSS_HOME \
     && rm wildfly-$WILDFLY_VERSION.tar.gz \

--- a/smoke-tests/images/servlet/src/wildfly.windows.dockerfile
+++ b/smoke-tests/images/servlet/src/wildfly.windows.dockerfile
@@ -3,8 +3,9 @@ ARG jdkImage
 # Unzip in a separate container so that zip file layer is not part of final image
 FROM mcr.microsoft.com/windows/servercore:1809 as builder
 ARG version
+ARG baseDownloadUrl
 
-ADD http://download.jboss.org/wildfly/${version}/wildfly-${version}.zip /server.zip
+ADD ${baseDownloadUrl}.zip /server.zip
 RUN ["powershell", "-Command", "expand-archive -Path /server.zip -DestinationPath /server"]
 
 FROM ${jdkImage}-windowsservercore-1809


### PR DESCRIPTION
Add smoke test images for websphere 8.5 and 9. Also add new versions for payara, wildfly and liberty.
Licenses for websphere images are available at https://hub.docker.com/r/ibmcom/websphere-traditional/ please review whether these conditions are ok for our usage.