### PR TITLE
Fix resteasy-3.0 latest test dep versions

### DIFF
--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/groovy/JaxRsHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/groovy/JaxRsHttpServerTest.groovy
@@ -221,7 +221,7 @@ abstract class JaxRsHttpServerTest<S> extends HttpServerTest<S> implements Agent
     false
   }
 
-  private static boolean shouldTestCompletableStageAsync() {
+  boolean shouldTestCompletableStageAsync() {
     Boolean.getBoolean("testLatestDeps")
   }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/build.gradle.kts
@@ -43,9 +43,9 @@ dependencies {
   testLibrary("io.undertow:undertow-servlet:1.4.28.Final")
   testLibrary("org.jboss.resteasy:resteasy-servlet-initializer:3.0.4.Final")
 
-  latestDepTestLibrary("org.jboss.resteasy:resteasy-servlet-initializer:5.+")
-  latestDepTestLibrary("org.jboss.resteasy:resteasy-jaxrs:3.+")
-  latestDepTestLibrary("org.jboss.resteasy:resteasy-undertow:3.+") {
+  latestDepTestLibrary("org.jboss.resteasy:resteasy-servlet-initializer:3.0.+")
+  latestDepTestLibrary("org.jboss.resteasy:resteasy-jaxrs:3.0.+")
+  latestDepTestLibrary("org.jboss.resteasy:resteasy-undertow:3.0.+") {
     exclude("org.jboss.resteasy", "resteasy-client")
   }
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/src/test/groovy/ResteasyHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/src/test/groovy/ResteasyHttpServerTest.groovy
@@ -27,4 +27,9 @@ class ResteasyHttpServerTest extends JaxRsHttpServerTest<UndertowJaxrsServer> {
   void stopServer(UndertowJaxrsServer server) {
     server.stop()
   }
+
+  // resteasy 3.0.x does not support JAX-RS 2.1
+  boolean shouldTestCompletableStageAsync() {
+    false
+  }
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/src/test/groovy/ResteasyJettyHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/javaagent/src/test/groovy/ResteasyJettyHttpServerTest.groovy
@@ -5,4 +5,8 @@
 
 class ResteasyJettyHttpServerTest extends JaxRsJettyHttpServerTest {
 
+  // resteasy 3.0.x does not support JAX-RS 2.1
+  boolean shouldTestCompletableStageAsync() {
+    false
+  }
 }


### PR DESCRIPTION
Follow-up from @laurit's comment https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4795/files#r762428544

resteasy-3.0 instrumentation only supports 3.0.x, since there is separate instrumentation to support resteasy 3.1+, so makes sense that the latest dependency tests should run against `3.0.+`