### PR TITLE
Add Java 18 smoke test images

### DIFF
--- a/.github/workflows/pr-smoke-test-grpc-images.yml
+++ b/.github/workflows/pr-smoke-test-grpc-images.yml
@@ -37,4 +37,5 @@ jobs:
           ./gradlew jibDockerBuild -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
           ./gradlew jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
           ./gradlew jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
+          ./gradlew jibDockerBuild -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
         working-directory: smoke-tests/images/grpc

--- a/.github/workflows/pr-smoke-test-quarkus-images.yml
+++ b/.github/workflows/pr-smoke-test-quarkus-images.yml
@@ -37,4 +37,5 @@ jobs:
         run: |
           ./gradlew jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
           ./gradlew jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
+          ./gradlew jibDockerBuild -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
         working-directory: smoke-tests/images/quarkus

--- a/.github/workflows/pr-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/pr-smoke-test-spring-boot-images.yml
@@ -37,4 +37,5 @@ jobs:
           ./gradlew jibDockerBuild -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
           ./gradlew jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
           ./gradlew jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
+          ./gradlew jibDockerBuild -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
         working-directory: smoke-tests/images/spring-boot

--- a/.github/workflows/publish-smoke-test-grpc-images.yml
+++ b/.github/workflows/publish-smoke-test-grpc-images.yml
@@ -49,6 +49,7 @@ jobs:
           ./gradlew jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
           ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
           ./gradlew jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          ./gradlew jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
         working-directory: smoke-tests/images/grpc
 
   issue:

--- a/.github/workflows/publish-smoke-test-quarkus-images.yml
+++ b/.github/workflows/publish-smoke-test-quarkus-images.yml
@@ -49,6 +49,7 @@ jobs:
           echo "Pushing to tag $TAG"
           ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
           ./gradlew jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          ./gradlew jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
         working-directory: smoke-tests/images/quarkus
 
   issue:

--- a/.github/workflows/publish-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/publish-smoke-test-spring-boot-images.yml
@@ -49,6 +49,7 @@ jobs:
           ./gradlew jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
           ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
           ./gradlew jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          ./gradlew jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
         working-directory: smoke-tests/images/spring-boot
 
   issue:

--- a/smoke-tests/images/grpc/build.gradle
+++ b/smoke-tests/images/grpc/build.gradle
@@ -42,6 +42,6 @@ def targetJDK = project.hasProperty("targetJDK") ? project.targetJDK : 11
 def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
-  from.image = "openjdk:$targetJDK-alpine"
+  from.image = "openjdk:$targetJDK"
   to.image = "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-grpc:jdk$targetJDK-$tag"
 }

--- a/smoke-tests/images/grpc/build.gradle
+++ b/smoke-tests/images/grpc/build.gradle
@@ -42,6 +42,6 @@ def targetJDK = project.hasProperty("targetJDK") ? project.targetJDK : 11
 def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
-  from.image = "bellsoft/liberica-openjdk-alpine:$targetJDK"
+  from.image = "openjdk:$targetJDK-alpine"
   to.image = "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-grpc:jdk$targetJDK-$tag"
 }

--- a/smoke-tests/images/play/build.gradle
+++ b/smoke-tests/images/play/build.gradle
@@ -39,7 +39,7 @@ def targetJDK = project.hasProperty("targetJDK") ? project.targetJDK : 11
 def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
-  from.image = "bellsoft/liberica-openjdk-alpine:$targetJDK"
+  from.image = "openjdk:$targetJDK-alpine"
   to.image = "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-play:jdk$targetJDK-$tag"
   container.mainClass = "play.core.server.ProdServerStart"
 }

--- a/smoke-tests/images/play/build.gradle
+++ b/smoke-tests/images/play/build.gradle
@@ -39,7 +39,7 @@ def targetJDK = project.hasProperty("targetJDK") ? project.targetJDK : 11
 def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
-  from.image = "openjdk:$targetJDK-alpine"
+  from.image = "openjdk:$targetJDK"
   to.image = "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-play:jdk$targetJDK-$tag"
   container.mainClass = "play.core.server.ProdServerStart"
 }

--- a/smoke-tests/images/quarkus/build.gradle
+++ b/smoke-tests/images/quarkus/build.gradle
@@ -33,7 +33,7 @@ def targetJDK = project.hasProperty("targetJDK") ? project.targetJDK : 11
 def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
