### PR TITLE
Ensure that netty 4.0 instrumentation is not applied to 4.1

### DIFF
--- a/instrumentation/netty/netty-3.8/javaagent/build.gradle.kts
+++ b/instrumentation/netty/netty-3.8/javaagent/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
 
   compileOnly("io.netty:netty:3.8.0.Final")
 
+  testInstrumentation(project(":instrumentation:netty:netty-4.0:javaagent"))
+  testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
+
   testLibrary("io.netty:netty:3.8.0.Final")
   testLibrary("com.ning:async-http-client:1.8.0")
 

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/NettyInstrumentationModule.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/NettyInstrumentationModule.java
@@ -5,17 +5,24 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v3_8;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class NettyInstrumentationModule extends InstrumentationModule {
   public NettyInstrumentationModule() {
     super("netty", "netty-3.8");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("org.jboss.netty.handler.codec.http.HttpMessage");
   }
 
   @Override

--- a/instrumentation/netty/netty-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/netty/netty-4.0/javaagent/build.gradle.kts
@@ -26,6 +26,10 @@ muzzle {
 dependencies {
   library("io.netty:netty-codec-http:4.0.0.Final")
   implementation(project(":instrumentation:netty:netty-4-common:javaagent"))
+
+  testInstrumentation(project(":instrumentation:netty:netty-3.8:javaagent"))
+  testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
+
   latestDepTestLibrary("io.netty:netty-codec-http:4.0.56.Final")
 }
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/BootstrapInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/BootstrapInstrumentation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_0;
 
 import static io.opentelemetry.javaagent.instrumentation.netty.v4_0.client.NettyClientSingletons.connectionInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.netty.channel.ChannelFuture;
@@ -31,7 +32,9 @@ public class BootstrapInstrumentation implements TypeInstrumentation {
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        named("doConnect").and(takesArgument(0, SocketAddress.class)),
+        named("doConnect")
+            .and(takesArgument(0, SocketAddress.class))
+            .and(returns(named("io.netty.channel.ChannelFuture"))),
         BootstrapInstrumentation.class.getName() + "$ConnectAdvice");
   }
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/NettyInstrumentationModule.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/NettyInstrumentationModule.java
@@ -27,8 +27,7 @@ public class NettyInstrumentationModule extends InstrumentationModule {
     return hasClassesNamed("io.netty.handler.codec.http.HttpMessage")
         .and(
             // Class added in 4.1.0 and not in 4.0.56 to avoid resolving this instrumentation
-            // completely
-            // when using 4.1.
+            // completely when using 4.1.
             not(hasClassesNamed("io.netty.handler.codec.http.CombinedHttpHeaders")));
   }
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/NettyInstrumentationModule.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/NettyInstrumentationModule.java
@@ -24,9 +24,12 @@ public class NettyInstrumentationModule extends InstrumentationModule {
 
   @Override
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    // Class added in 4.1.0 and not in 4.0.56 to avoid resolving this instrumentation completely
-    // when using 4.1.
-    return not(hasClassesNamed("io.netty.handler.codec.http.CombinedHttpHeaders"));
+    return hasClassesNamed("io.netty.handler.codec.http.HttpMessage")
+        .and(
+            // Class added in 4.1.0 and not in 4.0.56 to avoid resolving this instrumentation
+            // completely
+            // when using 4.1.
+            not(hasClassesNamed("io.netty.handler.codec.http.CombinedHttpHeaders")));
   }
 
   @Override

--- a/instrumentation/netty/netty-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/netty/netty-4.1/javaagent/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
   api(project(":instrumentation:netty:netty-4.1:library"))
   implementation(project(":instrumentation:netty:netty-4-common:javaagent"))
 
+  testInstrumentation(project(":instrumentation:netty:netty-3.8:javaagent"))
+  testInstrumentation(project(":instrumentation:netty:netty-4.0:javaagent"))
+
   // Contains logging handler
   testLibrary("io.netty:netty-handler:4.1.0.Final")
   testLibrary("io.netty:netty-transport-native-epoll:4.1.0.Final:linux-x86_64")

--- a/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCollectorTest.java
+++ b/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCollectorTest.java
@@ -132,7 +132,26 @@ class ReferenceCollectorTest {
     Map<String, ClassRef> references = collector.getReferences();
 
     assertThat(references).containsKey("muzzle.TestClasses$MethodBodyAdvice$SomeImplementation");
+    assertMethod(
+        references.get("muzzle.TestClasses$MethodBodyAdvice$SomeImplementation"),
+        "someMethod",
+        "()V",
+        PROTECTED_OR_HIGHER,
+        OwnershipFlag.NON_STATIC);
     assertThat(references).containsKey("muzzle.TestClasses$MethodBodyAdvice$B");
+    assertMethod(
+        references.get("muzzle.TestClasses$MethodBodyAdvice$B"),
+        "staticMethod",
+        "()V",
+        PROTECTED_OR_HIGHER,
+        OwnershipFlag.STATIC);
+    assertThat(references).containsKey("muzzle.TestClasses$MethodBodyAdvice$A");
+    assertMethod(
+        references.get("muzzle.TestClasses$MethodBodyAdvice$A"),
+        "<init>",
+        "()V",
+        PROTECTED_OR_HIGHER,
+        OwnershipFlag.NON_STATIC);
   }
 
   @Test

--- a/muzzle/src/test/java/muzzle/TestClasses.java
+++ b/muzzle/src/test/java/muzzle/TestClasses.java
@@ -104,6 +104,7 @@ public class TestClasses {
     public static MethodBodyAdvice.SomeInterface invokeDynamicMethod(
         MethodBodyAdvice.SomeImplementation a) {
       Runnable staticMethod = MethodBodyAdvice.B::staticMethod;
+      Runnable constructorMethod = MethodBodyAdvice.A::new;
       return a::someMethod;
     }
   }


### PR DESCRIPTION
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4612
Not completely sure how the linked issue happened, perhaps there are netty jars from different versions on the classpath, perhaps something else. This pr adds checking of method references to muzzle so that usages like `AttributeKey::new` would also be verified.