### PR TITLE
Avoid crashing on early 1.8 openjdk vms

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
@@ -44,9 +44,9 @@ public final class AgentInitializer {
    * @return true for oracle 1.8 before 1.8.0_40
    */
   private static boolean isEarlyOracle18() {
-    // Java HotSpot(TM) 64-Bit Server VM
+    // Java HotSpot(TM) 64-Bit Server VM or OpenJDK 64-Bit Server VM
     String vmName = System.getProperty("java.vm.name");
-    if (!vmName.contains("HotSpot")) {
+    if (!vmName.contains("HotSpot") && !vmName.contains("OpenJDK")) {
       return false;
     }
     // 1.8.0_31

--- a/smoke-tests/src/test/resources/crashearlyjdk8/CrashEarlyJdk8.java
+++ b/smoke-tests/src/test/resources/crashearlyjdk8/CrashEarlyJdk8.java
@@ -16,7 +16,7 @@ public class CrashEarlyJdk8 {
 
   public void test() {
     // run loop enough times for jit compiler to kick in
-    for (int i = 0; i < 10_000; i++) {
+    for (int i = 0; i < 100_000; i++) {
       this.bar(this::foo);
     }
   }


### PR DESCRIPTION
While looking at flaky tests I noticed that `CrashEarlyJdk8Test` is also flaky.