### PR TITLE
Add `http.route` to the server span when `ServerSpanNaming` is updated

### DIFF
--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> implements AgentTestTrait {
 
@@ -27,6 +29,13 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> 
   @Override
   boolean testCapturedHttpHeaders() {
     false
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
   }
 }
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/HttpSpanDecorator.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/HttpSpanDecorator.java
@@ -121,6 +121,7 @@ class HttpSpanDecorator extends BaseSpanDecorator {
   private void updateServerSpanName(Span serverSpan, Exchange exchange, Endpoint endpoint) {
     String path = getPath(exchange, endpoint);
     if (path != null) {
+      // TODO should update SERVER span name/route using ServerSpanNaming
       serverSpan.updateName(path);
     }
   }

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.groovy
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.RetryOnAddressAlreadyInUseTrait
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -20,6 +18,7 @@ import spock.lang.Shared
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class RestCamelTest extends AgentInstrumentationSpecification implements RetryOnAddressAlreadyInUseTrait {
 
@@ -100,6 +99,7 @@ class RestCamelTest extends AgentInstrumentationSpecification implements RetryOn
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" String
           }
         }
         it.span(3) {

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.groovy
@@ -99,7 +99,8 @@ class RestCamelTest extends AgentInstrumentationSpecification implements RetryOn
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
-            "$SemanticAttributes.HTTP_ROUTE" String
+            // TODO: camel instrumentation does not use ServerSpanNaming to update the route, so the matched route is provided by the servlet instrumentation
+            "$SemanticAttributes.HTTP_ROUTE" "/*"
           }
         }
         it.span(3) {

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.RetryOnAddressAlreadyInUseTrait
 import io.opentelemetry.instrumentation.test.utils.PortUtils
@@ -22,6 +20,7 @@ import spock.lang.Shared
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class TwoServicesWithDirectClientCamelTest extends AgentInstrumentationSpecification implements RetryOnAddressAlreadyInUseTrait {
 
@@ -136,6 +135,7 @@ class TwoServicesWithDirectClientCamelTest extends AgentInstrumentationSpecifica
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
             "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_ROUTE" String
           }
         }
         it.span(5) {

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
@@ -135,7 +135,8 @@ class TwoServicesWithDirectClientCamelTest extends AgentInstrumentationSpecifica
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
             "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" Long
-            "$SemanticAttributes.HTTP_ROUTE" String
+            // TODO: camel instrumentation does not use ServerSpanNaming to update the route, so the matched route is provided by the servlet instrumentation
+            "$SemanticAttributes.HTTP_ROUTE" "/*"
           }
         }
         it.span(5) {

--- a/instrumentation/armeria-1.3/testing/src/main/groovy/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpServerTest.groovy
+++ b/instrumentation/armeria-1.3/testing/src/main/groovy/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpServerTest.groovy
@@ -29,6 +29,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
@@ -39,11 +40,22 @@ abstract class AbstractArmeriaHttpServerTest extends HttpServerTest<Server> {
   abstract ServerBuilder configureServer(ServerBuilder serverBuilder)
 
   @Override
+  String expectedHttpRoute(ServerEndpoint endpoint) {
+    switch (endpoint) {
+      case NOT_FOUND:
+        // TODO(anuraaga): Revisit this when applying instrumenters to more libraries, Armeria
+        // currently reports '/*' which is a fallback route.
+        return "/*"
+      default:
+        return super.expectedHttpRoute(endpoint)
+    }
+  }
+
+  @Override
   List<AttributeKey<?>> extraAttributes() {
     [
       SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH,
       SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,
-      SemanticAttributes.HTTP_ROUTE,
       SemanticAttributes.HTTP_SERVER_NAME,
       SemanticAttributes.NET_PEER_NAME,
       SemanticAttributes.NET_TRANSPORT

--- a/instrumentation/dropwizard/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -93,14 +93,14 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> implements Ag
   }
 
   @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
+  String expectedHttpRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
-      case PATH_PARAM:
-        return "/path/{id}/param"
       case NOT_FOUND:
-        return "/*"
+        return getContextPath() + "/*"
+      case PATH_PARAM:
+        return getContextPath() + "/path/{id}/param"
       default:
-        return endpoint.resolvePath(address).path
+        return super.expectedHttpRoute(endpoint)
     }
   }
 

--- a/instrumentation/grails-3.0/javaagent/src/test/groovy/test/GrailsTest.groovy
+++ b/instrumentation/grails-3.0/javaagent/src/test/groovy/test/GrailsTest.groovy
@@ -66,7 +66,7 @@ class GrailsTest extends HttpServerTest<ConfigurableApplicationContext> implemen
   }
 
   @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
