### PR TITLE
Add settings docs for instrumentations

### DIFF
--- a/instrumentation/apache-camel-2.20/README.md
+++ b/instrumentation/apache-camel-2.20/README.md
@@ -1,0 +1,5 @@
+# Settings for the Apache Camel instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.apache-camel.experimental-span-attributes` | Boolean | `false` | Enables the capture of span attributes (experimental).  |

--- a/instrumentation/apache-camel-2.20/README.md
+++ b/instrumentation/apache-camel-2.20/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.apache-camel.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental).  |
+| `otel.instrumentation.apache-camel.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes.  |

--- a/instrumentation/apache-camel-2.20/README.md
+++ b/instrumentation/apache-camel-2.20/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.apache-camel.experimental-span-attributes` | Boolean | `false` | Enables the capture of span attributes (experimental).  |
+| `otel.instrumentation.apache-camel.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental).  |

--- a/instrumentation/aws-sdk/README.md
+++ b/instrumentation/aws-sdk/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.aws-sdk.experimental-span-attributes` | Boolean | `false` | Enables the capture of span attributes (experimental). |
+| `otel.instrumentation.aws-sdk.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/aws-sdk/README.md
+++ b/instrumentation/aws-sdk/README.md
@@ -1,0 +1,5 @@
+# Settings for the AWS SDK instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.aws-sdk.experimental-span-attributes` | Boolean | `false` | Enables the capture of span attributes (experimental). |

--- a/instrumentation/aws-sdk/README.md
+++ b/instrumentation/aws-sdk/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.aws-sdk.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.aws-sdk.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/couchbase/README.md
+++ b/instrumentation/couchbase/README.md
@@ -1,0 +1,5 @@
+# Settings for the Couchbase instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.couchbase.experimental-span-attributes` | Boolean | `false` | Enables the capture of span attributes (experimental for version 2.6 and higher of this instrumentation). |

--- a/instrumentation/couchbase/README.md
+++ b/instrumentation/couchbase/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.couchbase.experimental-span-attributes` | Boolean | `false` | Enables the capture of span attributes (experimental for version 2.6 and higher of this instrumentation). |
+| `otel.instrumentation.couchbase.experimental-span-attributes` | Boolean | `false` | Enables the capture of experimental span attributes (for version 2.6 and higher of this instrumentation). |

--- a/instrumentation/elasticsearch/README.md
+++ b/instrumentation/elasticsearch/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.elasticsearch.experimental-span-attributes` | `Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.elasticsearch.experimental-span-attributes` | `Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/elasticsearch/README.md
+++ b/instrumentation/elasticsearch/README.md
@@ -1,0 +1,5 @@
+# Settings for the elasticsearch instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.elasticsearch.experimental-span-attributes` | `Boolean | `false` | Enables the capture of span attributes (experimental). |

--- a/instrumentation/elasticsearch/README.md
+++ b/instrumentation/elasticsearch/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.elasticsearch.experimental-span-attributes` | `Boolean | `false` | Enables the capture of span attributes (experimental). |
+| `otel.instrumentation.elasticsearch.experimental-span-attributes` | `Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/executors/README.md
+++ b/instrumentation/executors/README.md
@@ -2,5 +2,5 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.executors.include` | Boolean | `false` | Whether to include property names. |
+| `otel.instrumentation.executors.include` | List | Empty | List of `Executor` subclasses to be instrumented. |
 | `otel.instrumentation.executors.include-all` | Boolean | `false` | Whether to instrument all classes that implement the `Executor` interface. |

--- a/instrumentation/executors/README.md
+++ b/instrumentation/executors/README.md
@@ -3,4 +3,4 @@
 | System property | Type | Default | Description |
 |---|---|---|---|
 | `otel.instrumentation.executors.include` | Boolean | `false` | Whether to include property names. |
-| `otel.instrumentation.executors.include-all` | Boolean | `false` | Whether to include both executors and prefixes. |
+| `otel.instrumentation.executors.include-all` | Boolean | `false` | Whether to instrument all classes that implement the `Executor` interface. |

--- a/instrumentation/executors/README.md
+++ b/instrumentation/executors/README.md
@@ -1,0 +1,6 @@
+# Settings for the executors instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.executors.include` | Boolean | `false` | Whether to include property names. |
+| `otel.instrumentation.executors.include-all` | Boolean | `false` | Whether to include both executors and prefixes. |

