### PR TITLE
Remove virtual field interfaces from reflection results

### DIFF
--- a/instrumentation/internal/internal-reflection/javaagent-integration-tests/build.gradle.kts
+++ b/instrumentation/internal/internal-reflection/javaagent-integration-tests/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
   testInstrumentation(project(":instrumentation:internal:internal-reflection:javaagent"))
+  testCompileOnly(project(":javaagent-bootstrap"))
 }

--- a/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/test/groovy/ReflectionTest.groovy
+++ b/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/test/groovy/ReflectionTest.groovy
@@ -4,7 +4,8 @@
  */
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
-
+import io.opentelemetry.javaagent.bootstrap.VirtualFieldAccessorMarker
+import io.opentelemetry.javaagent.bootstrap.VirtualFieldInstalledMarker
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 
@@ -37,16 +38,20 @@ class ReflectionTest extends AgentInstrumentationSpecification {
     methodFound == false
 
     and:
-    def interfaceClass = TestClass.getInterfaces().find {
-      it.getName().contains("VirtualFieldAccessor\$")
-    }
-    interfaceClass != null
-    def interfaceMethodFound = false
-    for (Method method : interfaceClass.getDeclaredMethods()) {
-      if (method.getName().contains("__opentelemetry")) {
-        interfaceMethodFound = true
-      }
-    }
-    interfaceMethodFound == false
+    // although marker interfaces are removed from getInterfaces() result class is still assignable
+    // to them
+    VirtualFieldInstalledMarker.isAssignableFrom(TestClass)
+    VirtualFieldAccessorMarker.isAssignableFrom(TestClass)
+    TestClass.getInterfaces().length == 2
+    TestClass.getInterfaces() == [Runnable, Serializable]
+  }
+
+  def "test generated serialVersionUID"() {
+    // expected value is computed with serialver utility that comes with jdk
+    expect:
+    ObjectStreamClass.lookup(TestClass).getSerialVersionUID() == -1508684692096503670L
+
+    and:
+    TestClass.getDeclaredFields().length == 0
   }
 }

