### PR TITLE
Capture servlet request parameters

### DIFF
--- a/docs/config/common.md
+++ b/docs/config/common.md
@@ -49,3 +49,16 @@ These configuration options are supported by all HTTP client and server instrume
 
 > **Note**: The property/environment variable names listed in the table are still experimental,
 > and thus are subject to change.
+
+## Capturing servlet request parameters
+
+You can configure the agent to capture predefined HTTP request parameter as span attributes for
+requests that are handled by Servlet API.
+Use the following property to define which servlet request parameters you want to capture:
+
+| System property                                                        | Environment variable                                                   | Description |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------- |
+| `otel.instrumentation.servlet.experimental.capture-request-parameters` | `OTEL_INSTRUMENTATION_SERVLET_EXPERIMENTAL_CAPTURE_REQUEST_PARAMETERS` | A comma-separated list of request parameter names.
+
+> **Note**: The property/environment variable names listed in the table are still experimental,
+> and thus are subject to change.

--- a/instrumentation/jetty/jetty-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/v11_0/Jetty11Singletons.java
+++ b/instrumentation/jetty/jetty-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/v11_0/Jetty11Singletons.java
@@ -28,7 +28,7 @@ public final class Jetty11Singletons {
               .addContextCustomizer(
                   (context, request, attributes) -> {
                     context = ServerSpanNaming.init(context, CONTAINER);
-                    return AppServerBridge.init(context, /* shouldRecordException= */ false);
+                    return new AppServerBridge.Builder().init(context);
                   })
               .build(INSTRUMENTATION_NAME, Servlet5Accessor.INSTANCE);
 

--- a/instrumentation/jetty/jetty-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/v8_0/Jetty8Singletons.java
+++ b/instrumentation/jetty/jetty-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/v8_0/Jetty8Singletons.java
@@ -28,7 +28,7 @@ public final class Jetty8Singletons {
               .addContextCustomizer(
                   (context, request, attributes) -> {
                     context = ServerSpanNaming.init(context, CONTAINER);
-                    return AppServerBridge.init(context, /* shouldRecordException= */ false);
+                    return new AppServerBridge.Builder().init(context);
                   })
               .build(INSTRUMENTATION_NAME, Servlet3Accessor.INSTANCE);
 

--- a/instrumentation/liberty/liberty/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/LibertySingletons.java
+++ b/instrumentation/liberty/liberty/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/LibertySingletons.java
@@ -27,7 +27,7 @@ public final class LibertySingletons {
               .addContextCustomizer(
                   (context, request, attributes) -> {
                     context = ServerSpanNaming.init(context, CONTAINER);
-                    return AppServerBridge.init(context);
+                    return new AppServerBridge.Builder().recordException().init(context);
                   })
               .build(INSTRUMENTATION_NAME, Servlet3Accessor.INSTANCE);
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/servlet/servlet-3.0/javaagent/build.gradle.kts
@@ -35,3 +35,7 @@ dependencies {
   latestDepTestLibrary("org.apache.tomcat.embed:tomcat-embed-core:9.+")
   latestDepTestLibrary("org.apache.tomcat.embed:tomcat-embed-jasper:9.+")
 }
+
+tasks.withType<Test>().configureEach {
+  jvmArgs("-Dotel.instrumentation.servlet.experimental.capture-request-parameters=test-parameter")
+}

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
@@ -14,6 +14,7 @@ import javax.servlet.Servlet
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_HEADERS
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_PARAMETERS
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -48,6 +49,7 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
     addServlet(context, AUTH_REQUIRED.path, servlet)
     addServlet(context, INDEXED_CHILD.path, servlet)
     addServlet(context, CAPTURE_HEADERS.path, servlet)
+    addServlet(context, CAPTURE_PARAMETERS.path, servlet)
   }
 
   protected ServerEndpoint lastRequest
@@ -64,6 +66,11 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
       SemanticAttributes.HTTP_SERVER_NAME,
       SemanticAttributes.NET_TRANSPORT
     ]
+  }
+
+  @Override
+  boolean testCapturedRequestParameters() {
+    true
   }
 
   boolean errorEndpointUsesSendError() {

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServlet3Test.groovy
@@ -14,6 +14,7 @@ import javax.servlet.http.HttpServletRequest
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_HEADERS
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_PARAMETERS
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -174,6 +175,7 @@ class JettyServlet3TestForward extends JettyDispatchTest {
     addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, RequestDispatcherServlet.Forward)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, RequestDispatcherServlet.Forward)
   }
 }
