### PR TITLE
Remove gradle scan publishing from CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,16 +65,3 @@ See [Debugging](docs/contributing/debugging.md)
 ### Understanding Muzzle
 
 See [Understanding Muzzle](docs/contributing/muzzle.md)
-
-### Troubleshooting PR build failures
-
-The build logs are very long and there is a lot of parallelization, so the logs can be hard to
-decipher, but if you scroll to the bottom you should see something like:
-
-```
-Publishing build scan...
-https://gradle.com/s/ila4qwp5lcf5s
-```
-
-Opening the build scan link can sometimes take several seconds (it's a large build), but it
-typically makes it a lot clearer what's failing.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,19 +28,9 @@ dependencyResolutionManagement {
 
 val gradleEnterpriseServer = "https://ge.opentelemetry.io"
 val isCI = System.getenv("CI") != null
-val geAccessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY") ?: ""
-
-// if GE access key is not given and we are in CI, then we publish to scans.gradle.com
 gradleEnterprise {
-  if (geAccessKey.isNotEmpty()) {
-    server = gradleEnterpriseServer
-  }
+  server = gradleEnterpriseServer
   buildScan {
-    // TODO remove this until legal approves
-    if (geAccessKey.isEmpty() && isCI) {
-      termsOfServiceUrl = "https://gradle.com/terms-of-service"
-      termsOfServiceAgree = "yes"
-    }
     publishAlways()
     this as com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
     publishIfAuthenticated()


### PR DESCRIPTION
Follow-up from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4663#issuecomment-974698892

Will send follow-follow-up to bring it back and request CNCF legal review on that PR.