### PR TITLE
Update supported application servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,9 @@ jobs:
           - windows-latest
           - ubuntu-latest
         smoke-test-suite:
-          - glassfish
           - jetty
           - liberty
+          - payara
           - tomcat
           - tomee
           - websphere

--- a/.github/workflows/nightly-no-cache.yml
+++ b/.github/workflows/nightly-no-cache.yml
@@ -121,9 +121,9 @@ jobs:
           - windows-latest
           - ubuntu-latest
         smoke-test-suite:
-          - glassfish
           - jetty
           - liberty
+          - payara
           - tomcat
           - tomee
           - websphere

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -156,9 +156,9 @@ jobs:
           - windows-latest
           - ubuntu-latest
         smoke-test-suite:
-          - glassfish
           - jetty
           - liberty
+          - payara
           - tomcat
           - tomee
           - websphere

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -115,9 +115,9 @@ jobs:
           - windows-latest
           - ubuntu-latest
         smoke-test-suite:
-          - glassfish
           - jetty
           - liberty
+          - payara
           - tomcat
           - tomee
           - websphere

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -155,9 +155,9 @@ jobs:
           - windows-latest
           - ubuntu-latest
         smoke-test-suite:
-          - glassfish
           - jetty
           - liberty
+          - payara
           - tomcat
           - tomee
           - websphere

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -67,9 +67,9 @@ jobs:
           - windows-latest
           - ubuntu-latest
         smoke-test-suite:
-          - glassfish
           - jetty
           - liberty
+          - payara
           - tomcat
           - tomee
           - websphere

--- a/docs/contributing/running-tests.md
+++ b/docs/contributing/running-tests.md
@@ -46,11 +46,11 @@ not relevant for most contributions. Explicitly specify `:smoke-tests:test` to r
 If you need to run a specific smoke test suite:
 
 ```
-./gradlew :smoke-tests:test -PsmokeTestSuite=glassfish
+./gradlew :smoke-tests:test -PsmokeTestSuite=payara
 ```
 
 If you are on Windows and you want to run the tests using linux containers:
 
 ```
-USE_LINUX_CONTAINERS=1 ./gradlew :smoke-tests:test -PsmokeTestSuite=glassfish
+USE_LINUX_CONTAINERS=1 ./gradlew :smoke-tests:test -PsmokeTestSuite=payara
 ```

--- a/docs/supported-libraries.md
+++ b/docs/supported-libraries.md
@@ -109,22 +109,19 @@ These are the supported libraries and frameworks:
 
 ## Application Servers
 
-These are the supported application servers:
+These are the application servers that the OpenTelemetry Javaagent is tested against:
 
