### PR TITLE
Copy in protobuf conventions from SDK repo.

### DIFF
--- a/conventions/build.gradle.kts
+++ b/conventions/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
   // When updating, update above in plugins too
   implementation("com.diffplug.spotless:spotless-plugin-gradle:5.16.0")
   implementation("com.google.guava:guava:30.1-jre")
+  implementation("gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:0.8.17")
   implementation("gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0")
   implementation("org.ow2.asm:asm:9.1")
   implementation("org.ow2.asm:asm-tree:9.1")

--- a/conventions/src/main/kotlin/otel.protobuf-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.protobuf-conventions.gradle.kts
@@ -1,0 +1,36 @@
+import com.google.protobuf.gradle.*
+
+plugins {
+  id("com.google.protobuf")
+
+  id("otel.java-conventions")
+}
+
+protobuf {
+  val versions: Map<String, String> by project
+  protoc {
+    // The artifact spec for the Protobuf Compiler
+    artifact = "com.google.protobuf:protoc:3.3.0"
+  }
+  plugins {
+    id("grpc") {
+      artifact = "io.grpc:protoc-gen-grpc-java:1.6.0"
+    }
+  }
+  generateProtoTasks {
+    all().configureEach {
+      plugins {
+        id("grpc")
+      }
+    }
+  }
+}
+
+afterEvaluate {
+  // Classpath when compiling protos, we add dependency management directly
+  // since it doesn't follow Gradle conventions of naming / properties.
+  dependencies {
+    add("compileProtoPath", platform(project(":dependencyManagement")))
+    add("testCompileProtoPath", platform(project(":dependencyManagement")))
+  }
+}

--- a/instrumentation/grpc-1.6/testing/build.gradle.kts
+++ b/instrumentation/grpc-1.6/testing/build.gradle.kts
@@ -6,7 +6,7 @@ import com.google.protobuf.gradle.protoc
 
 plugins {
   id("otel.java-conventions")
-  id("otel.java-conventions")
+  id("otel.protobuf-conventions")
 }
 
 val grpcVersion = "1.6.0"

--- a/instrumentation/grpc-1.6/testing/build.gradle.kts
+++ b/instrumentation/grpc-1.6/testing/build.gradle.kts
@@ -6,29 +6,10 @@ import com.google.protobuf.gradle.protoc
 
 plugins {
   id("otel.java-conventions")
-  id("com.google.protobuf") version "0.8.16"
+  id("otel.java-conventions")
 }
 
 val grpcVersion = "1.6.0"
-
-protobuf {
-  protoc {
-    // Download compiler rather than using locally installed version:
-    artifact = "com.google.protobuf:protoc:3.3.0"
-  }
-  plugins {
-    id("grpc") {
-      artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
-    }
-  }
-  generateProtoTasks {
-    all().configureEach {
-      plugins {
-        id("grpc")
-      }
-    }
-  }
-}
 
 dependencies {
   api(project(":testing-common"))

--- a/instrumentation/grpc-1.6/testing/build.gradle.kts
+++ b/instrumentation/grpc-1.6/testing/build.gradle.kts
@@ -1,9 +1,3 @@
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
-
 plugins {
   id("otel.java-conventions")
   id("otel.protobuf-conventions")


### PR DESCRIPTION
Maintaining things like Gradle version is easier across the three repos the more the logic is shared.