### PR TITLE
Don't block snapshot publishing on testLatestDeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,11 @@ jobs:
 
   snapshot:
     runs-on: ubuntu-latest
-    needs: [ build, test, testLatestDeps, smoke-test, examples, muzzle ]
+    # intentionally not blocking snapshot publishing on testLatestDeps
+    # because any time a new library version is released to maven central
+    # it can fail due to test code incompatibility with the new library version,
+    # or due to slight changes in emitted telemetry
+    needs: [ build, test, smoke-test, examples, muzzle ]
     if: github.repository == 'open-telemetry/opentelemetry-java-instrumentation'
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
`main` is not in a great spot right now because there hasn't been a successful CI build since I bumped the version to `1.9.0-SNAPSHOT` in #4675, which means there hasn't been a snapshot published for `1.9.0-SNAPSHOT`, which means the example extension and distro won't build outside of CI (in CI we build the snapshots locally and use `--init-script ../../.github/scripts/local.init.gradle.kts`).

The reason there hasn't been a successful CI is because of a few testLatestDeps problems #4676, #4679, #4682.

But really it seems better for testLatestDeps to not block snapshot publishing (it already doesn't block releases).