### PR TITLE
Don't capture http.target as metrics attribute

### DIFF
--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsTest.java
@@ -143,7 +143,6 @@ class HttpServerMetricsTest {
                                         .containsOnly(
                                             attributeEntry("http.scheme", "https"),
                                             attributeEntry("http.host", "host"),
-                                            attributeEntry("http.target", "/"),
                                             attributeEntry("http.method", "GET"),
                                             attributeEntry("http.status_code", 200),
                                             attributeEntry("http.flavor", "2.0"));

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsViewTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsViewTest.java
@@ -136,8 +136,6 @@ public class TemporaryMetricsViewTest {
         .containsOnly(
             attributeEntry(SemanticAttributes.HTTP_SCHEME.getKey(), "https"),
             attributeEntry(SemanticAttributes.HTTP_HOST.getKey(), "somehost"),
-            attributeEntry(
-                SemanticAttributes.HTTP_TARGET.getKey(), "/somehost/high/cardinality/12345"),
             attributeEntry(SemanticAttributes.HTTP_METHOD.getKey(), "GET"),
             attributeEntry(SemanticAttributes.HTTP_STATUS_CODE.getKey(), 500));
   }


### PR DESCRIPTION
Resolves #5047

Introduces experimental attribute `otel.instrumentation.metrics.experimental.use-http-target-fallback` to re-enable capturing of `http.target` when `http.route` is unavailable, primarily for testing purposes until `http.route` is captured consistently.