-  from.image = "bellsoft/liberica-openjdk-alpine:$targetJDK"
+  from.image = "openjdk:$targetJDK-alpine"
   to.image = "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-quarkus:jdk$targetJDK-$tag"
   container {
     mainClass = 'bogus'  // to suppress Jib warning about missing main class

--- a/smoke-tests/images/quarkus/build.gradle
+++ b/smoke-tests/images/quarkus/build.gradle
@@ -33,7 +33,7 @@ def targetJDK = project.hasProperty("targetJDK") ? project.targetJDK : 11
 def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
-  from.image = "openjdk:$targetJDK-alpine"
+  from.image = "openjdk:$targetJDK"
   to.image = "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-quarkus:jdk$targetJDK-$tag"
   container {
     mainClass = 'bogus'  // to suppress Jib warning about missing main class

--- a/smoke-tests/images/servlet/build.gradle
+++ b/smoke-tests/images/servlet/build.gradle
@@ -123,10 +123,10 @@ def configureImage(Task parentTask, server, dockerfile, version, vm, jdk, warPro
 
   def jdkImage
   if (vm == "hotspot") {
-    if (jdk <= 17) {
-      jdkImage = "eclipse-temurin:${jdk}"
-    } else {
+    if (jdk == "18") {
       jdkImage = "openjdk:${jdk}"
+    } else {
+      jdkImage = "eclipse-temurin:${jdk}"
     }
   } else if (vm == "openj9") {
     jdkImage = "adoptopenjdk:${jdk}-openj9"

--- a/smoke-tests/images/servlet/build.gradle
+++ b/smoke-tests/images/servlet/build.gradle
@@ -40,7 +40,8 @@ def targets = [
   "liberty"  : [
     // running configure.sh is failing while building the image with Java 17
     [version: ["20.0.0.12"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "16"], args: [release: "2020-11-11_0736"]],
-    [version: ["21.0.0.10"], vm: ["hotspot"], jdk: ["8", "11", "17", "18"], args: [release: "2021-09-20_1900"]],
+    // running configure.sh is failing while building the image with Java 18
+    [version: ["21.0.0.10"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [release: "2021-09-20_1900"]],
     [version: ["21.0.0.10"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [release: "2021-09-20_1900"]]
   ],
   "payara"   : [

--- a/smoke-tests/images/servlet/build.gradle
+++ b/smoke-tests/images/servlet/build.gradle
@@ -30,17 +30,17 @@ tasks.create("pushMatrix", DockerPushImage) {
 // Dockerfile name, args key passes raw arguments to docker build
 def targets = [
   "jetty"    : [
-    [version: ["9.4.39"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [sourceVersion: "9.4.39.v20210325"]],
+    [version: ["9.4.39"], vm: ["hotspot"], jdk: ["8", "11", "17", "18"], args: [sourceVersion: "9.4.39.v20210325"]],
     [version: ["9.4.39"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [sourceVersion: "9.4.39.v20210325"]],
-    [version: ["10.0.7"], vm: ["hotspot"], jdk: ["11", "17"], args: [sourceVersion: "10.0.7"]],
+    [version: ["10.0.7"], vm: ["hotspot"], jdk: ["11", "17", "18"], args: [sourceVersion: "10.0.7"]],
     [version: ["10.0.7"], vm: ["openj9"], jdk: ["11", "16"], args: [sourceVersion: "10.0.7"]],
-    [version: ["11.0.7"], vm: ["hotspot"], jdk: ["11", "17"], args: [sourceVersion: "11.0.7"], war: "servlet-5.0"],
+    [version: ["11.0.7"], vm: ["hotspot"], jdk: ["11", "17", "18"], args: [sourceVersion: "11.0.7"], war: "servlet-5.0"],
     [version: ["11.0.7"], vm: ["openj9"], jdk: ["11", "16"], args: [sourceVersion: "11.0.7"], war: "servlet-5.0"]
   ],
   "liberty"  : [
     // running configure.sh is failing while building the image with Java 17
     [version: ["20.0.0.12"], vm: ["hotspot", "openj9"], jdk: ["8", "11", "16"], args: [release: "2020-11-11_0736"]],
-    [version: ["21.0.0.10"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [release: "2021-09-20_1900"]],
+    [version: ["21.0.0.10"], vm: ["hotspot"], jdk: ["8", "11", "17", "18"], args: [release: "2021-09-20_1900"]],
     [version: ["21.0.0.10"], vm: ["openj9"], jdk: ["8", "11", "16"], args: [release: "2021-09-20_1900"]]
   ],
   "payara"   : [
@@ -49,19 +49,19 @@ def targets = [
   ],
   "tomcat"   : [
     [version: ["7.0.109"], vm: ["hotspot", "openj9"], jdk: ["8"], args: [majorVersion: "7"]],
-    [version: ["8.5.72"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "8"]],
+    [version: ["8.5.72"], vm: ["hotspot"], jdk: ["8", "11", "17", "18"], args: [majorVersion: "8"]],
     [version: ["8.5.72"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "8"]],
-    [version: ["9.0.54"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "9"]],
+    [version: ["9.0.54"], vm: ["hotspot"], jdk: ["8", "11", "17", "18"], args: [majorVersion: "9"]],
     [version: ["9.0.54"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "9"]],
-    [version: ["10.0.12"], vm: ["hotspot"], jdk: ["8", "11", "17"], args: [majorVersion: "10"], war: "servlet-5.0"],
+    [version: ["10.0.12"], vm: ["hotspot"], jdk: ["8", "11", "17", "18"], args: [majorVersion: "10"], war: "servlet-5.0"],
     [version: ["10.0.12"], vm: ["openj9"], jdk: ["8", "11"], args: [majorVersion: "10"], war: "servlet-5.0"]
   ],
   "tomee"    : [
     [version: ["7.0.9"], vm: ["hotspot", "openj9"], jdk: ["8"]],
     [version: ["7.1.4"], vm: ["hotspot", "openj9"], jdk: ["8"]],
-    [version: ["8.0.8"], vm: ["hotspot"], jdk: ["8", "11", "17"]],
+    [version: ["8.0.8"], vm: ["hotspot"], jdk: ["8", "11", "17", "18"]],
     [version: ["8.0.8"], vm: ["openj9"], jdk: ["8", "11", "16"]],
-    [version: ["9.0.0-M7"], vm: ["hotspot"], jdk: ["8", "11", "17"], war: "servlet-5.0"],
+    [version: ["9.0.0-M7"], vm: ["hotspot"], jdk: ["8", "11", "17", "18"], war: "servlet-5.0"],
     [version: ["9.0.0-M7"], vm: ["openj9"], jdk: ["8", "11", "16"], war: "servlet-5.0"]
   ],
   "websphere": [
@@ -69,7 +69,7 @@ def targets = [
   ],
   "wildfly"  : [
     [version: ["13.0.0.Final"], vm: ["hotspot", "openj9"], jdk: ["8"]],
-    [version: ["17.0.1.Final", "21.0.0.Final", "25.0.1.Final"], vm: ["hotspot"], jdk: ["8", "11", "17"]],
+    [version: ["17.0.1.Final", "21.0.0.Final", "25.0.1.Final"], vm: ["hotspot"], jdk: ["8", "11", "17", "18"]],
     [version: ["17.0.1.Final", "21.0.0.Final", "25.0.1.Final"], vm: ["openj9"], jdk: ["8", "11", "16"]]
   ]
 ]
@@ -123,7 +123,11 @@ def configureImage(Task parentTask, server, dockerfile, version, vm, jdk, warPro
 
   def jdkImage
   if (vm == "hotspot") {
-    jdkImage = "eclipse-temurin:${jdk}"
+    if (jdk <= 17) {
+      jdkImage = "eclipse-temurin:${jdk}"
+    } else {
+      jdkImage = "openjdk:${jdk}"
+    }
   } else if (vm == "openj9") {
     jdkImage = "adoptopenjdk:${jdk}-openj9"
   } else {

--- a/smoke-tests/images/spring-boot/build.gradle
+++ b/smoke-tests/images/spring-boot/build.gradle
@@ -36,7 +36,7 @@ def targetJDK = project.hasProperty("targetJDK") ? project.targetJDK : 11
 def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
-  from.image = "openjdk:$targetJDK-alpine"
+  from.image = "openjdk:$targetJDK"
   to.image = "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-spring-boot:jdk$targetJDK-$tag"
   container.ports = ["8080"]
 }

--- a/smoke-tests/images/spring-boot/build.gradle
+++ b/smoke-tests/images/spring-boot/build.gradle
@@ -36,7 +36,7 @@ def targetJDK = project.hasProperty("targetJDK") ? project.targetJDK : 11
 def tag = findProperty("tag") ?: new Date().format("yyyyMMdd.HHmmSS")
 
 jib {
-  from.image = "bellsoft/liberica-openjdk-alpine:$targetJDK"
+  from.image = "openjdk:$targetJDK-alpine"
   to.image = "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-spring-boot:jdk$targetJDK-$tag"
   container.ports = ["8080"]
 }


### PR DESCRIPTION
@iNikem I know you like `bellsoft/liberica-openjdk-alpine` images, but the `openjdk` ones have all the early access releases (even `19-ea` already).