### PR TITLE
Add debug logging to SpringTemplateJms1Test

### DIFF
--- a/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/SpringTemplateJms2Test.groovy
+++ b/instrumentation/jms-1.1/javaagent/src/jms2Test/groovy/SpringTemplateJms2Test.groovy
@@ -112,7 +112,6 @@ class SpringTemplateJms2Test extends AgentInstrumentationSpecification {
         session -> template.getMessageConverter().toMessage("responded!", session)
       }
     }
-    // wait for thread to start, we expect the first span to be from receive
     TextMessage receivedMessage = template.sendAndReceive(destination) {
       session -> template.getMessageConverter().toMessage(messageText, session)
     }


### PR DESCRIPTION
https://ge.opentelemetry.io/s/s4cecxm4roguc/tests/:instrumentation:jms-1.1:javaagent:test/SpringTemplateJms1Test/send%20and%20receive%20message%20generates%20spans%20%5Bdestination:%20queue:%2F%2FSpringTemplateJms1,%20destinationType:%20queue,%20destinationName:%20SpringTemplateJms1,%20%230%5D
Based on the existing test output it is hard to tell whether it failed because timeout was exceeded or something else. Hopefully added logging will tell us whether timeout should be increased.