### PR TITLE
Generate jApiCmp report under the build folder

### DIFF
--- a/conventions/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -73,7 +73,7 @@ tasks {
     packageExcludes = listOf("*.internal", "*.internal.*")
     val baseVersionString = if (apiBaseVersion == null) "latest" else baselineVersion
     val newVersionString = if (apiNewVersion == null) "current" else apiNewVersion
-    txtOutputFile = file("$rootDir/docs/apidiffs/${newVersionString}_vs_${baseVersionString}/${base.archivesName.get()}.txt")
+    txtOutputFile = file("$buildDir/apidiffs/${newVersionString}_vs_${baseVersionString}/${base.archivesName.get()}.txt")
   }
   // have the check task depend on the api comparison task, to make it more likely it will get used.
   named("check") {


### PR DESCRIPTION
Otherwise those reports live in some limbo space. Being outside of the build folder, they are not cleaned by `gradle clean`. At the same time they are not added to git. Until we establish a proper workflow around them, let them be generated under the `build` folder.