### PR TITLE
Remove test that doesn't seem to check what is intended

### DIFF
--- a/javaagent/src/test/groovy/io/opentelemetry/javaagent/classloading/ClassLoadingTest.groovy
+++ b/javaagent/src/test/groovy/io/opentelemetry/javaagent/classloading/ClassLoadingTest.groovy
@@ -94,25 +94,4 @@ class ClassLoadingTest extends Specification {
     loader2.count > 0
     loader1.count == loader2.count
   }
-
-  def "can find classes but not resources loaded onto the bootstrap classpath"() {
-    expect:
-    Class.forName(name) != null
-
-    // Resources from bootstrap injected jars can't be loaded.
-    // https://github.com/raphw/byte-buddy/pull/496
-    if (onTestClasspath) {
-      assert ClassLoader.getSystemClassLoader().getResource(resource) != null
-    } else {
-      assert ClassLoader.getSystemClassLoader().getResource(resource) == null
-    }
-
-
-    where:
-    name                                                                 | onTestClasspath
-    "io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge" | true
-    // This test case fails on ibm j9.  Perhaps this rule only applies to OpenJdk based jvms?
-//    "io.opentelemetry.javaagent.instrumentation.api.concurrent.State" | false
-    resource = name.replace(".", "/") + ".class"
-  }
 }


### PR DESCRIPTION
Happened to randomly read this file and could make no sense of this test.

`onTestClasspath` is set to true even though the class isn't on the test classpath, it's in the agent (using debugger on the result of `getResource()` it is obviously reading from the agent jar). This probably predates our usage of a real javaagent for tests.

`.concurrent.State` doesn't exist anymore so I tried `PropagatedContext` in a debugger, and saw the same behavior with Java8BytecodeBridge, can load class, can get resource. The title of the test says "can find classes but not resources" which doesn't seem to ever apply at least in this test code.

Blame shows glassfish-related commits from 3 years ago, I suspect our glassfish smoke tests are doing the needed job while this test doesn't seem to test anything important.