### PR TITLE
Allow using GE if locally authenticated

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,12 +31,14 @@ val isCI = System.getenv("CI") != null
 val geAccessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY") ?: ""
 
 // if GE access key is not given and we are in CI, then we publish to scans.gradle.com
+val useScansGradleCom = isCI && geAccessKey.isEmpty()
+
 gradleEnterprise {
-  if (geAccessKey.isNotEmpty()) {
+  if (!useScansGradleCom) {
     server = gradleEnterpriseServer
   }
   buildScan {
-    if (isCI && geAccessKey.isEmpty()) {
+    if (useScansGradleCom) {
       termsOfServiceUrl = "https://gradle.com/terms-of-service"
       termsOfServiceAgree = "yes"
     }


### PR DESCRIPTION
Locally one can authenticate against GE using a file in `~/.gradle` folder. In this case we still want to publish to GE and not to `scans.gradle.com`.