### PR TITLE
Sql sanitizer: sanitize double quoted strings only in couchbase queries

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/db/SqlDialect.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/db/SqlDialect.java
@@ -5,9 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.db;
 
-/**
- * Enumeration of sql dialects that are handled differently by {@link SqlStatementSanitizer}.
- */
+/** Enumeration of sql dialects that are handled differently by {@link SqlStatementSanitizer}. */
 public enum SqlDialect {
   DEFAULT,
   // couchbase uses double quotes for string literals

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/db/SqlDialect.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/db/SqlDialect.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.db;
+
+/**
+ * Enumeration of sql dialects that are handled differently by {@link SqlStatementSanitizer}.
+ */
+public enum SqlDialect {
+  DEFAULT,
+  // couchbase uses double quotes for string literals
+  COUCHBASE
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/db/SqlStatementSanitizer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/db/SqlStatementSanitizer.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.api.internal.SupportabilityMetric
 
 import io.opentelemetry.instrumentation.api.caching.Cache;
 import io.opentelemetry.instrumentation.api.internal.SupportabilityMetrics;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -19,19 +20,55 @@ import javax.annotation.Nullable;
 public final class SqlStatementSanitizer {
   private static final SupportabilityMetrics supportability = SupportabilityMetrics.instance();
 
-  private static final Cache<String, SqlStatementInfo> sqlToStatementInfoCache =
+  private static final Cache<StatementKey, SqlStatementInfo> sqlToStatementInfoCache =
       Cache.builder().setMaximumSize(1000).build();
 
   public static SqlStatementInfo sanitize(@Nullable String statement) {
+    return sanitize(statement, SqlDialect.DEFAULT);
+  }
+
+  public static SqlStatementInfo sanitize(@Nullable String statement, SqlDialect dialect) {
     if (!isStatementSanitizationEnabled() || statement == null) {
       return SqlStatementInfo.create(statement, null, null);
     }
     return sqlToStatementInfoCache.computeIfAbsent(
-        statement,
+        new StatementKey(statement, dialect),
         k -> {
           supportability.incrementCounter(SQL_STATEMENT_SANITIZER_CACHE_MISS);
-          return AutoSqlSanitizer.sanitize(statement);
+          return AutoSqlSanitizer.sanitize(statement, dialect);
         });
+  }
+
+  private static final class StatementKey {
+    private final String statement;
+    private final SqlDialect dialect;
+
+    StatementKey(String statement, SqlDialect dialect) {
+      this.statement = statement;
+      this.dialect = dialect;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      StatementKey that = (StatementKey) o;
+      return statement.equals(that.statement) && dialect == that.dialect;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(statement, dialect);
+    }
+
+    @Override
+    public String toString() {
+      return "StatementKey(statement=" + statement + ", dialect=" + dialect + ")";
+    }
   }
 
   private SqlStatementSanitizer() {}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/db/SqlStatementSanitizer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/db/SqlStatementSanitizer.java
@@ -8,9 +8,9 @@ package io.opentelemetry.instrumentation.api.db;
 import static io.opentelemetry.instrumentation.api.db.StatementSanitizationConfig.isStatementSanitizationEnabled;
 import static io.opentelemetry.instrumentation.api.internal.SupportabilityMetrics.CounterNames.SQL_STATEMENT_SANITIZER_CACHE_MISS;
 
+import com.google.auto.value.AutoValue;
 import io.opentelemetry.instrumentation.api.caching.Cache;
 import io.opentelemetry.instrumentation.api.internal.SupportabilityMetrics;
-import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 public final class SqlStatementSanitizer {
   private static final SupportabilityMetrics supportability = SupportabilityMetrics.instance();
 
-  private static final Cache<StatementKey, SqlStatementInfo> sqlToStatementInfoCache =
+  private static final Cache<CacheKey, SqlStatementInfo> sqlToStatementInfoCache =
       Cache.builder().setMaximumSize(1000).build();
 
   public static SqlStatementInfo sanitize(@Nullable String statement) {
@@ -32,43 +32,23 @@ public final class SqlStatementSanitizer {
       return SqlStatementInfo.create(statement, null, null);
     }
     return sqlToStatementInfoCache.computeIfAbsent(
-        new StatementKey(statement, dialect),
+        CacheKey.create(statement, dialect),
         k -> {
           supportability.incrementCounter(SQL_STATEMENT_SANITIZER_CACHE_MISS);
           return AutoSqlSanitizer.sanitize(statement, dialect);
         });
   }
 
-  private static final class StatementKey {
-    private final String statement;
-    private final SqlDialect dialect;
+  @AutoValue
+  abstract static class CacheKey {
 
-    StatementKey(String statement, SqlDialect dialect) {
-      this.statement = statement;
-      this.dialect = dialect;
+    static CacheKey create(String statement, SqlDialect dialect) {
+      return new AutoValue_SqlStatementSanitizer_CacheKey(statement, dialect);
     }
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      StatementKey that = (StatementKey) o;
-      return statement.equals(that.statement) && dialect == that.dialect;
-    }
+    abstract String getStatement();
 
-    @Override
-    public int hashCode() {
-      return Objects.hash(statement, dialect);
-    }
-
-    @Override
-    public String toString() {
-      return "StatementKey(statement=" + statement + ", dialect=" + dialect + ")";
-    }
+    abstract SqlDialect getDialect();
   }
 
   private SqlStatementSanitizer() {}

--- a/instrumentation-api/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api/src/main/jflex/SqlSanitizer.jflex
@@ -30,10 +30,6 @@ DOLLAR_QUOTED_STR = "$$" [^$]* "$$"
 WHITESPACE        = [ \t\r\n]+
 
 %{
-  static SqlStatementInfo sanitize(String statement) {
-    return sanitize(statement, SqlDialect.SQL);
-  }
-
   static SqlStatementInfo sanitize(String statement, SqlDialect dialect) {
     AutoSqlSanitizer sanitizer = new AutoSqlSanitizer(new java.io.StringReader(statement));
     sanitizer.dialect = dialect;

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseQuerySanitizer.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseQuerySanitizer.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.couchbase.v2_0;
 
+import io.opentelemetry.instrumentation.api.db.SqlDialect;
 import io.opentelemetry.instrumentation.api.db.SqlStatementInfo;
 import io.opentelemetry.instrumentation.api.db.SqlStatementSanitizer;
 import java.lang.invoke.MethodHandle;
@@ -115,7 +116,7 @@ public final class CouchbaseQuerySanitizer {
   }
 
   private static SqlStatementInfo sanitizeString(String query) {
-    return SqlStatementSanitizer.sanitize(query);
+    return SqlStatementSanitizer.sanitize(query, SqlDialect.COUCHBASE);
   }
 
   private CouchbaseQuerySanitizer() {}


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4593
While looking at https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4595 I started thinking about how we could avoid copying the whole sanitizer and came up with this.