+  String expectedHttpRoute(ServerEndpoint endpoint) {
     if (endpoint == PATH_PARAM) {
       return getContextPath() + "/test/path"
     } else if (endpoint == QUERY_PARAM) {

--- a/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyFilterchainServerTest.groovy
+++ b/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyFilterchainServerTest.groovy
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
-import java.nio.charset.StandardCharsets
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.glassfish.grizzly.filterchain.BaseFilter
 import org.glassfish.grizzly.filterchain.FilterChain
 import org.glassfish.grizzly.filterchain.FilterChainBuilder
@@ -25,6 +26,7 @@ import org.glassfish.grizzly.nio.transport.TCPNIOTransportBuilder
 import org.glassfish.grizzly.utils.DelayedExecutor
 import org.glassfish.grizzly.utils.IdleTimeoutFilter
 
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.Executors
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
@@ -59,6 +61,18 @@ class GrizzlyFilterchainServerTest extends HttpServerTest<HttpServer> implements
   @Override
   void stopServer(HttpServer httpServer) {
     transport.shutdownNow()
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
+  }
+
+  @Override
+  String expectedServerSpanName(ServerEndpoint endpoint) {
+    return "HTTP GET"
   }
 
   @Override
@@ -229,10 +243,5 @@ class GrizzlyFilterchainServerTest extends HttpServerTest<HttpServer> implements
         }
       }
     }
-  }
-
-  @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
-    return "HTTP GET"
   }
 }

--- a/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyTest.groovy
+++ b/instrumentation/grizzly-2.0/javaagent/src/test/groovy/GrizzlyTest.groovy
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.glassfish.grizzly.http.server.HttpHandler
 import org.glassfish.grizzly.http.server.HttpServer
 import org.glassfish.grizzly.http.server.Request
@@ -40,6 +42,18 @@ class GrizzlyTest extends HttpServerTest<HttpServer> implements AgentTestTrait {
     server.start()
 
     return server
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
+  }
+
+  @Override
+  String expectedServerSpanName(ServerEndpoint endpoint) {
+    return "HTTP GET"
   }
 
   @Override
@@ -106,11 +120,6 @@ class GrizzlyTest extends HttpServerTest<HttpServer> implements AgentTestTrait {
         Response.status(INDEXED_CHILD.status).entity(INDEXED_CHILD.body).build()
       }
     }
-  }
-
-  @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
-    return "HTTP GET"
   }
 
   static class ExceptionHttpHandler extends HttpHandler {

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -36,6 +36,7 @@ class JaxRsAnnotations1InstrumentationTest extends AgentInstrumentationSpecifica
           kind SERVER
           hasNoParent()
           attributes {
+            "$SemanticAttributes.HTTP_ROUTE" paramName
           }
         }
         span(1) {

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JerseyTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/test/groovy/JerseyTest.groovy
@@ -38,9 +38,10 @@ class JerseyTest extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          name expectedSpanName
+          name expectedRoute
           kind SERVER
           attributes {
+            "$SemanticAttributes.HTTP_ROUTE" expectedRoute
           }
         }
 
@@ -56,7 +57,7 @@ class JerseyTest extends AgentInstrumentationSpecification {
     }
 
     where:
-    resource           | expectedSpanName      | controllerName | expectedResponse
+    resource           | expectedRoute         | controllerName | expectedResponse
     "/test/hello/bob"  | "/test/hello/{name}"  | "Test1.hello"  | "Test1 bob!"
     "/test2/hello/bob" | "/test2/hello/{name}" | "Test2.hello"  | "Test2 bob!"
     "/test3/hi/bob"    | "/test3/hi/{name}"    | "Test3.hello"  | "Test3 bob!"
