### PR TITLE
Fix flaky spring batch test

### DIFF
--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/springbatch/TestItemWriter.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/springbatch/TestItemWriter.groovy
@@ -8,7 +8,7 @@ package springbatch
 import org.springframework.batch.item.ItemWriter
 
 class TestItemWriter implements ItemWriter<Integer> {
-  final List<Integer> items = new ArrayList()
+  final List<Integer> items = Collections.synchronizedList(new ArrayList())
 
   @Override
   void write(List<? extends Integer> items) throws Exception {


### PR DESCRIPTION
Items list can be modified concurrently from 2 threads.
https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P1D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=JavaConfigBatchJobTest&tests.sortField=FLAKY&tests.test=should%20trace%20partitioned%20job&tests.unstableOnly=true