### PR TITLE
Add level config to logback instrumentation

### DIFF
--- a/instrumentation/logback/logback-appender-1.0/javaagent/README.md
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/README.md
@@ -1,0 +1,5 @@
+# Settings for the Logback Appender instrumentation
+
+| System property                                            | Type   | Default | Description                           |
+|------------------------------------------------------------|--------|---------|---------------------------------------|
+| `otel.instrumentation.logback-appender.experimental.level` | String | None    | The minimum level of logs to capture. |

--- a/instrumentation/logback/logback-appender-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/build.gradle.kts
@@ -29,4 +29,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental log attributes
   jvmArgs("-Dotel.instrumentation.logback-appender.experimental.capture-mdc-attributes=*")
+  jvmArgs("-Dotel.instrumentation.logback-appender.experimental.level=INFO")
 }

--- a/instrumentation/logback/logback-appender-1.0/javaagent/src/test/groovy/LogbackTest.groovy
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/src/test/groovy/LogbackTest.groovy
@@ -124,4 +124,12 @@ class LogbackTest extends AgentInstrumentationSpecification {
     assertThat(log.getAttributes().get(AttributeKey.stringKey("logback.mdc.key1"))).isEqualTo("val1")
     assertThat(log.getAttributes().get(AttributeKey.stringKey("logback.mdc.key2"))).isEqualTo("val2")
   }
+
+  def "test level configuration"() {
+    when:
+    LoggerFactory.getLogger("DebugLogger").debug("xyz")
+
+    then:
+    assertThat(logs).isEmpty()
+  }
 }

--- a/instrumentation/logback/logback-appender-1.0/javaagent/src/test/resources/logback-test.xml
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/src/test/resources/logback-test.xml
@@ -12,10 +12,11 @@
   <logger name="abc" level="INFO"/>
   <logger name="def" level="WARN"/>
 
+  <logger name="DebugLogger" level="DEBUG"/>
+
   <root level="INFO">
     <appender-ref ref="console"/>
   </root>
 
-  <logger name="org.testcontainers" level="WARN"/>
   <logger name="io.opentelemetry.testing.internal" level="WARN"/>
 </configuration>

--- a/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental log attributes
   jvmArgs("-Dotel.instrumentation.logback-appender.experimental.capture-mdc-attributes=*")
+  jvmArgs("-Dotel.instrumentation.logback-appender.experimental.level=INFO")
 }

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/OpenTelemetryAppenderConfigTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/OpenTelemetryAppenderConfigTest.java
@@ -150,4 +150,12 @@ class OpenTelemetryAppenderConfigTest {
             logData.getAttributes().get(AttributeKey.stringKey("logback.mdc.key2")))
         .isEqualTo("val2");
   }
+
+  @Test
+  void shouldNotLogDueToLevelConfiguration() {
+    LoggerFactory.getLogger("DebugLogger").debug("log message 1");
+
+    List<LogData> logDataList = logExporter.getFinishedLogItems();
+    assertThat(logDataList).isEmpty();
+  }
 }

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/internal/LoggingEventMapperTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/internal/LoggingEventMapperTest.java
@@ -10,6 +10,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.entry;
 
+import ch.qos.logback.classic.Level;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -22,7 +23,7 @@ public class LoggingEventMapperTest {
   @Test
   public void testDefault() {
     // given
-    LoggingEventMapper mapper = new LoggingEventMapper(emptyList());
+    LoggingEventMapper mapper = new LoggingEventMapper(Level.ALL, emptyList());
     Map<String, String> contextData = new HashMap<>();
     contextData.put("key1", "value1");
     contextData.put("key2", "value2");
@@ -38,7 +39,7 @@ public class LoggingEventMapperTest {
   @Test
   public void testSome() {
     // given
-    LoggingEventMapper mapper = new LoggingEventMapper(singletonList("key2"));
+    LoggingEventMapper mapper = new LoggingEventMapper(Level.ALL, singletonList("key2"));
     Map<String, String> contextData = new HashMap<>();
     contextData.put("key1", "value1");
     contextData.put("key2", "value2");
@@ -53,9 +54,9 @@ public class LoggingEventMapperTest {
   }
 
   @Test
-  public void testAll() {
+  public void testWildcard() {
     // given
-    LoggingEventMapper mapper = new LoggingEventMapper(singletonList("*"));
+    LoggingEventMapper mapper = new LoggingEventMapper(Level.ALL, singletonList("*"));
     Map<String, String> contextData = new HashMap<>();
     contextData.put("key1", "value1");
     contextData.put("key2", "value2");

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/resources/logback-test.xml
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/resources/logback-test.xml
@@ -8,12 +8,15 @@
       </pattern>
     </encoder>
   </appender>
-  <appender name="OpenTelemetry" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+  <appender name="OpenTelemetry"
+    class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
   </appender>
+
+  <logger name="DebugLogger" level="DEBUG"/>
 
   <root level="INFO">
     <appender-ref ref="console"/>
-    <appender-ref ref="OpenTelemetry" />
+    <appender-ref ref="OpenTelemetry"/>
   </root>
 
 </configuration>

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingLogsCustomizer.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingLogsCustomizer.java
@@ -12,7 +12,7 @@ import io.opentelemetry.instrumentation.sdk.appender.DelegatingLogEmitterProvide
 import io.opentelemetry.javaagent.extension.AgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.SdkLogEmitterProvider;
-import io.opentelemetry.sdk.logs.export.BatchLogProcessor;
+import io.opentelemetry.sdk.logs.export.SimpleLogProcessor;
 
 @AutoService(AgentListener.class)
 public class AgentTestingLogsCustomizer implements AgentListener {
@@ -24,8 +24,7 @@ public class AgentTestingLogsCustomizer implements AgentListener {
     SdkLogEmitterProvider logEmitterProvider =
         SdkLogEmitterProvider.builder()
             .setResource(autoConfiguredOpenTelemetrySdk.getResource())
-            .addLogProcessor(
-                BatchLogProcessor.builder(AgentTestingExporterFactory.logExporter).build())
+            .addLogProcessor(SimpleLogProcessor.create(AgentTestingExporterFactory.logExporter))
             .build();
 
     GlobalLogEmitterProvider.set(DelegatingLogEmitterProvider.from(logEmitterProvider));


### PR DESCRIPTION
Adds an experimental config `otel.instrumentation.logback-appender.experimental.level` that serves as a minimum threshold for the logs that are captured.

The current default in this PR is `ALL` (matching existing behavior), but I could also see `INFO` being a good default.

I will add similar config to log4j and java.util.logging instrumentation if this is approved.