### PR TITLE
Add spotless to standalone subprojects

### DIFF
--- a/benchmark-overhead/build.gradle.kts
+++ b/benchmark-overhead/build.gradle.kts
@@ -1,5 +1,14 @@
 plugins {
   id("java")
+  id("com.diffplug.spotless") version "6.1.2"
+}
+
+spotless {
+  java {
+    googleJavaFormat()
+    licenseHeaderFile(rootProject.file("../buildscripts/spotless.license.java"), "(package|import|public)")
+    target("src/**/*.java")
+  }
 }
 
 repositories {

--- a/benchmark-overhead/src/test/java/io/opentelemetry/OverheadTests.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/OverheadTests.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -41,7 +42,7 @@ public class OverheadTests {
   private static final Network NETWORK = Network.newNetwork();
   private static GenericContainer<?> collector;
   private final NamingConventions namingConventions = new NamingConventions();
-  private final Map<String,Long> runDurations = new HashMap<>();
+  private final Map<String, Long> runDurations = new HashMap<>();
 
   @BeforeAll
   static void setUp() {
@@ -71,7 +72,8 @@ public class OverheadTests {
                 fail("Unhandled exception in " + config.getName(), e);
               }
             });
-    List<AppPerfResults> results = new ResultsCollector(namingConventions.local, runDurations).collect(config);
+    List<AppPerfResults> results =
+        new ResultsCollector(namingConventions.local, runDurations).collect(config);
     new MainResultsPersister(config).write(results);
   }
 

--- a/benchmark-overhead/src/test/java/io/opentelemetry/agents/Agent.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/agents/Agent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.agents;
 
 import java.net.MalformedURLException;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/agents/AgentResolver.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/agents/AgentResolver.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.agents;
 
 import java.net.URL;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/agents/LatestAgentSnapshotResolver.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/agents/LatestAgentSnapshotResolver.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.agents;
 
 import static org.joox.JOOX.$;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/config/Configs.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/config/Configs.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.config;
 
 import io.opentelemetry.agents.Agent;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/config/TestConfig.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/config/TestConfig.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.config;
 
 import io.opentelemetry.agents.Agent;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/containers/CollectorContainer.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/containers/CollectorContainer.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.containers;
 
 import org.slf4j.Logger;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/containers/K6Container.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/containers/K6Container.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.containers;
 
 import io.opentelemetry.agents.Agent;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/containers/PetClinicRestContainer.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/containers/PetClinicRestContainer.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.containers;
 
 import io.opentelemetry.agents.Agent;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/containers/PostgresContainer.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/containers/PostgresContainer.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.containers;
 
 import org.slf4j.Logger;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/AppPerfResults.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/AppPerfResults.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.results;
 
 import io.opentelemetry.agents.Agent;
@@ -55,11 +56,11 @@ public class AppPerfResults {
     return bytesToMegs(this.totalAllocated);
   }
 
