### PR TITLE
Limit jaxrs latest dependencies to exclude beta version 6

### DIFF
--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   testLibrary("io.undertow:undertow-servlet:1.4.28.Final")
   testLibrary("org.jboss.resteasy:resteasy-servlet-initializer:3.0.4.Final")
 
+  latestDepTestLibrary("org.jboss.resteasy:resteasy-servlet-initializer:5.+")
   latestDepTestLibrary("org.jboss.resteasy:resteasy-jaxrs:3.+")
   latestDepTestLibrary("org.jboss.resteasy:resteasy-undertow:3.+") {
     exclude("org.jboss.resteasy", "resteasy-client")

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/build.gradle.kts
@@ -41,7 +41,11 @@ dependencies {
   testLibrary("org.jboss.resteasy:resteasy-servlet-initializer:3.1.0.Final")
 
   // artifact name changed from 'resteasy-jaxrs' to 'resteasy-core' starting from version 4.0.0
-  latestDepTestLibrary("org.jboss.resteasy:resteasy-core:+")
+  latestDepTestLibrary("org.jboss.resteasy:resteasy-core:5.+")
+  latestDepTestLibrary("org.jboss.resteasy:resteasy-servlet-initializer:5.+")
+  latestDepTestLibrary("org.jboss.resteasy:resteasy-undertow:5.+") {
+    exclude("org.jboss.resteasy", "resteasy-client")
+  }
 }
 
 tasks {


### PR DESCRIPTION
Fixes #4793 
Fixes #4792
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4798
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4799