### PR TITLE
Enable Armeria server instrumentation notFound() test

### DIFF
--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetClientAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetClientAttributesExtractor.java
@@ -3,27 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.armeria.v1_3.internal;
+package io.opentelemetry.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-public final class ArmeriaNetServerAttributesExtractor
-    extends InetSocketAddressNetServerAttributesExtractor<RequestContext, RequestLog> {
+final class ArmeriaNetClientAttributesExtractor
+    extends InetSocketAddressNetClientAttributesExtractor<RequestContext, RequestLog> {
 
   @Override
-  public String transport(RequestContext ctx) {
+  public String transport(RequestContext ctx, @Nullable RequestLog requestLog) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getAddress(RequestContext ctx) {
+  public InetSocketAddress getAddress(RequestContext ctx, @Nullable RequestLog requestLog) {
     SocketAddress address = ctx.remoteAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesExtractor.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesExtractor.java
@@ -3,27 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.armeria.v1_3.internal;
+package io.opentelemetry.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-public final class ArmeriaNetClientAttributesExtractor
-    extends InetSocketAddressNetClientAttributesExtractor<RequestContext, RequestLog> {
+final class ArmeriaNetServerAttributesExtractor
+    extends InetSocketAddressNetServerAttributesExtractor<RequestContext, RequestLog> {
 
   @Override
-  public String transport(RequestContext ctx, @Nullable RequestLog requestLog) {
+  public String transport(RequestContext ctx) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getAddress(RequestContext ctx, @Nullable RequestLog requestLog) {
+  public InetSocketAddress getAddress(RequestContext ctx) {
     SocketAddress address = ctx.remoteAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTracingBuilder.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTracingBuilder.java
@@ -21,8 +21,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
-import io.opentelemetry.instrumentation.armeria.v1_3.internal.ArmeriaNetClientAttributesExtractor;
-import io.opentelemetry.instrumentation.armeria.v1_3.internal.ArmeriaNetServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.ArrayList;
 import java.util.List;

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/OpenTelemetryService.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/OpenTelemetryService.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -36,15 +35,7 @@ final class OpenTelemetryService extends SimpleDecoratingHttpService {
     if (span.isRecording()) {
       ctx.log()
           .whenComplete()
-          .thenAccept(
-              log -> {
-                if (log.responseHeaders().status().equals(HttpStatus.NOT_FOUND)) {
-                  // Assume a not-found request was not served. The route we use by default will be
-                  // some fallback like `/*` which is not as useful as the requested path.
-                  span.updateName(ctx.path());
-                }
-                instrumenter.end(context, ctx, log, log.responseCause());
-              });
+          .thenAccept(log -> instrumenter.end(context, ctx, log, log.responseCause()));
     }
 
     try (Scope ignored = context.makeCurrent()) {

--- a/instrumentation/armeria-1.3/testing/src/main/groovy/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpServerTest.groovy
+++ b/instrumentation/armeria-1.3/testing/src/main/groovy/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpServerTest.groovy
@@ -51,12 +51,6 @@ abstract class AbstractArmeriaHttpServerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  boolean testNotFound() {
-    // currently span name is /notFound which indicates it won't be low-cardinality
-    false
-  }
-
-  @Override
   Server startServer(int port) {
     ServerBuilder sb = Server.builder()
 


### PR DESCRIPTION
I noticed that there was a bit of code in the `OpenTelemetryService` class that seems to contradict our general approach to how we treat 404 request routes/span names.