### PR TITLE
Use versioned download url

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ if you are looking for documentation on using those.
 
 ## Getting Started
 
-Download the [latest version](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar).
+Download the [latest version](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.9.1/opentelemetry-javaagent.jar).
 
 This package includes the instrumentation agent as well as
 instrumentations for all supported libraries and all available data exporters.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,10 +19,12 @@ Before making the release:
   git checkout -b v1.9.x upstream/main
   git push upstream v1.9.x
   ```
-* Merge a PR to the release branch updating the version (remove `-SNAPSHOT`) in these files:
-  * version.gradle.kts
-  * examples/distro/build.gradle
-  * examples/extension/build.gradle
+* Merge a PR to the release branch with the following changes
+  * Remove `-SNAPSHOT` from the version in these files:
+    * version.gradle.kts
+    * examples/distro/build.gradle
+    * examples/extension/build.gradle
+  * Bump the version in the download link in the root `README.md` file
 
 Open the release build workflow in your browser [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/release-build.yml).
 
@@ -38,10 +40,12 @@ and pushes a git tag with the version number.
 
 After making the release:
 
-* Merge a PR to `main` bumping the version (keeping `-SNAPSHOT`) in these files:
-  * version.gradle.kts
-  * examples/distro/build.gradle
-  * examples/extension/build.gradle
+* Merge a PR to `main` with the following changes
+  * Bump version in these files to the next `-SNAPSHOT` version (e.g. from `1.9.0-SNAPSHOT` to `1.10.0-SNAPSHOT`)
+    * version.gradle.kts
+    * examples/distro/build.gradle
+    * examples/extension/build.gradle
+  * Bump the version in the download link in the root `README.md` file
 
 ## Announcement
 


### PR DESCRIPTION
IIRC this was raised when we were having problems depending on collector `latest` images, and there was interest encouraging the "best practice" of using versioned download urls.

Closes #3516