### PR TITLE
Fix log4j2 appender docs

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.16/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.16/library/README.md
@@ -7,6 +7,9 @@ the [OpenTelemetry Log SDK](https://github.com/open-telemetry/opentelemetry-java
 
 To use it, add the following modules to your application's classpath.
 
+Replace `OPENTELEMETRY_VERSION` with the latest
+stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
+
 **Maven**
 
 ```xml
@@ -14,14 +17,14 @@ To use it, add the following modules to your application's classpath.
   <dependency>
     <groupId>io.opentelemetry.instrumentation</groupId>
     <artifactId>opentelemetry-log4j-appender-2.16</artifactId>
-    <version>{version}</version>
+    <version>OPENTELEMETRY_VERSION</version>
     <scope>runtime</scope>
   </dependency>
   <dependency>
     <!-- The SDK appender is required to configure the appender with the OpenTelemetry Log SDK -->
     <groupId>io.opentelemetry.instrumentation</groupId>
     <artifactId>opentelemetry-instrumentation-sdk-appender</artifactId>
-    <version>{version}</version>
+    <version>OPENTELEMETRY_VERSION</version>
   </dependency>
 </dependencies>
 ```
@@ -30,13 +33,13 @@ To use it, add the following modules to your application's classpath.
 
 ```kotlin
 dependencies {
-  runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.16:{version}")
+  runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.16:OPENTELEMETRY_VERSION")
   // The SDK appender is required to configure the appender with the OpenTelemetry Log SDK
-  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-sdk-appender:{version}")
+  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-sdk-appender:OPENTELEMETRY_VERSION")
 }
 ```
 
-The following demonstrates how you might configure the appender in your `logback.xml` configuration:
+The following demonstrates how you might configure the appender in your `log4j2.xml` configuration:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/instrumentation/log4j/log4j-appender-2.16/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.16/library/README.md
@@ -8,7 +8,7 @@ the [OpenTelemetry Log SDK](https://github.com/open-telemetry/opentelemetry-java
 To use it, add the following modules to your application's classpath.
 
 Replace `OPENTELEMETRY_VERSION` with the latest
-stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
+stable [release](https://search.maven.org/search?q=g:io.opentelemetry.instrumentation).
 
 **Maven**
 
@@ -60,7 +60,8 @@ The following demonstrates how you might configure the appender in your `log4j2.
 </Configuration>
 ```
 
-Next, associate the `OpenTelemetryAppender` with a `SdkLogEmitterProvider` in your application:
+Next, associate the `OpenTelemetryAppender` configured via `log4j2.xml` with
+a `SdkLogEmitterProvider` in your application:
 
 ```
 SdkLogEmitterProvider logEmitterProvider =

--- a/instrumentation/log4j/log4j-appender-2.16/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.16/library/README.md
@@ -1,0 +1,74 @@
+# Log4j2 Appender
+
+This module provides a Log4j2 [appender](https://logging.apache.org/log4j/2.x/manual/appenders.html)
+which forwards Log4j2 log events to
+the [OpenTelemetry Log SDK](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk/logs)
+.
+
+To use it, add the following modules to your application's classpath.
+
+**Maven**
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>io.opentelemetry.instrumentation</groupId>
+    <artifactId>opentelemetry-log4j-appender-2.16</artifactId>
+    <version>{version}</version>
+    <scope>runtime</scope>
+  </dependency>
+  <dependency>
+    <!-- The SDK appender is required to configure the appender with the OpenTelemetry Log SDK -->
+    <groupId>io.opentelemetry.instrumentation</groupId>
+    <artifactId>opentelemetry-instrumentation-sdk-appender</artifactId>
+    <version>{version}</version>
+  </dependency>
+</dependencies>
+```
+
+**Gradle**
+
+```kotlin
+dependencies {
+  runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.16:{version}")
+  // The SDK appender is required to configure the appender with the OpenTelemetry Log SDK
+  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-sdk-appender:{version}")
+}
+```
+
+The following demonstrates how you might configure the appender in your `logback.xml` configuration:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" packages="io.opentelemetry.instrumentation.log4j.appender.v2_16">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout
+          pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} traceId: %X{trace_id} spanId: %X{span_id} flags: %X{trace_flags} - %msg%n"/>
+    </Console>
+    <OpenTelemetry name="OpenTelemetryAppender"/>
+  </Appenders>
+  <Loggers>
+    <Root>
+      <AppenderRef ref="OpenTelemetryAppender" level="All"/>
+      <AppenderRef ref="Console" level="All"/>
+    </Root>
+  </Loggers>
+</Configuration>
+```
+
+Next, associate the `OpenTelemetryAppender` with a `SdkLogEmitterProvider` in your application:
+
+```
+SdkLogEmitterProvider logEmitterProvider =
+  SdkLogEmitterProvider.builder()
+    .setResource(Resource.create(...))
+    .addLogProcessor(...)
+    .build();
+GlobalLogEmitterProvider.set(DelegatingLogEmitterProvider.from(logEmitterProvider));
+```
+
+In this example Log4j2 log events will be sent to both the console appender and
+the `OpenTelemetryAppender`, which will drop the logs until `GlobalLogEmitterProvider.set(..)` is
+called. Once initialized, logs will be emitted to a `LogEmitter` obtained from
+the `SdkLogEmitterProvider`.

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.16/library-autoconfigure/README.md
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.16/library-autoconfigure/README.md
@@ -1,6 +1,9 @@
-# Log4j 2 Integration
+# Log4j2 Autoconfigure Integration
 
-This module provides Log4j2 extensions related to OpenTelemetry.
+This module provides a Log4j2 `ContextDataProvider` that injects trace context from active spans
+into log context.
+
+## Usage
 
 To use it, add the module to your application's runtime classpath.
 
@@ -11,8 +14,8 @@ To use it, add the module to your application's runtime classpath.
 <dependencies>
   <dependency>
     <groupId>io.opentelemetry.instrumentation</groupId>
-    <artifactId>opentelemetry-log4j-2.13.2</artifactId>
-    <version>0.17.0-alpha</version>
+    <artifactId>opentelemetry-log4j-context-data-2.16-autoconfigure</artifactId>
+    <version>{version}</version>
     <scope>runtime</scope>
   </dependency>
 </dependencies>
@@ -22,11 +25,9 @@ To use it, add the module to your application's runtime classpath.
 
 ```kotlin
 dependencies {
-  runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-2.13.2:0.17.0-alpha")
+  runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-context-data-2.16-autoconfigure:{version}")
 }
 ```
-
-## OpenTelemetry Context Data Provider
 
 `OpenTelemetryContextDataProvider` implements the Log4j2 `ContextDataProvider` SPI, and injects the
 trace ID and span ID from an active span into
@@ -63,51 +64,3 @@ You can use these keys when defining an appender in your `log4j.xml` configurati
   </Loggers>
 </Configuration>
 ```
-
-## OpenTelemetry Appender
-
-`OpenTelemetryAppender` is a
-Log4j2 [appender](https://logging.apache.org/log4j/2.x/manual/appenders.html) that can be used to
-forward log events to
-the [OpenTelemetry Log SDK](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk/logs)
-.
-
-The following demonstrates how you might configure the appender in your `log4j.xml` configuration:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="io.opentelemetry.instrumentation.log4j.v2_16">
-  <Appenders>
-    <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout
-          pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} traceId: %X{trace_id} spanId: %X{span_id} flags: %X{trace_flags} - %msg%n"/>
-    </Console>
-    <OpenTelemetry name="OpenTelemetryAppender"/>
-  </Appenders>
-  <Loggers>
-    <Root>
-      <AppenderRef ref="OpenTelemetryAppender" level="All"/>
-      <AppenderRef ref="Console" level="All"/>
-    </Root>
-  </Loggers>
-</Configuration>
-```
-
-Next, associate the `OpenTelemetryAppender` with a `SdkLogEmitterProvider` in your application:
-
-```
-SdkLogEmitterProvider logEmitterProvider =
-  SdkLogEmitterProvider.builder()
-    .setResource(Resource.create(...))
-    .addLogProcessor(...)
-    .build();
-OpenTelemetryLog4j.initialize(logEmitterProvider);
-```
-
-**Note:** In order to initialize the `OpenTelemetryAppender` your application must depend on the
-OpenTelemetry log sdk (`io.opentelemetry:opentelemetry-sdk-logs`).
-
-In this example Log4j2 logs will be sent to both the console appender and
-the `OpenTelemetryAppender`, which will drop the logs until `OpenTelemetryLog4j.initialize(..)` is
-called. Once initialized, logs will be emitted to a `LogEmitter` obtained from
-the `SdkLogEmitterProvider`.

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.16/library-autoconfigure/README.md
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.16/library-autoconfigure/README.md
@@ -8,7 +8,7 @@ into log context.
 To use it, add the module to your application's runtime classpath.
 
 Replace `OPENTELEMETRY_VERSION` with the latest
-stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
+stable [release](https://search.maven.org/search?q=g:io.opentelemetry.instrumentation).
 
 **Maven**
 

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.16/library-autoconfigure/README.md
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.16/library-autoconfigure/README.md
@@ -7,6 +7,9 @@ into log context.
 
 To use it, add the module to your application's runtime classpath.
 
+Replace `OPENTELEMETRY_VERSION` with the latest
+stable [release](https://search.maven.org/search?q=g:io.opentelemetry).
+
 **Maven**
 
 ```xml
@@ -15,7 +18,7 @@ To use it, add the module to your application's runtime classpath.
   <dependency>
     <groupId>io.opentelemetry.instrumentation</groupId>
     <artifactId>opentelemetry-log4j-context-data-2.16-autoconfigure</artifactId>
-    <version>{version}</version>
+    <version>OPENTELEMETRY_VERSION</version>
     <scope>runtime</scope>
   </dependency>
 </dependencies>
@@ -25,7 +28,7 @@ To use it, add the module to your application's runtime classpath.
 
 ```kotlin
 dependencies {
-  runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-context-data-2.16-autoconfigure:{version}")
+  runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-context-data-2.16-autoconfigure:OPENTELEMETRY_VERSION")
 }
 ```
 


### PR DESCRIPTION
Fixes the out of date docs for the `io.opentelemetry.instrumentation:opentelemetry-log4j-context-data-2.16-autoconfigure` module, and adds docs for the `io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.16` module. 