@@ -76,9 +77,10 @@ class JerseyTest extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          name expectedSpanName
+          name expectedRoute
           kind SERVER
           attributes {
+            "$SemanticAttributes.HTTP_ROUTE" expectedRoute
           }
         }
         span(1) {
@@ -94,7 +96,7 @@ class JerseyTest extends AgentInstrumentationSpecification {
     }
 
     where:
-    resource        | expectedSpanName | controller1Name | expectedResponse
-    "/test3/nested" | "/test3/nested"  | "Test3.nested"  | "Test3 nested!"
+    resource        | expectedRoute   | controller1Name | expectedResponse
+    "/test3/nested" | "/test3/nested" | "Test3.nested"  | "Test3 nested!"
   }
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/groovy/JaxRsFilterTest.groovy
@@ -135,6 +135,7 @@ abstract class JaxRsFilterTest extends AgentInstrumentationSpecification {
           kind SERVER
           if (!runsOnServer()) {
             attributes {
+              "$SemanticAttributes.HTTP_ROUTE" parentResourceName
             }
           }
         }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/groovy/JaxRsHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/groovy/JaxRsHttpServerTest.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -20,6 +18,7 @@ import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 
@@ -287,6 +286,7 @@ abstract class JaxRsHttpServerTest<S> extends HttpServerTest<S> implements Agent
         "$SemanticAttributes.HTTP_SERVER_NAME" String
         "$SemanticAttributes.NET_TRANSPORT" IP_TCP
         "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long } // Optional
+        "$SemanticAttributes.HTTP_ROUTE" path
         if (fullUrl.getPath().endsWith(ServerEndpoint.CAPTURE_HEADERS.getPath())) {
           "http.request.header.x_test_request" { it == ["test"] }
           "http.response.header.x_test_response" { it == ["test"] }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/groovy/JaxrsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/groovy/JaxrsAnnotationsInstrumentationTest.groovy
@@ -36,6 +36,7 @@ abstract class JaxrsAnnotationsInstrumentationTest extends AgentInstrumentationS
           kind SERVER
           hasNoParent()
           attributes {
+            "$SemanticAttributes.HTTP_ROUTE" paramName
           }
         }
         span(1) {

--- a/instrumentation/jetty/jetty-11.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty/jetty-11.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
@@ -142,6 +142,13 @@ class JettyHandlerTest extends HttpServerTest<Server> implements AgentTestTrait 
   }
 
   @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
+  }
+
+  @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
     "HTTP GET"
   }

--- a/instrumentation/jetty/jetty-8.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty/jetty-8.0/javaagent/src/test/groovy/JettyHandlerTest.groovy
@@ -143,6 +143,13 @@ class JettyHandlerTest extends HttpServerTest<Server> implements AgentTestTrait 
   }
 
   @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
+  }
+
+  @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
     "HTTP GET"
   }

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -23,6 +21,7 @@ import java.nio.file.Files
 
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.api.trace.StatusCode.ERROR
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 //TODO should this be HttpServerTest?
 class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
@@ -85,15 +84,17 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
+          def route = "/$jspWebappContext/$jspFileName"
+
           hasNoParent()
