### PR TITLE
Set bytebuddy task's classFileVersion

### DIFF
--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-generation.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-generation.gradle.kts
@@ -1,5 +1,6 @@
 import io.opentelemetry.javaagent.muzzle.generation.ClasspathByteBuddyPlugin
 import io.opentelemetry.javaagent.muzzle.generation.ClasspathTransformation
+import net.bytebuddy.ClassFileVersion
 import net.bytebuddy.build.gradle.ByteBuddySimpleTask
 import net.bytebuddy.build.gradle.Transformation
 
@@ -67,6 +68,7 @@ fun createLanguageTask(
   return tasks.register<ByteBuddyTask>(name) {
     setGroup("Byte Buddy")
     outputs.cacheIf { true }
+    classFileVersion = ClassFileVersion.JAVA_V8
     var transformationClassPath = inputClasspath
     val compileTask = compileTaskProvider.get()
     if (compileTask is AbstractCompile) {


### PR DESCRIPTION
To avoid this scary warning (and possible build cache pollution?)

`Could not locate Java target version, build is JDK dependant: 17`