### PR TITLE
v1.9.x: Shade class references within AWS SDK service files. (#4719)

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
@@ -6,6 +6,9 @@ plugins {
 
 tasks.withType<ShadowJar>().configureEach {
   mergeServiceFiles()
+  // Merge any AWS SDK service files that may be present (too bad they didn't just use normal
+  // service loader...)
+  mergeServiceFiles("software/amazon/awssdk/global/handlers")
 
   exclude("**/module-info.class")
 


### PR DESCRIPTION
Cherry picking #4719 to the 1.9.x release branch.