### PR TITLE
Update supported frameworks and suppressing instrumentation docs

### DIFF
--- a/docs/supported-libraries.md
+++ b/docs/supported-libraries.md
@@ -29,7 +29,10 @@ These are the supported libraries and frameworks:
 | [Apache Dubbo](https://github.com/apache/dubbo/)                                                                                      | 2.7+ (not including 3.x yet)   |
 | [Apache HttpAsyncClient](https://hc.apache.org/index.html)                                                                            | 4.1+                           |
 | [Apache HttpClient](https://hc.apache.org/index.html)                                                                                 | 2.0+                           |
+| [Apache Kafka](https://kafka.apache.org/20/javadoc/overview-summary.html)                                                             | 0.11+                          |
+| [Apache MyFaces](https://myfaces.apache.org/)                                                                                         | 1.2+ (not including 3.x yet)   |
 | [Apache RocketMQ](https://rocketmq.apache.org/)                                                                                       | 4.8+                           |
+| [Apache Struts 2](https://github.com/apache/struts)                                                                                   | 2.3+                           |
 | [Apache Tapestry](https://tapestry.apache.org/)                                                                                       | 5.4+                           |
 | [Apache Wicket](https://wicket.apache.org/)                                                                                           | 8.0+                           |
 | [Armeria](https://armeria.dev)                                                                                                        | 1.3+                           |
@@ -39,13 +42,17 @@ These are the supported libraries and frameworks:
 | [Cassandra Driver](https://github.com/datastax/java-driver)                                                                           | 3.0+                           |
 | [Couchbase Client](https://github.com/couchbase/couchbase-java-client)                                                                | 2.0+ and 3.1+                  |
 | [Dropwizard Views](https://www.dropwizard.io/en/latest/manual/views.html)                                                             | 0.7+                           |
+| [Eclipse Grizzly](https://javaee.github.io/grizzly/httpserverframework.html)                                                          | 2.0+ (disabled by default)     |
+| [Eclipse Jersey](https://eclipse-ee4j.github.io/jersey/)                                                                              | 2.0+ (not including 3.x yet)   |
+| [Eclipse Jetty HTTP Client](https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/client/HttpClient.html)                   | 9.2+ (not including 10+ yet)   |
+| [Eclipse Metro](https://projects.eclipse.org/projects/ee4j.metro)                                                                     | 2.2+ (not including 3.x yet)   |
+| [Eclipse Mojarra](https://projects.eclipse.org/projects/ee4j.mojarra)                                                                 | 1.2+ (not including 3.x yet)   |
 | [Elasticsearch API](https://www.elastic.co/guide/en/elasticsearch/client/java-api/current/index.html)                                 | 5.0+                           |
 | [Elasticsearch REST Client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/index.html)                        | 5.0+                           |
 | [Finatra](https://github.com/twitter/finatra)                                                                                         | 2.9+                           |
 | [Geode Client](https://geode.apache.org/)                                                                                             | 1.4+                           |
 | [Google HTTP Client](https://github.com/googleapis/google-http-java-client)                                                           | 1.19+                          |
 | [Grails](https://grails.org/)                                                                                                         | 3.0+                           |
-| [Grizzly](https://javaee.github.io/grizzly/httpserverframework.html)                                                                  | 2.0+ (disabled by default)     |
 | [gRPC](https://github.com/grpc/grpc-java)                                                                                             | 1.6+                           |
 | [GWT](http://www.gwtproject.org/)                                                                                                     | 2.0+                           |
 | [Hibernate](https://github.com/hibernate/hibernate-orm)                                                                               | 3.3+                           |
@@ -58,20 +65,14 @@ These are the supported libraries and frameworks:
 | [Java Http Client](https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/package-summary.html)               | Java 11+                       |
 | [JDBC](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/package-summary.html)                                     | Java 8+                        |
 | [Jedis](https://github.com/xetorthio/jedis)                                                                                           | 1.4+                           |
-| [Jersey](https://eclipse-ee4j.github.io/jersey/)                                                                                      | 2.0+ (not including 3.x yet)   |
-| [Jetty HTTP Client](https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/client/HttpClient.html)                           | 9.2+ (not including 10+ yet)   |
 | [JMS](https://javaee.github.io/javaee-spec/javadocs/javax/jms/package-summary.html)                                                   | 1.1+                           |
 | [JSP](https://javaee.github.io/javaee-spec/javadocs/javax/servlet/jsp/package-summary.html)                                           | 2.3+                           |
-| [Kafka](https://kafka.apache.org/20/javadoc/overview-summary.html)                                                                    | 0.11+                          |
 | [Kubernetes Client](https://github.com/kubernetes-client/java)                                                                        | 7.0+                           |
 | [Lettuce](https://github.com/lettuce-io/lettuce-core)                                                                                 | 4.0+                           |
 | [Log4j 1](https://logging.apache.org/log4j/1.2/)                                                                                      | 1.2+                           |
 | [Log4j 2](https://logging.apache.org/log4j/2.x/)                                                                                      | 2.7+                           |
 | [Logback](http://logback.qos.ch/)                                                                                                     | 1.0+                           |
-| [Metro](https://projects.eclipse.org/projects/ee4j.metro)                                                                             | 2.2+ (not including 3.x yet)   |
-| [Mojarra](https://projects.eclipse.org/projects/ee4j.mojarra)                                                                         | 1.2+ (not including 3.x yet)   |
 | [MongoDB Driver](https://mongodb.github.io/mongo-java-driver/)                                                                        | 3.1+                           |
-| [MyFaces](https://myfaces.apache.org/)                                                                                                | 1.2+ (not including 3.x yet)   |
 | [Netty](https://github.com/netty/netty)                                                                                               | 3.8+                           |
 | [OkHttp](https://github.com/square/okhttp/)                                                                                           | 3.0+                           |
 | [Play](https://github.com/playframework/playframework)                                                                                | 2.4+ (not including 2.8.x yet) |
@@ -92,13 +93,12 @@ These are the supported libraries and frameworks:
 | [Spring Data](https://spring.io/projects/spring-data)                                                                                 | 1.8+                           |
 | [Spring Integration](https://spring.io/projects/spring-integration)                                                                   | 4.1+                           |
 | [Spring Kafka](https://spring.io/projects/spring-kafka)                                                                               | 2.7+                           |
-| [Spring Rabbit](https://spring.io/projects/spring-amqp)                                                                               | 1.0+                           |
+| [Spring RabbitMQ](https://spring.io/projects/spring-amqp)                                                                             | 1.0+                           |
 | [Spring Scheduling](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/scheduling/package-summary.html)       | 3.1+                           |
 | [Spring Web MVC](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/servlet/mvc/package-summary.html)     | 3.1+                           |
 | [Spring Web Services](https://spring.io/projects/spring-ws)                                                                           | 2.0+                           |
-| [Spring Webflux](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/reactive/package-summary.html)        | 5.0+                           |
+| [Spring WebFlux](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/reactive/package-summary.html)        | 5.0+                           |
 | [Spymemcached](https://github.com/couchbase/spymemcached)                                                                             | 2.12+                          |
-| [Struts2](https://github.com/apache/struts)                                                                                           | 2.3+                           |
 | [Twilio](https://github.com/twilio/twilio-java)                                                                                       | 6.6+ (not including 8.x yet)   |
 | [Undertow](https://undertow.io/)                                                                                                      | 1.4+                           |
 | [Vaadin](https://vaadin.com/)                                                                                                         | 14.2+                          |

--- a/docs/suppressing-instrumentation.md
+++ b/docs/suppressing-instrumentation.md
@@ -75,7 +75,7 @@ corresponding instrumentation `name`:
 | OkHttp | okhttp|
 | OpenLiberty | liberty |
 | OpenTelemetry Trace annotations | opentelemetry-annotations |
-| OpenTelemetry SDK | opentelemetry-api |
+| OpenTelemetry API | opentelemetry-api |
 | OSHI (Operating System and Hardware Information) | oshi |
 | Play Framework | play|
 | Play WS HTTP Client | play-ws|

--- a/docs/suppressing-instrumentation.md
+++ b/docs/suppressing-instrumentation.md
@@ -25,7 +25,9 @@ corresponding instrumentation `name`:
 | Apache HttpAsyncClient | apache-httpasyncclient|
 | Apache HttpClient | apache-httpclient|
 | Apache Kafka | kafka |
+| Apache MyFaces | myfaces|
 | Apache RocketMQ | rocketmq-client|
+| Apache Struts 2 | struts|
 | Apache Tapestry | tapestry|
 | Apache Tomcat | tomcat|
 | Apache Wicket | wicket|
@@ -35,7 +37,14 @@ corresponding instrumentation `name`:
 | AWS SDK | aws-sdk|
 | Couchbase | couchbase|
 | Dropwizard Views | dropwizard-views |
+| Eclipse Grizzly | grizzly|
+| Eclipse Jersey | jersey|
+| Eclipse Jetty | jetty|
+| Eclipse Jetty HTTP Client | jetty-httpclient|
+| Eclipse Metro | metro|
+| Eclipse Mojarra | mojarra|
 | Eclipse OSGi | eclipse-osgi |
+| Eclipse Vert.x | vertx |
 | Elasticsearch client | elasticsearch-transport|
 | Elasticsearch REST client | elasticsearch-rest|
 | Google Guava | guava|
@@ -44,7 +53,6 @@ corresponding instrumentation `name`:
 | Grails | grails|
 | GRPC | grpc|
 | Hibernate | hibernate|
-| Java EE Grizzly | grizzly|
 | Java HTTP Client | java-http-client |
 | Java `HttpURLConnection` | http-url-connection |
 | Java JDBC | jdbc |
@@ -55,14 +63,9 @@ corresponding instrumentation `name`:
 | JAX-RS (Client) | jaxrs-client|
 | JAX-RS (Server) | jaxrs|
 | JAX-WS | jaxws|
-| JAX-WS Metro | metro|
-| Jetty | jetty|
 | JMS | jms|
-| JSF Mojarra | mojarra|
-| JSF MyFaces | myfaces|
 | JSP | jsp |
 | K8s Client | kubernetes-client|
-| Kotlin HTTP (kHttp) | khttp |
 | kotlinx.coroutines | kotlinx-coroutines |
 | Log4j | log4j|
 | Logback | logback|
@@ -72,9 +75,11 @@ corresponding instrumentation `name`:
 | OkHttp | okhttp|
 | OpenLiberty | liberty |
 | OpenTelemetry Trace annotations | opentelemetry-annotations |
+| OpenTelemetry SDK | opentelemetry-api |
 | OSHI (Operating System and Hardware Information) | oshi |
 | Play Framework | play|
 | Play WS HTTP Client | play-ws|
+| Quartz | quartz|
 | RabbitMQ Client | rabbitmq|
 | Ratpack | ratpack|
 | ReactiveX RxJava | rxjava2, rxjava3 |
@@ -85,20 +90,22 @@ corresponding instrumentation `name`:
 | Rediscala | rediscala|
 | Scala executors | scala-executors |
 | Spark Web Framework | spark|
+| Spring Batch | spring-batch|
 | Spring Core | spring-core|
 | Spring Data | spring-data|
 | Spring Integration | spring-integration|
+| Spring Kafka | spring-kafka|
+| Spring RabbitMQ | spring-rabbit|
 | Spring Scheduling | spring-scheduling|
-| Spring Webflux | spring-webflux|
-| Spring WebMVC | spring-webmvc|
-| Spring WS | spring-ws|
+| Spring Web | spring-web|
+| Spring WebFlux | spring-webflux|
+| Spring Web MVC | spring-webmvc|
+| Spring Web Services | spring-ws|
 | Spymemcached | spymemcached|
-| Struts | struts|
 | Twilio SDK | twilio|
 | Twitter Finatra | finatra|
 | Undertow | undertow|
 | Vaadin | vaadin|
-| Vert.x RxJava2 | vertx |
 
 **Note:** When using environment variables, dashes (`-`) should be converted to
 underscores (`_`). For example, to suppress traces from `akka-actor` library, set


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4694
An alternative would be to make `opentelemetry-api` instrumentation an internal instrumentation that would not be disabled by default enabled flag.