### PR TITLE
Cross test log4j javaagent instrumentation

### DIFF
--- a/instrumentation/log4j/log4j-2.16/javaagent/build.gradle.kts
+++ b/instrumentation/log4j/log4j-2.16/javaagent/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
 
   implementation(project(":instrumentation:log4j:log4j-2.16:library-autoconfigure"))
 
+  testInstrumentation(project(":instrumentation:log4j:log4j-2.7:javaagent"))
+
   testImplementation(project(":instrumentation:log4j:log4j-2-common:testing"))
 }
 

--- a/instrumentation/log4j/log4j-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/log4j/log4j-2.7/javaagent/build.gradle.kts
@@ -14,6 +14,8 @@ muzzle {
 dependencies {
   library("org.apache.logging.log4j:log4j-core:2.7")
 
+  testInstrumentation(project(":instrumentation:log4j:log4j-2.16:javaagent"))
+
   testImplementation(project(":instrumentation:log4j:log4j-2-common:testing"))
 
   latestDepTestLibrary("org.apache.logging.log4j:log4j-core:2.15.0")


### PR DESCRIPTION
It would probably pass even if both were applied since it would just overwrite the mdc, but a good practice to apply everywhere for consistency I think.