### PR TITLE
Improve vert.x rx error handling

### DIFF
--- a/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -62,11 +62,11 @@ class VertxRxCircuitBreakerWebClientTest extends HttpClientTest<HttpRequest<?>> 
 
   void sendRequestWithCallback(HttpRequest<?> request, Consumer<AsyncResult> consumer) {
     breaker.execute({ command ->
-      request.rxSend().doOnSuccess {
-        command.complete(it)
-      }.doOnError {
-        command.fail(it)
-      }.subscribe()
+      request.rxSend().subscribe({ response ->
+        command.complete(response)
+      }, { throwable ->
+        command.fail(throwable)
+      })
     }, {
       consumer.accept(it)
     })

--- a/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/instrumentation/vertx-reactive-3.5/javaagent/src/version35Test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -63,11 +63,11 @@ class VertxRxCircuitBreakerWebClientTest extends HttpClientTest<HttpRequest<?>> 
 
   void sendRequestWithCallback(HttpRequest<?> request, Consumer<AsyncResult> consumer) {
     breaker.executeCommand({ command ->
-      request.rxSend().doOnSuccess {
-        command.complete(it)
-      }.doOnError {
-        command.fail(it)
-      }.subscribe()
+      request.rxSend().subscribe({ response ->
+        command.complete(response)
+      }, { throwable ->
+        command.fail(throwable)
+      })
     }, {
       consumer.accept(it)
     })


### PR DESCRIPTION
I suspect that we are currently not using vert.x correctly as tests that end with failure and use a callback like `connection error (unopened port) with callback` log an exception
```
io.reactivex.exceptions.OnErrorNotImplementedException: Connection refused: localhost/127.0.0.1:61
	at io.reactivex.internal.functions.Functions$OnErrorMissingConsumer.accept(Functions.java:704)
	at io.reactivex.internal.functions.Functions$OnErrorMissingConsumer.accept(Functions.java:701)
	at io.reactivex.internal.observers.ConsumerSingleObserver.onError(ConsumerSingleObserver.java:45)
	at io.opentelemetry.javaagent.shaded.instrumentation.rxjava2.TracingSingleObserver.onError(TracingSingleObserver.java:61)
	at io.reactivex.internal.operators.single.SingleDoOnError$DoOnError.onError(SingleDoOnError.java:63)
```
After this change `OnErrorNotImplementedException` is not logged any more.