### PR TITLE
Print out thread dump on strict context check failure

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ContextStorageCloser.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ContextStorageCloser.java
@@ -51,6 +51,7 @@ public final class ContextStorageCloser {
   private abstract static class ContextRestorer {
     abstract void restore();
 
+    @SuppressWarnings("SystemOut")
     boolean runWithRestore(AutoCloseable target) {
       try {
         target.close();

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ContextStorageCloser.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/ContextStorageCloser.java
@@ -41,7 +41,8 @@ public final class ContextStorageCloser {
     // retry close when scope leak was reported.
     await()
         .ignoreException(AssertionError.class)
-        .atMost(Duration.ofSeconds(15))
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofSeconds(1))
         .until(() -> restorer.runWithRestore(storage));
   }
 
@@ -57,6 +58,15 @@ public final class ContextStorageCloser {
       } catch (Throwable throwable) {
         restore();
         if (throwable instanceof AssertionError) {
+          System.err.println();
+          for (Map.Entry<Thread, StackTraceElement[]> threadEntry :
+              Thread.getAllStackTraces().entrySet()) {
+            System.err.println("Thread " + threadEntry.getKey());
+            for (StackTraceElement stackTraceElement : threadEntry.getValue()) {
+              System.err.println("\t" + stackTraceElement);
+            }
+            System.err.println();
+          }
           throw (AssertionError) throwable;
         }
         throw new IllegalStateException(throwable);


### PR DESCRIPTION
When looking at https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4658 I noticed that the root cause of strict context check failure is actually
```
io.opentelemetry.testing.internal.armeria.client.ResponseTimeoutException: null
	at io.opentelemetry.testing.internal.armeria.client.ResponseTimeoutException.get(ResponseTimeoutException.java:36)
	at io.opentelemetry.testing.internal.armeria.internal.common.CancellationScheduler.invokeTask(CancellationScheduler.java:463)
	at io.opentelemetry.testing.internal.armeria.internal.common.CancellationScheduler.lambda$init0$2(CancellationScheduler.java:124)
	at <unknown class>.run(Unknown Source)
	at io.opentelemetry.testing.internal.armeria.common.RequestContext.lambda$makeContextAware$3(RequestContext.java:546)
	at <unknown class>.run(Unknown Source)
	at io.opentelemetry.testing.internal.io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
	at io.opentelemetry.testing.internal.io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:170)
	at io.opentelemetry.testing.internal.io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.opentelemetry.testing.internal.io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.opentelemetry.testing.internal.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:384)
	at io.opentelemetry.testing.internal.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.opentelemetry.testing.internal.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.opentelemetry.testing.internal.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:826)
```
As the request has timed out the thread that is processing it can naturally have scopes one. Perhaps dumping thread stacks will give us an idea what this thread is actually doing and why the request timed out.