### PR TITLE
Increase timeout for hystrix tests

### DIFF
--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableChainTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import com.netflix.hystrix.HystrixCommandProperties
 import com.netflix.hystrix.HystrixObservableCommand
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixObservableTest.groovy
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 import com.netflix.hystrix.HystrixCommandProperties
 import com.netflix.hystrix.HystrixObservable
 import com.netflix.hystrix.HystrixObservableCommand

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
@@ -4,6 +4,8 @@
  */
 
 import com.netflix.hystrix.HystrixCommand
+import com.netflix.hystrix.HystrixCommandProperties
+import com.netflix.hystrix.HystrixObservableCommand
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 
 import java.util.concurrent.BlockingQueue
@@ -17,7 +19,7 @@ class HystrixTest extends AgentInstrumentationSpecification {
 
   def "test command #action"() {
     setup:
-    def command = new HystrixCommand<String>(asKey("ExampleGroup")) {
+    def command = new HystrixCommand<String>(setter("ExampleGroup")) {
       @Override
       protected String run() throws Exception {
         return tracedMethod()
@@ -77,7 +79,7 @@ class HystrixTest extends AgentInstrumentationSpecification {
 
   def "test command #action fallback"() {
     setup:
-    def command = new HystrixCommand<String>(asKey("ExampleGroup")) {
+    def command = new HystrixCommand<String>(setter("ExampleGroup")) {
       @Override
       protected String run() throws Exception {
         throw new IllegalArgumentException()
@@ -137,5 +139,12 @@ class HystrixTest extends AgentInstrumentationSpecification {
       }
       queue.take()
     }
+  }
+
+  def setter(String key) {
+    def setter = new HystrixCommand.Setter(asKey(key))
+    setter.andCommandPropertiesDefaults(new HystrixCommandProperties.Setter()
+      .withExecutionTimeoutInMilliseconds(10_000))
+    return setter
   }
 }

--- a/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/javaagent/src/test/groovy/HystrixTest.groovy
@@ -5,7 +5,6 @@
 
 import com.netflix.hystrix.HystrixCommand
 import com.netflix.hystrix.HystrixCommandProperties
-import com.netflix.hystrix.HystrixObservableCommand
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 
 import java.util.concurrent.BlockingQueue


### PR DESCRIPTION
According to https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=HystrixObservableTest&tests.sortField=FLAKY&tests.unstableOnly=true hystrix tests sometimes timeout