### PR TITLE
Update patch release docs

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -1,52 +1,17 @@
-# Releases a patch by cherrypicking commits into a release branch based on the previous
-# release tag.
+# Releases a new patch version from a release branch
 name: Patch Release Build
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: The version to tag the release with, e.g., 1.2.1, 1.2.2
+      release-branch-name:
+        description: The release branch to use, e.g. v1.9.x
         required: true
-      commits:
-        description: List of commit shas to cherrypick. Multiple shas should be separated by spaces.
-        required: false
+      version:
+        # TODO (trask) this is redundant
+        description: The version of the release, e.g. 1.9.0 (without the "v" prefix)
+        required: true
 
 jobs:
-  prepare-release-branch:
-    runs-on: ubuntu-latest
-    outputs:
-      release-branch-name: ${{ steps.parse-release-branch.outputs.release-branch-name }}
-    steps:
-      - id: parse-release-branch
-        name: Parse release branch name
-        run: |
-          # Sets the release-branch-name output to the version number with the last non-period element replaced with an 'x' and preprended with v.
-          echo "::set-output name=release-branch-name::$(echo '${{ github.event.inputs.version }}' | sed -E 's/([^.]+)\.([^.]+)\.([^.]+)/v\1.\2.x/')"
-          # Sets the release-tag-name output to the version number with the last non-period element replace with a '0' and prepended with v
-          echo "::set-output name=release-tag-name::$(echo '${{ github.event.inputs.version }}' | sed -E 's/([^.]+)\.([^.]+)\.([^.]+)/v\1.\2.0/')"
-
-      - id: checkout-release-branch
-        name: Check out release branch
-        continue-on-error: true
-        uses: actions/checkout@v2.3.4
-        with:
-          ref: ${{ steps.parse-release-branch.outputs.release-branch-name }}
-          fetch-depth: 0
-
-      - id: checkout-release-tag
-        name: Check out release tag
-        if: ${{ steps.checkout-release-branch.outcome == 'failure' }}
-        uses: actions/checkout@v2.3.4
-        with:
-          ref: ${{ steps.parse-release-branch.outputs.release-tag-name }}
-          fetch-depth: 0
-
-      - name: Create release branch
-        if: ${{ steps.checkout-release-tag.outcome == 'success' }}
-        run: |
-          git checkout -b ${{ steps.parse-release-branch.outputs.release-branch-name }}
-          git push --set-upstream origin ${{ steps.parse-release-branch.outputs.release-branch-name }}
-
   test:
     runs-on: ubuntu-latest
     needs: prepare-release-branch
@@ -91,12 +56,6 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-
-      - name: Cherrypicks
-        if: ${{ github.event.inputs.commits != '' }}
-        run: |
-          git fetch origin main
-          git cherry-pick ${{ github.event.inputs.commits }} 
 
       - name: Test
         run: ./gradlew test -PtestJavaVersion=${{ matrix.test-java-version }} -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false
@@ -159,12 +118,6 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-      - name: Cherrypicks
-        if: ${{ github.event.inputs.commits != '' }}
-        run: |
-          git fetch origin main
-          git cherry-pick ${{ github.event.inputs.commits }}
-
       - name: Test
         run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}
 
@@ -197,12 +150,6 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-
-      - name: Cherrypicks
-        if: ${{ github.event.inputs.commits != '' }}
-        run: |
-          git fetch origin main
-          git cherry-pick ${{ github.event.inputs.commits }}
 
       - name: Local publish of artifacts
         # javadoc task fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
@@ -241,12 +188,6 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-      - name: Cherrypicks
-        if: ${{ github.event.inputs.commits != '' }}
-        run: |
-          git fetch origin main
-          git cherry-pick ${{ github.event.inputs.commits }}
-
       - name: Build and publish artifacts
         uses: burrunan/gradle-cache-action@v1.10
         with:
@@ -269,9 +210,6 @@ jobs:
         run: ../gradlew build publishPlugins
         working-directory: gradle-plugins
 
