### PR TITLE
Temurin JDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Build
@@ -39,7 +39,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Build
@@ -67,13 +67,13 @@ jobs:
         name: Set up JDK ${{ matrix.test-java-version }}-${{ matrix.vm }} for running tests
         uses: actions/setup-java@v2
         with:
-          distribution: adopt-${{ matrix.vm }}
+          distribution: temurin-${{ matrix.vm }}
           java-version: ${{ matrix.test-java-version }}
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Test
@@ -95,7 +95,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Test
@@ -139,7 +139,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Test
@@ -164,7 +164,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -191,7 +191,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -219,7 +219,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Local publish of artifacts
@@ -271,7 +271,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Build and publish artifact snapshots

--- a/.github/workflows/nightly-codeql-analysis.yml
+++ b/.github/workflows/nightly-codeql-analysis.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Java 11
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Autobuild

--- a/.github/workflows/nightly-no-cache.yml
+++ b/.github/workflows/nightly-no-cache.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -39,7 +39,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -73,13 +73,13 @@ jobs:
         name: Set up JDK ${{ matrix.test-java-version }}-${{ matrix.vm }} for running tests
         uses: actions/setup-java@v2
         with:
-          distribution: adopt-${{ matrix.vm }}
+          distribution: temurin-${{ matrix.vm }}
           java-version: ${{ matrix.test-java-version }}
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -101,7 +101,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -145,7 +145,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -170,7 +170,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Build
@@ -39,7 +39,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Build
@@ -67,13 +67,13 @@ jobs:
         name: Set up JDK ${{ matrix.test-java-version }}-${{ matrix.vm }} for running tests
         uses: actions/setup-java@v2
         with:
-          distribution: adopt-${{ matrix.vm }}
+          distribution: temurin-${{ matrix.vm }}
           java-version: ${{ matrix.test-java-version }}
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Test
@@ -95,7 +95,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Test
@@ -139,7 +139,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Test
@@ -164,7 +164,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -191,7 +191,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -219,7 +219,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Local publish of artifacts

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -30,13 +30,13 @@ jobs:
         name: Set up JDK ${{ matrix.test-java-version }} for running tests
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: ${{ matrix.test-java-version }}
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Restore cache
@@ -91,7 +91,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Restore cache
@@ -124,7 +124,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -166,7 +166,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Build and publish artifacts

--- a/.github/workflows/pr-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/pr-smoke-test-fake-backend-images.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies
@@ -52,7 +52,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/pr-smoke-test-grpc-images.yml
+++ b/.github/workflows/pr-smoke-test-grpc-images.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/pr-smoke-test-play-images.yml
+++ b/.github/workflows/pr-smoke-test-play-images.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/pr-smoke-test-quarkus-images.yml
+++ b/.github/workflows/pr-smoke-test-quarkus-images.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/pr-smoke-test-servlet-images.yml
+++ b/.github/workflows/pr-smoke-test-servlet-images.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/pr-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/pr-smoke-test-spring-boot-images.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Start deadlock detector
@@ -55,7 +55,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Build
@@ -87,13 +87,13 @@ jobs:
         name: Set up JDK ${{ matrix.test-java-version }}-${{ matrix.vm }} for running tests
         uses: actions/setup-java@v2
         with:
-          distribution: adopt-${{ matrix.vm }}
+          distribution: temurin-${{ matrix.vm }}
           java-version: ${{ matrix.test-java-version }}
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Start deadlock detector
@@ -160,7 +160,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Test
@@ -182,7 +182,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -209,7 +209,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Run muzzle
@@ -231,7 +231,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Local publish of artifacts

--- a/.github/workflows/publish-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/publish-smoke-test-fake-backend-images.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies
@@ -65,7 +65,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/publish-smoke-test-grpc-images.yml
+++ b/.github/workflows/publish-smoke-test-grpc-images.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/publish-smoke-test-play-images.yml
+++ b/.github/workflows/publish-smoke-test-play-images.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/publish-smoke-test-quarkus-images.yml
+++ b/.github/workflows/publish-smoke-test-quarkus-images.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/publish-smoke-test-servlet-images.yml
+++ b/.github/workflows/publish-smoke-test-servlet-images.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/publish-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/publish-smoke-test-spring-boot-images.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache gradle dependencies

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -30,13 +30,13 @@ jobs:
         name: Set up JDK ${{ matrix.test-java-version }} for running tests
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: ${{ matrix.test-java-version }}
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Restore cache
@@ -91,7 +91,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Restore cache
@@ -124,7 +124,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Cache Gradle Wrapper
@@ -167,7 +167,7 @@ jobs:
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Build and publish artifacts


### PR DESCRIPTION
https://github.com/actions/setup-java/blob/main/README.md

NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates.
