### PR TITLE
Simplify the thread-safe handling of the globalLogEmitterProvider

### DIFF
--- a/instrumentation-api-appender/build.gradle.kts
+++ b/instrumentation-api-appender/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
   api("io.opentelemetry:opentelemetry-api")
 
   testImplementation("org.assertj:assertj-core")
+  testImplementation("org.mockito:mockito-core")
 }

--- a/instrumentation-api-appender/src/test/java/io/opentelemetry/instrumentation/api/appender/GlobalLogEmitterProviderTest.java
+++ b/instrumentation-api-appender/src/test/java/io/opentelemetry/instrumentation/api/appender/GlobalLogEmitterProviderTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.api.appender;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,7 +34,7 @@ class GlobalLogEmitterProviderTest {
   @Test
   void setThenSet() {
     setLogEmitterProvider();
-    assertThatThrownBy(() -> GlobalLogEmitterProvider.set(NoopLogEmitterProvider.INSTANCE))
+    assertThatThrownBy(() -> GlobalLogEmitterProvider.set(mock(LogEmitterProvider.class)))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("GlobalLogEmitterProvider.set has already been called")
         .hasStackTraceContaining("setLogEmitterProvider");
@@ -40,18 +42,23 @@ class GlobalLogEmitterProviderTest {
 
   @Test
   void getThenSet() {
-    assertThat(getLogEmitterProvider()).isInstanceOf(NoopLogEmitterProvider.class);
-    assertThatThrownBy(() -> GlobalLogEmitterProvider.set(NoopLogEmitterProvider.INSTANCE))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("GlobalLogEmitterProvider.set has already been called")
-        .hasStackTraceContaining("getLogEmitterProvider");
+    LogEmitterProvider existingProvider = GlobalLogEmitterProvider.get();
+    assertSame(existingProvider, NoopLogEmitterProvider.INSTANCE);
+    LogEmitterProvider newProvider = mock(LogEmitterProvider.class);
+    GlobalLogEmitterProvider.set(newProvider);
+    assertSame(newProvider, GlobalLogEmitterProvider.get());
   }
 
-  private static void setLogEmitterProvider() {
+  @Test
+  void okToSetNoopMultipleTimes() {
     GlobalLogEmitterProvider.set(NoopLogEmitterProvider.INSTANCE);
+    GlobalLogEmitterProvider.set(NoopLogEmitterProvider.INSTANCE);
+    GlobalLogEmitterProvider.set(NoopLogEmitterProvider.INSTANCE);
+    GlobalLogEmitterProvider.set(NoopLogEmitterProvider.INSTANCE);
+    // pass
   }
 
-  private static LogEmitterProvider getLogEmitterProvider() {
-    return GlobalLogEmitterProvider.get();
+  private void setLogEmitterProvider() {
+    GlobalLogEmitterProvider.set(mock(LogEmitterProvider.class));
   }
 }

--- a/instrumentation-api-appender/src/test/java/io/opentelemetry/instrumentation/api/appender/GlobalLogEmitterProviderTest.java
+++ b/instrumentation-api-appender/src/test/java/io/opentelemetry/instrumentation/api/appender/GlobalLogEmitterProviderTest.java
@@ -58,7 +58,7 @@ class GlobalLogEmitterProviderTest {
     // pass
   }
 
-  private void setLogEmitterProvider() {
+  private static void setLogEmitterProvider() {
     GlobalLogEmitterProvider.set(mock(LogEmitterProvider.class));
   }
 }


### PR DESCRIPTION
Follow-up on some comments in #4917 

@trask This should show what I was getting at with my comments before. There are two slight semantic differences with this approach: 1) calling `get()` before `set()` is ok, you just get the NoOp impl. 2) calling `set()` multiple times with the NoOp impl is fine. I think this is acceptable, but others could differ.

I completely understand if we don't want to do this because it's inconsistent with the others.