-  double getMinHeapUsedMB(){
+  double getMinHeapUsedMB() {
     return bytesToMegs(this.heapUsed.min);
   }
 
-  double getMaxHeapUsedMB(){
+  double getMaxHeapUsedMB() {
     return bytesToMegs(this.heapUsed.max);
   }
 
@@ -70,6 +71,7 @@ public class AppPerfResults {
   String getAgentName() {
     return agent.getName();
   }
+
   static Builder builder() {
     return new Builder();
   }
@@ -164,32 +166,32 @@ public class AppPerfResults {
       return this;
     }
 
-    Builder averageNetworkWrite(long averageNetworkWrite){
+    Builder averageNetworkWrite(long averageNetworkWrite) {
       this.averageNetworkWrite = averageNetworkWrite;
       return this;
     }
 
-    Builder averageJvmUserCpu(float averageJvmUserCpu){
+    Builder averageJvmUserCpu(float averageJvmUserCpu) {
       this.averageJvmUserCpu = averageJvmUserCpu;
       return this;
     }
 
-    Builder maxJvmUserCpu(float maxJvmUserCpu){
+    Builder maxJvmUserCpu(float maxJvmUserCpu) {
       this.maxJvmUserCpu = maxJvmUserCpu;
       return this;
     }
 
-    Builder averageMachineCpuTotal(float averageMachineCpuTotal){
+    Builder averageMachineCpuTotal(float averageMachineCpuTotal) {
       this.averageMachineCpuTotal = averageMachineCpuTotal;
       return this;
     }
 
-    Builder runDurationMs(long runDurationMs){
+    Builder runDurationMs(long runDurationMs) {
       this.runDurationMs = runDurationMs;
       return this;
     }
 
-    Builder totalGcPauseNanos(long totalGcPauseNanos){
+    Builder totalGcPauseNanos(long totalGcPauseNanos) {
       this.totalGcPauseNanos = totalGcPauseNanos;
       return this;
     }
@@ -199,20 +201,20 @@ public class AppPerfResults {
     public final long min;
     public final long max;
 
-    public MinMax(){
+    public MinMax() {
       this(Long.MAX_VALUE, Long.MIN_VALUE);
     }
 
-    public MinMax(long min, long max){
+    public MinMax(long min, long max) {
       this.min = min;
       this.max = max;
     }
 
-    public MinMax withMin(long min){
+    public MinMax withMin(long min) {
       return new MinMax(min, max);
     }
 
-    public MinMax withMax(long max){
+    public MinMax withMax(long max) {
       return new MinMax(min, max);
     }
   }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/ConsoleResultsPersister.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/ConsoleResultsPersister.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.results;
 
 import java.util.List;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/CsvPersister.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/CsvPersister.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.results;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -18,30 +19,32 @@ import java.util.stream.Collectors;
 class CsvPersister implements ResultsPersister {
 
   // The fields as they are output, in order, but spread across agents
-  private final static List<FieldSpec> FIELDS = Arrays.asList(
-      FieldSpec.of("startupDurationMs", r -> r.startupDurationMs),
-      FieldSpec.of("minHeapUsed", r -> r.heapUsed.min),
-      FieldSpec.of("maxHeapUsed", r -> r.heapUsed.max),
-      FieldSpec.of("totalAllocatedMB", r -> r.getTotalAllocatedMB()),
-      FieldSpec.of("totalGCTime", r -> r.totalGCTime),
-      FieldSpec.of("maxThreadContextSwitchRate", r -> r.maxThreadContextSwitchRate),
-      FieldSpec.of("iterationAvg", r -> r.iterationAvg),
-      FieldSpec.of("iterationP95", r -> r.iterationP95),
-      FieldSpec.of("requestAvg", r -> r.requestAvg),
-      FieldSpec.of("requestP95", r -> r.requestP95),
-      FieldSpec.of("netReadAvg", r -> r.averageNetworkRead),
-      FieldSpec.of("netWriteAvg", r -> r.averageNetworkWrite),
-      FieldSpec.of("peakThreadCount", r -> r.peakThreadCount),
-      FieldSpec.of("averageCpuUser", r -> r.averageJvmUserCpu),
-      FieldSpec.of("maxCpuUser", r -> r.maxJvmUserCpu),
-      FieldSpec.of("averageMachineCpuTotal", r -> r.averageMachineCpuTotal),
-      FieldSpec.of("runDurationMs", r -> r.runDurationMs),
-      FieldSpec.of("gcPauseMs", r -> NANOSECONDS.toMillis(r.totalGcPauseNanos))
-  );
+  private static final List<FieldSpec> FIELDS =
+      Arrays.asList(
+          FieldSpec.of("startupDurationMs", r -> r.startupDurationMs),
+          FieldSpec.of("minHeapUsed", r -> r.heapUsed.min),
+          FieldSpec.of("maxHeapUsed", r -> r.heapUsed.max),
+          FieldSpec.of("totalAllocatedMB", r -> r.getTotalAllocatedMB()),
+          FieldSpec.of("totalGCTime", r -> r.totalGCTime),
+          FieldSpec.of("maxThreadContextSwitchRate", r -> r.maxThreadContextSwitchRate),
+          FieldSpec.of("iterationAvg", r -> r.iterationAvg),
+          FieldSpec.of("iterationP95", r -> r.iterationP95),
+          FieldSpec.of("requestAvg", r -> r.requestAvg),
+          FieldSpec.of("requestP95", r -> r.requestP95),
+          FieldSpec.of("netReadAvg", r -> r.averageNetworkRead),
+          FieldSpec.of("netWriteAvg", r -> r.averageNetworkWrite),
+          FieldSpec.of("peakThreadCount", r -> r.peakThreadCount),
+          FieldSpec.of("averageCpuUser", r -> r.averageJvmUserCpu),
+          FieldSpec.of("maxCpuUser", r -> r.maxJvmUserCpu),
+          FieldSpec.of("averageMachineCpuTotal", r -> r.averageMachineCpuTotal),
+          FieldSpec.of("runDurationMs", r -> r.runDurationMs),
+          FieldSpec.of("gcPauseMs", r -> NANOSECONDS.toMillis(r.totalGcPauseNanos)));
 
   private final Path resultsFile;
 
-  public CsvPersister(Path resultsFile) {this.resultsFile = resultsFile;}
+  public CsvPersister(Path resultsFile) {
+    this.resultsFile = resultsFile;
+  }
 
   @Override
   public void write(List<AppPerfResults> results) {
@@ -98,14 +101,14 @@ class CsvPersister implements ResultsPersister {
 
   static class FieldSpec {
     private final String name;
-    private final Function<AppPerfResults,Object> getter;
+    private final Function<AppPerfResults, Object> getter;
 
     public FieldSpec(String name, Function<AppPerfResults, Object> getter) {
       this.name = name;
       this.getter = getter;
     }
 
-    static FieldSpec of(String name, Function<AppPerfResults,Object> getter){
+    static FieldSpec of(String name, Function<AppPerfResults, Object> getter) {
       return new FieldSpec(name, getter);
     }
   }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/FileSummaryPersister.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/FileSummaryPersister.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.results;
 
 import java.io.FileNotFoundException;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/MainResultsPersister.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/MainResultsPersister.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.results;
 
 import io.opentelemetry.config.TestConfig;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/PrintStreamPersister.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/PrintStreamPersister.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.results;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -17,7 +18,9 @@ class PrintStreamPersister implements ResultsPersister {
 
   private final PrintStream out;
 
-  public PrintStreamPersister(PrintStream out) {this.out = out;}
+  public PrintStreamPersister(PrintStream out) {
+    this.out = out;
+  }
 
   @Override
   public void write(List<AppPerfResults> results) {
@@ -25,14 +28,21 @@ class PrintStreamPersister implements ResultsPersister {
     out.println("----------------------------------------------------------");
     out.println(" Run at " + new Date());
     out.printf(" %s : %s\n", config.getName(), config.getDescription());
-    out.printf(" %d users, %d iterations\n", config.getConcurrentConnections(), config.getTotalIterations());
+    out.printf(
+        " %d users, %d iterations\n",
+        config.getConcurrentConnections(), config.getTotalIterations());
     out.println("----------------------------------------------------------");
 
     display(results, "Agent", appPerfResults -> appPerfResults.agent.getName());
-    display(results, "Run duration", res -> {
-      Duration duration = Duration.ofMillis(res.runDurationMs);
-      return String.format("%02d:%02d:%02d", duration.toHours(), duration.toMinutesPart(), duration.toSecondsPart());
-    });
+    display(
+        results,
+        "Run duration",
+        res -> {
+          Duration duration = Duration.ofMillis(res.runDurationMs);
+          return String.format(
+              "%02d:%02d:%02d",
+              duration.toHours(), duration.toMinutesPart(), duration.toSecondsPart());
+        });
     display(results, "Avg. CPU (user) %", res -> String.valueOf(res.averageJvmUserCpu));
     display(results, "Max. CPU (user) %", res -> String.valueOf(res.maxJvmUserCpu));
     display(results, "Avg. mch tot cpu %", res -> String.valueOf(res.averageMachineCpuTotal));
@@ -42,7 +52,10 @@ class PrintStreamPersister implements ResultsPersister {
     display(results, "Max heap used (MB)", res -> format(res.getMaxHeapUsedMB()));
     display(results, "Thread switch rate", res -> String.valueOf(res.maxThreadContextSwitchRate));
     display(results, "GC time (ms)", res -> String.valueOf(res.totalGCTime));
-    display(results, "GC pause time (ms)", res -> String.valueOf(NANOSECONDS.toMillis(res.totalGcPauseNanos)));
+    display(
+        results,
+        "GC pause time (ms)",
+        res -> String.valueOf(NANOSECONDS.toMillis(res.totalGcPauseNanos)));
     display(results, "Req. mean (ms)", res -> format(res.requestAvg));
     display(results, "Req. p95 (ms)", res -> format(res.requestP95));
     display(results, "Iter. mean (ms)", res -> format(res.iterationAvg));
@@ -52,16 +65,17 @@ class PrintStreamPersister implements ResultsPersister {
     display(results, "Peak threads", res -> String.valueOf(res.peakThreadCount));
   }
 
-  private void display(List<AppPerfResults> results, String pref, Function<AppPerfResults, String> vs) {
+  private void display(
+      List<AppPerfResults> results, String pref, Function<AppPerfResults, String> vs) {
     out.printf("%-20s: ", pref);
-    results.forEach(result -> {
-      out.printf("%17s", vs.apply(result));
-    });
+    results.forEach(
+        result -> {
+          out.printf("%17s", vs.apply(result));
+        });
     out.println();
   }
 
   private String format(double d) {
     return String.format("%.2f", d);
   }
-
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/ResultsCollector.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/ResultsCollector.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.results;
 
 import com.jayway.jsonpath.JsonPath;
@@ -27,7 +28,6 @@ public class ResultsCollector {
     this.runDurations = runDurations;
   }
 
-
   public List<AppPerfResults> collect(TestConfig config) {
     return config.getAgents().stream()
         .map(a -> readAgentResults(a, config))
@@ -36,10 +36,11 @@ public class ResultsCollector {
 
   private AppPerfResults readAgentResults(Agent agent, TestConfig config) {
     try {
-      AppPerfResults.Builder builder = AppPerfResults.builder()
-          .agent(agent)
-          .runDurationMs(runDurations.get(agent.getName()))
-          .config(config);
+      AppPerfResults.Builder builder =
+          AppPerfResults.builder()
+              .agent(agent)
+              .runDurationMs(runDurations.get(agent.getName()))
+              .config(config);
 
       builder = addStartupTime(builder, agent);
       builder = addK6Results(builder, agent);
@@ -134,5 +135,4 @@ public class ResultsCollector {
   private long computeTotalGcPauseNanos(Path jfrFile) throws IOException {
     return JFRUtils.sumLongEventValues(jfrFile, "jdk.GCPhasePause", "duration");
   }
-
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/results/ResultsPersister.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/results/ResultsPersister.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.results;
 
 import java.util.List;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/util/JFRUtils.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/util/JFRUtils.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.util;
 
 import io.opentelemetry.results.AppPerfResults.MinMax;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/util/NamingConvention.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/util/NamingConvention.java
@@ -2,6 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package io.opentelemetry.util;
 
 import io.opentelemetry.agents.Agent;

--- a/benchmark-overhead/src/test/java/io/opentelemetry/util/NamingConventions.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/util/NamingConventions.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.util;
 
 /** An container to hold both the local and container naming conventions. */

--- a/conventions/build.gradle.kts
+++ b/conventions/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
   implementation("com.diffplug.spotless:spotless-plugin-gradle:6.1.2")
   implementation("com.google.guava:guava:31.0.1-jre")
   implementation("gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:0.8.18")
-  implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.1")
+  implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
   implementation("org.ow2.asm:asm:9.1")
   implementation("org.ow2.asm:asm-tree:9.1")
   implementation("org.apache.httpcomponents:httpclient:4.5.13")

--- a/conventions/build.gradle.kts
+++ b/conventions/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   `kotlin-dsl`
   // When updating, update below in dependencies too
-  id("com.diffplug.spotless") version "5.16.0"
+  id("com.diffplug.spotless") version "6.1.2"
 }
 
 spotless {
@@ -35,7 +35,7 @@ dependencies {
   implementation("org.apache.maven:maven-aether-provider:3.3.9")
 
   // When updating, update above in plugins too
-  implementation("com.diffplug.spotless:spotless-plugin-gradle:5.16.0")
+  implementation("com.diffplug.spotless:spotless-plugin-gradle:6.1.2")
   implementation("com.google.guava:guava:31.0.1-jre")
   implementation("gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:0.8.18")
   implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.1")

--- a/examples/distro/build.gradle
+++ b/examples/distro/build.gradle
@@ -1,10 +1,22 @@
 group 'io.opentelemetry.example'
 version '1.0-SNAPSHOT'
 
+buildscript {
+  repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
+  }
+  dependencies {
+    classpath "com.diffplug.spotless:spotless-plugin-gradle:6.1.2"
+  }
+}
+
 subprojects {
   version = rootProject.version
 
   apply plugin: "java"
+  apply plugin: "com.diffplug.spotless"
 
   ext {
     versions = [
@@ -32,6 +44,14 @@ subprojects {
     maven {
       name = "sonatype"
       url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+    }
+  }
+
+  spotless {
+    java {
+      googleJavaFormat()
+      licenseHeaderFile(rootProject.file("../../buildscripts/spotless.license.java"), "(package|import|public)")
+      target("src/**/*.java")
     }
   }
 

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoIdGenerator.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoIdGenerator.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.sdk.trace.IdGenerator;

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoPropagator.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoPropagator.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.context.Context;

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoPropagatorProvider.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoPropagatorProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.context.propagation.TextMapPropagator;

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoPropertySource.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoPropertySource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.javaagent.extension.config.ConfigPropertySource;

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoResourceProvider.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoResourceProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.api.common.Attributes;

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoSampler.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoSampler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.api.common.Attributes;

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoSdkTracerProviderConfigurer.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoSdkTracerProviderConfigurer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoSpanExporter.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoSpanExporter.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;

--- a/examples/distro/custom/src/main/java/com/example/javaagent/DemoSpanProcessor.java
+++ b/examples/distro/custom/src/main/java/com/example/javaagent/DemoSpanProcessor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.context.Context;

--- a/examples/distro/instrumentation/servlet-3/src/main/java/com/example/javaagent/instrumentation/DemoServlet3Instrumentation.java
+++ b/examples/distro/instrumentation/servlet-3/src/main/java/com/example/javaagent/instrumentation/DemoServlet3Instrumentation.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.instrumentation;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType;

--- a/examples/distro/instrumentation/servlet-3/src/main/java/com/example/javaagent/instrumentation/DemoServlet3InstrumentationModule.java
+++ b/examples/distro/instrumentation/servlet-3/src/main/java/com/example/javaagent/instrumentation/DemoServlet3InstrumentationModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.instrumentation;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;

--- a/examples/distro/instrumentation/servlet-3/src/test/java/com/example/javaagent/instrumentation/DemoServlet3InstrumentationTest.java
+++ b/examples/distro/instrumentation/servlet-3/src/test/java/com/example/javaagent/instrumentation/DemoServlet3InstrumentationTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.instrumentation;
 
 import static io.opentelemetry.sdk.testing.assertj.TracesAssert.assertThat;

--- a/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/OkHttpUtils.java
+++ b/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/OkHttpUtils.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.smoketest;
 
 import java.util.concurrent.TimeUnit;

--- a/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
+++ b/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.smoketest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SpringBootSmokeTest.java
+++ b/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SpringBootSmokeTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.smoketest;
 
 import io.opentelemetry.api.trace.TraceId;

--- a/examples/extension/build.gradle
+++ b/examples/extension/build.gradle
@@ -11,6 +11,7 @@ plugins {
   See https://imperceptiblethoughts.com/shadow/ for more details about Shadow plugin.
    */
   id "com.github.johnrengelman.shadow" version "6.1.0"
+  id "com.diffplug.spotless" version "6.1.2"
 
   id "io.opentelemetry.instrumentation.muzzle-generation" version "1.10.0-alpha-SNAPSHOT"
   id "io.opentelemetry.instrumentation.muzzle-check" version "1.10.0-alpha-SNAPSHOT"
@@ -47,6 +48,14 @@ configurations {
   This agent is used only during integration test.
   */
   otel
+}
+
+spotless {
+  java {
+    googleJavaFormat()
+    licenseHeaderFile(rootProject.file("../../buildscripts/spotless.license.java"), "(package|import|public)")
+    target("src/**/*.java")
+  }
 }
 
 dependencies {

--- a/examples/extension/src/main/java/com/example/javaagent/DemoIdGenerator.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoIdGenerator.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.sdk.trace.IdGenerator;

--- a/examples/extension/src/main/java/com/example/javaagent/DemoIgnoredTypesConfigurer.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoIgnoredTypesConfigurer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import com.google.auto.service.AutoService;

--- a/examples/extension/src/main/java/com/example/javaagent/DemoPropagator.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoPropagator.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.context.Context;

--- a/examples/extension/src/main/java/com/example/javaagent/DemoPropagatorProvider.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoPropagatorProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import com.google.auto.service.AutoService;

--- a/examples/extension/src/main/java/com/example/javaagent/DemoPropertySource.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoPropertySource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import com.google.auto.service.AutoService;

--- a/examples/extension/src/main/java/com/example/javaagent/DemoResourceProvider.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoResourceProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import com.google.auto.service.AutoService;

--- a/examples/extension/src/main/java/com/example/javaagent/DemoSampler.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoSampler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.api.common.Attributes;

--- a/examples/extension/src/main/java/com/example/javaagent/DemoSdkTracerProviderConfigurer.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoSdkTracerProviderConfigurer.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import com.google.auto.service.AutoService;

--- a/examples/extension/src/main/java/com/example/javaagent/DemoSpanExporter.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoSpanExporter.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;

--- a/examples/extension/src/main/java/com/example/javaagent/DemoSpanProcessor.java
+++ b/examples/extension/src/main/java/com/example/javaagent/DemoSpanProcessor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent;
 
 import io.opentelemetry.context.Context;

--- a/examples/extension/src/main/java/com/example/javaagent/instrumentation/DemoServlet3Instrumentation.java
+++ b/examples/extension/src/main/java/com/example/javaagent/instrumentation/DemoServlet3Instrumentation.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.instrumentation;
 
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;

--- a/examples/extension/src/main/java/com/example/javaagent/instrumentation/DemoServlet3InstrumentationModule.java
+++ b/examples/extension/src/main/java/com/example/javaagent/instrumentation/DemoServlet3InstrumentationModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.instrumentation;
 
 import static java.util.Collections.singletonList;

--- a/examples/extension/src/test/java/com/example/javaagent/smoketest/IntegrationTest.java
+++ b/examples/extension/src/test/java/com/example/javaagent/smoketest/IntegrationTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.smoketest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/examples/extension/src/test/java/com/example/javaagent/smoketest/OkHttpUtils.java
+++ b/examples/extension/src/test/java/com/example/javaagent/smoketest/OkHttpUtils.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.smoketest;
 
 import java.util.concurrent.TimeUnit;

--- a/examples/extension/src/test/java/com/example/javaagent/smoketest/SpringBootIntegrationTest.java
+++ b/examples/extension/src/test/java/com/example/javaagent/smoketest/SpringBootIntegrationTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.example.javaagent.smoketest;
 
 import io.opentelemetry.api.trace.TraceId;

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
   implementation("org.eclipse.aether:aether-transport-http:1.1.0")
   implementation("org.apache.maven:maven-aether-provider:3.3.9")
 
-  implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.1")
+  implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
 
   testImplementation("org.assertj:assertj-core:3.21.0")
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/AkkaHttpTestAsyncWebServer.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/AkkaHttpTestAsyncWebServer.scala
@@ -31,7 +31,7 @@ object AkkaHttpTestAsyncWebServer {
             def doCall(): HttpResponse = {
               val resp = HttpResponse(status =
                 endpoint.getStatus
-              ) //.withHeaders(headers.Type)resp.contentType = "text/plain"
+              ) // .withHeaders(headers.Type)resp.contentType = "text/plain"
               endpoint match {
                 case SUCCESS => resp.withEntity(endpoint.getBody)
                 case INDEXED_CHILD =>

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/AkkaHttpTestWebServer.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/AkkaHttpTestWebServer.scala
@@ -27,7 +27,7 @@ object AkkaHttpTestWebServer {
     )
   }
 
-  val route = { //handleExceptions(exceptionHandler) {
+  val route = { // handleExceptions(exceptionHandler) {
     path(SUCCESS.rawPath) {
       complete(
         HttpResponse(status = SUCCESS.getStatus).withEntity(SUCCESS.getBody)

--- a/smoke-tests/images/fake-backend/build.gradle
+++ b/smoke-tests/images/fake-backend/build.gradle
@@ -7,6 +7,7 @@ plugins {
   id "com.bmuschko.docker-remote-api" version "6.7.0"
   id "com.github.johnrengelman.shadow" version "6.1.0"
   id "de.undercouch.download" version "4.1.1"
+  id "com.diffplug.spotless" version "6.1.2"
 }
 
 group = "io.opentelemetry"
@@ -18,6 +19,14 @@ repositories {
 
 compileJava {
   options.release.set(11)
+}
+
+spotless {
+  java {
+    googleJavaFormat()
+    licenseHeaderFile(rootProject.file("../../../buildscripts/spotless.license.java"), "(package|import|public)")
+    target("src/**/*.java")
+  }
 }
 
 dependencies {

--- a/smoke-tests/images/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
+++ b/smoke-tests/images/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeBackendMain.java
@@ -1,17 +1,6 @@
 /*
  * Copyright The OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.smoketest.fakebackend;

--- a/smoke-tests/images/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeLogsCollectorService.java
+++ b/smoke-tests/images/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeLogsCollectorService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.smoketest.fakebackend;
 
 import com.google.common.collect.ImmutableList;

--- a/smoke-tests/images/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeMetricsCollectorService.java
+++ b/smoke-tests/images/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeMetricsCollectorService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.smoketest.fakebackend;
 
 import com.google.common.collect.ImmutableList;

--- a/smoke-tests/images/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeTraceCollectorService.java
+++ b/smoke-tests/images/fake-backend/src/main/java/io/opentelemetry/smoketest/fakebackend/FakeTraceCollectorService.java
@@ -1,17 +1,6 @@
 /*
  * Copyright The OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.smoketest.fakebackend;

--- a/smoke-tests/images/grpc/build.gradle
+++ b/smoke-tests/images/grpc/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id "java"
   id "com.google.cloud.tools.jib" version "3.1.4"
+  id "com.diffplug.spotless" version "6.1.2"
 }
 
 group = "io.opentelemetry"
@@ -14,6 +15,14 @@ repositories {
     content {
       includeGroup "io.opentelemetry"
     }
+  }
+}
+
+spotless {
+  java {
+    googleJavaFormat()
+    licenseHeaderFile(rootProject.file("../../../buildscripts/spotless.license.java"), "(package|import|public)")
+    target("src/**/*.java")
   }
 }
 

--- a/smoke-tests/images/play/build.gradle
+++ b/smoke-tests/images/play/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id "org.gradle.playframework" version "0.12"
   id "com.google.cloud.tools.jib" version "3.1.4"
+  id "com.diffplug.spotless" version "6.1.2"
 }
 
 ext {
@@ -27,6 +28,14 @@ repositories {
 }
 
 description = "Play Integration Tests."
+
+spotless {
+  scala {
+    scalafmt()
+    licenseHeaderFile(rootProject.file("../../../buildscripts/spotless.license.java"), "(package|import|public)")
+    target("src/**/*.scala")
+  }
+}
 
 dependencies {
   implementation "com.typesafe.play:play-guice_$scalaVersion:$playVersion"

--- a/smoke-tests/images/quarkus/build.gradle
+++ b/smoke-tests/images/quarkus/build.gradle
@@ -8,6 +8,7 @@ plugins {
   id "java"
   id "io.quarkus"
   id "com.google.cloud.tools.jib" version "3.1.4"
+  id "com.diffplug.spotless" version "6.1.2"
 }
 
 group = "io.opentelemetry"
@@ -16,6 +17,14 @@ version = "0.0.1-SNAPSHOT"
 repositories {
   mavenCentral()
   mavenLocal()
+}
+
+spotless {
+  java {
+    googleJavaFormat()
+    licenseHeaderFile(rootProject.file("../../../buildscripts/spotless.license.java"), "(package|import|public)")
+    target("src/**/*.java")
+  }
 }
 
 dependencies {

--- a/smoke-tests/images/quarkus/src/main/java/io/opentelemetry/smoketest/quarkus/HelloResource.java
+++ b/smoke-tests/images/quarkus/src/main/java/io/opentelemetry/smoketest/quarkus/HelloResource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.smoketest.quarkus;
 
 import javax.ws.rs.GET;

--- a/smoke-tests/images/servlet/servlet-3.0/build.gradle
+++ b/smoke-tests/images/servlet/servlet-3.0/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id "war"
+  id "com.diffplug.spotless" version "6.1.2"
 }
 
 compileJava {
@@ -8,6 +9,14 @@ compileJava {
 
 repositories {
   mavenCentral()
+}
+
+spotless {
+  java {
+    googleJavaFormat()
+    licenseHeaderFile(rootProject.file("../../../buildscripts/spotless.license.java"), "(package|import|public)")
+    target("src/**/*.java")
+  }
 }
 
 dependencies {

--- a/smoke-tests/images/servlet/servlet-3.0/src/main/java/io/opentelemetry/smoketest/matrix/ExceptionRequestListener.java
+++ b/smoke-tests/images/servlet/servlet-3.0/src/main/java/io/opentelemetry/smoketest/matrix/ExceptionRequestListener.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.smoketest.matrix;
 
 import javax.servlet.ServletRequestEvent;

--- a/smoke-tests/images/servlet/servlet-5.0/build.gradle
+++ b/smoke-tests/images/servlet/servlet-5.0/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id "war"
+  id "com.diffplug.spotless" version "6.1.2"
 }
 
 compileJava {
@@ -8,6 +9,14 @@ compileJava {
 
 repositories {
   mavenCentral()
+}
+
+spotless {
+  java {
+    googleJavaFormat()
+    licenseHeaderFile(rootProject.file("../../../buildscripts/spotless.license.java"), "(package|import|public)")
+    target("src/**/*.java")
+  }
 }
 
 dependencies {

--- a/smoke-tests/images/servlet/servlet-5.0/src/main/java/io/opentelemetry/smoketest/matrix/ExceptionRequestListener.java
+++ b/smoke-tests/images/servlet/servlet-5.0/src/main/java/io/opentelemetry/smoketest/matrix/ExceptionRequestListener.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.smoketest.matrix;
 
 import jakarta.servlet.ServletRequestEvent;

--- a/smoke-tests/images/spring-boot/build.gradle
+++ b/smoke-tests/images/spring-boot/build.gradle
@@ -3,6 +3,7 @@ plugins {
   id "io.spring.dependency-management" version "1.0.9.RELEASE"
   id "java"
   id "com.google.cloud.tools.jib" version "3.1.4"
+  id "com.diffplug.spotless" version "6.1.2"
 }
 
 group = "io.opentelemetry"
@@ -16,6 +17,14 @@ repositories {
     content {
       includeGroup "io.opentelemetry"
     }
+  }
+}
+
+spotless {
+  java {
+    googleJavaFormat()
+    licenseHeaderFile(rootProject.file("../../../buildscripts/spotless.license.java"), "(package|import|public)")
+    target("src/**/*.java")
   }
 }
 

--- a/smoke-tests/images/spring-boot/src/main/java/io/opentelemetry/smoketest/springboot/SpringbootApplication.java
+++ b/smoke-tests/images/spring-boot/src/main/java/io/opentelemetry/smoketest/springboot/SpringbootApplication.java
@@ -1,17 +1,6 @@
 /*
  * Copyright The OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.smoketest.springboot;

--- a/smoke-tests/images/spring-boot/src/main/java/io/opentelemetry/smoketest/springboot/controller/PropagatingController.java
+++ b/smoke-tests/images/spring-boot/src/main/java/io/opentelemetry/smoketest/springboot/controller/PropagatingController.java
@@ -1,17 +1,6 @@
 /*
  * Copyright The OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.smoketest.springboot.controller;

--- a/smoke-tests/images/spring-boot/src/main/java/io/opentelemetry/smoketest/springboot/controller/WebController.java
+++ b/smoke-tests/images/spring-boot/src/main/java/io/opentelemetry/smoketest/springboot/controller/WebController.java
@@ -1,17 +1,6 @@
 /*
  * Copyright The OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.smoketest.springboot.controller;


### PR DESCRIPTION
Adds spotless to these standalone projects:

* benchmark-overhead
* examples/distro
* examples/extension
* smoke-tests/images/*

Split out into separate commits (adding configuration vs applying spotless) for easier review.