### PR TITLE
Make testing agent jar more consistent with real agent jar

### DIFF
--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -42,7 +42,7 @@ val exporterSlimLibs by configurations.creating {
 }
 
 // exclude dependencies that are to be placed in bootstrap from agent libs - they won't be added to inst/
-listOf(javaagentLibs, exporterLibs, exporterSlimLibs).forEach {
+listOf(baseJavaagentLibs, javaagentLibs, exporterLibs, exporterSlimLibs).forEach {
   it.run {
     exclude("org.slf4j")
     exclude("io.opentelemetry", "opentelemetry-api")


### PR DESCRIPTION
Noticed OpenTelemetry API and friends shaded under `inst/` directory of the testing agent jar.