-          name "/$jspWebappContext/$jspFileName"
+          name route
           kind SERVER
           attributes {
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/$jspFileName"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
@@ -101,6 +102,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
             "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long } // Optional
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -140,21 +142,24 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
+          def route = "/$jspWebappContext/getQuery.jsp"
+
           hasNoParent()
-          name "/$jspWebappContext/getQuery.jsp"
+          name route
           kind SERVER
           attributes {
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/getQuery.jsp?$queryString"
+            "$SemanticAttributes.HTTP_TARGET" "$route?$queryString"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -190,15 +195,17 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
+          def route = "/$jspWebappContext/post.jsp"
+
           hasNoParent()
-          name "/$jspWebappContext/post.jsp"
+          name route
           kind SERVER
           attributes {
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/post.jsp"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "POST"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
@@ -206,6 +213,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
             "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -237,8 +245,10 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
+          def route = "/$jspWebappContext/$jspFileName"
+
           hasNoParent()
-          name "/$jspWebappContext/$jspFileName"
+          name route
           kind SERVER
           status ERROR
           event(0) {
@@ -258,13 +268,14 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/$jspFileName"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 500
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -314,21 +325,24 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
+          def route = "/$jspWebappContext/includes/includeHtml.jsp"
+
           hasNoParent()
-          name "/$jspWebappContext/includes/includeHtml.jsp"
+          name route
           kind SERVER
           attributes {
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/includes/includeHtml.jsp"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -359,21 +373,24 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 7) {
         span(0) {
+          def route = "/$jspWebappContext/includes/includeMulti.jsp"
+
           hasNoParent()
-          name "/$jspWebappContext/includes/includeMulti.jsp"
+          name route
           kind SERVER
           attributes {
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/includes/includeMulti.jsp"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -434,8 +451,10 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
+          def route = "/$jspWebappContext/$jspFileName"
+
           hasNoParent()
-          name "/$jspWebappContext/$jspFileName"
+          name route
           kind SERVER
           status ERROR
           errorEvent(JasperException, String)
@@ -444,13 +463,14 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/$jspFileName"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 500
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -482,8 +502,10 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
+          def route = "/$jspWebappContext/*"
+
           hasNoParent()
-          name "/$jspWebappContext/*"
+          name route
           kind SERVER
           attributes {
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"
@@ -497,6 +519,7 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
       }

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
-
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -21,6 +19,7 @@ import java.nio.file.Files
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.api.trace.StatusCode.UNSET
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP
 
 class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
 
@@ -83,21 +82,24 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 5) {
         span(0) {
+          def route = "/$jspWebappContext/$forwardFromFileName"
+
           hasNoParent()
-          name "/$jspWebappContext/$forwardFromFileName"
+          name route
           kind SERVER
           attributes {
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/$forwardFromFileName"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -149,21 +151,24 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
+          def route = "/$jspWebappContext/forwards/forwardToHtml.jsp"
+
           hasNoParent()
-          name "/$jspWebappContext/forwards/forwardToHtml.jsp"
+          name route
           kind SERVER
           attributes {
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/forwards/forwardToHtml.jsp"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -194,21 +199,24 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 9) {
         span(0) {
+          def route = "/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
+
           hasNoParent()
-          name "/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
+          name route
           kind SERVER
           attributes {
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -287,21 +295,24 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 7) {
         span(0) {
+          def route = "/$jspWebappContext/forwards/forwardToJspForward.jsp"
+
           hasNoParent()
-          name "/$jspWebappContext/forwards/forwardToJspForward.jsp"
+          name route
           kind SERVER
           attributes {
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/forwards/forwardToJspForward.jsp"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -364,8 +375,10 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
+          def route = "/$jspWebappContext/forwards/forwardToCompileError.jsp"
+
           hasNoParent()
-          name "/$jspWebappContext/forwards/forwardToCompileError.jsp"
+          name route
           kind SERVER
           status ERROR
           errorEvent(JasperException, String)
@@ -374,13 +387,14 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/forwards/forwardToCompileError.jsp"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 500
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {
@@ -423,8 +437,10 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
+          def route = "/$jspWebappContext/forwards/forwardToNonExistent.jsp"
+
           hasNoParent()
-          name "/$jspWebappContext/forwards/forwardToNonExistent.jsp"
+          name route
           kind SERVER
           status UNSET
           attributes {
@@ -432,13 +448,14 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.NET_PEER_PORT" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_HOST" "localhost:$port"
-            "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/forwards/forwardToNonExistent.jsp"
+            "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 404
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SERVER_NAME" String
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "$SemanticAttributes.HTTP_ROUTE" route
           }
         }
         span(1) {

--- a/instrumentation/ktor-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerTest.groovy
+++ b/instrumentation/ktor-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerTest.groovy
@@ -13,7 +13,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 import java.util.concurrent.TimeUnit
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 
 class KtorHttpServerTest extends HttpServerTest<ApplicationEngine> implements LibraryTestTrait {
 
@@ -35,12 +35,23 @@ class KtorHttpServerTest extends HttpServerTest<ApplicationEngine> implements Li
   }
 
   @Override
+  boolean testPathParam() {
+    true
+  }
+
+  @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
+    def route = expectedHttpRoute(endpoint)
+    return route == null ? "HTTP GET" : route
+  }
+
+  @Override
+  String expectedHttpRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
-      case NOT_FOUND:
-        return "HTTP GET"
+      case PATH_PARAM:
+        return getContextPath() + "/path/{id}/param"
       default:
-        return endpoint.resolvePath(address).path
+        return super.expectedHttpRoute(endpoint)
     }
   }
 

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ServerTest.groovy
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.jboss.netty.bootstrap.ServerBootstrap
 import org.jboss.netty.buffer.ChannelBuffer
 import org.jboss.netty.buffer.ChannelBuffers
@@ -157,6 +159,13 @@ class Netty38ServerTest extends HttpServerTest<ServerBootstrap> implements Agent
   @Override
   void stopServer(ServerBootstrap server) {
     server?.shutdown()
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
   }
 
   @Override

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
@@ -24,8 +24,10 @@ import io.netty.handler.codec.http.QueryStringDecoder
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
@@ -126,6 +128,13 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup> implements AgentT
   @Override
   void stopServer(EventLoopGroup server) {
     server?.shutdownGracefully()
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
   }
 
   @Override

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ServerTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ServerTest.groovy
@@ -23,8 +23,10 @@ import io.netty.handler.codec.http.QueryStringDecoder
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE
@@ -125,6 +127,13 @@ class Netty41ServerTest extends HttpServerTest<EventLoopGroup> implements AgentT
   @Override
   void stopServer(EventLoopGroup server) {
     server?.shutdownGracefully()
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
   }
 
   @Override

--- a/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.4/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -5,12 +5,13 @@
 
 package server
 
-
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import play.mvc.Results
 import play.routing.RoutingDsl
 import play.server.Server
@@ -100,6 +101,13 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
       }
       childOf((SpanData) parent)
     }
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
   }
 
   @Override

--- a/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/javaagent/src/test/groovy/server/PlayServerTest.groovy
@@ -5,11 +5,13 @@
 
 package server
 
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import play.BuiltInComponents
 import play.Mode
 import play.mvc.Controller
@@ -97,6 +99,13 @@ class PlayServerTest extends HttpServerTest<Server> implements AgentTestTrait {
         errorEvent(Exception, EXCEPTION.body)
       }
     }
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
   }
 
   @Override

--- a/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackHttpServerTest.groovy
+++ b/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackHttpServerTest.groovy
@@ -152,7 +152,7 @@ abstract class AbstractRatpackHttpServerTest extends HttpServerTest<RatpackServe
   }
 
   @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
+  String expectedHttpRoute(ServerEndpoint endpoint) {
     return endpoint.status == 404 ? "/" : endpoint == PATH_PARAM ? "/path/:id/param" : endpoint.path
   }
 }

--- a/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
+++ b/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
@@ -128,14 +128,10 @@ abstract class AbstractRatpackRoutesTest extends InstrumentationSpecification {
             if (extraAttributes.contains(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH)) {
               "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
             }
-            if (extraAttributes.contains(SemanticAttributes.HTTP_ROUTE)) {
-              // TODO(anuraaga): Revisit this when applying instrumenters to more libraries, Armeria
-              // currently reports '/*' which is a fallback route.
-              "$SemanticAttributes.HTTP_ROUTE" String
-            }
             if (extraAttributes.contains(SemanticAttributes.HTTP_SERVER_NAME)) {
               "$SemanticAttributes.HTTP_SERVER_NAME" String
             }
+            "$SemanticAttributes.HTTP_ROUTE" "/$route"
           }
         }
         if (hasHandlerSpan()) {

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/server/RatpackRoutesTest.groovy
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/server/RatpackRoutesTest.groovy
@@ -28,7 +28,6 @@ class RatpackRoutesTest extends AbstractRatpackRoutesTest implements LibraryTest
   @Override
   List<AttributeKey<?>> extraAttributes() {
     return [
-      SemanticAttributes.HTTP_ROUTE,
       SemanticAttributes.NET_TRANSPORT
     ]
   }

--- a/instrumentation/restlet/restlet-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v1_0/AbstractRestletServerTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v1_0/AbstractRestletServerTest.groovy
@@ -165,14 +165,14 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
+  String expectedHttpRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case PATH_PARAM:
         return getContextPath() + "/path/{id}/param"
       case NOT_FOUND:
         return getContextPath() + "/*"
       default:
-        return endpoint.resolvePath(address).path
+        return super.expectedHttpRoute(endpoint)
     }
   }
 

--- a/instrumentation/restlet/restlet-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v1_0/AbstractServletServerTest.groovy
+++ b/instrumentation/restlet/restlet-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v1_0/AbstractServletServerTest.groovy
@@ -71,17 +71,16 @@ abstract class AbstractServletServerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
+  String expectedHttpRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case PATH_PARAM:
         return getContextPath() + "/path/{id}/param"
       case NOT_FOUND:
         return getContextPath() + "/*"
       default:
-        return endpoint.resolvePath(address).path
+        return super.expectedHttpRoute(endpoint)
     }
   }
-
 
   static class TestApp extends Application {
 

--- a/instrumentation/restlet/restlet-2.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v2_0/AbstractRestletServerTest.groovy
+++ b/instrumentation/restlet/restlet-2.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v2_0/AbstractRestletServerTest.groovy
@@ -178,14 +178,14 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
+  String expectedHttpRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case PATH_PARAM:
         return getContextPath() + "/path/{id}/param"
       case NOT_FOUND:
         return getContextPath() + "/*"
       default:
-        return endpoint.resolvePath(address).path
+        return super.expectedHttpRoute(endpoint)
     }
   }
 

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/JettyServlet2Test.groovy
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/test/groovy/JettyServlet2Test.groovy
@@ -72,6 +72,13 @@ class JettyServlet2Test extends HttpServerTest<Server> implements AgentTestTrait
   }
 
   @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
