### PR TITLE
Fix codenarc

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -121,6 +121,9 @@ dependencies {
   testImplementation("org.slf4j:jcl-over-slf4j")
   testImplementation("org.slf4j:jul-to-slf4j")
   testImplementation("com.github.stefanbirkner:system-rules")
+
+  codenarc("org.codenarc:CodeNarc:2.2.0")
+  codenarc(platform("org.codehaus.groovy:groovy-bom:3.0.9"))
 }
 
 tasks {
@@ -283,7 +286,6 @@ afterEvaluate {
 
 codenarc {
   configFile = rootProject.file("buildscripts/codenarc.groovy")
-  toolVersion = "2.0.0"
 }
 
 checkstyle {

--- a/instrumentation/java-util-logging/javaagent/src/test/groovy/JavaUtilLoggingTest.groovy
+++ b/instrumentation/java-util-logging/javaagent/src/test/groovy/JavaUtilLoggingTest.groovy
@@ -55,7 +55,7 @@ class JavaUtilLoggingTest extends AgentInstrumentationSpecification {
       assertThat(log.getSeverity()).isEqualTo(severity)
       assertThat(log.getSeverityText()).isEqualTo(severityText)
       if (exception) {
-        assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo(IllegalStateException.class.getName())
+        assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo(IllegalStateException.getName())
         assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_MESSAGE)).isEqualTo("hello")
         assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_STACKTRACE)).contains(JavaUtilLoggingTest.name)
       } else {

--- a/instrumentation/log4j/log4j-appender-1.2/javaagent/src/test/groovy/Log4j1Test.groovy
+++ b/instrumentation/log4j/log4j-appender-1.2/javaagent/src/test/groovy/Log4j1Test.groovy
@@ -53,7 +53,7 @@ class Log4j1Test extends AgentInstrumentationSpecification {
       assertThat(log.getSeverity()).isEqualTo(severity)
       assertThat(log.getSeverityText()).isEqualTo(severityText)
       if (exception) {
-        assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo(IllegalStateException.class.getName())
+        assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo(IllegalStateException.getName())
         assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_MESSAGE)).isEqualTo("hello")
         assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_STACKTRACE)).contains(Log4j1Test.name)
       } else {

--- a/instrumentation/log4j/log4j-appender-2.16/javaagent/src/test/groovy/Log4j2Test.groovy
+++ b/instrumentation/log4j/log4j-appender-2.16/javaagent/src/test/groovy/Log4j2Test.groovy
@@ -56,7 +56,7 @@ class Log4j2Test extends AgentInstrumentationSpecification {
       assertThat(log.getSeverity()).isEqualTo(severity)
       assertThat(log.getSeverityText()).isEqualTo(severityText)
       if (exception) {
-        assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo(IllegalStateException.class.getName())
+        assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo(IllegalStateException.getName())
         assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_MESSAGE)).isEqualTo("hello")
         assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_STACKTRACE)).contains(Log4j2Test.name)
       } else {
@@ -93,12 +93,12 @@ class Log4j2Test extends AgentInstrumentationSpecification {
 
   def "test context data"() {
     when:
-    ThreadContext.put("key1", "val1");
-    ThreadContext.put("key2", "val2");
+    ThreadContext.put("key1", "val1")
+    ThreadContext.put("key2", "val2")
     try {
       logger.info("xyz")
     } finally {
-      ThreadContext.clearMap();
+      ThreadContext.clearMap()
     }
 
     then:

--- a/instrumentation/logback/logback-appender-1.0/javaagent/src/test/groovy/LogbackTest.groovy
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/src/test/groovy/LogbackTest.groovy
@@ -16,8 +16,8 @@ import static org.awaitility.Awaitility.await
 
 class LogbackTest extends AgentInstrumentationSpecification {
 
-  private static final Logger abcLogger = LoggerFactory.getLogger("abc");
-  private static final Logger defLogger = LoggerFactory.getLogger("def");
+  private static final Logger abcLogger = LoggerFactory.getLogger("abc")
+  private static final Logger defLogger = LoggerFactory.getLogger("def")
 
   @Unroll
   def "test logger=#loggerName method=#testMethod with exception=#exception and parent=#parent"() {
@@ -55,7 +55,7 @@ class LogbackTest extends AgentInstrumentationSpecification {
       assertThat(log.getSeverity()).isEqualTo(severity)
       assertThat(log.getSeverityText()).isEqualTo(severityText)
       if (exception) {
-        assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo(IllegalStateException.class.getName())
+        assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_TYPE)).isEqualTo(IllegalStateException.getName())
         assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_MESSAGE)).isEqualTo("hello")
         assertThat(log.getAttributes().get(SemanticAttributes.EXCEPTION_STACKTRACE)).contains(LogbackTest.name)
       } else {


### PR DESCRIPTION
codenarc was failing (but not failing the build) when there was groovy 3.0 code in the test (e.g. lambdas)