### PR TITLE
update the webclient instrumentation example in the documentation

### DIFF
--- a/instrumentation/spring/spring-webflux-5.0/library/README.md
+++ b/instrumentation/spring/spring-webflux-5.0/library/README.md
@@ -86,7 +86,7 @@ public class WebClientConfig {
       WebClient webClient = WebClient.create();
       SpringWebfluxTracing instrumentation = SpringWebfluxTracing.create(openTelemetry);
 
-      return webClient.mutate().filter(instrumentation::addClientTracingFilter);
+      return webClient.mutate().filters(instrumentation::addClientTracingFilter);
    }
 }
 ```


### PR DESCRIPTION
the `filter` method does not compile in this example, use `filters` instead of `filter`.