### PR TITLE
Fix NPE in rmi server instrumentation

### DIFF
--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RemoteServerInstrumentation.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RemoteServerInstrumentation.java
@@ -57,6 +57,9 @@ public class RemoteServerInstrumentation implements TypeInstrumentation {
 
       // TODO review and unify with all other SERVER instrumentation
       Context parentContext = THREAD_LOCAL_CONTEXT.getAndResetContext();
+      if (parentContext == null) {
+        return;
+      }
       request = ClassAndMethod.create(declaringClass, methodName);
       if (!instrumenter().shouldStart(parentContext, request)) {
         return;


### PR DESCRIPTION
When running the app from https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4982 with javaagent noticed the following exception in debug log
```
[otel.javaagent 2022-01-07 13:05:14:257 +0200] [main] DEBUG io.opentelemetry.javaagent.bootstrap.ExceptionLogger - Failed to handle exception in instrumentation for javax.management.remote.rmi.RMIServerImpl on jdk.internal.loader.ClassLoaders$AppClassLoader@7ad041f3
java.lang.NullPointerException: Cannot invoke "io.opentelemetry.javaagent.shaded.io.opentelemetry.context.Context.get(io.opentelemetry.javaagent.shaded.io.opentelemetry.context.ContextKey)" because "context" is null
	at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.SpanKey.fromContextOrNull(SpanKey.java:70)
	at io.opentelemetry.javaagent.shaded.instrumentation.api.instrumenter.SuppressIfSameSpanKeyStrategy.shouldSuppress(SuppressIfSameSpanKeyStrategy.java:33)
	at io.opentelemetry.javaagent.shaded.instrumentation.api.instrumenter.CompositeSuppressionStrategy.shouldSuppress(CompositeSuppressionStrategy.java:54)
	at io.opentelemetry.javaagent.shaded.instrumentation.api.instrumenter.Instrumenter.shouldStart(Instrumenter.java:138)
	at java.management.rmi/javax.management.remote.rmi.RMIServerImpl.setMBeanServer(RMIServerImpl.java:139)
	at java.management.rmi/javax.management.remote.rmi.RMIConnectorServer.start(RMIConnectorServer.java:450)
	at jdk.management.agent/sun.management.jmxremote.ConnectorBootstrap.startLocalConnectorServer(ConnectorBootstrap.java:583)
	at jdk.management.agent/jdk.internal.agent.Agent.startLocalManagementAgent(Agent.java:318)
	at jdk.management.agent/jdk.internal.agent.Agent.startAgent(Agent.java:450)
	at jdk.management.agent/jdk.internal.agent.Agent.startAgent(Agent.java:599)
```