### PR TITLE
Fix kotlin coroutines test latest deps

### DIFF
--- a/instrumentation/kotlinx-coroutines/javaagent/src/test/kotlin/KotlinCoroutineTests.kt
+++ b/instrumentation/kotlinx-coroutines/javaagent/src/test/kotlin/KotlinCoroutineTests.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.selects.select
@@ -37,9 +38,9 @@ class KotlinCoroutineTests(private val dispatcher: CoroutineDispatcher) {
       }
     }
 
-    producer.consumeAsFlow().collect {
+    producer.consumeAsFlow().onEach {
       tracedChild("consume_$it")
-    }
+    }.collect()
   }
 
   fun tracePreventedByCancellation() {


### PR DESCRIPTION
test latest deps is broken with `org.jetbrains.kotlinx:kotlinx-coroutines-core` 1.6.0-RC2 release (seems what used to be a warning turned into an error now)

see https://youtrack.jetbrains.com/issue/KT-44047 for history about the warning