### PR TITLE
Fix multi-layer JDBC driver call depth calculation

### DIFF
--- a/instrumentation/jdbc/javaagent/build.gradle.kts
+++ b/instrumentation/jdbc/javaagent/build.gradle.kts
@@ -33,4 +33,7 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
   jvmArgs("-Dotel.instrumentation.jdbc-datasource.enabled=true")
+  // this is needed to guarantee that if a layered JDBC driver is excluded then
+  // the underlying driver is still correctly instrumented
+  jvmArgs("-Dotel.javaagent.exclude-classes=io.opentelemetry.javaagent.instrumentation.jdbc.excluded.*")
 }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
@@ -20,6 +20,7 @@ import io.opentelemetry.instrumentation.jdbc.internal.DbRequest;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.api.CallDepth;
+import java.sql.SQLException;
 import java.sql.Statement;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -62,7 +63,16 @@ public class StatementInstrumentation implements TypeInstrumentation {
       // using CallDepth prevents this, because this check happens before Connection#getMetadata()
       // is called - the first recursive Statement call is just skipped and we do not create a span
       // for it
-      callDepth = CallDepth.forClass(Statement.class);
+      // the call depth should be anchored to the specific connection of this statement to avoid
+      // suppressing spans for layered JDBC drivers (that should be performed by semantic
+      // suppression)
+      // it's possible however that getting the connection throws an SQLException hence falling back
+      // to the call depth of a generic Statement.
+      try {
+        callDepth = CallDepth.forClass(statement.getConnection().getClass());
+      } catch (SQLException e) {
+        callDepth = CallDepth.forClass(Statement.class);
+      }
       if (callDepth.getAndIncrement() > 0) {
         return;
       }

--- a/instrumentation/jdbc/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jdbc/excluded/TwoLayerDbCallingConnection.java
+++ b/instrumentation/jdbc/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jdbc/excluded/TwoLayerDbCallingConnection.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.jdbc.excluded;
+
+import io.opentelemetry.instrumentation.jdbc.TestConnection;
+import io.opentelemetry.instrumentation.jdbc.TestPreparedStatement;
+import io.opentelemetry.instrumentation.jdbc.TestStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+class TwoLayerDbCallingConnection extends TestConnection {
+  final Connection inner;
+
+  TwoLayerDbCallingConnection(Connection inner) {
+    this.inner = inner;
+  }
+
+  @Override
+  public Statement createStatement() throws SQLException {
+    return new TestStatement(this) {
+      @Override
+      public ResultSet executeQuery(String sql) throws SQLException {
+        return inner.createStatement().executeQuery(sql);
+      }
+    };
+  }
+
+  @Override
+  public PreparedStatement prepareStatement(String sql) throws SQLException {
+    return new TestPreparedStatement(this) {
+      @Override
+      public ResultSet executeQuery() throws SQLException {
+        return inner.prepareStatement(sql).executeQuery(sql);
+      }
+    };
+  }
+}


### PR DESCRIPTION
The #2756 request introduced a check on the call depth of the JDBC instrumentation that limits tracing with multi-layered drivers. For example, with Apache Calcite, the Calcite JDBC driver is caught on the call stack and none of the underlying connections are traced.

For a better support of different use cases the check should be anchored to the specific connection instead of the generic JDBC interface.