### PR TITLE
Fix api misuse in vert.x reactive tests

### DIFF
--- a/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -40,7 +40,7 @@ class VertxRxCircuitBreakerWebClientTest extends HttpClientTest<HttpRequest<?>> 
 
   @Override
   HttpRequest<?> buildRequest(String method, URI uri, Map<String, String> headers) {
-    def request = client.request(HttpMethod.valueOf(method), getPort(uri), uri.host, "$uri")
+    def request = client.requestAbs(HttpMethod.valueOf(method), "$uri")
     headers.each { request.putHeader(it.key, it.value) }
     return request
   }

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/client/VertxRxWebClientTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/client/VertxRxWebClientTest.groovy
@@ -31,7 +31,7 @@ class VertxRxWebClientTest extends HttpClientTest<HttpRequest<Buffer>> implement
 
   @Override
   HttpRequest<Buffer> buildRequest(String method, URI uri, Map<String, String> headers) {
-    def request = client.request(HttpMethod.valueOf(method), getPort(uri), uri.host, "$uri")
+    def request = client.requestAbs(HttpMethod.valueOf(method), "$uri")
     headers.each { request.putHeader(it.key, it.value) }
     return request
   }

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/java/client/VertxRxSingleConnection.java
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/java/client/VertxRxSingleConnection.java
@@ -14,11 +14,8 @@ import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.ext.web.client.HttpRequest;
 import io.vertx.reactivex.ext.web.client.HttpResponse;
 import io.vertx.reactivex.ext.web.client.WebClient;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ExecutionException;
 
 public class VertxRxSingleConnection implements SingleConnection {
   private final WebClient webClient;
@@ -41,17 +38,10 @@ public class VertxRxSingleConnection implements SingleConnection {
   }
 
   @Override
-  public int doRequest(String path, Map<String, String> headers) throws ExecutionException {
+  public int doRequest(String path, Map<String, String> headers) {
     String requestId = Objects.requireNonNull(headers.get(REQUEST_ID_HEADER));
 
-    String url;
-    try {
-      url = new URL("http", host, port, path).toString();
-    } catch (MalformedURLException e) {
-      throw new ExecutionException(e);
-    }
-
-    HttpRequest<Buffer> request = webClient.request(HttpMethod.GET, port, host, url);
+    HttpRequest<Buffer> request = webClient.request(HttpMethod.GET, port, host, path);
     headers.forEach(request::putHeader);
 
     HttpResponse<?> response = fetchResponse(request);

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -41,7 +41,7 @@ class VertxRxCircuitBreakerWebClientTest extends HttpClientTest<HttpRequest<?>> 
 
   @Override
   HttpRequest<?> buildRequest(String method, URI uri, Map<String, String> headers) {
-    def request = client.request(HttpMethod.valueOf(method), getPort(uri), uri.host, "$uri")
+    def request = client.requestAbs(HttpMethod.valueOf(method), "$uri")
     headers.each { request.putHeader(it.key, it.value) }
     return request
   }

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/client/VertxRxWebClientTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/client/VertxRxWebClientTest.groovy
@@ -32,7 +32,7 @@ class VertxRxWebClientTest extends HttpClientTest<HttpRequest<Buffer>> implement
 
   @Override
   HttpRequest<Buffer> buildRequest(String method, URI uri, Map<String, String> headers) {
-    def request = client.request(HttpMethod.valueOf(method), getPort(uri), uri.host, "$uri")
+    def request = client.requestAbs(HttpMethod.valueOf(method), "$uri")
     headers.each { request.putHeader(it.key, it.value) }
     return request
   }

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/java/client/VertxRxSingleConnection.java
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/java/client/VertxRxSingleConnection.java
@@ -14,11 +14,8 @@ import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.ext.web.client.HttpRequest;
 import io.vertx.reactivex.ext.web.client.HttpResponse;
 import io.vertx.reactivex.ext.web.client.WebClient;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ExecutionException;
 
 public class VertxRxSingleConnection implements SingleConnection {
   private final WebClient webClient;
@@ -41,17 +38,10 @@ public class VertxRxSingleConnection implements SingleConnection {
   }
 
   @Override
-  public int doRequest(String path, Map<String, String> headers) throws ExecutionException {
+  public int doRequest(String path, Map<String, String> headers) {
     String requestId = Objects.requireNonNull(headers.get(REQUEST_ID_HEADER));
 
-    String url;
-    try {
-      url = new URL("http", host, port, path).toString();
-    } catch (MalformedURLException e) {
-      throw new ExecutionException(e);
-    }
-
-    HttpRequest<Buffer> request = webClient.request(HttpMethod.GET, port, host, url);
+    HttpRequest<Buffer> request = webClient.request(HttpMethod.GET, port, host, path);
     headers.forEach(request::putHeader);
 
     HttpResponse<?> response = fetchResponse(request);


### PR DESCRIPTION
Api that expects path shouldn't be called with absolute url. Hopefully this is the final piece needed for https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4730