### PR TITLE
Temporary fix for spring-webmvc test latest deps

### DIFF
--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/build.gradle.kts
@@ -40,6 +40,10 @@ dependencies {
   testLibrary("org.springframework.boot:spring-boot-starter-web:1.5.17.RELEASE")
   testLibrary("org.springframework.boot:spring-boot-starter-security:1.5.17.RELEASE")
 
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:2.5.+")
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-web:2.5.+")
+  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-security:2.5.+")
+
   testImplementation("org.springframework.security.oauth:spring-security-oauth2:2.0.16.RELEASE")
 
   // For spring security


### PR DESCRIPTION
Not sure what the problem is, just trying to stabilize `main` (and find out the full scope of instrumentations that are broken in spring boot 2.6.0). Will open tracking issue for real fix.