### PR TITLE
Fix flaky elasticsearch rest 5 test

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/ElasticsearchRest5Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/ElasticsearchRest5Test.groovy
@@ -117,7 +117,8 @@ class ElasticsearchRest5Test extends AgentInstrumentationSpecification {
     Map result = new JsonSlurper().parseText(EntityUtils.toString(requestResponse.entity))
 
     expect:
-    result.status == "green"
+    // usually this test reports green status, but sometimes it is yellow
+    result.status == "green" || result.status == "yellow"
 
     assertTraces(1) {
       trace(0, 3) {


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=ElasticsearchRest5Test&tests.sortField=FLAKY&tests.test=test%20elasticsearch%20status%20async&tests.unstableOnly=true
Occasionally test fails because status is `yellow` instead of the expected `green`. For us it isn't really important what it is. Although we have the same test for other elasticsearch versions this is the only version where it has failed.