### PR TITLE
Update library autoconfigure artifact names

### DIFF
--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
   id("otel.library-instrumentation")
 }
 
+base.archivesName.set("apache-dubbo-autoconfigure-2.7")
+
 dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   id("otel.library-instrumentation")
 }
 
-base.archivesName.set("${base.archivesName.get()}-autoconfigure")
+base.archivesName.set("aws-sdk-autoconfigure-1.11")
 
 dependencies {
   implementation(project(":instrumentation:aws-sdk:aws-sdk-1.11:library"))

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   id("otel.library-instrumentation")
 }
 
-base.archivesName.set("${base.archivesName.get()}-autoconfigure")
+base.archivesName.set("aws-sdk-autoconfigure-2.2")
 
 dependencies {
   implementation(project(":instrumentation:aws-sdk:aws-sdk-2.2:library"))

--- a/instrumentation/log4j/log4j-thread-context/log4j-thread-context-2.16/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/log4j/log4j-thread-context/log4j-thread-context-2.16/library-autoconfigure/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   id("otel.library-instrumentation")
 }
 
-base.archivesName.set("${base.archivesName.get()}-autoconfigure")
+base.archivesName.set("log4j-thread-context-autoconfigure-2.16")
 
 dependencies {
   library("org.apache.logging.log4j:log4j-core:2.16.0")


### PR DESCRIPTION
Update artifact names for the `library-autoconfigure` artifacts:
* apache-dubbo-2.7-autoconfigure -> apache-dubbo-autoconfigure-2.7
* aws-sdk-1.11-autoconfigure -> aws-sdk-autoconfigure-1.11
* aws-sdk-2.2-autoconfigure -> aws-sdk-autoconfigure-2.2
* log4j-thread-context-2.16-autoconfigure -> log4j-thread-context-autoconfigure-2.16

The previous name could make sense too (it's `-autoconfigure` appended on to the artifact name that it autoconfigures, except I guess for dubbo which doesn't have a non-autoconfigure artifact yet).

But I think keeping the base version at the end seems better for consistency of this (already weird) artifact naming.