### PR TITLE
Make AgentClassLoaderAccess methods public

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/javaagent/testing/common/AgentClassLoaderAccess.java
+++ b/testing-common/src/main/java/io/opentelemetry/javaagent/testing/common/AgentClassLoaderAccess.java
@@ -24,6 +24,7 @@ public final class AgentClassLoaderAccess {
     }
   }
 
+  // public for use by downstream distros
   public static Class<?> loadClass(String name) {
     try {
       return agentClassLoader.loadClass(name);

--- a/testing-common/src/main/java/io/opentelemetry/javaagent/testing/common/AgentClassLoaderAccess.java
+++ b/testing-common/src/main/java/io/opentelemetry/javaagent/testing/common/AgentClassLoaderAccess.java
@@ -24,7 +24,7 @@ public final class AgentClassLoaderAccess {
     }
   }
 
-  static Class<?> loadClass(String name) {
+  public static Class<?> loadClass(String name) {
     try {
       return agentClassLoader.loadClass(name);
     } catch (ClassNotFoundException e) {


### PR DESCRIPTION
This class used to have a public getter that exposed the agent/extension classloader and we were using it in our distro's tests; the `loadClass()` method is pretty much equivalent to that.