### PR TITLE
Additional http.status_code assertion

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -969,6 +969,9 @@ public abstract class AbstractHttpClientTest<REQUEST> {
               if (responseCode != null) {
                 assertThat(attrs)
                     .containsEntry(SemanticAttributes.HTTP_STATUS_CODE, (long) responseCode);
+              } else {
+                // worth adding AttributesAssert.doesNotContainKey?
+                assertThat(attrs.get(SemanticAttributes.HTTP_STATUS_CODE)).isNull();
               }
             });
   }


### PR DESCRIPTION
Reviewing #4870 made me want this assertion.

@anuraaga the old (groovy-based) attribute assertions kept track of the attributes that were asserted against, and would fail if there were any additional attributes outside of those expected ones. For the new (java-based) attribute assertions, I think we'd want to build up the expected entry assertions and pass them all at once to something like `containsOnly` (which exists already, but only supports exact matches, i.e. no `hasEntrySatisfying` support)?