@@ -209,6 +211,7 @@ class JettyServlet3TestInclude extends JettyDispatchTest {
     addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Include)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, RequestDispatcherServlet.Include)
   }
 }
@@ -236,6 +239,7 @@ class JettyServlet3TestDispatchImmediate extends JettyDispatchTest {
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, TestServlet3.DispatchImmediate)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch/recursive", TestServlet3.DispatchRecursive)
   }
@@ -263,6 +267,7 @@ class JettyServlet3TestDispatchAsync extends JettyDispatchTest {
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, TestServlet3.DispatchAsync)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch/recursive", TestServlet3.DispatchRecursive)
   }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
@@ -40,6 +40,9 @@ class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandle
 
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
+    if (endpoint == ServerEndpoint.CAPTURE_PARAMETERS) {
+      return "HTTP POST"
+    }
     "HTTP GET"
   }
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TestServlet3.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TestServlet3.groovy
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletResponse
 import java.util.concurrent.CountDownLatch
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_HEADERS
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_PARAMETERS
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -51,6 +52,10 @@ class TestServlet3 {
             break
           case CAPTURE_HEADERS:
             resp.setHeader("X-Test-Response", req.getHeader("X-Test-Request"))
+            resp.status = endpoint.status
+            resp.writer.print(endpoint.body)
+            break
+          case CAPTURE_PARAMETERS:
             resp.status = endpoint.status
             resp.writer.print(endpoint.body)
             break
@@ -104,6 +109,11 @@ class TestServlet3 {
                 resp.writer.print(endpoint.body)
                 context.complete()
                 break
+              case CAPTURE_PARAMETERS:
+                resp.status = endpoint.status
+                resp.writer.print(endpoint.body)
+                context.complete()
+                break
               case ERROR:
                 resp.status = endpoint.status
                 resp.writer.print(endpoint.body)
@@ -151,6 +161,10 @@ class TestServlet3 {
               break
             case CAPTURE_HEADERS:
               resp.setHeader("X-Test-Response", req.getHeader("X-Test-Request"))
+              resp.status = endpoint.status
+              resp.writer.print(endpoint.body)
+              break
+            case CAPTURE_PARAMETERS:
               resp.status = endpoint.status
               resp.writer.print(endpoint.body)
               break

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3Test.groovy
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeoutException
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_HEADERS
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_PARAMETERS
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -351,6 +352,7 @@ class TomcatServlet3TestForward extends TomcatDispatchTest {
     addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, RequestDispatcherServlet.Forward)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, RequestDispatcherServlet.Forward)
   }
 }
@@ -391,6 +393,7 @@ class TomcatServlet3TestInclude extends TomcatDispatchTest {
     addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Include)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, RequestDispatcherServlet.Include)
   }
 }
@@ -417,6 +420,7 @@ class TomcatServlet3TestDispatchImmediate extends TomcatDispatchTest {
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, TestServlet3.DispatchImmediate)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, TestServlet3.DispatchImmediate)
     addServlet(context, "/dispatch/recursive", TestServlet3.DispatchRecursive)
   }
@@ -439,6 +443,7 @@ class TomcatServlet3TestDispatchAsync extends TomcatDispatchTest {
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, TestServlet3.DispatchAsync)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, TestServlet3.DispatchAsync)
     addServlet(context, "/dispatch/recursive", TestServlet3.DispatchRecursive)
   }

--- a/instrumentation/servlet/servlet-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/servlet/servlet-5.0/javaagent/build.gradle.kts
@@ -21,3 +21,7 @@ dependencies {
   testLibrary("org.apache.tomcat.embed:tomcat-embed-core:10.0.0")
   testLibrary("org.apache.tomcat.embed:tomcat-embed-jasper:10.0.0")
 }
+
+tasks.withType<Test>().configureEach {
+  jvmArgs("-Dotel.instrumentation.servlet.experimental.capture-request-parameters=test-parameter")
+}

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -93,6 +94,13 @@ public class Servlet5Accessor implements ServletAccessor<HttpServletRequest, Htt
   @Override
   public Iterable<String> getRequestHeaderNames(HttpServletRequest httpServletRequest) {
     return Collections.list(httpServletRequest.getHeaderNames());
+  }
+
+  @Override
+  public List<String> getRequestParameterValues(
+      HttpServletRequest httpServletRequest, String name) {
+    String[] values = httpServletRequest.getParameterValues(name);
+    return values == null ? Collections.emptyList() : Arrays.asList(values);
   }
 
   @Override

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_PARAMETERS
+
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -47,6 +49,7 @@ abstract class AbstractServlet5Test<SERVER, CONTEXT> extends HttpServerTest<SERV
     addServlet(context, AUTH_REQUIRED.path, servlet)
     addServlet(context, INDEXED_CHILD.path, servlet)
     addServlet(context, CAPTURE_HEADERS.path, servlet)
