### PR TITLE
Suppress muzzle warning from spring integration instrumentation

### DIFF
--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/SpringIntegrationInstrumentationModule.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/SpringIntegrationInstrumentationModule.java
@@ -5,17 +5,24 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.integration;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class SpringIntegrationInstrumentationModule extends InstrumentationModule {
   public SpringIntegrationInstrumentationModule() {
     super("spring-integration", "spring-integration-4.1");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("org.springframework.messaging.support.ChannelInterceptor");
   }
 
   @Override


### PR DESCRIPTION
Currently there is a muzzle warning in every spring app that does not include spring-messaging jar.