+  }
+
+  @Override
   List<AttributeKey<?>> extraAttributes() {
     [
       SemanticAttributes.HTTP_SERVER_NAME,

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
@@ -18,6 +18,7 @@ import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEn
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
@@ -58,6 +59,16 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
   AggregatedHttpRequest request(ServerEndpoint uri, String method) {
     lastRequest = uri
     super.request(uri, method)
+  }
+
+  @Override
+  String expectedHttpRoute(ServerEndpoint endpoint) {
+    switch (endpoint) {
+      case NOT_FOUND:
+        return getContextPath() + "/*"
+      default:
+        return super.expectedHttpRoute(endpoint)
+    }
   }
 
   @Override

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.servlet.ServletHandler
@@ -36,6 +38,13 @@ class JettyServletHandlerTest extends AbstractServlet3Test<Server, ServletHandle
       sendErrorSpan(trace, index, handlerSpan)
     }
     super.responseSpan(trace, index, controllerSpan, handlerSpan, method, endpoint)
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
   }
 
   @Override

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_PARAMETERS
-
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
@@ -15,9 +13,11 @@ import jakarta.servlet.Servlet
 
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_HEADERS
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.CAPTURE_PARAMETERS
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.INDEXED_CHILD
+import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static io.opentelemetry.instrumentation.test.base.HttpServerTest.ServerEndpoint.SUCCESS
@@ -67,6 +67,16 @@ abstract class AbstractServlet5Test<SERVER, CONTEXT> extends HttpServerTest<SERV
 
   boolean errorEndpointUsesSendError() {
     true
+  }
+
+  @Override
+  String expectedHttpRoute(ServerEndpoint endpoint) {
+    switch (endpoint) {
+      case NOT_FOUND:
+        return getContextPath() + "/*"
+      default:
+        return super.expectedHttpRoute(endpoint)
+    }
   }
 
   @Override

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import jakarta.servlet.Servlet
 import jakarta.servlet.ServletException
 import jakarta.servlet.http.HttpServletRequest