+    addServlet(context, CAPTURE_PARAMETERS.path, servlet)
   }
 
   protected ServerEndpoint lastRequest
@@ -55,6 +58,11 @@ abstract class AbstractServlet5Test<SERVER, CONTEXT> extends HttpServerTest<SERV
   AggregatedHttpRequest request(ServerEndpoint uri, String method) {
     lastRequest = uri
     super.request(uri, method)
+  }
+
+  @Override
+  boolean testCapturedRequestParameters() {
+    true
   }
 
   boolean errorEndpointUsesSendError() {

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServlet5Test.groovy
@@ -13,6 +13,7 @@ import spock.lang.IgnoreIf
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_HEADERS
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_PARAMETERS
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -148,6 +149,7 @@ class JettyServlet5TestForward extends JettyDispatchTest {
     addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, RequestDispatcherServlet.Forward)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, RequestDispatcherServlet.Forward)
   }
 }
@@ -184,6 +186,8 @@ class JettyServlet5TestInclude extends JettyDispatchTest {
     addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Include)
+    addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, RequestDispatcherServlet.Include)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, RequestDispatcherServlet.Include)
   }
 }
@@ -207,6 +211,7 @@ class JettyServlet5TestDispatchImmediate extends JettyDispatchTest {
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet5.DispatchImmediate)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, TestServlet5.DispatchImmediate)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, TestServlet5.DispatchImmediate)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, TestServlet5.DispatchImmediate)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, TestServlet5.DispatchImmediate)
     addServlet(context, "/dispatch/recursive", TestServlet5.DispatchRecursive)
   }
@@ -230,6 +235,7 @@ class JettyServlet5TestDispatchAsync extends JettyDispatchTest {
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet5.DispatchAsync)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, TestServlet5.DispatchAsync)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, TestServlet5.DispatchAsync)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, TestServlet5.DispatchAsync)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, TestServlet5.DispatchAsync)
     addServlet(context, "/dispatch/recursive", TestServlet5.DispatchRecursive)
   }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
@@ -16,6 +16,9 @@ class JettyServletHandlerTest extends AbstractServlet5Test<Object, Object> {
 
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
+    if (ServerEndpoint.CAPTURE_PARAMETERS == endpoint) {
+      return "HTTP POST"
+    }
     "HTTP GET"
   }
 

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TestServlet5.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TestServlet5.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_PARAMETERS
+
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import jakarta.servlet.RequestDispatcher
 import jakarta.servlet.ServletException
@@ -52,6 +54,10 @@ class TestServlet5 {
             break
           case CAPTURE_HEADERS:
             resp.setHeader("X-Test-Response", req.getHeader("X-Test-Request"))
+            resp.status = endpoint.status
+            resp.writer.print(endpoint.body)
+            break
+          case CAPTURE_PARAMETERS:
             resp.status = endpoint.status
             resp.writer.print(endpoint.body)
             break
@@ -105,6 +111,11 @@ class TestServlet5 {
                 resp.writer.print(endpoint.body)
                 context.complete()
                 break
+              case CAPTURE_PARAMETERS:
+                resp.status = endpoint.status
+                resp.writer.print(endpoint.body)
+                context.complete()
+                break
               case ERROR:
                 resp.status = endpoint.status
                 resp.writer.print(endpoint.body)
@@ -152,6 +163,10 @@ class TestServlet5 {
               break
             case CAPTURE_HEADERS:
               resp.setHeader("X-Test-Response", req.getHeader("X-Test-Request"))
+              resp.status = endpoint.status
+              resp.writer.print(endpoint.body)
+              break
+            case CAPTURE_PARAMETERS:
               resp.status = endpoint.status
               resp.writer.print(endpoint.body)
               break

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5Test.groovy
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeoutException
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_HEADERS
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_PARAMETERS
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
@@ -350,6 +351,7 @@ class TomcatServlet5TestForward extends TomcatDispatchTest {
     addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, RequestDispatcherServlet.Forward)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, RequestDispatcherServlet.Forward)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, RequestDispatcherServlet.Forward)
   }
 }
