### PR TITLE
Add muzzle option to override version limit

### DIFF
--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 }
 
 // Select a random set of versions to test
-val RANGE_COUNT_LIMIT = 10
+val RANGE_COUNT_LIMIT = Integer.getInteger("otel.javaagent.muzzle.versions.limit", 10)
 
 val muzzleConfig = extensions.create<MuzzleExtension>("muzzle")
 


### PR DESCRIPTION
Occasionally useful for verifying all versions locally, enable with

```
./gradlew :instrumentation:[...]:javaagent:muzzle -Dotel.javaagent.muzzle.versions.limit=1000
```