### PR TITLE
Always forbid system.out by errorprone

### DIFF
--- a/conventions/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -21,10 +21,6 @@ tasks {
 
       excludedPaths.set(".*/build/generated/.*|.*/concurrentlinkedhashmap/.*")
 
-      if (System.getenv("CI") == null) {
-        disable("SystemOut")
-      }
-
       disable("BooleanParameter")
 
       // Doesn't work well with Java 8


### PR DESCRIPTION
This `if` currently breaks CI-Local gradle cache