### PR TITLE
Attempt to fix flaky micrometer test

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/micrometer/v1_5/GaugeTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/micrometer/v1_5/GaugeTest.java
@@ -131,7 +131,6 @@ class GaugeTest {
                         .hasDoubleGauge()
                         .points()
                         .satisfiesExactly(point -> assertThat(point).hasValue(42))));
-    testing.clearData();
 
     // when
     WeakReference<AtomicLong> numWeakRef = new WeakReference<>(num);
@@ -139,6 +138,7 @@ class GaugeTest {
     GcUtils.awaitGc(numWeakRef);
 
     // then
+    testing.clearData();
     Thread.sleep(100); // interval of the test metrics exporter
     testing.waitAndAssertMetrics(
         INSTRUMENTATION_NAME, "testWeakRefGauge", AbstractIterableAssert::isEmpty);


### PR DESCRIPTION
https://ge.opentelemetry.io/s/ufhrijfpxyaos/tests/:instrumentation:micrometer:micrometer-1.5:javaagent:test/io.opentelemetry.javaagent.instrumentation.micrometer.v1_5.GaugeTest/testWeakRefGauge()?expanded-stacktrace=WyIwIl0&top-execution=1
I guess it is possible that new metrics arrive between clearing the test data and clearing weak ref.