-| Application server                                                                        | Version                     | JVM              | OS                             |
-| ----------------------------------------------------------------------------------------- | --------------------------- | ---------------- | ------------------------------ |
-| [Glassfish](https://javaee.github.io/glassfish/)                                          | 5.0.x, 5.1.x                | OpenJDK 8, 11    | Ubuntu 18, Windows Server 2019 |
-| [JBoss EAP](https://www.redhat.com/en/technologies/jboss-middleware/application-platform) | 7.1.x, 7.3.x                | OpenJDK 8, 11    | Ubuntu 18, Windows Server 2019 |
-| [Jetty](https://www.eclipse.org/jetty/)                                                   | 9.4.x, 10.0.x, 11.0.x       | OpenJDK 8, 11    | Ubuntu 20                      |
-| [Payara](https://www.payara.fish/)                                                        | 5.0.x, 5.1.x                | OpenJDK 8, 11    | Ubuntu 18, Windows Server 2019 |
-| [Tomcat](http://tomcat.apache.org/)                                                       | 7.0.x, 8.5.x, 9.0.x, 10.0.x | OpenJDK 8, 11    | Ubuntu 18                      |
-| [TomEE](https://tomee.apache.org/)                                                        | 7.x, 8.x                    | OpenJDK 8, 11    | Ubuntu 18                      |
-| [Weblogic](https://www.oracle.com/java/weblogic/)                                         | 12.x                        | Oracle JDK 8     | Oracle Linux 7, 8              |
-| [Weblogic](https://www.oracle.com/java/weblogic/)                                         | 14.x                        | Oracle JDK 8, 11 | Oracle Linux 7, 8              |
-| [Websphere Liberty Profile](https://www.ibm.com/cloud/websphere-liberty)                  | 20.x, 21.x                  | OpenJDK 8, 11    | Ubuntu 18, Windows Server 2019 |
-| [Websphere Traditional](https://www.ibm.com/cloud/websphere-application-server)           | 8.5.5.x, 9.0.x              | IBM JDK 8        | Red Hat Enterprise Linux 8.4   |
-| [WildFly](https://www.wildfly.org/)                                                       | 13.x                        | OpenJDK 8        | Ubuntu 18, Windows Server 2019 |
-| [WildFly](https://www.wildfly.org/)                                                       | 17.x, 21.x, 25.x            | OpenJDK 8, 11    | Ubuntu 18, Windows Server 2019 |
+| Application server                                                                        | Version                     | JVM               | OS                             |
+| ----------------------------------------------------------------------------------------- | --------------------------- | ----------------- | ------------------------------ |
+| [Jetty](https://www.eclipse.org/jetty/)                                                   | 9.4.x, 10.0.x, 11.0.x       | OpenJDK 8, 11, 17 | Ubuntu 18, Windows Server 2019 |
+| [Payara](https://www.payara.fish/)                                                        | 5.0.x, 5.1.x                | OpenJDK 8, 11     | Ubuntu 18, Windows Server 2019 |
+| [Tomcat](http://tomcat.apache.org/)                                                       | 7.0.x                       | OpenJDK 8         | Ubuntu 18, Windows Server 2019 |
+| [Tomcat](http://tomcat.apache.org/)                                                       | 7.0.x, 8.5.x, 9.0.x, 10.0.x | OpenJDK 8, 11, 17 | Ubuntu 18, Windows Server 2019 |
+| [TomEE](https://tomee.apache.org/)                                                        | 7.x, 8.x                    | OpenJDK 8, 11, 17 | Ubuntu 18, Windows Server 2019 |
+| [Websphere Liberty Profile](https://www.ibm.com/cloud/websphere-liberty)                  | 20.x, 21.x                  | OpenJDK 8         | Ubuntu 18, Windows Server 2019 |
+| [Websphere Traditional](https://www.ibm.com/cloud/websphere-application-server)           | 8.5.5.x, 9.0.x              | IBM JDK 8         | Red Hat Enterprise Linux 8.4   |
+| [WildFly](https://www.wildfly.org/)                                                       | 13.x                        | OpenJDK 8         | Ubuntu 18, Windows Server 2019 |
+| [WildFly](https://www.wildfly.org/)                                                       | 17.x, 21.x, 25.x            | OpenJDK 8, 11, 17 | Ubuntu 18, Windows Server 2019 |
 
 ## JVMs and operating systems
 

--- a/docs/supported-libraries.md
+++ b/docs/supported-libraries.md
@@ -109,7 +109,7 @@ These are the supported libraries and frameworks:
 
 ## Application Servers
 
-These are the application servers that the OpenTelemetry Javaagent is tested against:
+These are the application servers that the smoke tests are run against:
 
 | Application server                                                                        | Version                     | JVM               | OS                             |
 | ----------------------------------------------------------------------------------------- | --------------------------- | ----------------- | ------------------------------ |
@@ -125,7 +125,7 @@ These are the application servers that the OpenTelemetry Javaagent is tested aga
 
 ## JVMs and operating systems
 
-These are the supported JVM version and OS configurations which the javaagent is tested on:
+These are the JVMs and operating systems that the integration tests are run against:
 
 | JVM                                               | Versions  | OS                             |
 | ------------------------------------------------- | --------- | ------------------------------ |

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -56,7 +56,7 @@ tasks {
     enabled = enabled && gradle.startParameter.taskNames.any { it.startsWith(":smoke-tests:") }
 
     val suites = mapOf(
-      "glassfish" to listOf("**/GlassFish*.*"),
+      "payara" to listOf("**/Payara*.*"),
       "jetty" to listOf("**/Jetty*.*"),
       "liberty" to listOf("**/Liberty*.*"),
       "tomcat" to listOf("**/Tomcat*.*"),

--- a/smoke-tests/images/servlet/build.gradle
+++ b/smoke-tests/images/servlet/build.gradle
@@ -29,7 +29,7 @@ tasks.create("pushMatrix", DockerPushImage) {
 // Each line under appserver describes one matrix of (version x vm x jdk), dockerfile key overrides
 // Dockerfile name, args key passes raw arguments to docker build
 def targets = [
-  "jetty": [
+  "jetty"    : [
     [version: ["9.4.39"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [sourceVersion: "9.4.39.v20210325"]],
     [version: ["9.4.39"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [sourceVersion: "9.4.39.v20210325"]],
     [version: ["10.0.7"], vm: ["hotspot"], jdk: ["11", "17"], args: [sourceVersion: "10.0.7"]],
@@ -37,7 +37,17 @@ def targets = [
     [version: ["11.0.7"], vm: ["hotspot"], jdk: ["11", "17"], args: [sourceVersion: "11.0.7"], war: "servlet-5.0"],
     [version: ["11.0.7"], vm: ["openj9"], jdk: ["11", "16"], args: [sourceVersion: "11.0.7"], war: "servlet-5.0"]
   ],
-  "tomcat": [
+  "liberty"  : [
+    // running configure.sh is failing while building the image with Java 17
+    [version: ["20.0.0.12"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "16"], args: [release: "2020-11-11_0736"]],
+    [version: ["21.0.0.10"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [release: "2021-09-20_1900"]],
+    [version: ["21.0.0.10"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [release: "2021-09-20_1900"]]
+  ],
+  "payara"   : [
+    [version: ["5.2020.6"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]],
+    [version: ["5.2021.8"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]]
+  ],
+  "tomcat"   : [
     [version: ["7.0.109"], vm: ["hotspot", "openj9"], jdk: ["8"], args: [majorVersion: "7"]],
     [version: ["8.5.72"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "8"]],
     [version: ["8.5.72"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "8"]],
@@ -46,7 +56,7 @@ def targets = [
     [version: ["10.0.12"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "10"], war: "servlet-5.0"],
     [version: ["10.0.12"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "10"], war: "servlet-5.0"]
   ],
-  "tomee": [
+  "tomee"    : [
     [version: ["7.0.9"], vm: ["hotspot", "openj9"], jdk: ["8"]],
     [version: ["7.1.4"], vm: ["hotspot", "openj9"], jdk: ["8"]],
     [version: ["8.0.8"], vm: ["hotspot"], jdk: ["8", "11", "17"]],
@@ -54,23 +64,13 @@ def targets = [
     [version: ["9.0.0-M7"], vm: ["hotspot"], jdk: ["8", "11", "17"], war: "servlet-5.0"],
     [version: ["9.0.0-M7"], vm: ["openj9"], jdk: ["8", "11", "16"], war: "servlet-5.0"]
   ],
-  "payara": [
-    [version: ["5.2020.6"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]],
-    [version: ["5.2021.8"], vm: ["hotspot", "openj9"], jdk: ["8", "11"]]
+  "websphere": [
+    [version: ["8.5.5.20", "9.0.5.9"], vm: ["openj9"], jdk: ["8"], windows: false]
   ],
-  "wildfly": [
+  "wildfly"  : [
     [version: ["13.0.0.Final"], vm: ["hotspot", "openj9"], jdk: ["8"]],
     [version: ["17.0.1.Final", "21.0.0.Final", "25.0.1.Final"], vm: ["hotspot"], jdk: ["8", "11", "17"]],
     [version: ["17.0.1.Final", "21.0.0.Final", "25.0.1.Final"], vm: ["openj9"], jdk: ["8", "11", "16"]]
-  ],
-  "liberty": [
-    // running configure.sh is failing while building the image with Java 17
-    [version: ["20.0.0.12"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "16"], args: [release: "2020-11-11_0736"]],
-    [version: ["21.0.0.10"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [release: "2021-09-20_1900"]],
-    [version: ["21.0.0.10"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [release: "2021-09-20_1900"]]
-  ],
-  "websphere": [
-    [version: ["8.5.5.20", "9.0.5.9"], vm: ["openj9"], jdk: ["8"], windows: false]
   ]
 ]
 

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PayaraSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PayaraSmokeTest.groovy
@@ -7,7 +7,7 @@ package io.opentelemetry.smoketest
 
 import java.time.Duration
 
-abstract class GlassFishSmokeTest extends AppServerTest {
+abstract class PayaraSmokeTest extends AppServerTest {
 
   protected String getTargetImagePrefix() {
     "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-servlet-payara"
@@ -44,26 +44,33 @@ abstract class GlassFishSmokeTest extends AppServerTest {
 }
 
 @AppServer(version = "5.2020.6", jdk = "8")
-class GlassFish52020Jdk8 extends GlassFishSmokeTest {
+class Payara52020Jdk8 extends PayaraSmokeTest {
 }
+
 @AppServer(version = "5.2020.6", jdk = "8-openj9")
-class GlassFish52020Jdk8Openj9 extends GlassFishSmokeTest {
+class Payara52020Jdk8Openj9 extends PayaraSmokeTest {
 }
+
 @AppServer(version = "5.2020.6", jdk = "11")
-class GlassFish52020Jdk11 extends GlassFishSmokeTest {
+class Payara52020Jdk11 extends PayaraSmokeTest {
 }
+
 @AppServer(version = "5.2020.6", jdk = "11-openj9")
-class GlassFish52020Jdk11Openj9 extends GlassFishSmokeTest {
+class Payara52020Jdk11Openj9 extends PayaraSmokeTest {
 }
+
 @AppServer(version = "5.2021.8", jdk = "8")
-class GlassFish52021Jdk8 extends GlassFishSmokeTest {
+class Payara52021Jdk8 extends PayaraSmokeTest {
 }
+
 @AppServer(version = "5.2021.8", jdk = "8-openj9")
-class GlassFish52021Jdk8Openj9 extends GlassFishSmokeTest {
+class Payara52021Jdk8Openj9 extends PayaraSmokeTest {
 }
+
 @AppServer(version = "5.2021.8", jdk = "11")
-class GlassFish52021Jdk11 extends GlassFishSmokeTest {
+class Payara52021Jdk11 extends PayaraSmokeTest {
 }
+
 @AppServer(version = "5.2021.8", jdk = "11-openj9")
-class GlassFish52021Jdk11Openj9 extends GlassFishSmokeTest {
+class Payara52021Jdk11Openj9 extends PayaraSmokeTest {
 }


### PR DESCRIPTION
A few things
* Rename "glassfish" to "payara" in a few places
* Re-alphabetize
* Update the supported application servers doc to reflect current smoke test matrix