### PR TITLE
Ask Animalsniffer to always produce report

### DIFF
--- a/conventions/src/main/kotlin/otel.animalsniffer-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.animalsniffer-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import ru.vyarus.gradle.plugin.animalsniffer.AnimalSniffer
+
 plugins {
   `java-library`
 
@@ -10,4 +12,7 @@ dependencies {
 
 animalsniffer {
   sourceSets = listOf(java.sourceSets.main.get())
+}
+tasks.withType<AnimalSniffer> {
+  reports.text.required.set(true)
 }

--- a/conventions/src/main/kotlin/otel.animalsniffer-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.animalsniffer-conventions.gradle.kts
@@ -14,5 +14,6 @@ animalsniffer {
   sourceSets = listOf(java.sourceSets.main.get())
 }
 tasks.withType<AnimalSniffer> {
+  // always having declared output makes this task properly participate in tasks up-to-date checks
   reports.text.required.set(true)
 }


### PR DESCRIPTION
The main result of this change is that Animalsniffer tasks now always has declared output and thus properly participate in tasks up-to-date checks