### PR TITLE
1.9.x branch: Fix reactor-netty memory/connection leak (#4867)

### DIFF
--- a/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/AbstractReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/AbstractReactorNettyHttpClientTest.groovy
@@ -191,6 +191,32 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
     }
   }
 
+  def "should not leak connections"() {
+    given:
+    def uniqueChannelHashes = new HashSet<>()
+    def httpClient = createHttpClient()
+      .doOnConnect({ uniqueChannelHashes.add(it.channelHash())})
+    def uri = "http://localhost:${server.httpPort()}/success"
+
+    def count = 100
+
+    when:
+    (1..count).forEach({
+      runWithSpan("parent") {
+        def status = httpClient.get().uri(uri)
+          .responseSingle { resp, content ->
+            // Make sure to consume content since that's when we close the span.
+            content.map { resp.status().code() }
+          }.block()
+        assert status == 200
+      }
+    })
+
+    then:
+    traces.size() == count
+    uniqueChannelHashes.size() == 1
+  }
+
   private static void assertSameSpan(SpanData expected, AtomicReference<Span> actual) {
     def expectedSpanContext = expected.spanContext
     def actualSpanContext = actual.get().spanContext


### PR DESCRIPTION
Almost clean cherry-pick of #4867 for the 1.9.x branch (there was a one-line conflict in test class requiring manual resolution).

See discussion at https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4862#issuecomment-1006917936