### PR TITLE
Remove grails lates dep restriction

### DIFF
--- a/instrumentation/grails-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/grails-3.0/javaagent/build.gradle.kts
@@ -43,8 +43,4 @@ dependencies {
 
   testLibrary("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
   testLibrary("org.springframework.boot:spring-boot-starter-tomcat:$springBootVersion")
-
-  latestDepTestLibrary("org.grails:grails-plugin-url-mappings:4.0.+")
-  latestDepTestLibrary("org.springframework.boot:spring-boot-autoconfigure:2.1.17.RELEASE")
-  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-tomcat:2.1.17.RELEASE")
 }


### PR DESCRIPTION
Initially grails latest version was restricted to 4.0.x because it was the latest stable release and the next 4.1.x required groovy3.