### PR TITLE
Quartz 2.0: Fix instrumentation name

### DIFF
--- a/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzTracingBuilder.java
+++ b/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzTracingBuilder.java
@@ -16,7 +16,7 @@ import org.quartz.JobExecutionContext;
 /** A builder of {@link QuartzTracing}. */
 public final class QuartzTracingBuilder {
 
-  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.quartz-1.7";
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.quartz-2.0";
 
   private final OpenTelemetry openTelemetry;
 


### PR DESCRIPTION
Just noticed that the name still claimed quartz 1.7 even tho it's 2.0+ now.