### PR TITLE
Rework build scan configuration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,23 +33,32 @@ val geAccessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY") ?: ""
 // if GE access key is not given and we are in CI, then we publish to scans.gradle.com
 val useScansGradleCom = isCI && geAccessKey.isEmpty()
 
-gradleEnterprise {
-  if (!useScansGradleCom) {
-    server = gradleEnterpriseServer
-  }
-  buildScan {
-    if (useScansGradleCom) {
+if (useScansGradleCom) {
+  gradleEnterprise {
+    buildScan {
       termsOfServiceUrl = "https://gradle.com/terms-of-service"
       termsOfServiceAgree = "yes"
+      isUploadInBackground = !isCI
+      publishAlways()
+
+      capture {
+        isTaskInputFiles = true
+      }
     }
-    publishAlways()
-    this as com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
-    publishIfAuthenticated()
+  }
+} else {
+  gradleEnterprise {
+    server = gradleEnterpriseServer
+    buildScan {
+      isUploadInBackground = !isCI
 
-    isUploadInBackground = !isCI
+      this as com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
+      publishIfAuthenticated()
+      publishAlways()
 
-    capture {
-      isTaskInputFiles = true
+      capture {
+        isTaskInputFiles = true
+      }
     }
   }
 }


### PR DESCRIPTION
Publishing build scans to `ge.opentelemetry.io` requires authentication, publishing to `scans.gradle.com` does not. Instead of adding one more `if` to conditionally include that requirement, I reworked `gradleEnterprise` configuration in two separate blocks.