### PR TITLE
Try to make tomcat async servlet exception test less flaky

### DIFF
--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TestServlet3.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TestServlet3.groovy
@@ -112,7 +112,13 @@ class TestServlet3 {
                 break
               case EXCEPTION:
                 resp.status = endpoint.status
-                resp.writer.print(endpoint.body)
+                def writer = resp.writer
+                writer.print(endpoint.body)
+                if (req.getClass().getName().contains("catalina")) {
+                  // on tomcat close the writer to ensure response is sent immediately, otherwise
+                  // there is a chance that tomcat resets the connection before the response is sent
+                  writer.close()
+                }
                 throw new ServletException(endpoint.body)
             }
           }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TestServlet5.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TestServlet5.groovy
@@ -113,7 +113,13 @@ class TestServlet5 {
                 break
               case EXCEPTION:
                 resp.status = endpoint.status
-                resp.writer.print(endpoint.body)
+                def writer = resp.writer
+                writer.print(endpoint.body)
+                if (req.getClass().getName().contains("catalina")) {
+                  // on tomcat close the writer to ensure response is sent immediately, otherwise
+                  // there is a chance that tomcat resets the connection before the response is sent
+                  writer.close()
+                }
                 throw new ServletException(endpoint.body)
             }
           }

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/AsyncServlet.groovy
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/AsyncServlet.groovy
@@ -62,6 +62,10 @@ class AsyncServlet extends HttpServlet {
               resp.writer.print(endpoint.body)
               break
             case EXCEPTION:
+              resp.status = endpoint.status
+              def writer = resp.writer
+              writer.print(endpoint.body)
+              writer.close()
               throw new ServletException(endpoint.body)
           }
         }

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/AsyncServlet.groovy
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/AsyncServlet.groovy
@@ -62,7 +62,9 @@ class AsyncServlet extends AbstractHttpServlet {
               break
             case EXCEPTION:
               resp.status = endpoint.status
-              resp.writer.print(endpoint.body)
+              def writer = resp.writer
+              writer.print(endpoint.body)
+              writer.close()
               throw new ServletException(endpoint.body)
           }
         }


### PR DESCRIPTION
According to https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.sortField=FLAKY&tests.unstableOnly=true `test exception` with async servlet on tomcat is the most flaky test we have. Here is an attempt to make it stable by forcing response to be sent before exception is thrown which could trigger tomcat resetting connection to the client.