### PR TITLE
Ignore exceptions from closing jax-rs response

### DIFF
--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-common/javaagent/src/test/groovy/JaxRsClientTest.groovy
@@ -40,7 +40,9 @@ abstract class JaxRsClientTest extends HttpClientTest<Invocation.Builder> implem
     try {
       def body = BODY_METHODS.contains(method) ? Entity.text("") : null
       def response = request.build(method, body).invoke()
-      response.close()
+      try {
+        response.close()
+      } catch (IOException ignore) {}
       return response.status
     } catch (ProcessingException exception) {
       throw exception.getCause()


### PR DESCRIPTION
Apparently closing response can throw an IOException https://ge.opentelemetry.io/s/ngxxx45655pqi/tests/:instrumentation:jaxrs-client:jaxrs-client-2.0:jaxrs-client-2.0-common:javaagent:test/JerseyClientTest/basic%20request%20with%201%20redirect?expanded-stacktrace=WyIwLTEiXQ