@@ -390,6 +392,8 @@ class TomcatServlet5TestInclude extends TomcatDispatchTest {
     addServlet(context, "/dispatch" + ERROR.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + EXCEPTION.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, RequestDispatcherServlet.Include)
+    addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, RequestDispatcherServlet.Include)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, RequestDispatcherServlet.Include)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, RequestDispatcherServlet.Include)
   }
 }
@@ -416,6 +420,7 @@ class TomcatServlet5TestDispatchImmediate extends TomcatDispatchTest {
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet5.DispatchImmediate)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, TestServlet5.DispatchImmediate)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, TestServlet5.DispatchImmediate)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, TestServlet5.DispatchImmediate)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, TestServlet5.DispatchImmediate)
     addServlet(context, "/dispatch/recursive", TestServlet5.DispatchRecursive)
   }
@@ -438,6 +443,7 @@ class TomcatServlet5TestDispatchAsync extends TomcatDispatchTest {
     addServlet(context, "/dispatch" + REDIRECT.path, TestServlet5.DispatchAsync)
     addServlet(context, "/dispatch" + AUTH_REQUIRED.path, TestServlet5.DispatchAsync)
     addServlet(context, "/dispatch" + CAPTURE_HEADERS.path, TestServlet5.DispatchAsync)
+    addServlet(context, "/dispatch" + CAPTURE_PARAMETERS.path, TestServlet5.DispatchAsync)
     addServlet(context, "/dispatch" + INDEXED_CHILD.path, TestServlet5.DispatchAsync)
     addServlet(context, "/dispatch/recursive", TestServlet5.DispatchRecursive)
   }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/BaseServletHelper.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/BaseServletHelper.java
@@ -16,6 +16,7 @@ import io.opentelemetry.instrumentation.api.servlet.AppServerBridge;
 import io.opentelemetry.instrumentation.api.servlet.MappingResolver;
 import io.opentelemetry.instrumentation.api.servlet.ServerSpanNaming;
 import io.opentelemetry.instrumentation.api.servlet.ServletContextPath;
+import io.opentelemetry.instrumentation.api.tracer.ServerSpan;
 import io.opentelemetry.instrumentation.servlet.ServletAccessor;
 import io.opentelemetry.instrumentation.servlet.naming.ServletSpanNameProvider;
 import java.util.function.Function;
