### PR TITLE
Fix npe in apache http client 4.0 instrumentation

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentation.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentation.java
@@ -257,6 +257,9 @@ public class ApacheHttpClientInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
       Context parentContext = currentContext();
+
+      otelRequest = new ApacheHttpClientRequest(host, request);
+
       if (!instrumenter().shouldStart(parentContext, otelRequest)) {
         return;
       }


### PR DESCRIPTION
NPE is logged when running some apache http client 4.0 tests. For example `trace request with callback and parent` in  `ApacheClientHostAbsoluteUriRequest`.