### PR TITLE
v1.9.x: Use ratpack 1.4.1 for testing (#4748)

### DIFF
--- a/instrumentation/ratpack-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/ratpack-1.4/javaagent/build.gradle.kts
@@ -17,7 +17,9 @@ dependencies {
 
   testImplementation(project(":instrumentation:ratpack-1.4:testing"))
 
-  testLibrary("io.ratpack:ratpack-test:1.4.0")
+  // 1.4.0 has a bug which makes tests flaky
+  // (https://github.com/ratpack/ratpack/commit/dde536ac138a76c34df03a0642c88d64edde688e)
+  testLibrary("io.ratpack:ratpack-test:1.4.1")
 
   if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
     testImplementation("com.sun.activation:jakarta.activation:1.2.2")
@@ -26,3 +28,19 @@ dependencies {
 
 // Requires old Guava. Can't use enforcedPlatform since predates BOM
 configurations.testRuntimeClasspath.resolutionStrategy.force("com.google.guava:guava:19.0")
+
+// to allow all tests to pass we need to choose a specific netty version
+if (!(findProperty("testLatestDeps") as Boolean)) {
+  configurations.configureEach {
+    if (!name.contains("muzzle")) {
+      resolutionStrategy {
+        eachDependency {
+          // specifying a fixed version for all libraries with io.netty group
+          if (requested.group == "io.netty") {
+            useVersion("4.1.31.Final")
+          }
+        }
+      }
+    }
+  }
+}

--- a/instrumentation/ratpack-1.4/library/build.gradle.kts
+++ b/instrumentation/ratpack-1.4/library/build.gradle.kts
@@ -8,7 +8,9 @@ dependencies {
 
   testImplementation(project(":instrumentation:ratpack-1.4:testing"))
 
-  testLibrary("io.ratpack:ratpack-test:1.4.0")
+  // 1.4.0 has a bug which makes tests flaky
+  // (https://github.com/ratpack/ratpack/commit/dde536ac138a76c34df03a0642c88d64edde688e)
+  testLibrary("io.ratpack:ratpack-test:1.4.1")
   testLibrary("io.ratpack:ratpack-guice:1.4.0")
 
   if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
@@ -18,3 +20,19 @@ dependencies {
 
 // Requires old Guava. Can't use enforcedPlatform since predates BOM
 configurations.testRuntimeClasspath.resolutionStrategy.force("com.google.guava:guava:19.0")
+
+// to allow all tests to pass we need to choose a specific netty version
+if (!(findProperty("testLatestDeps") as Boolean)) {
+  configurations.configureEach {
+    if (!name.contains("muzzle")) {
+      resolutionStrategy {
+        eachDependency {
+          // specifying a fixed version for all libraries with io.netty group
+          if (requested.group == "io.netty") {
+            useVersion("4.1.31.Final")
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Cherry picking #4748 because v1.9.x PRs #4752 and #4753 are failing, which makes me concerned that patch release build will likely fail as well.