--- a/instrumentation/external-annotations/README.md
+++ b/instrumentation/external-annotations/README.md
@@ -1,0 +1,6 @@
+# Settings for the external annotations instrumentation
+
+| System property 	| Environment variable 	| Type 	| Default 	| Description 	|
+|-----------------	|----------------------	|------	|---------	|-------------	|
+| `otel.instrumentation.external-annotations.include` | `TRACE_ANNOTATIONS_CONFIG` | String	| Default annotations | Configuration for trace annotations, in the form of a pattern that matches `'package.Annotation$Name;*'`.
+| `otel.instrumentation.external-annotations.exclude-methods` | `TRACE_ANNOTATED_METHODS_EXCLUDE_CONFIG` | String | |  All methods to be excluded from auto-instrumentation by annotation-based advices. |

--- a/instrumentation/external-annotations/README.md
+++ b/instrumentation/external-annotations/README.md
@@ -1,6 +1,6 @@
 # Settings for the external annotations instrumentation
 
-| System property 	| Environment variable 	| Type 	| Default 	| Description 	|
-|-----------------	|----------------------	|------	|---------	|-------------	|
-| `otel.instrumentation.external-annotations.include` | `TRACE_ANNOTATIONS_CONFIG` | String	| Default annotations | Configuration for trace annotations, in the form of a pattern that matches `'package.Annotation$Name;*'`.
-| `otel.instrumentation.external-annotations.exclude-methods` | `TRACE_ANNOTATED_METHODS_EXCLUDE_CONFIG` | String | |  All methods to be excluded from auto-instrumentation by annotation-based advices. |
+| System property 	| Type 	| Default 	| Description 	|
+|-----------------	|------	|---------	|-------------	|
+| `otel.instrumentation.external-annotations.include` | String	| Default annotations | Configuration for trace annotations, in the form of a pattern that matches `'package.Annotation$Name;*'`.
+| `otel.instrumentation.external-annotations.exclude-methods` | String |  | All methods to be excluded from auto-instrumentation by annotation-based advices. |

--- a/instrumentation/grpc-1.6/README.md
+++ b/instrumentation/grpc-1.6/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.grpc.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.grpc.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/grpc-1.6/README.md
+++ b/instrumentation/grpc-1.6/README.md
@@ -1,0 +1,5 @@
+# Settings for the gRPC instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.grpc.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/guava-10.0/README.md
+++ b/instrumentation/guava-10.0/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.guava.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.guava.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/guava-10.0/README.md
+++ b/instrumentation/guava-10.0/README.md
@@ -1,0 +1,5 @@
+# Settings for the Guava instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.guava.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/hibernate/README.md
+++ b/instrumentation/hibernate/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.hibernate.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.hibernate.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/hibernate/README.md
+++ b/instrumentation/hibernate/README.md
@@ -1,0 +1,5 @@
+# Settings for the Hibernate instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.hibernate.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/hystrix-1.4/javaagent/README.md
+++ b/instrumentation/hystrix-1.4/javaagent/README.md
@@ -1,0 +1,5 @@
+# Settings for the Hystrix instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.hystrix.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/hystrix-1.4/javaagent/README.md
+++ b/instrumentation/hystrix-1.4/javaagent/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.hystrix.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.hystrix.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/jaxrs/README.md
+++ b/instrumentation/jaxrs/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.jaxrs.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.jaxrs.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/jaxrs/README.md
+++ b/instrumentation/jaxrs/README.md
@@ -1,0 +1,5 @@
+# Settings for the Jaxrs instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.jaxrs.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/jsp-2.3/README.md
+++ b/instrumentation/jsp-2.3/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.jsp.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.jsp.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/jsp-2.3/README.md
+++ b/instrumentation/jsp-2.3/README.md
@@ -1,0 +1,5 @@
+# Settings for the JSP instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.jsp.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/kafka/kafka-clients/README.md
+++ b/instrumentation/kafka/kafka-clients/README.md
@@ -2,5 +2,5 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |
 | `otel.instrumentation.kafka.client-propagation.enabled` | Boolean | `true` | Enables remote context propagation via Kafka message headers. |

