### PR TITLE
Update release process

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,10 +1,10 @@
-# Releases a new minor / major version from the HEAD of the main branch
+# Releases a new minor / major version from a release branch
 name: Release Build
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
+      release-branch-name:
+        description: The release branch to use, e.g. v1.9.x
         required: true
 
 jobs:
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
         with:
+          ref: ${{ github.event.inputs.release-branch-name }}
           fetch-depth: 0
 
       - id: setup-test-java
@@ -80,6 +81,7 @@ jobs:
 
       - uses: actions/checkout@v2.3.4
         with:
+          ref: ${{ github.event.inputs.release-branch-name }}
           fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
@@ -112,6 +114,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
         with:
+          ref: ${{ github.event.inputs.release-branch-name }}
           fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
@@ -150,6 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
         with:
+          ref: ${{ github.event.inputs.release-branch-name }}
           fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,10 @@ Before making the release:
 
 * Merge a PR to `main` updating the `CHANGELOG.md`
 * Create a release branch, e.g. `v1.9.x`
+  ```
+  git checkout -b v1.9.x upstream/main
+  git push upstream v1.9.x
+  ```
 * Create a new commit on the release branch to update the version (remove `-SNAPSHOT`) in these files:
   * version.gradle.kts
   * examples/distro/build.gradle

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,7 +19,7 @@ Before making the release:
   git checkout -b v1.9.x upstream/main
   git push upstream v1.9.x
   ```
-* Create a new commit on the release branch to update the version (remove `-SNAPSHOT`) in these files:
+* Push a new commit to the release branch updating the version (remove `-SNAPSHOT`) in these files:
   * version.gradle.kts
   * examples/distro/build.gradle
   * examples/extension/build.gradle

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,23 +13,24 @@ as the last step, which publishes a snapshot build to
 
 Before making the release:
 
-* Update `CHANGELOG.md`
-* Update the version (remove `-SNAPSHOT`) in these files:
+* Merge a PR to `main` updating the `CHANGELOG.md`
+* Create a release branch, e.g. `v1.9.x`
+* Create a new commit on the release branch to update the version (remove `-SNAPSHOT`) in these files:
   * version.gradle.kts
   * examples/distro/build.gradle
   * examples/extension/build.gradle
 
 Open the release build workflow in your browser [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/release-build.yml).
 
-You will see a button that says "Run workflow". Press the button, enter the version number you want
-to release in the input field that pops up, and then press "Run workflow".
+You will see a button that says "Run workflow". Press the button, enter the release branch
+(e.g. `v1.9.x`) in the input field that pops up, and then press "Run workflow".
 
 This triggers the release process, which builds the artifacts, publishes the artifacts, and creates
 and pushes a git tag with the version number.
 
 After making the release:
 
-* Update the version (bump and add `-SNAPSHOT`) in these files:
+* Merge a PR to `main` bumping the version (keeping `-SNAPSHOT`) in these files:
   * version.gradle.kts
   * examples/distro/build.gradle
   * examples/extension/build.gradle


### PR DESCRIPTION
Will update patch release process later since there's an open question of whether we should automate cherry-picking or not for patch releases since it requires requesting a CLA exception:

> Bot accounts are not recommended, as they require special work to pass CLA checks. If pushing automatically-generated, non-copyrightable code using a bot account is required, an explanation should be sent to the Governance Committee for review and forwarding to the EasyCLA team to exempt the bot's commits from the CLA requirement.

https://github.com/open-telemetry/community/blob/main/docs/using-github-extensions.md#writing-your-github-actions-pipelines