### PR TITLE
Fix gradle warning

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -21,6 +21,10 @@ configurations.named("compileOnly") {
   extendsFrom(bbGradlePlugin)
 }
 
+java {
+  toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+}
+
 dependencies {
   implementation("com.google.guava:guava:30.1.1-jre")
   // we need to use byte buddy variant that does not shade asm


### PR DESCRIPTION
Fixes gradle warning:

```
> Task :gradle-plugins:compileKotlin
'compileJava' task (current target is 11) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.
```