### PR TITLE
Akka http server span names are always akka.request #3478

### DIFF
--- a/instrumentation/play/play-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/PlayTracer.java
+++ b/instrumentation/play/play-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/PlayTracer.java
@@ -23,6 +23,8 @@ public class PlayTracer extends BaseTracer {
       if (!pathOption.isEmpty()) {
         String path = pathOption.get();
         span.updateName(path);
+      } else {
+        span.updateName(request.path());
       }
     }
   }

--- a/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -110,6 +110,5 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
     return endpoint.getPath();
-    //return "HTTP GET"
   }
 }

--- a/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -97,7 +97,7 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
   @Override
   void handlerSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
-      name "play.request"
+      name endpoint.getPath()
       kind INTERNAL
       if (endpoint == EXCEPTION) {
         status StatusCode.ERROR
@@ -109,6 +109,7 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
 
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
-    return "HTTP GET"
+    return endpoint.getPath();
+    //return "HTTP GET"
   }
 }

--- a/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -109,6 +109,6 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
 
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
-    return endpoint.getPath();
+    return endpoint.getPath()
   }
 }

--- a/instrumentation/play/play-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/PlayTracer.java
+++ b/instrumentation/play/play-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/PlayTracer.java
@@ -64,6 +64,10 @@ public class PlayTracer extends BaseTracer {
       if (defOption != null && !defOption.isEmpty()) {
         String path = defOption.get().path();
         span.updateName(path);
+      } else {
+        if (request != null) {
+          span.updateName(request.path());
+        }
       }
     }
   }

--- a/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -89,7 +89,7 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
 
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
-    return endpoint.getPath();
+    return endpoint.getPath()
   }
 
 }

--- a/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -77,7 +77,7 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
   @Override
   void handlerSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
-      name "play.request"
+      name endpoint.getPath()
       kind INTERNAL
       childOf((SpanData) parent)
       if (endpoint == EXCEPTION) {
@@ -89,7 +89,8 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
 
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
-    return "akka.request"
+    return endpoint.getPath();
+    // return "akka.request"
   }
 
 }

--- a/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -90,7 +90,6 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
     return endpoint.getPath();
-    // return "akka.request"
   }
 
 }


### PR DESCRIPTION
Open Telemetry java instrumentation to a Scala Akka service.  Akka server span name is hardcoded with akka.request.
Make sure AkkaHttpServerInstrumentationTest is retrofitted after the fix.   also double check TomcatHandlerTest.
Expected to see  GET /v1/{user} would generate a span name /v1/{user}