@@ -26,6 +27,7 @@ public abstract class BaseServletHelper<REQUEST, RESPONSE> {
   protected final ServletAccessor<REQUEST, RESPONSE> accessor;
   private final ServletSpanNameProvider<REQUEST> spanNameProvider;
   private final Function<REQUEST, String> contextPathExtractor;
+  private final ServletRequestParametersExtractor<REQUEST, RESPONSE> parameterExtractor;
 
   protected BaseServletHelper(
       Instrumenter<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>> instrumenter,
@@ -34,6 +36,10 @@ public abstract class BaseServletHelper<REQUEST, RESPONSE> {
     this.accessor = accessor;
     this.spanNameProvider = new ServletSpanNameProvider<>(accessor);
     this.contextPathExtractor = accessor::getRequestContextPath;
+    this.parameterExtractor =
+        ServletRequestParametersExtractor.enabled()
+            ? new ServletRequestParametersExtractor<>(accessor)
+            : null;
   }
 
   public boolean shouldStart(Context parentContext, ServletRequestContext<REQUEST> requestContext) {
@@ -83,7 +89,22 @@ public abstract class BaseServletHelper<REQUEST, RESPONSE> {
       ServerSpanNaming.updateServerSpanName(
           result, servlet ? SERVLET : FILTER, spanNameProvider, mappingResolver, request);
     }
+
+    captureServletAttributes(context, request);
+
     return result;
+  }
+
+  private void captureServletAttributes(Context context, REQUEST request) {
+    if (parameterExtractor == null || !AppServerBridge.captureServletAttributes(context)) {
+      return;
+    }
+    Span serverSpan = ServerSpan.fromContextOrNull(context);
+    if (serverSpan == null) {
+      return;
+    }
+
+    parameterExtractor.setAttributes(request, (key, value) -> serverSpan.setAttribute(key, value));
   }
 
   /*

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletInstrumenterBuilder.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletInstrumenterBuilder.java
@@ -74,6 +74,11 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
             .addAttributesExtractor(netAttributesExtractor)
             .addAttributesExtractor(additionalAttributesExtractor)
             .addRequestMetrics(HttpServerMetrics.get());
+    if (ServletRequestParametersExtractor.enabled()) {
+      AttributesExtractor<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
+          requestParametersExtractor = new ServletRequestParametersExtractor<>(accessor);
+      builder.addAttributesExtractor(requestParametersExtractor);
+    }
     for (ContextCustomizer<? super ServletRequestContext<REQUEST>> contextCustomizer :
         contextCustomizers) {
       builder.addContextCustomizer(contextCustomizer);

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletRequestParametersExtractor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletRequestParametersExtractor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.servlet;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.instrumentation.api.caching.Cache;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.servlet.ServletAccessor;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.BiConsumer;
+import javax.annotation.Nullable;
+
+public class ServletRequestParametersExtractor<REQUEST, RESPONSE>
+    implements AttributesExtractor<
+        ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>> {
+  private static final List<String> CAPTURE_REQUEST_PARAMETERS =
+      Config.get().getList("otel.instrumentation.servlet.experimental.capture-request-parameters");
+
+  private static final Cache<String, AttributeKey<List<String>>> parameterKeysCache =
+      Cache.builder().build();
+
+  private final ServletAccessor<REQUEST, RESPONSE> accessor;
+
+  public ServletRequestParametersExtractor(ServletAccessor<REQUEST, RESPONSE> accessor) {
+    this.accessor = accessor;
+  }
+
+  public static boolean enabled() {
+    return !CAPTURE_REQUEST_PARAMETERS.isEmpty();
+  }
+
+  public void setAttributes(
+      REQUEST request, BiConsumer<AttributeKey<List<String>>, List<String>> consumer) {
+    for (String name : CAPTURE_REQUEST_PARAMETERS) {
+      List<String> values = accessor.getRequestParameterValues(request, name);
+      if (!values.isEmpty()) {
+        consumer.accept(parameterAttributeKey(name), values);
+      }
+    }
+  }
+
+  @Override
+  public void onStart(AttributesBuilder attributes, ServletRequestContext<REQUEST> requestContext) {
+    REQUEST request = requestContext.request();
+    setAttributes(request, (key, value) -> set(attributes, key, value));
+  }
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      ServletRequestContext<REQUEST> requestContext,
+      @Nullable ServletResponseContext<RESPONSE> responseContext,
+      @Nullable Throwable error) {}
+
+  private static AttributeKey<List<String>> parameterAttributeKey(String headerName) {
+    return parameterKeysCache.computeIfAbsent(headerName, n -> createKey(n));
+  }
+
+  private static AttributeKey<List<String>> createKey(String parameterName) {
+    // normalize parameter name similarly as is done with header names when header values are
+    // captured as span attributes
+    parameterName = parameterName.toLowerCase(Locale.ROOT);
+    String key = "servlet.request.parameter." + parameterName.replace('-', '_');
+    return AttributeKey.stringArrayKey(key);
+  }
+}

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletRequestParametersExtractor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletRequestParametersExtractor.java
@@ -7,12 +7,13 @@ package io.opentelemetry.javaagent.instrumentation.servlet;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.instrumentation.api.caching.Cache;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.servlet.ServletAccessor;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
@@ -22,8 +23,8 @@ public class ServletRequestParametersExtractor<REQUEST, RESPONSE>
   private static final List<String> CAPTURE_REQUEST_PARAMETERS =
       Config.get().getList("otel.instrumentation.servlet.experimental.capture-request-parameters");
 
-  private static final Cache<String, AttributeKey<List<String>>> parameterKeysCache =
-      Cache.builder().build();
+  private static final ConcurrentMap<String, AttributeKey<List<String>>> parameterKeysCache =
+      new ConcurrentHashMap<>();
 
   private final ServletAccessor<REQUEST, RESPONSE> accessor;
 

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/ServletAccessor.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/ServletAccessor.java
@@ -47,6 +47,8 @@ public interface ServletAccessor<REQUEST, RESPONSE> {
 
   Iterable<String> getRequestHeaderNames(REQUEST request);
 
+  List<String> getRequestParameterValues(REQUEST request, String name);
+
   String getRequestServletPath(REQUEST request);
 
   String getRequestPathInfo(REQUEST request);

--- a/instrumentation/servlet/servlet-javax-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/javax/JavaxServletAccessor.java
+++ b/instrumentation/servlet/servlet-javax-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/javax/JavaxServletAccessor.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.servlet.javax;
 
 import io.opentelemetry.instrumentation.servlet.ServletAccessor;
 import java.security.Principal;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -88,6 +89,13 @@ public abstract class JavaxServletAccessor<R> implements ServletAccessor<HttpSer
   @Override
   public Iterable<String> getRequestHeaderNames(HttpServletRequest httpServletRequest) {
     return Collections.list(httpServletRequest.getHeaderNames());
+  }
+
+  @Override
+  public List<String> getRequestParameterValues(
+      HttpServletRequest httpServletRequest, String name) {
+    String[] values = httpServletRequest.getParameterValues(name);
+    return values == null ? Collections.emptyList() : Arrays.asList(values);
   }
 
   @Override

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/build.gradle.kts
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/build.gradle.kts
@@ -17,3 +17,7 @@ dependencies {
   // Make sure nothing breaks due to both 7.0 and 10.0 modules being present together
   testInstrumentation(project(":instrumentation:tomcat:tomcat-7.0:javaagent"))
 }
+
+tasks.withType<Test>().configureEach {
+  jvmArgs("-Dotel.instrumentation.servlet.experimental.capture-request-parameters=test-parameter")
+}

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TestServlet.java
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TestServlet.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 public class TestServlet extends HttpServlet {
 
   @Override
-  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+  protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     String path = req.getServletPath();
 
     HttpServerTest.ServerEndpoint serverEndpoint = HttpServerTest.ServerEndpoint.forPath(path);

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatHandlerTest.groovy
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatHandlerTest.groovy
@@ -44,6 +44,11 @@ class TomcatHandlerTest extends HttpServerTest<Tomcat> implements AgentTestTrait
   }
 
   @Override
+  boolean testCapturedRequestParameters() {
+    true
+  }
+
+  @Override
   Tomcat startServer(int port) {
     Tomcat tomcat = new Tomcat()
     tomcat.setBaseDir(File.createTempDir().absolutePath)

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/build.gradle.kts
@@ -25,3 +25,7 @@ dependencies {
   latestDepTestLibrary("org.apache.tomcat.embed:tomcat-embed-core:[9.+, 10)")
   latestDepTestLibrary("org.apache.tomcat.embed:tomcat-embed-jasper:[9.+, 10)")
 }
+
+tasks.withType<Test>().configureEach {
+  jvmArgs("-Dotel.instrumentation.servlet.experimental.capture-request-parameters=test-parameter")
+}

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TestServlet.java
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TestServlet.java
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletResponse;
 public class TestServlet extends HttpServlet {
 
   @Override
-  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+  protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     String path = req.getServletPath();
 
     HttpServerTest.ServerEndpoint serverEndpoint = HttpServerTest.ServerEndpoint.forPath(path);

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatHandlerTest.groovy
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatHandlerTest.groovy
@@ -44,6 +44,11 @@ class TomcatHandlerTest extends HttpServerTest<Tomcat> implements AgentTestTrait
   }
 
   @Override
+  boolean testCapturedRequestParameters() {
+    true
+  }
+
+  @Override
   Tomcat startServer(int port) {
     Tomcat tomcat = new Tomcat()
     tomcat.setBaseDir(File.createTempDir().absolutePath)

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatInstrumenterFactory.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatInstrumenterFactory.java
@@ -53,7 +53,11 @@ public final class TomcatInstrumenterFactory {
         .addContextCustomizer(
             (context, request, attributes) -> {
               context = ServerSpanNaming.init(context, CONTAINER);
-              return AppServerBridge.init(context);
+
+              return new AppServerBridge.Builder()
+                  .captureServletAttributes()
+                  .recordException()
+                  .init(context);
             })
         .addRequestMetrics(HttpServerMetrics.get())
         .newServerInstrumenter(TomcatRequestGetter.INSTANCE);

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowSingletons.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowSingletons.java
@@ -48,7 +48,11 @@ public final class UndertowSingletons {
                   // span is ended when counter reaches 0, we start from 2 which accounts for the
                   // handler that started the span and exchange completion listener
                   context = UndertowActiveHandlers.init(context, 2);
-                  return AppServerBridge.init(context);
+
+                  return new AppServerBridge.Builder()
+                      .captureServletAttributes()
+                      .recordException()
+                      .init(context);
                 })
             .addRequestMetrics(HttpServerMetrics.get())
             .newServerInstrumenter(UndertowExchangeGetter.INSTANCE);


### PR DESCRIPTION
This pr implements capturing HTTP request parameters as span attributes when request is handled by servlet api. Similarly to capturing HTTP headers only parameters that are explicitly configured will be captured.