### PR TITLE
Predeclare spotless deps to allow high concurrency

### DIFF
--- a/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import com.diffplug.gradle.spotless.SpotlessExtension
+
 plugins {
   id("com.diffplug.spotless")
 }
@@ -44,5 +46,26 @@ spotless {
     indentWithSpaces()
     trimTrailingWhitespace()
     endWithNewline()
+  }
+}
+
+if (project == rootProject) {
+  spotless {
+    predeclareDeps()
+  }
+
+  with(extensions["spotlessPredeclare"] as SpotlessExtension) {
+    java {
+      googleJavaFormat()
+    }
+    scala {
+      scalafmt()
+    }
+    kotlin {
+      ktlint()
+    }
+    kotlinGradle {
+      ktlint()
+    }
   }
 }

--- a/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -49,6 +49,7 @@ spotless {
   }
 }
 
+// Use root declared tool deps to avoid issues with high concurrency.
 if (project == rootProject) {
   spotless {
     predeclareDeps()


### PR DESCRIPTION
I haven't been able to succeed with recent spotless versions on a 16-core machine, but it seems the very latest version added this workaround which causes tools to only be resolved in a single, root project, instead of every project causing deadlocks.