### PR TITLE
Bump grpc and spring boot smoke test images from Java 16 to 17

### DIFF
--- a/.github/workflows/pr-smoke-test-grpc-images.yml
+++ b/.github/workflows/pr-smoke-test-grpc-images.yml
@@ -36,5 +36,5 @@ jobs:
         run: |
           ./gradlew jibDockerBuild -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
           ./gradlew jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
-          ./gradlew jibDockerBuild -PtargetJDK=16 -Djib.httpTimeout=120000 -Djib.console=plain
+          ./gradlew jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
         working-directory: smoke-tests/images/grpc

--- a/.github/workflows/pr-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/pr-smoke-test-spring-boot-images.yml
@@ -36,5 +36,5 @@ jobs:
         run: |
           ./gradlew jibDockerBuild -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
           ./gradlew jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
-          ./gradlew jibDockerBuild -PtargetJDK=16 -Djib.httpTimeout=120000 -Djib.console=plain
+          ./gradlew jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
         working-directory: smoke-tests/images/spring-boot

--- a/.github/workflows/publish-smoke-test-grpc-images.yml
+++ b/.github/workflows/publish-smoke-test-grpc-images.yml
@@ -48,7 +48,7 @@ jobs:
           echo "Pushing to tag $TAG"
           ./gradlew jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
           ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
-          ./gradlew jib -PtargetJDK=16 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          ./gradlew jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
         working-directory: smoke-tests/images/grpc
 
   issue:

--- a/.github/workflows/publish-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/publish-smoke-test-spring-boot-images.yml
@@ -48,7 +48,7 @@ jobs:
           echo "Pushing to tag $TAG"
           ./gradlew jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
           ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
-          ./gradlew jib -PtargetJDK=16 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          ./gradlew jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
         working-directory: smoke-tests/images/spring-boot
 
   issue:


### PR DESCRIPTION
Missed these earlier. Will follow up with PR to bump tests to use these new images once published.