### PR TITLE
Fix time units in HTTP & RPC metrics

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
@@ -54,7 +54,7 @@ public final class HttpClientMetrics implements RequestListener {
     duration =
         meter
             .histogramBuilder("http.client.duration")
-            .setUnit("milliseconds")
+            .setUnit("ms")
             .setDescription("The duration of the outbound HTTP request")
             .build();
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
@@ -64,7 +64,7 @@ public final class HttpServerMetrics implements RequestListener {
     duration =
         meter
             .histogramBuilder("http.server.duration")
-            .setUnit("milliseconds")
+            .setUnit("ms")
             .setDescription("The duration of the inbound HTTP request")
             .build();
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientMetrics.java
@@ -45,7 +45,7 @@ public final class RpcClientMetrics implements RequestListener {
         meter
             .histogramBuilder("rpc.client.duration")
             .setDescription("The duration of an outbound RPC invocation")
-            .setUnit("milliseconds")
+            .setUnit("ms")
             .build();
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetrics.java
@@ -45,7 +45,7 @@ public final class RpcServerMetrics implements RequestListener {
         meter
             .histogramBuilder("rpc.server.duration")
             .setDescription("The duration of an inbound RPC invocation")
-            .setUnit("milliseconds")
+            .setUnit("ms")
             .build();
   }
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsTest.java
@@ -93,6 +93,7 @@ class HttpClientMetricsTest {
                       metric ->
                           assertThat(metric)
                               .hasName("http.client.duration")
+                              .hasUnit("ms")
                               .hasDoubleHistogram()
                               .points()
                               .satisfiesExactly(

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsTest.java
@@ -132,6 +132,7 @@ class HttpServerMetricsTest {
                       metric ->
                           assertThat(metric)
                               .hasName("http.server.duration")
+                              .hasUnit("ms")
                               .hasDoubleHistogram()
                               .points()
                               .satisfiesExactly(

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientMetricsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientMetricsTest.java
@@ -99,6 +99,7 @@ class RpcClientMetricsTest {
                       metric ->
                           MetricAssertions.assertThat(metric)
                               .hasName("rpc.client.duration")
+                              .hasUnit("ms")
                               .hasDoubleHistogram()
                               .points()
                               .satisfiesExactly(
@@ -132,6 +133,7 @@ class RpcClientMetricsTest {
                       metric ->
                           MetricAssertions.assertThat(metric)
                               .hasName("rpc.client.duration")
+                              .hasUnit("ms")
                               .hasDoubleHistogram()
                               .points()
                               .satisfiesExactly(

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetricsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetricsTest.java
@@ -99,6 +99,7 @@ class RpcServerMetricsTest {
                       metric ->
                           MetricAssertions.assertThat(metric)
                               .hasName("rpc.server.duration")
+                              .hasUnit("ms")
                               .hasDoubleHistogram()
                               .points()
                               .satisfiesExactly(
@@ -131,6 +132,7 @@ class RpcServerMetricsTest {
                       metric ->
                           MetricAssertions.assertThat(metric)
                               .hasName("rpc.server.duration")
+                              .hasUnit("ms")
                               .hasDoubleHistogram()
                               .points()
                               .satisfiesExactly(


### PR DESCRIPTION
`s/milliseconds/ms/`