### PR TITLE
Disable incremental Kotlin compilation.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,6 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m \
 # This property is not mentioned in Gradle documentation
 # See https://github.com/gradle/gradle/issues/15214 for background info
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
+
+# Workaround https://youtrack.jetbrains.com/issue/KT-34862
+kotlin.incremental=false


### PR DESCRIPTION
I've seen very mysterious build failures that resolve with `--no-build-cache` which I think can be helped with this.