### PR TITLE
Connect AgentLogEmitterProvider global during OpenTelemetryInstaller 

### DIFF
--- a/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingHelper.java
+++ b/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingHelper.java
@@ -31,11 +31,12 @@ public final class JavaUtilLoggingHelper {
       return;
     }
 
+    String instrumentationName = logRecord.getLoggerName();
+    if (instrumentationName == null || instrumentationName.isEmpty()) {
+      instrumentationName = "ROOT";
+    }
     LogBuilder builder =
-        AgentLogEmitterProvider.get()
-            .logEmitterBuilder(logRecord.getLoggerName())
-            .build()
-            .logBuilder();
+        AgentLogEmitterProvider.get().logEmitterBuilder(instrumentationName).build().logBuilder();
     mapLogRecord(builder, logRecord);
     builder.emit();
   }

--- a/instrumentation/log4j/log4j-appender-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v1_2/Log4jHelper.java
+++ b/instrumentation/log4j/log4j-appender-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v1_2/Log4jHelper.java
@@ -24,8 +24,12 @@ public final class Log4jHelper {
 
   // TODO (trask) capture MDC
   public static void capture(Category logger, Priority level, Object message, Throwable throwable) {
+    String instrumentationName = logger.getName();
+    if (instrumentationName == null || instrumentationName.isEmpty()) {
+      instrumentationName = "ROOT";
+    }
     LogBuilder builder =
-        AgentLogEmitterProvider.get().logEmitterBuilder(logger.getName()).build().logBuilder();
+        AgentLogEmitterProvider.get().logEmitterBuilder(instrumentationName).build().logBuilder();
 
     // message
     if (message != null) {

--- a/instrumentation/log4j/log4j-appender-2.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v2_16/Log4jHelper.java
+++ b/instrumentation/log4j/log4j-appender-2.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v2_16/Log4jHelper.java
@@ -23,9 +23,12 @@ public final class Log4jHelper {
       new LogEventMapper<>(ContextDataAccessorImpl.INSTANCE);
 
   public static void capture(Logger logger, Level level, Message message, Throwable throwable) {
-
+    String instrumentationName = logger.getName();
+    if (instrumentationName == null || instrumentationName.isEmpty()) {
+      instrumentationName = "ROOT";
+    }
     LogBuilder builder =
-        AgentLogEmitterProvider.get().logEmitterBuilder(logger.getName()).build().logBuilder();
+        AgentLogEmitterProvider.get().logEmitterBuilder(instrumentationName).build().logBuilder();
     Map<String, String> contextData = ThreadContext.getImmutableContext();
     mapper.mapLogEvent(builder, message, level, throwable, null, contextData);
     builder.emit();

--- a/instrumentation/log4j/log4j-appender-2.16/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_16/OpenTelemetryAppender.java
+++ b/instrumentation/log4j/log4j-appender-2.16/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_16/OpenTelemetryAppender.java
@@ -66,12 +66,12 @@ public class OpenTelemetryAppender extends AbstractAppender {
 
   @Override
   public void append(LogEvent event) {
+    String instrumentationName = event.getLoggerName();
+    if (instrumentationName == null || instrumentationName.isEmpty()) {
+      instrumentationName = "ROOT";
+    }
     LogBuilder builder =
-        logEmitterProviderHolder
-            .get()
-            .logEmitterBuilder(event.getLoggerName())
-            .build()
-            .logBuilder();
+        logEmitterProviderHolder.get().logEmitterBuilder(instrumentationName).build().logBuilder();
     ReadOnlyStringMap contextData = event.getContextData();
     mapper.mapLogEvent(
         builder,

--- a/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/internal/LoggingEventMapper.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/internal/LoggingEventMapper.java
@@ -53,8 +53,12 @@ public final class LoggingEventMapper {
   }
 
   public void emit(LogEmitterProvider logEmitterProvider, ILoggingEvent event) {
+    String instrumentationName = event.getLoggerName();
+    if (instrumentationName == null || instrumentationName.isEmpty()) {
+      instrumentationName = "ROOT";
+    }
     LogBuilder builder =
-        logEmitterProvider.logEmitterBuilder(event.getLoggerName()).build().logBuilder();
+        logEmitterProvider.logEmitterBuilder(instrumentationName).build().logBuilder();
     mapLoggingEvent(builder, event);
     builder.emit();
   }

--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/appender/internal/AgentLogEmitterProvider.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/appender/internal/AgentLogEmitterProvider.java
@@ -20,10 +20,20 @@ public final class AgentLogEmitterProvider {
   /**
    * Sets the {@link LogEmitterProvider} that should be used by the agent. Future calls to {@link
    * #get()} will return the provided {@link LogEmitterProvider} instance. It should only be called
-   * once - an attempt to call it a second time will result in an error.
+   * once - an attempt to call it a second time will result in an error. If trying to set the
+   * instance {@link LogEmitterProvider} multiple times in tests, use {@link
+   * LogEmitterProviderHolder#resetForTest()} between them.
    */
   public static void set(LogEmitterProvider logEmitterProvider) {
     delegate.set(logEmitterProvider);
+  }
+
+  /**
+   * Unsets the {@link LogEmitterProvider}. This is only meant to be used from tests which need to
+   * reconfigure {@link LogEmitterProvider}.
+   */
+  public static void resetForTest() {
+    delegate.resetForTest();
   }
 
   private AgentLogEmitterProvider() {}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -5,13 +5,17 @@
 
 package io.opentelemetry.javaagent.tooling;
 
+import io.opentelemetry.instrumentation.api.appender.internal.LogEmitterProvider;
 import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.instrumentation.sdk.appender.internal.DelegatingLogEmitterProvider;
 import io.opentelemetry.javaagent.bootstrap.AgentInitializer;
 import io.opentelemetry.javaagent.instrumentation.api.OpenTelemetrySdkAccess;
+import io.opentelemetry.javaagent.instrumentation.api.appender.internal.AgentLogEmitterProvider;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.SdkLogEmitterProvider;
 import java.util.Arrays;
 
 public class OpenTelemetryInstaller {
@@ -46,6 +50,11 @@ public class OpenTelemetryInstaller {
           CompletableResultCode.ofAll(Arrays.asList(traceResult, metricsResult))
               .join(timeout, unit);
         });
+
+    SdkLogEmitterProvider sdkLogEmitterProvider = autoConfiguredSdk.getOpenTelemetrySdk()
+        .getSdkLogEmitterProvider();
+    LogEmitterProvider logEmitterProvider = DelegatingLogEmitterProvider.from(sdkLogEmitterProvider);
+    AgentLogEmitterProvider.set(logEmitterProvider);
 
     return autoConfiguredSdk;
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -51,9 +51,10 @@ public class OpenTelemetryInstaller {
               .join(timeout, unit);
         });
 
-    SdkLogEmitterProvider sdkLogEmitterProvider = autoConfiguredSdk.getOpenTelemetrySdk()
-        .getSdkLogEmitterProvider();
-    LogEmitterProvider logEmitterProvider = DelegatingLogEmitterProvider.from(sdkLogEmitterProvider);
+    SdkLogEmitterProvider sdkLogEmitterProvider =
+        autoConfiguredSdk.getOpenTelemetrySdk().getSdkLogEmitterProvider();
+    LogEmitterProvider logEmitterProvider =
+        DelegatingLogEmitterProvider.from(sdkLogEmitterProvider);
     AgentLogEmitterProvider.set(logEmitterProvider);
 
     return autoConfiguredSdk;

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingLogsCustomizer.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingLogsCustomizer.java
@@ -28,6 +28,7 @@ public class AgentTestingLogsCustomizer implements AgentListener {
                 BatchLogProcessor.builder(AgentTestingExporterFactory.logExporter).build())
             .build();
 
+    AgentLogEmitterProvider.resetForTest();
     AgentLogEmitterProvider.set(DelegatingLogEmitterProvider.from(logEmitterProvider));
   }
 }


### PR DESCRIPTION
I was having some challenges around #5048 related to this.

Instrumentation uses the global holder for the log emitter. The `LogEmitterProvider` from the autoconfigured SDK was not being stitched to the global holder during install time, so instrumentations were not yet able to actually emit logs. This remedies that.

I confirmed that this this change allows logs to be exported (when the logs exporter is set).

Thanks to @mateuszrzeszutek for help spelunking to find this disconnect.