### PR TITLE
Add startup check to all rabbitmq container usages

### DIFF
--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/WithRabbitProducerConsumerTrait.groovy
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/groovy/WithRabbitProducerConsumerTrait.groovy
@@ -15,6 +15,7 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.messaging.support.MessageBuilder
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
 
 import java.time.Duration
 
@@ -30,7 +31,8 @@ trait WithRabbitProducerConsumerTrait {
   def startRabbit(Class<?> additionalContext = null) {
     rabbitMqContainer = new GenericContainer('rabbitmq:latest')
       .withExposedPorts(5672)
-      .withStartupTimeout(Duration.ofSeconds(120))
+      .waitingFor(Wait.forLogMessage(".*Server startup complete.*", 1))
+      .withStartupTimeout(Duration.ofMinutes(2))
     rabbitMqContainer.start()
 
     def producerApp = new SpringApplication(getContextClasses(ProducerConfig, additionalContext))

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
@@ -15,6 +15,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
 import spock.lang.Shared
 
 import java.time.Duration
@@ -37,7 +38,8 @@ class ContextPropagationTest extends AgentInstrumentationSpecification {
   def setupSpec() {
     rabbitMqContainer = new GenericContainer('rabbitmq:latest')
       .withExposedPorts(5672)
-      .withStartupTimeout(Duration.ofSeconds(120))
+      .waitingFor(Wait.forLogMessage(".*Server startup complete.*", 1))
+      .withStartupTimeout(Duration.ofMinutes(2))
     rabbitMqContainer.start()
 
     def app = new SpringApplication(ConsumerConfig)


### PR DESCRIPTION
Continuation of https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4813
Previous pr added startup check to some rabbitmq usages, if I interpret the flaky test results correct this seems to have worked. This pr adds the same startup check to other rabbitmq container usages in the hope that this will get rid of flakiness like https://ge.opentelemetry.io/s/qu73cs57tjqr6/tests/:instrumentation:spring:spring-integration-4.1:javaagent:test/SpringCloudStreamRabbitTest/should%20propagate%20context%20through%20RabbitMQ?top-execution=1