### PR TITLE
Retry rocketmq batch test when it fails

### DIFF
--- a/instrumentation/rocketmq-client-4.8/testing/src/main/groovy/io/opentelemetry/instrumentation/rocketmq/TracingMessageListener.groovy
+++ b/instrumentation/rocketmq-client-4.8/testing/src/main/groovy/io/opentelemetry/instrumentation/rocketmq/TracingMessageListener.groovy
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.rocketmq
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
 import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyContext
 import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus
 import org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly
@@ -13,9 +15,27 @@ import org.apache.rocketmq.common.message.MessageExt
 import static io.opentelemetry.instrumentation.test.utils.TraceUtils.runInternalSpan
 
 class TracingMessageListener implements MessageListenerOrderly {
+  private AtomicInteger lastBatchSize = new AtomicInteger()
+  private CountDownLatch messageReceived = new CountDownLatch(1)
+
   @Override
   ConsumeOrderlyStatus consumeMessage(List<MessageExt> list, ConsumeOrderlyContext consumeOrderlyContext) {
+    lastBatchSize.set(list.size())
+    messageReceived.countDown()
     runInternalSpan("messageListener")
     return ConsumeOrderlyStatus.SUCCESS
+  }
+
+  void reset() {
+    messageReceived = new CountDownLatch(1)
+    lastBatchSize.set(0)
+  }
+
+  void waitForMessages() {
+    messageReceived.await()
+  }
+
+  int getLastBatchSize() {
+    return lastBatchSize.get()
   }
 }


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.instrumentation.rocketmq.RocketMqClientTest&tests.sortField=FLAKY&tests.test=test%20rocketmq%20produce%20and%20batch%20consume&tests.unstableOnly=true
This is probably the most flaky test we have now. As far as I understand the issue is that this test should receive the 2 sent messages at the same time and process them as one batch, which doesn't seem to always happen. This pr adds a hack to retry sending the messages when they are not handled in together.