@@ -13,6 +15,13 @@ import spock.lang.IgnoreIf
 
 @IgnoreIf({ !jvm.java11Compatible })
 class JettyServletHandlerTest extends AbstractServlet5Test<Object, Object> {
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
+  }
 
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {

--- a/instrumentation/spark-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/sparkjava/RoutesInstrumentation.java
+++ b/instrumentation/spark-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/sparkjava/RoutesInstrumentation.java
@@ -43,6 +43,7 @@ public class RoutesInstrumentation implements TypeInstrumentation {
 
       Span span = Java8BytecodeBridge.currentSpan();
       if (span != null && routeMatch != null) {
+        // TODO should update SERVER span name/route using ServerSpanNaming
         span.updateName(routeMatch.getMatchUri());
       }
     }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/SpringWebFluxServerTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/server/base/SpringWebFluxServerTest.groovy
@@ -5,9 +5,10 @@
 
 package server.base
 
-
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ConfigurableApplicationContext
 
@@ -32,6 +33,13 @@ abstract class SpringWebFluxServerTest extends HttpServerTest<ConfigurableApplic
   @Override
   void stopServer(ConfigurableApplicationContext ctx) {
     ctx.close()
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
   }
 
   @Override

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -88,7 +88,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   }
 
   @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
+  String expectedHttpRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case PATH_PARAM:
         return getContextPath() + "/path/{id}/param"
