### PR TITLE
Cleaner manifest preservation

### DIFF
--- a/examples/extension/build.gradle
+++ b/examples/extension/build.gradle
@@ -99,23 +99,22 @@ dependencies {
   add("codegen", "ch.qos.logback:logback-classic:1.2.3")
 }
 
-//Extracts manifest from OpenTelemetry Java agent to reuse it later
-task agentManifest(type: Copy) {
-  from zipTree(configurations.otel.singleFile).matching {
-    include 'META-INF/MANIFEST.MF'
-  }
-  into buildDir
-}
-
 //Produces a copy of upstream javaagent with this extension jar included inside it
 //The location of extension directory inside agent jar is hard-coded in the agent source code
 task extendedAgent(type: Jar) {
-  dependsOn agentManifest
   archiveFileName = "opentelemetry-javaagent.jar"
-  manifest.from "$buildDir/META-INF/MANIFEST.MF"
   from zipTree(configurations.otel.singleFile)
   from(tasks.shadowJar.archiveFile) {
     into "extensions"
+  }
+
+  //Preserve MANIFEST.MF file from the upstream javaagent
+  doFirst {
+    manifest.from(
+      zipTree(configurations.otel.singleFile).matching {
+        include 'META-INF/MANIFEST.MF'
+      }.singleFile
+    )
   }
 }
 

--- a/examples/extension/build.gradle
+++ b/examples/extension/build.gradle
@@ -102,6 +102,7 @@ dependencies {
 //Produces a copy of upstream javaagent with this extension jar included inside it
 //The location of extension directory inside agent jar is hard-coded in the agent source code
 task extendedAgent(type: Jar) {
+  dependsOn(configurations.otel)
   archiveFileName = "opentelemetry-javaagent.jar"
   from zipTree(configurations.otel.singleFile)
   from(tasks.shadowJar.archiveFile) {

--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -25,23 +25,18 @@ dependencies {
 }
 
 tasks {
-  // Extracts manifest from OpenTelemetry Java agent to reuse it later
-  val agentManifest by registering(Copy::class) {
-    dependsOn(agent)
-    from(
-      zipTree(agent.singleFile).matching {
-        include("META-INF/MANIFEST.MF")
-      }
-    )
-    into("$buildDir/tmp")
-  }
-
   jar {
-    dependsOn(agentManifest)
-    manifest.from("$buildDir/tmp/META-INF/MANIFEST.MF")
     from(zipTree(agent.singleFile))
     from(extensionLibs) {
       into("extensions")
+    }
+
+    doFirst {
+      manifest.from(
+        zipTree(agent.singleFile).matching {
+          include("META-INF/MANIFEST.MF")
+        }.singleFile
+      )
     }
   }
 

--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
 
 tasks {
   jar {
+    dependsOn(agent)
     from(zipTree(agent.singleFile))
     from(extensionLibs) {
       into("extensions")


### PR DESCRIPTION
This removes two Gradle deprecation warnings: last two from [here](https://ge.opentelemetry.io/s/vfad6d4taxwc4/deprecations)