--- a/instrumentation/kafka/kafka-clients/README.md
+++ b/instrumentation/kafka/kafka-clients/README.md
@@ -3,4 +3,4 @@
 | System property | Type | Default | Description |
 |---|---|---|---|
 | `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
-| `otel.instrumentation.kafka.client-propagation.enabled` | Boolean | `true` | Enables client propagation. |
+| `otel.instrumentation.kafka.client-propagation.enabled` | Boolean | `true` | Enables remote context propagation via Kafka message headers. |

--- a/instrumentation/kafka/kafka-clients/README.md
+++ b/instrumentation/kafka/kafka-clients/README.md
@@ -1,0 +1,6 @@
+# Settings for the Kafka client instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.kafka.client-propagation.enabled` | Boolean | `true` | Enables client propagation. |

--- a/instrumentation/kubernetes-client-7.0/README.md
+++ b/instrumentation/kubernetes-client-7.0/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.kubernetes-client.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.kubernetes-client.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/kubernetes-client-7.0/README.md
+++ b/instrumentation/kubernetes-client-7.0/README.md
@@ -1,0 +1,5 @@
+# Settings for the Kubernetes client instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.kubernetes-client.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/lettuce/README.md
+++ b/instrumentation/lettuce/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.lettuce.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.lettuce.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/lettuce/README.md
+++ b/instrumentation/lettuce/README.md
@@ -1,0 +1,5 @@
+# Settings for the Lettuce instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.lettuce.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/methods/README.md
+++ b/instrumentation/methods/README.md
@@ -2,4 +2,4 @@
 
 | System property 	| Type 	| Default 	| Description 	|
 |-----------------	|------	|---------	|-------------	|