@@ -97,7 +97,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
       case LOGIN:
         return getContextPath() + "/*"
       default:
-        return super.expectedServerSpanName(endpoint)
+        return super.expectedHttpRoute(endpoint)
     }
   }
 

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/test/groovy/test/filter/ServletFilterTest.groovy
@@ -90,14 +90,14 @@ class ServletFilterTest extends HttpServerTest<ConfigurableApplicationContext> i
   }
 
   @Override
-  String expectedServerSpanName(ServerEndpoint endpoint) {
+  String expectedHttpRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case PATH_PARAM:
         return getContextPath() + "/path/{id}/param"
       case NOT_FOUND:
         return getContextPath() + "/**"
       default:
-        return super.expectedServerSpanName(endpoint)
+        return super.expectedHttpRoute(endpoint)
     }
   }
 

--- a/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
+++ b/instrumentation/struts-2.3/javaagent/src/test/groovy/Struts2ActionSpanTest.groovy
@@ -71,14 +71,14 @@ class Struts2ActionSpanTest extends HttpServerTest<Server> implements AgentTestT
     }
   }
 
-  String expectedServerSpanName(ServerEndpoint endpoint) {
+  String expectedHttpRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case PATH_PARAM:
         return getContextPath() + "/path/{id}/param"
       case NOT_FOUND:
         return getContextPath() + "/*"
       default:
-        return endpoint.resolvePath(address).path
+        return super.expectedHttpRoute(endpoint)
     }
   }
 

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatAsyncTest.groovy
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatAsyncTest.groovy
@@ -100,6 +100,16 @@ class TomcatAsyncTest extends HttpServerTest<Tomcat> implements AgentTestTrait {
   }
 
   @Override
+  String expectedHttpRoute(ServerEndpoint endpoint) {
+    switch (endpoint) {
+      case NOT_FOUND:
+        return getContextPath() + "/*"
+      default:
+        return super.expectedHttpRoute(endpoint)
+    }
+  }
+
+  @Override
   List<AttributeKey<?>> extraAttributes() {
     [
       SemanticAttributes.HTTP_SERVER_NAME,

--- a/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatHandlerTest.groovy
+++ b/instrumentation/tomcat/tomcat-10.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v10_0/TomcatHandlerTest.groovy
@@ -35,12 +35,8 @@ class TomcatHandlerTest extends HttpServerTest<Tomcat> implements AgentTestTrait
 
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
-    switch (endpoint) {
-      case NOT_FOUND:
-        return "HTTP GET"
-      default:
-        return endpoint.resolvePath(address).path
-    }
+    def route = expectedHttpRoute(endpoint)
+    return route == null ? "HTTP GET" : route
   }
 
   @Override

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatAsyncTest.groovy
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatAsyncTest.groovy
@@ -100,6 +100,16 @@ class TomcatAsyncTest extends HttpServerTest<Tomcat> implements AgentTestTrait {
   }
 
   @Override
+  String expectedHttpRoute(ServerEndpoint endpoint) {
+    switch (endpoint) {
+      case NOT_FOUND:
+        return getContextPath() + "/*"
+      default:
+        return super.expectedHttpRoute(endpoint)
+    }
+  }
+
+  @Override
   List<AttributeKey<?>> extraAttributes() {
     [
       SemanticAttributes.HTTP_SERVER_NAME,

--- a/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatHandlerTest.groovy
+++ b/instrumentation/tomcat/tomcat-7.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/tomcat/v7_0/TomcatHandlerTest.groovy
@@ -35,12 +35,8 @@ class TomcatHandlerTest extends HttpServerTest<Tomcat> implements AgentTestTrait
 
   @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
-    switch (endpoint) {
-      case NOT_FOUND:
-        return "HTTP GET"
-      default:
-        return endpoint.resolvePath(address).path
-    }
+    def route = expectedHttpRoute(endpoint)
+    return route == null ? "HTTP GET" : route
   }
 
   @Override

--- a/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerDispatchTest.groovy
+++ b/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerDispatchTest.groovy
@@ -97,6 +97,13 @@ class UndertowServerDispatchTest extends HttpServerTest<Undertow> implements Age
   }
 
   @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
+  }
+
+  @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
     return "HTTP GET"
   }

