### PR TITLE
Update garbage collector instruments to be async counters

### DIFF
--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
@@ -42,8 +42,7 @@ public final class GarbageCollector {
       labelSets.add(Attributes.of(GC_KEY, gc.getName()));
     }
     meter
-        .gaugeBuilder("runtime.jvm.gc.time")
-        .ofLongs()
+        .counterBuilder("runtime.jvm.gc.time")
         .setDescription("Time spent in a given JVM garbage collector in milliseconds.")
         .setUnit("ms")
         .buildWithCallback(
@@ -54,8 +53,7 @@ public final class GarbageCollector {
               }
             });
     meter
-        .gaugeBuilder("runtime.jvm.gc.count")
-        .ofLongs()
+        .counterBuilder("runtime.jvm.gc.count")
         .setDescription(
             "The number of collections that have occurred for a given JVM garbage collector.")
         .setUnit("collections")


### PR DESCRIPTION
A couple fellow New Relic engineers, Mike LaSpina and Erika Arnold, noticed that the garbage collection metrics are being reported as gauges when the values being observed are actually cumulative counts.

This PR fixes that, and as a result, causes the metrics to be exported as sums by default instead of gauges. 