### PR TITLE
Fix release tagging

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -279,6 +279,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ github.event.inputs.version }}
+          commitish: ${{ needs.prepare-release-branch.outputs.release-branch-name }}
           release_name: Release v${{ github.event.inputs.version }}
           draft: true
           prerelease: false

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -195,6 +195,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ github.event.inputs.version }}
+          commitish: ${{ github.event.inputs.release-branch-name }}
           release_name: Release v${{ github.event.inputs.version }}
           draft: true
           prerelease: false


### PR DESCRIPTION
I caught this when making the release last week (manually updated the commit before publishing the release).