### PR TITLE
Retry elasticsearch startup

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -4,10 +4,12 @@
  */
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import java.util.concurrent.TimeUnit
 import org.elasticsearch.client.Client
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.env.Environment
+import org.elasticsearch.http.BindHttpException
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.Node
 import org.elasticsearch.node.internal.InternalSettingsPreparer
@@ -19,6 +21,7 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await
 
 class Elasticsearch5NodeClientTest extends AbstractElasticsearchNodeClientTest {
   public static final long TIMEOUT = 10000 // 10 seconds
@@ -49,7 +52,16 @@ class Elasticsearch5NodeClientTest extends AbstractElasticsearchNodeClientTest {
       .put("discovery.type", "local")
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
-    testNode.start()
+    // retry when starting elasticsearch fails with
+    // org.elasticsearch.http.BindHttpException: Failed to resolve host [[]]
+    // Caused by: java.net.SocketException: No such device (getFlags() failed)
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .ignoreException(BindHttpException)
+      .until({
+        testNode.start()
+        true
+      })
     client = testNode.client()
     runWithSpan("setup") {
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -4,11 +4,13 @@
  */
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import java.util.concurrent.TimeUnit
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.transport.TransportAddress
 import org.elasticsearch.env.Environment
+import org.elasticsearch.http.BindHttpException
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.Node
 import org.elasticsearch.node.internal.InternalSettingsPreparer
@@ -23,6 +25,7 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await
 
 class Elasticsearch5TransportClientTest extends AbstractElasticsearchTransportClientTest {
   public static final long TIMEOUT = 10000 // 10 seconds
@@ -53,7 +56,16 @@ class Elasticsearch5TransportClientTest extends AbstractElasticsearchTransportCl
       .put("discovery.type", "local")
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
-    testNode.start()
+    // retry when starting elasticsearch fails with
+    // org.elasticsearch.http.BindHttpException: Failed to resolve host [[]]
+    // Caused by: java.net.SocketException: No such device (getFlags() failed)
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .ignoreException(BindHttpException)
+      .until({
+        testNode.start()
+        true
+      })
     tcpPublishAddress = testNode.injector().getInstance(TransportService).boundAddress().publishAddress()
 
     client = new PreBuiltTransportClient(

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -4,11 +4,13 @@
  */
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import java.util.concurrent.TimeUnit
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.elasticsearch.client.Client
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.env.Environment
+import org.elasticsearch.http.BindHttpException
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.InternalSettingsPreparer
 import org.elasticsearch.node.Node
@@ -20,6 +22,7 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await
 
 class Elasticsearch53NodeClientTest extends AbstractElasticsearchNodeClientTest {
   public static final long TIMEOUT = 10000 // 10 seconds
@@ -50,7 +53,16 @@ class Elasticsearch53NodeClientTest extends AbstractElasticsearchNodeClientTest 
       .put("discovery.type", "single-node")
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
-    testNode.start()
+    // retry when starting elasticsearch fails with
+    // org.elasticsearch.http.BindHttpException: Failed to resolve host [[]]
+    // Caused by: java.net.SocketException: No such device (getFlags() failed)
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .ignoreException(BindHttpException)
+      .until({
+        testNode.start()
+        true
+      })
     client = testNode.client()
     runWithSpan("setup") {
       // this may potentially create multiple requests and therefore multiple spans, so we wrap this call

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -4,12 +4,14 @@
  */
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import java.util.concurrent.TimeUnit
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.io.FileSystemUtils
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.transport.TransportAddress
 import org.elasticsearch.env.Environment
+import org.elasticsearch.http.BindHttpException
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.InternalSettingsPreparer
 import org.elasticsearch.node.Node
@@ -24,6 +26,7 @@ import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await
 
 class Elasticsearch53TransportClientTest extends AbstractElasticsearchTransportClientTest {
   public static final long TIMEOUT = 10000 // 10 seconds
@@ -55,7 +58,16 @@ class Elasticsearch53TransportClientTest extends AbstractElasticsearchTransportC
       .put("discovery.type", "single-node")
       .build()
     testNode = new Node(new Environment(InternalSettingsPreparer.prepareSettings(settings)), [Netty3Plugin])
-    testNode.start()
+    // retry when starting elasticsearch fails with
+    // org.elasticsearch.http.BindHttpException: Failed to resolve host [[]]
+    // Caused by: java.net.SocketException: No such device (getFlags() failed)
+    await()
+      .atMost(10, TimeUnit.SECONDS)
+      .ignoreException(BindHttpException)
+      .until({
+        testNode.start()
+        true
+      })
     tcpPublishAddress = testNode.injector().getInstance(TransportService).boundAddress().publishAddress()
 
     client = new PreBuiltTransportClient(


### PR DESCRIPTION
Occasionally elasticsearch fails to start with https://ge.opentelemetry.io/s/jryl5wekbgtde/tests/:instrumentation:elasticsearch:elasticsearch-transport-5.3:javaagent:test/Elasticsearch53NodeClientTest/initializationError?expanded-stacktrace=WyIwLTEiLCIwIl0&top-execution=1 My guess it is caused by testcontainers/docker tests running at the same time messing with networking.