### PR TITLE
Support ratpack functional tests

### DIFF
--- a/instrumentation/ratpack-1.4/library/build.gradle.kts
+++ b/instrumentation/ratpack-1.4/library/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
   library("io.ratpack:ratpack-core:1.4.0")
 
   testImplementation(project(":instrumentation:ratpack-1.4:testing"))
-  testImplementation("io.ratpack:ratpack-guice:1.4.0")
+  testLibrary("io.ratpack:ratpack-guice:1.4.0")
 
   if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
     testImplementation("com.sun.activation:jakarta.activation:1.2.2")

--- a/instrumentation/ratpack-1.4/library/build.gradle.kts
+++ b/instrumentation/ratpack-1.4/library/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
   library("io.ratpack:ratpack-core:1.4.0")
 
   testImplementation(project(":instrumentation:ratpack-1.4:testing"))
+  testImplementation("io.ratpack:ratpack-guice:1.4.0")
 
   if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
     testImplementation("com.sun.activation:jakarta.activation:1.2.2")

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryExecInterceptor.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryExecInterceptor.java
@@ -11,7 +11,7 @@ import ratpack.exec.ExecInterceptor;
 import ratpack.exec.Execution;
 import ratpack.func.Block;
 
-public final class OpenTelemetryExecInterceptor implements ExecInterceptor {
+final class OpenTelemetryExecInterceptor implements ExecInterceptor {
 
   static final ExecInterceptor INSTANCE = new OpenTelemetryExecInterceptor();
 

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryExecInterceptor.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryExecInterceptor.java
@@ -11,7 +11,7 @@ import ratpack.exec.ExecInterceptor;
 import ratpack.exec.Execution;
 import ratpack.func.Block;
 
-final class OpenTelemetryExecInterceptor implements ExecInterceptor {
+public final class OpenTelemetryExecInterceptor implements ExecInterceptor {
 
   static final ExecInterceptor INSTANCE = new OpenTelemetryExecInterceptor();
 

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryServerHandler.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryServerHandler.java
@@ -15,7 +15,7 @@ import ratpack.handling.Handler;
 import ratpack.http.Request;
 import ratpack.http.Response;
 
-final class OpenTelemetryServerHandler implements Handler {
+public final class OpenTelemetryServerHandler implements Handler {
 
   private final Instrumenter<Request, Response> instrumenter;
 

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryServerHandler.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryServerHandler.java
@@ -15,7 +15,7 @@ import ratpack.handling.Handler;
 import ratpack.http.Request;
 import ratpack.http.Response;
 
-public final class OpenTelemetryServerHandler implements Handler {
+final class OpenTelemetryServerHandler implements Handler {
 
   private final Instrumenter<Request, Response> instrumenter;
 

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracing.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracing.java
@@ -40,7 +40,7 @@ public final class RatpackTracing {
     return new RatpackTracingBuilder(openTelemetry);
   }
 
-  private final OpenTelemetryServerHandler serverHandler;
+  public final OpenTelemetryServerHandler serverHandler;
 
   RatpackTracing(Instrumenter<Request, Response> serverInstrumenter) {
     serverHandler = new OpenTelemetryServerHandler(serverInstrumenter);

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracing.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracing.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.ratpack;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import ratpack.exec.ExecInterceptor;
-import ratpack.handling.Handler;
 import ratpack.handling.HandlerDecorator;
 import ratpack.http.Request;
 import ratpack.http.Response;
@@ -48,7 +47,7 @@ public final class RatpackTracing {
     serverHandler = new OpenTelemetryServerHandler(serverInstrumenter);
   }
 
-  public Handler getOpenTelemetryServerHandler() {
+  public OpenTelemetryServerHandler getOpenTelemetryServerHandler() {
     return serverHandler;
   }
 

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracing.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracing.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.ratpack;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import ratpack.exec.ExecInterceptor;
+import ratpack.handling.Handler;
 import ratpack.handling.HandlerDecorator;
 import ratpack.http.Request;
 import ratpack.http.Response;
@@ -40,10 +42,18 @@ public final class RatpackTracing {
     return new RatpackTracingBuilder(openTelemetry);
   }
 
-  public final OpenTelemetryServerHandler serverHandler;
+  private final OpenTelemetryServerHandler serverHandler;
 
   RatpackTracing(Instrumenter<Request, Response> serverInstrumenter) {
     serverHandler = new OpenTelemetryServerHandler(serverInstrumenter);
+  }
+
+  public Handler getOpenTelemetryServerHandler() {
+    return serverHandler;
+  }
+
+  public ExecInterceptor getOpenTelemetryExecInterceptor() {
+    return OpenTelemetryExecInterceptor.INSTANCE;
   }
 
   /** Configures the {@link RegistrySpec} with OpenTelemetry. */

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracing.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracing.java
@@ -47,20 +47,12 @@ public final class RatpackTracing {
     serverHandler = new OpenTelemetryServerHandler(serverInstrumenter);
   }
 
-  /**
-   * This method returns the {@link OpenTelemetryServerHandler} instance to support Ratpack Registry binding
-   *
-   * @return The OpenTelemetryServerHandler instance
-   */
+  /** Returns instance of {@link OpenTelemetryServerHandler} to support Ratpack Registry binding. */
   public OpenTelemetryServerHandler getOpenTelemetryServerHandler() {
     return serverHandler;
   }
 
-  /**
-   * This method returns the {@link ExecInterceptor} instance to support Ratpack Registry binding
-   *
-   * @return The ExecInterceptor instance
-   */
+  /** Returns instance of {@link ExecInterceptor} to support Ratpack Registry binding. */
   public ExecInterceptor getOpenTelemetryExecInterceptor() {
     return OpenTelemetryExecInterceptor.INSTANCE;
   }

--- a/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracing.java
+++ b/instrumentation/ratpack-1.4/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracing.java
@@ -47,10 +47,20 @@ public final class RatpackTracing {
     serverHandler = new OpenTelemetryServerHandler(serverInstrumenter);
   }
 
+  /**
+   * This method returns the {@link OpenTelemetryServerHandler} instance to support Ratpack Registry binding
+   *
+   * @return The OpenTelemetryServerHandler instance
+   */
   public OpenTelemetryServerHandler getOpenTelemetryServerHandler() {
     return serverHandler;
   }
 
+  /**
+   * This method returns the {@link ExecInterceptor} instance to support Ratpack Registry binding
+   *
+   * @return The ExecInterceptor instance
+   */
   public ExecInterceptor getOpenTelemetryExecInterceptor() {
     return OpenTelemetryExecInterceptor.INSTANCE;
   }

--- a/instrumentation/ratpack-1.4/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/RatpackFunctionalTest.groovy
+++ b/instrumentation/ratpack-1.4/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/RatpackFunctionalTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.ratpack
+
+
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.export.SpanExporter
+import ratpack.impose.ForceDevelopmentImposition
+import ratpack.impose.ImpositionsSpec
+import ratpack.impose.UserRegistryImposition
+import ratpack.registry.Registry
+import ratpack.test.MainClassApplicationUnderTest
+
+class RatpackFunctionalTest extends MainClassApplicationUnderTest {
+
+  Registry registry
+  @Lazy InMemorySpanExporter spanExporter = registry.get(SpanExporter) as InMemorySpanExporter
+
+  RatpackFunctionalTest(Class<?> mainClass) {
+    super(mainClass)
+    getAddress()
+  }
+
+  @Override
+  void addImpositions(ImpositionsSpec impositions) {
+    impositions.add(ForceDevelopmentImposition.of(false))
+    impositions.add(UserRegistryImposition.of { r ->
+      registry = r
+      registry
+    })
+  }
+}

--- a/instrumentation/ratpack-1.4/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/server/RatpackServerApplicationTest.groovy
+++ b/instrumentation/ratpack-1.4/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/server/RatpackServerApplicationTest.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.ratpack.server
+
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import groovy.transform.CompileStatic
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.ratpack.OpenTelemetryExecInterceptor
+import io.opentelemetry.instrumentation.ratpack.OpenTelemetryServerHandler
+import io.opentelemetry.instrumentation.ratpack.RatpackFunctionalTest
+import io.opentelemetry.instrumentation.ratpack.RatpackTracing
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import ratpack.guice.Guice
+import ratpack.server.RatpackServer
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import javax.inject.Singleton
+
+class RatpackServerApplicationTest extends Specification {
+
+  def app = new RatpackFunctionalTest(RatpackApp)
+
+  def "add span on handlers"() {
+    expect:
+    app.test { httpClient -> "hi-foo" == httpClient.get("foo").body.text }
+
+    new PollingConditions().eventually {
+      def spanData = app.spanExporter.finishedSpanItems.find { it.name == "/foo" }
+      def attributes = spanData.attributes.asMap()
+
+      spanData.kind == SpanKind.SERVER
+      attributes[SemanticAttributes.HTTP_ROUTE] == "/foo"
+      attributes[SemanticAttributes.HTTP_TARGET] == "/foo"
+      attributes[SemanticAttributes.HTTP_METHOD] == "GET"
+      attributes[SemanticAttributes.HTTP_STATUS_CODE] == 200L
+    }
+  }
+
+  def "ignore handlers before OpenTelemetryServerHandler"() {
+    expect:
+    app.test { httpClient -> "ignored" == httpClient.get("ignore").body.text }
+
+    new PollingConditions(initialDelay: 0.1, timeout: 0.3).eventually {
+      !app.spanExporter.finishedSpanItems.any { it.name == "/ignore" }
+    }
+  }
+}
+
+
+@CompileStatic
+class OpenTelemetryModule extends AbstractModule {
+  @Override
+  protected void configure() {
+    bind(SpanExporter).toInstance(InMemorySpanExporter.create())
+  }
+
+  @Singleton
+  @Provides
+  OpenTelemetryServerHandler ratpackServerHandler(OpenTelemetry openTelemetry) {
+    return RatpackTracing.create(openTelemetry).serverHandler
+  }
+
+  @Provides
+  @Singleton
+  OpenTelemetry providesOpenTelemetry(SpanExporter spanExporter) {
+    def tracerProvider = SdkTracerProvider.builder()
+      .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+      .build()
+    return OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build()
+  }
+}
+
+@CompileStatic
+class RatpackApp {
+  static void main(String... args) {
+    RatpackServer.start { server ->
+      server
+        .registry(
+          Guice.registry { bindings ->
+            bindings
+              .module(OpenTelemetryModule)
+              .bind(OpenTelemetryExecInterceptor)
+          }
+        )
+        .handlers { chain ->
+          chain
+            .get("ignore") { ctx -> ctx.render("ignored") }
+            .all(OpenTelemetryServerHandler)
+            .get("foo") { ctx -> ctx.render("hi-foo") }
+        }
+    }
+  }
+}
+

--- a/instrumentation/ratpack-1.4/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/server/RatpackServerTest.groovy
+++ b/instrumentation/ratpack-1.4/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/server/RatpackServerTest.groovy
@@ -1,0 +1,160 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.ratpack.server
+
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.instrumentation.ratpack.RatpackTracing
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import ratpack.exec.Blocking
+import ratpack.registry.Registry
+import ratpack.test.embed.EmbeddedApp
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class RatpackServerTest extends Specification {
+
+  def spanExporter = InMemorySpanExporter.create()
+  def tracerProvider = SdkTracerProvider.builder()
+    .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+    .build()
+
+  def openTelemetry = OpenTelemetrySdk.builder()
+    .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+    .setTracerProvider(tracerProvider).build()
+
+  def ratpackTracing = RatpackTracing.create(openTelemetry)
+
+  def cleanup() {
+    spanExporter.reset()
+  }
+
+  def "add span on handlers"() {
+    given:
+    def app = EmbeddedApp.of { spec ->
+      spec.registry { Registry.of { ratpackTracing.configureServerRegistry(it) } }
+      spec.handlers { chain ->
+        chain.get("foo") { ctx -> ctx.render("hi-foo") }
+      }
+    }
+
+    when:
+    app.test { httpClient -> "hi-foo" == httpClient.get("foo").body.text }
+
+    then:
+    new PollingConditions().eventually {
+      def spanData = spanExporter.finishedSpanItems.find { it.name == "/foo" }
+      def attributes = spanData.attributes.asMap()
+
+      spanData.kind == SpanKind.SERVER
+      attributes[SemanticAttributes.HTTP_ROUTE] == "/foo"
+      attributes[SemanticAttributes.HTTP_TARGET] == "/foo"
+      attributes[SemanticAttributes.HTTP_METHOD] == "GET"
+      attributes[SemanticAttributes.HTTP_STATUS_CODE] == 200L
+    }
+  }
+
+  def "propagate trace with instrumented async operations"() {
+    expect:
+    def app = EmbeddedApp.of { spec ->
+      spec.registry { Registry.of { ratpackTracing.configureServerRegistry(it) } }
+      spec.handlers { chain ->
+        chain.get("foo") { ctx ->
+          ctx.render("hi-foo")
+          Blocking.op {
+            def span = openTelemetry.getTracer("any-tracer").spanBuilder("a-span").startSpan()
+            span.makeCurrent().withCloseable {
+              span.addEvent("an-event")
+              span.end()
+            }
+          }.then()
+        }
+      }
+    }
+
+    app.test { httpClient ->
+      "hi-foo" == httpClient.get("foo").body.text
+
+      new PollingConditions().eventually {
+        def spanData = spanExporter.finishedSpanItems.find { it.name == "/foo" }
+        def spanDataChild = spanExporter.finishedSpanItems.find { it.name == "a-span" }
+
+        spanData.kind == SpanKind.SERVER
+        spanData.traceId == spanDataChild.traceId
+        spanDataChild.parentSpanId == spanData.spanId
+        spanDataChild.events.any { it.name == "an-event" }
+
+        def attributes = spanData.attributes.asMap()
+        attributes[SemanticAttributes.HTTP_ROUTE] == "/foo"
+        attributes[SemanticAttributes.HTTP_TARGET] == "/foo"
+        attributes[SemanticAttributes.HTTP_METHOD] == "GET"
+        attributes[SemanticAttributes.HTTP_STATUS_CODE] == 200L
+      }
+    }
+  }
+
+  def "propagate trace with instrumented async concurrent operations"() {
+    expect:
+    def app = EmbeddedApp.of { spec ->
+      spec.registry { Registry.of { ratpackTracing.configureServerRegistry(it) } }
+      spec.handlers { chain ->
+        chain.get("bar") { ctx ->
+          ctx.render("hi-bar")
+          Blocking.op {
+            def span = openTelemetry.getTracer("any-tracer").spanBuilder("another-span").startSpan()
+            span.makeCurrent().withCloseable {
+              span.addEvent("an-event")
+              span.end()
+            }
+          }.then()
+        }
+        chain.get("foo") { ctx ->
+          ctx.render("hi-foo")
+          Blocking.op {
+            def span = openTelemetry.getTracer("any-tracer").spanBuilder("a-span").startSpan()
+            span.makeCurrent().withCloseable {
+              span.addEvent("an-event")
+              span.end()
+            }
+          }.then()
+        }
+      }
+    }
+
+    app.test { httpClient ->
+      "hi-foo" == httpClient.get("foo").body.text
+      "hi-bar" == httpClient.get("bar").body.text
+      new PollingConditions().eventually {
+        def spanData = spanExporter.finishedSpanItems.find { it.name == "/foo" }
+        def spanDataChild = spanExporter.finishedSpanItems.find { it.name == "a-span" }
+
+        def spanData2 = spanExporter.finishedSpanItems.find { it.name == "/bar" }
+        def spanDataChild2 = spanExporter.finishedSpanItems.find { it.name == "another-span" }
+
+        spanData.kind == SpanKind.SERVER
+        spanData.traceId == spanDataChild.traceId
+        spanDataChild.parentSpanId == spanData.spanId
+        spanDataChild.events.any { it.name == "an-event" }
+
+        spanData2.kind == SpanKind.SERVER
+        spanData2.traceId == spanDataChild2.traceId
+        spanDataChild2.parentSpanId == spanData2.spanId
+        spanDataChild2.events.any { it.name == "an-event" }
+
+        def attributes = spanData.attributes.asMap()
+        attributes[SemanticAttributes.HTTP_ROUTE] == "/foo"
+        attributes[SemanticAttributes.HTTP_TARGET] == "/foo"
+        attributes[SemanticAttributes.HTTP_METHOD] == "GET"
+        attributes[SemanticAttributes.HTTP_STATUS_CODE] == 200L
+      }
+    }
+  }
+}


### PR DESCRIPTION
By making `public` `OpenTelemetryExecInterceptor` and `OpenTelemetryServerHandler` allows to manually initialize RatpackTracing. 

Initializing manually `OpenTelemetry` adds support for Ratpack functional tests because we can create impositions and/or access the Ratpack registry to get the `SpanExporter`.

Also, being able to decide the position in the Ratpack chain of `OpenTelemetryServerHandler` helps not to require custom `Sampler` to ignore handlers where instrumentation is not needed.

This PR, will allow to add instrumentation to Ratpack HttpClient