--- a/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
+++ b/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
@@ -106,6 +106,13 @@ class UndertowServerTest extends HttpServerTest<Undertow> implements AgentTestTr
   }
 
   @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
+  }
+
+  @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
     return "HTTP GET"
   }

--- a/instrumentation/vertx/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/server/VertxRxHttpServerTest.groovy
+++ b/instrumentation/vertx/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/server/VertxRxHttpServerTest.groovy
@@ -5,8 +5,10 @@
 
 package server
 
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.vertx.core.DeploymentOptions
 import io.vertx.core.Promise
 import io.vertx.core.Vertx

--- a/instrumentation/vertx/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/server/VertxRxHttpServerTest.groovy
+++ b/instrumentation/vertx/vertx-reactive-3.5/javaagent/src/latestDepTest/groovy/server/VertxRxHttpServerTest.groovy
@@ -63,6 +63,13 @@ class VertxRxHttpServerTest extends HttpServerTest<Vertx> implements AgentTestTr
   }
 
   @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
+  }
+
+  @Override
   String expectedServerSpanName(ServerEndpoint endpoint) {
     switch (endpoint) {
       case PATH_PARAM:

--- a/instrumentation/vertx/vertx-reactive-3.5/javaagent/src/version35Test/groovy/server/VertxRxHttpServerTest.groovy
+++ b/instrumentation/vertx/vertx-reactive-3.5/javaagent/src/version35Test/groovy/server/VertxRxHttpServerTest.groovy
@@ -5,9 +5,10 @@
 
 package server
 
-
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.vertx.core.DeploymentOptions
 import io.vertx.core.Future
 import io.vertx.core.Vertx
@@ -61,6 +62,13 @@ class VertxRxHttpServerTest extends HttpServerTest<Vertx> implements AgentTestTr
   @Override
   boolean testPathParam() {
     return true
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
   }
 
   @Override

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/RoutingContextHandlerWrapper.java
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/RoutingContextHandlerWrapper.java
@@ -33,8 +33,7 @@ public final class RoutingContextHandlerWrapper implements Handler<RoutingContex
     Span serverSpan = ServerSpan.fromContextOrNull(Context.current());
     try {
       if (serverSpan != null) {
-        // TODO should update only SERVER span using
-        // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/465
+        // TODO should update SERVER span name/route using ServerSpanNaming
         serverSpan.updateName(context.currentRoute().getPath());
       }
     } catch (RuntimeException ex) {

--- a/instrumentation/vertx/vertx-web-3.0/testing/src/main/groovy/server/AbstractVertxHttpServerTest.groovy
+++ b/instrumentation/vertx/vertx-web-3.0/testing/src/main/groovy/server/AbstractVertxHttpServerTest.groovy
@@ -5,8 +5,10 @@
 
 package server
 
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.DeploymentOptions
 import io.vertx.core.Vertx
@@ -57,6 +59,13 @@ abstract class AbstractVertxHttpServerTest extends HttpServerTest<Vertx> impleme
   boolean verifyServerSpanEndTime() {
     // server spans are ended inside of the controller spans
     return false
+  }
+
+  @Override
+  Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
+    def attributes = super.httpAttributes(endpoint)
+    attributes.remove(SemanticAttributes.HTTP_ROUTE)
+    attributes
   }
 
   @Override

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/AttributesAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/AttributesAssert.groovy
@@ -36,11 +36,11 @@ class AttributesAssert {
     assertedAttributes.add(name)
     def value = attributes.get(name)
     if (expected instanceof Pattern) {
-      assert value =~ expected
+      assert value =~ expected, "value '$value' does not match regex '$expected'"
     } else if (expected instanceof Class) {
-      assert ((Class) expected).isInstance(value)
+      assert ((Class) expected).isInstance(value), "value '$value' is not an instance of $expected.name"
     } else if (expected instanceof Closure) {
-      assert ((Closure) expected).call(value)
+      assert ((Closure) expected).call(value), "value '$value' fails the passed predicate"
     } else {
       assert value == expected
     }


### PR DESCRIPTION
Another part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/442 (which actually mostly resolves that issue, but this still needs a couple of refactorings to look good, so I won't close it until it's all done)

This PR adds `http.route` attribute to spans (no metrics yet; another PR) and introduces several TODOs - I'll track them in #442. 