### PR TITLE
Update triagers and maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @anuraaga @iNikem @jkwatson @laurit @mateuszrzeszutek @pavolloffay @trask @tylerbenson
+* @anuraaga @iNikem @jkwatson @laurit @mateuszrzeszutek @pavolloffay @trask

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Triagers ([@open-telemetry/java-instrumentation-triagers](https://github.com/orgs/open-telemetry/teams/java-instrumentation-triagers)):
 
+- [Jack Berg](https://github.com/jack-berg), New Relic
 - [Jason Plumb](https://github.com/breedx-splk), Splunk
-- [Sergei Malafeev](https://github.com/malafeev), Lightstep
 
 Approvers ([@open-telemetry/java-instrumentation-approvers](https://github.com/orgs/open-telemetry/teams/java-instrumentation-approvers)):
 
@@ -155,7 +155,6 @@ Maintainers ([@open-telemetry/java-instrumentation-maintainers](https://github.c
 - [Mateusz Rzeszutek](https://github.com/mateuszrzeszutek), Splunk
 - [Nikita Salnikov-Tarnovski](https://github.com/iNikem), Splunk
 - [Trask Stalnaker](https://github.com/trask), Microsoft
-- [Tyler Benson](https://github.com/tylerbenson), DataDog
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).
 


### PR DESCRIPTION
Removing inactive triagers and maintainers.

Adding @jack-berg as triager.

@tylerbenson @malafeev we hope to see you back here some day in the future!