-| `otel.instrumentation.methods.include` | String| None | List of methods to include for tracing. An empty lists doesn't generate any TypeInstrumentation for muzzle to analyze. |
+| `otel.instrumentation.methods.include` | String| None | List of methods to include for tracing. See [Creating spans around methods with otel.instrumentation.methods.include](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/manual-instrumentation.md#creating-spans-around-methods-with-otelinstrumentationmethodsinclude). |

--- a/instrumentation/methods/README.md
+++ b/instrumentation/methods/README.md
@@ -2,4 +2,4 @@
 
 | System property 	| Type 	| Default 	| Description 	|
 |-----------------	|------	|---------	|-------------	|
-| `otel.instrumentation.methods.include` | String| None | List of methods to include for tracing. See [Creating spans around methods with otel.instrumentation.methods.include](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/manual-instrumentation.md#creating-spans-around-methods-with-otelinstrumentationmethodsinclude). |
+| `otel.instrumentation.methods.include` | String| None | List of methods to include for tracing. See [Creating spans around methods with `otel.instrumentation.methods.include`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/manual-instrumentation.md#creating-spans-around-methods-with-otelinstrumentationmethodsinclude). |

--- a/instrumentation/methods/README.md
+++ b/instrumentation/methods/README.md
@@ -1,0 +1,5 @@
+# Settings for the methods instrumentation
+
+| System property 	| Type 	| Default 	| Description 	|
+|-----------------	|------	|---------	|-------------	|
+| `otel.instrumentation.methods.include` | String| None | List of methods to include for tracing. An empty lists doesn't generate any TypeInstrumentation for muzzle to analyze. |

--- a/instrumentation/netty/README.md
+++ b/instrumentation/netty/README.md
@@ -2,5 +2,5 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.netty.always-create-connect-span` | Boolean | `false` | Enable the creation of Connect spans by default for Netty 4.0 and higher instrumentation. |
+| `otel.instrumentation.netty.always-create-connect-span` | Boolean | `false` | Enable the creation of Connect and DNS spans by default for Netty 4.0 and higher instrumentation. |
 | `otel.instrumentation.netty.ssl-telemetry.enabled` | Boolean | `false ` | Enable SSL telemetry for Netty 4.0 and higher instrumentation. |

--- a/instrumentation/netty/README.md
+++ b/instrumentation/netty/README.md
@@ -1,0 +1,6 @@
+# Settings for the Netty instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.netty.always-create-connect-span` | Boolean | `false` | Enable the creation of Connect spans by default for Netty 4.0 and higher instrumentation. |
+| `otel.instrumentation.netty.ssl-telemetry.enabled` | Boolean | `false ` | Enable SSL telemetry for Netty 4.0 and higher instrumentation. |

--- a/instrumentation/opentelemetry-annotations-1.0/README.md
+++ b/instrumentation/opentelemetry-annotations-1.0/README.md
@@ -2,5 +2,4 @@
 
 | Environment variable 	| Type 	| Default 	| Description 	|
 |-----------------	|------	|---------	|-------------	|
-| `TRACE_ANNOTATED_METHODS_EXCLUDE_CONFIG` | String |  | All methods to be excluded from auto-instrumentation by annotation-based advices. |
 | `otel.instrumentation.external-annotations.exclude-methods` | String |  | All methods to be excluded from auto-instrumentation by annotation-based advices. |

--- a/instrumentation/opentelemetry-annotations-1.0/README.md
+++ b/instrumentation/opentelemetry-annotations-1.0/README.md
@@ -1,0 +1,5 @@
+# Settings for the OpenTelemetry Annotations integration
+
+| Environment variable 	| Type 	| Default 	| Description 	|
+|-----------------	|------	|---------	|-------------	|
+| `TRACE_ANNOTATED_METHODS_EXCLUDE_CONFIG` | String |  | All methods to be excluded from auto-instrumentation by annotation-based advices. |

--- a/instrumentation/opentelemetry-annotations-1.0/README.md
+++ b/instrumentation/opentelemetry-annotations-1.0/README.md
@@ -3,3 +3,4 @@
 | Environment variable 	| Type 	| Default 	| Description 	|
 |-----------------	|------	|---------	|-------------	|
 | `TRACE_ANNOTATED_METHODS_EXCLUDE_CONFIG` | String |  | All methods to be excluded from auto-instrumentation by annotation-based advices. |
+| `otel.instrumentation.external-annotations.exclude-methods` | String |  | All methods to be excluded from auto-instrumentation by annotation-based advices. |

--- a/instrumentation/rabbitmq-2.7/README.md
+++ b/instrumentation/rabbitmq-2.7/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.rabbitmq.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.rabbitmq.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/rabbitmq-2.7/README.md
+++ b/instrumentation/rabbitmq-2.7/README.md
@@ -1,0 +1,5 @@
+# Settings for the RabbitMQ instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.rabbitmq.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/reactor/reactor-3.1/README.md
+++ b/instrumentation/reactor/reactor-3.1/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.reactor.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.reactor.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |

--- a/instrumentation/reactor/reactor-3.1/README.md
+++ b/instrumentation/reactor/reactor-3.1/README.md
@@ -1,0 +1,5 @@
+# Settings for the Reactor 3.1 instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.reactor.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |

--- a/instrumentation/reactor/reactor-netty/README.md
+++ b/instrumentation/reactor/reactor-netty/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.reactor-netty.always-create-connect-span` | Boolean | `false` | Enable the creation of Connect spans by default. |
+| `otel.instrumentation.reactor-netty.always-create-connect-span` | Boolean | `false` | Enable the creation of Connect and DNS spans by default. |

--- a/instrumentation/reactor/reactor-netty/README.md
+++ b/instrumentation/reactor/reactor-netty/README.md
@@ -1,0 +1,5 @@
+# Settings for the Reactor Netty instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.reactor-netty.always-create-connect-span` | Boolean | `false` | Enable the creation of Connect spans by default. |

--- a/instrumentation/rocketmq-client-4.8/README.md
+++ b/instrumentation/rocketmq-client-4.8/README.md
@@ -3,4 +3,4 @@
 | System property | Type | Default | Description |
 |---|---|---|---|
 | `otel.instrumentation.rocketmq-client.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |
-| `otel.instrumentation.rocketmq-client.propagation` | Boolean | `true` | Enables remote context propagation via Kafka message headers. |
+| `otel.instrumentation.rocketmq-client.propagation` | Boolean | `true` | Enables remote context propagation via RocketMQ message headers. |

--- a/instrumentation/rocketmq-client-4.8/README.md
+++ b/instrumentation/rocketmq-client-4.8/README.md
@@ -1,0 +1,6 @@
+# Settings for the Apache RocketMQ client instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.rocketmq-client.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.rocketmq-client.propagation` | Boolean | `true` | Enable propagation. |

--- a/instrumentation/rocketmq-client-4.8/README.md
+++ b/instrumentation/rocketmq-client-4.8/README.md
@@ -2,5 +2,5 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.rocketmq-client.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
-| `otel.instrumentation.rocketmq-client.propagation` | Boolean | `true` | Enable propagation. |
+| `otel.instrumentation.rocketmq-client.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |
+| `otel.instrumentation.rocketmq-client.propagation` | Boolean | `true` | Enables remote context propagation via Kafka message headers. |

--- a/instrumentation/rxjava/README.md
+++ b/instrumentation/rxjava/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.rxjava.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental) for RxJava 2 and 3 instrumentation. |
+| `otel.instrumentation.rxjava.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes for RxJava 2 and 3 instrumentation. |

--- a/instrumentation/rxjava/README.md
+++ b/instrumentation/rxjava/README.md
@@ -1,0 +1,5 @@
+# Settings for the RxJava instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.rxjava.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental) for RxJava 2 and 3 instrumentation. |

--- a/instrumentation/servlet/README.md
+++ b/instrumentation/servlet/README.md
@@ -5,7 +5,7 @@
 | System property | Type | Default | Description |
 |---|---|---|---|
 | `otel.instrumentation.servlet.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
- `otel.instrumentation.servlet.experimental.capture-request-parameters` | List | Request parameters to be captured (experimental). |
+ `otel.instrumentation.servlet.experimental.capture-request-parameters` | List | Empty | Request parameters to be captured (experimental). |
 
 ## A word about version
 

--- a/instrumentation/servlet/README.md
+++ b/instrumentation/servlet/README.md
@@ -1,5 +1,12 @@
 # Instrumentation for Java Servlets
 
+# Settings
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.servlet.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+ `otel.instrumentation.servlet.experimental.capture-request-parameters` | List | Request parameters to be captured (experimental). |
+
 ## A word about version
 
 We support Servlet API starting from version 2.2. 

--- a/instrumentation/servlet/README.md
+++ b/instrumentation/servlet/README.md
@@ -5,7 +5,7 @@
 | System property | Type | Default | Description |
 |---|---|---|---|
 | `otel.instrumentation.servlet.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
- `otel.instrumentation.servlet.experimental.capture-request-parameters` | List | Empty | Request parameters to be captured (experimental). |
+| `otel.instrumentation.servlet.experimental.capture-request-parameters` | List | Empty | Request parameters to be captured (experimental). |
 
 ## A word about version
 

--- a/instrumentation/servlet/README.md
+++ b/instrumentation/servlet/README.md
@@ -4,7 +4,7 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.servlet.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental). |
+| `otel.instrumentation.servlet.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |
 | `otel.instrumentation.servlet.experimental.capture-request-parameters` | List | Empty | Request parameters to be captured (experimental). |
 
 ## A word about version

--- a/instrumentation/spring/README.md
+++ b/instrumentation/spring/README.md
@@ -16,7 +16,7 @@ In this guide we will be using a running example. In section one and two, we wil
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.spring-integration.global-channel-interceptor-patterns` | List | `*` | List of Spring singletons to be captured. |
+| `otel.instrumentation.spring-integration.global-channel-interceptor-patterns` | List | `*` | An array of Spring channel name patterns that will be intercepted. See [Spring Integration docs](https://docs.spring.io/spring-integration/reference/html/channel.html#global-channel-configuration-interceptors) for more details. |
 | `otel.instrumentation.spring-webflux.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes for Spring WebFlux version 5.0. |
 | `otel.instrumentation.spring-webmvc.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes for Sprinv Web MVC 3.1. |
 

--- a/instrumentation/spring/README.md
+++ b/instrumentation/spring/README.md
@@ -17,8 +17,8 @@ In this guide we will be using a running example. In section one and two, we wil
 | System property | Type | Default | Description |
 |---|---|---|---|
 | `otel.instrumentation.spring-integration.global-channel-interceptor-patterns` | List | `*` | List of Spring singletons to be captured. |
-| `otel.instrumentation.spring-webflux.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental) for Spring WebFlux version 5.0. |
-| `otel.instrumentation.spring-webmvc.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental) for Sprinv Web MVC 3.1. |
+| `otel.instrumentation.spring-webflux.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes for Spring WebFlux version 5.0. |
+| `otel.instrumentation.spring-webmvc.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes for Sprinv Web MVC 3.1. |
 
 # Manual Instrumentation Guide
 

--- a/instrumentation/spring/README.md
+++ b/instrumentation/spring/README.md
@@ -12,6 +12,14 @@ The [third section](#auto-instrumentation-using-spring-starters) with build on t
 
 In this guide we will be using a running example. In section one and two, we will create two spring web services using Spring Boot. We will then trace requests between these services using two different approaches. Finally, in section three we will explore tools documented in [opentelemetry-spring-boot-autoconfigure](/spring-boot-autoconfigure/README.md#features) which can improve this process.
 
+# Settings 
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.spring-integration.global-channel-interceptor-patterns` | List | `*` | List of Spring singletons to be captured. |
+| `otel.instrumentation.spring-webflux.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental) for Spring WebFlux version 5.0. |
+| `otel.instrumentation.spring-webmvc.experimental-span-attributes` | Boolean | `false` | Enable the capture of span attributes (experimental) for Sprinv Web MVC 3.1. |
+
 # Manual Instrumentation Guide
 
 ## Create two Spring Projects

--- a/instrumentation/spymemcached-2.12/README.md
+++ b/instrumentation/spymemcached-2.12/README.md
@@ -1,0 +1,5 @@
+# Settings for the Spymemcached instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.spymemcached.experimental-span-attributes` | Boolean | `false` | Enables the capture of span attributes (experimental). |

--- a/instrumentation/spymemcached-2.12/README.md
+++ b/instrumentation/spymemcached-2.12/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.spymemcached.experimental-span-attributes` | Boolean | `false` | Enables the capture of span attributes (experimental). |
+| `otel.instrumentation.spymemcached.experimental-span-attributes` | Boolean | `false` | Enables the capture of experimental span attributes. |

--- a/instrumentation/twilio-6.6/README.md
+++ b/instrumentation/twilio-6.6/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.twilio.experimental-span-attributes` | Boolean | `false` | Enables the capture of span attributes (experimental). |
+| `otel.instrumentation.twilio.experimental-span-attributes` | Boolean | `false` | Enables the capture of experimental span attributes. |

--- a/instrumentation/twilio-6.6/README.md
+++ b/instrumentation/twilio-6.6/README.md
@@ -1,0 +1,5 @@
+# Settings for the Twilio instrumentation
+
+| System property | Type | Default | Description |
+|---|---|---|---|
+| `otel.instrumentation.twilio.experimental-span-attributes` | Boolean | `false` | Enables the capture of span attributes (experimental). |


### PR DESCRIPTION
This PR adds README files with known instrumentation settings to each applicable instrumentation folder.

Thanks @trask for creating the grep one-liner that made it possible to extract the settings:

```bash
grep -Pzoh -r --include '*.java' 'Config.get\(\)\s*.get\K[^(]*\([^)]*[)]' instrumentation | tr -d '\n' | tr -d ' ' | xargs -0 -n1 echo | sort | uniq
```

I see some opportunity for automation here—that is, if we connect that grep output to the content patterns in this PR. Thanks also to @mateuszrzeszutek for checking the list with me.

Cheers!
F.

