### PR TITLE
Fix Intellij (re-)import

### DIFF
--- a/conventions/build.gradle.kts
+++ b/conventions/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
   `kotlin-dsl`
   // When updating, update below in dependencies too
-  id("com.diffplug.spotless") version "6.0.4"
+  // TEMPORARY NOTE: Intellij (re-)import is currently failing with 6.0.3 and 6.0.4
+  id("com.diffplug.spotless") version "6.0.2"
 }
 
 spotless {
@@ -35,7 +36,7 @@ dependencies {
   implementation("org.apache.maven:maven-aether-provider:3.3.9")
 
   // When updating, update above in plugins too
-  implementation("com.diffplug.spotless:spotless-plugin-gradle:6.0.4")
+  implementation("com.diffplug.spotless:spotless-plugin-gradle:6.0.2")
   implementation("com.google.guava:guava:31.0.1-jre")
   implementation("gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:0.8.18")
   implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.0")


### PR DESCRIPTION
Partial revert of #4863

Intellij (re-)import is currently failing with spotless 6.0.3 and 6.0.4

Would be good to get confirmation that this is reproducible by someone else and not just a local issue.

![image](https://user-images.githubusercontent.com/218610/145730410-c1dd847d-4d23-4aaa-bfbf-f15bd9e41059.png)