-      - name: Push cherry-picked changes to the release branch
-        run: git push
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1.1.4
@@ -279,7 +217,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ github.event.inputs.version }}
-          commitish: ${{ needs.prepare-release-branch.outputs.release-branch-name }}
+          commitish: ${{ github.event.inputs.release-branch-name }}
           release_name: Release v${{ github.event.inputs.version }}
           draft: true
           prerelease: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,15 +19,19 @@ Before making the release:
   git checkout -b v1.9.x upstream/main
   git push upstream v1.9.x
   ```
-* Push a new commit to the release branch updating the version (remove `-SNAPSHOT`) in these files:
+* Merge a PR to the release branch updating the version (remove `-SNAPSHOT`) in these files:
   * version.gradle.kts
   * examples/distro/build.gradle
   * examples/extension/build.gradle
 
 Open the release build workflow in your browser [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/release-build.yml).
 
-You will see a button that says "Run workflow". Press the button, enter the release branch
-(e.g. `v1.9.x`) in the input field that pops up, and then press "Run workflow".
+You will see a button that says "Run workflow". Press the button, then enter the release branch
+to use (e.g. `v1.9.x`) and the version of the release (e.g. `1.9.0`). Yes there is redundancy
+between these two inputs that we plan to address.
+
+You will see a button that says "Run workflow". Press the button, enter the release branch to use
+and the version of the release.
 
 This triggers the release process, which builds the artifacts, publishes the artifacts, and creates
 and pushes a git tag with the version number.
@@ -56,63 +60,18 @@ In general, patch releases are only made for bug-fixes for the following types o
 * Memory leaks
 * Deadlocks
 
+Before making the release:
+
+* Merge PR(s) containing the desired patches to the release branch
+* Merge a PR to the release branch updating the `CHANGELOG.md`
+* Merge a PR to the release branch updating the version in these files:
+  * version.gradle.kts
+  * examples/distro/build.gradle
+  * examples/extension/build.gradle
+
 To make a patch release, open the patch release build workflow in your browser
 [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/patch-release-build.yml).
 
-You will see a button that says "Run workflow". Press the button, enter the version number you want
-to release in the input field for version that pops up and the commits you want to cherrypick.
-If you are entering multiple commits, they should be separated by spaces. Then, press "Run workflow".
-
-The automated branch creation will fail if any of the yaml files differ between the release branch
-and `main`:
-
-```
-Switched to a new branch 'v1.6.x'
-To https://github.com/open-telemetry/opentelemetry-java-instrumentation
-! [remote rejected]     v1.6.x -> v1.6.x (refusing to allow a GitHub App to create or update workflow `.github/workflows/pr-smoke-test-fake-backend-images.yml` without `workflows` permission)
-```
-
-and you will need to manually create it before proceeding, e.g.
-
-```
-git checkout -b v1.6.x v1.6.0
-git push upstream v1.6.x
-```
-
-If the commits cannot be cleanly applied to the release branch, for example because it has diverged
-too much from main, then the workflow will fail before building. In this case, you will need to
-prepare the release branch manually.
-
-This example will assume patching into release branch `v1.6.x` from a git repository with remotes
-named `origin` and `upstream`.
-
-```
-$ git remote -v
-origin	git@github.com:username/opentelemetry-java.git (fetch)
-origin	git@github.com:username/opentelemetry-java.git (push)
-upstream	git@github.com:open-telemetry/opentelemetry-java.git (fetch)
-upstream	git@github.com:open-telemetry/opentelemetry-java.git (push)
-```
-
-First, checkout the release branch
-
-```
-git fetch upstream v1.6.x
-git checkout upstream/v1.6.x
-```
-
-Apply cherrypicks manually and commit. It is ok to apply multiple cherrypicks in a single commit.
-Use a commit message such as "Manual cherrypick for commits commithash1, commithash2".
-
-After committing the change, push to your fork's branch.
-
-```
-git push origin v1.6.x
-```
-
-Create a PR to have code review and merge this into upstream's release branch. As this was not
-applied automatically, we need to do code review to make sure the manual cherrypick is correct.
-
-After it is merged, Run the patch release workflow again, but leave the commits input field blank.
-The release will be made with the current state of the release branch, which is what you prepared
-above.
+You will see a button that says "Run workflow". Press the button, then enter the release branch
+to use (e.g. `v1.9.x`) and the version of the release (e.g. `1.9.1`). Yes there is redundancy
+between these two inputs that we plan to address.


### PR DESCRIPTION
My thought about removing the auto- cherry picking is that the manual cherry pick PRs will give us review/approval/traceability on the patch release process, and then no need for checking before hitting the patch release button.