### PR TITLE
Fix spring-kafka latest dep tests

### DIFF
--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/groovy/SpringKafkaInstrumentationTest.groovy
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/groovy/SpringKafkaInstrumentationTest.groovy
@@ -215,14 +215,9 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
         .build()
     }
 
-    @KafkaListener(id = "testListener", topics = "testTopic", containerFactory = "batchFactory")
-    void listener(List<ConsumerRecord<String, String>> records) {
-      runInternalSpan("consumer")
-      records.forEach({ record ->
-        if (record.value() == "error") {
-          throw new IllegalArgumentException("boom")
-        }
-      })
+    @Bean
+    Listener listener() {
+      return new Listener()
     }
 
     @Bean
@@ -239,6 +234,19 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
         container.setInterceptBeforeTx(true)
       })
       factory
+    }
+  }
+
+  static class Listener {
+
+    @KafkaListener(id = "testListener", topics = "testTopic", containerFactory = "batchFactory")
+    void listener(List<ConsumerRecord<String, String>> records) {
+      runInternalSpan("consumer")
+      records.forEach({ record ->
+        if (record.value() == "error") {
+          throw new IllegalArgumentException("boom")
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
Broke today with release of spring boot 2.6:

```
Error creating bean with name 'springKafkaInstrumentationTest.ConsumerConfig': Requested bean is currently in creation: Is there an unresolvable circular reference?
```