### PR TITLE
Publish gradle scans from PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,3 +65,16 @@ See [Debugging](docs/contributing/debugging.md)
 ### Understanding Muzzle
 
 See [Understanding Muzzle](docs/contributing/muzzle.md)
+
+### Troubleshooting PR build failures
+
+The build logs are very long and there is a lot of parallelization, so the logs can be hard to
+decipher, but if you scroll to the bottom you should see something like:
+
+```
+Publishing build scan...
+https://gradle.com/s/ila4qwp5lcf5s
+```
+
+Opening the build scan link can sometimes take several seconds (it's a large build), but it
+typically makes it a lot clearer what's failing.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,9 +28,18 @@ dependencyResolutionManagement {
 
 val gradleEnterpriseServer = "https://ge.opentelemetry.io"
 val isCI = System.getenv("CI") != null
+val geAccessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY") ?: ""
+
+// if GE access key is not given and we are in CI, then we publish to scans.gradle.com
 gradleEnterprise {
-  server = gradleEnterpriseServer
+  if (geAccessKey.isNotEmpty()) {
+    server = gradleEnterpriseServer
+  }
   buildScan {
+    if (isCI && geAccessKey.isEmpty()) {
+      termsOfServiceUrl = "https://gradle.com/terms-of-service"
+      termsOfServiceAgree = "yes"
+    }
     publishAlways()
     this as com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
     publishIfAuthenticated()


### PR DESCRIPTION
There is an open question whether we can legally accept Gradle's [Terms of Use](https://gradle.com/terms-of-service) from a GitHub Action:

```
    if (isCI && geAccessKey.isEmpty()) {
      termsOfServiceUrl = "https://gradle.com/terms-of-service"
      termsOfServiceAgree = "yes"
    }
```