--- a/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/test/java/TestClass.java
+++ b/instrumentation/internal/internal-reflection/javaagent-integration-tests/src/test/java/TestClass.java
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-public class TestClass implements Runnable {
+import java.io.Serializable;
+
+public class TestClass implements Runnable, Serializable {
 
   @Override
   public void run() {}

--- a/instrumentation/internal/internal-reflection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/reflection/ClassInstrumentation.java
+++ b/instrumentation/internal/internal-reflection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/reflection/ClassInstrumentation.java
@@ -81,13 +81,13 @@ public class ClassInstrumentation implements TypeInstrumentation {
                 super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
                 // filter the result of call to getInterfaces0, which is used on hotspot, and
                 // J9VMInternals.getInterfaces which is used on openj9
-                if ((opcode == Opcodes.INVOKEVIRTUAL
+                if (((opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKESPECIAL)
                         && "getInterfaces0".equals(name)
                         && "()[Ljava/lang/Class;".equals(descriptor))
                     || (opcode == Opcodes.INVOKESTATIC
                         && "getInterfaces".equals(name)
                         && "java/lang/J9VMInternals".equals(owner)
-                        && "()[Ljava/lang/Class;".equals(descriptor))) {
+                        && "(Ljava/lang/Class;)[Ljava/lang/Class;".equals(descriptor))) {
                   mv.visitVarInsn(Opcodes.ALOAD, 0);
                   mv.visitMethodInsn(
                       Opcodes.INVOKESTATIC,

--- a/instrumentation/internal/internal-reflection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/reflection/ClassInstrumentation.java
+++ b/instrumentation/internal/internal-reflection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/reflection/ClassInstrumentation.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.internal.reflection;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.pool.TypePool;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+public class ClassInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("java.lang.Class");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyTransformer(
+        (builder, typeDescription, classLoader, module) ->
+            builder.visit(
+                new AsmVisitorWrapper() {
+                  @Override
+                  public int mergeWriter(int flags) {
+                    return flags | ClassWriter.COMPUTE_MAXS;
+                  }
+
+                  @Override
+                  public int mergeReader(int flags) {
+                    return flags;
+                  }
+
+                  @Override
+                  public ClassVisitor wrap(
+                      TypeDescription instrumentedType,
+                      ClassVisitor classVisitor,
+                      Implementation.Context implementationContext,
+                      TypePool typePool,
+                      FieldList<FieldDescription.InDefinedShape> fields,
+                      MethodList<?> methods,
+                      int writerFlags,
+                      int readerFlags) {
+                    return new ClassClassVisitor(classVisitor);
+                  }
+                }));
+  }
+
+  private static class ClassClassVisitor extends ClassVisitor {
+
+    ClassClassVisitor(ClassVisitor cv) {
+      super(Opcodes.ASM7, cv);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(
+        int access, String name, String descriptor, String signature, String[] exceptions) {
+      MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+      if ("getInterfaces".equals(name)
+          && ("()[Ljava/lang/Class;".equals(descriptor)
+              || "(Z)[Ljava/lang/Class;".equals(descriptor))) {
+        mv =
+            new MethodVisitor(api, mv) {
+              @Override
+              public void visitMethodInsn(
+                  int opcode, String owner, String name, String descriptor, boolean isInterface) {
+                super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                // filter the result of call to getInterfaces0, which is used on hotspot, and
+                // J9VMInternals.getInterfaces which is used on openj9
+                if ((opcode == Opcodes.INVOKEVIRTUAL
+                        && "getInterfaces0".equals(name)
+                        && "()[Ljava/lang/Class;".equals(descriptor))
+                    || (opcode == Opcodes.INVOKESTATIC
+                        && "getInterfaces".equals(name)
+                        && "java/lang/J9VMInternals".equals(owner)
+                        && "()[Ljava/lang/Class;".equals(descriptor))) {
+                  mv.visitVarInsn(Opcodes.ALOAD, 0);
+                  mv.visitMethodInsn(
+                      Opcodes.INVOKESTATIC,
+                      Type.getInternalName(ReflectionHelper.class),
+                      "filterInterfaces",
+                      "([Ljava/lang/Class;Ljava/lang/Class;)[Ljava/lang/Class;",
+                      false);
+                }
+              }
+            };
+      }
+      return mv;
+    }
+  }
+}

--- a/instrumentation/internal/internal-reflection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/reflection/ReflectionIgnoredTypesConfigurer.java
+++ b/instrumentation/internal/internal-reflection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/reflection/ReflectionIgnoredTypesConfigurer.java
@@ -17,5 +17,6 @@ public class ReflectionIgnoredTypesConfigurer implements IgnoredTypesConfigurer 
   public void configure(Config config, IgnoredTypesBuilder builder) {
     builder.allowClass("jdk.internal.reflect.Reflection");
     builder.allowClass("sun.reflect.Reflection");
+    builder.allowClass("java.lang.Class");
   }
 }

--- a/instrumentation/internal/internal-reflection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/reflection/ReflectionInstrumentationModule.java
+++ b/instrumentation/internal/internal-reflection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/reflection/ReflectionInstrumentationModule.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.internal.reflection;
 
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -26,6 +26,6 @@ public class ReflectionInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new ReflectionInstrumentation());
+    return asList(new ClassInstrumentation(), new ReflectionInstrumentation());
   }
 }

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/VirtualFieldAccessorMarker.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/VirtualFieldAccessorMarker.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.bootstrap;
+
+/** A marker interface implemented by virtual field accessor classes. */
+public interface VirtualFieldAccessorMarker {}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfacesGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfacesGenerator.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.javaagent.tooling.field.GeneratedVirtualFieldName
 import static io.opentelemetry.javaagent.tooling.field.GeneratedVirtualFieldNames.getRealGetterName;
 import static io.opentelemetry.javaagent.tooling.field.GeneratedVirtualFieldNames.getRealSetterName;
 
+import io.opentelemetry.javaagent.bootstrap.VirtualFieldAccessorMarker;
 import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings;
 import java.util.HashMap;
 import java.util.Map;
@@ -54,6 +55,7 @@ final class FieldAccessorInterfacesGenerator {
         .makeInterface()
         .merge(SyntheticState.SYNTHETIC)
         .name(getFieldAccessorInterfaceName(typeName, fieldTypeName))
+        .implement(VirtualFieldAccessorMarker.class)
         .defineMethod(
             getRealGetterName(typeName, fieldTypeName),
             fieldTypeDesc,


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4370
I initially planned to use asm `SerialVersionUIDAdder` to add `serialVersionUID` field to serializable classes that don't declare it. This is needed to make sure that instrumented version of class has the same `serialVersionUID` as uninstrumented version. This approach failed with one of spring-batch tests because inside spring there is code that copies instances of an internal spring class via reflection and fails because it can't write to `serialVersionUID` which is a static final field. We can't use the same reflection filtering code as we use for fields & methods added by virtual field implementetion because that filtering completely removes these members from reflection results. For `serialVersionUID` we'd need it to be visible from `getDeclaredField`, so that `ObjectStreamClass` can read it, and hidden from `getDeclaredFields`, so that code that isn't explicitly looking for it wouldn't stumble upon it. Instead of attempting to remove `serialVersionUID` from `getDeclaredFields` I chose to remove interfaces added by virtual field implementation from the result of `getInterfaces`. This makes the default `serialVersionUID` computation algorithm return the correct result on instrumented classes and there is no need to precompute `serialVersionUID`  for them.