### PR TITLE
Use github action env files

### DIFF
--- a/.github/workflows/publish-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/publish-smoke-test-fake-backend-images.yml
@@ -31,12 +31,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Tag
-        run: echo "::set-env name=TAG::$(date '+%Y%m%d').$GITHUB_RUN_ID"
+        run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
       - name: Build Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -Djib.httpTimeout=120000 -Djib.console=plain -PextraTag=$TAG
+          arguments: jib -Djib.httpTimeout=120000 -Djib.console=plain -PextraTag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/fake-backend
 
   publishWindows:
@@ -66,12 +66,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Tag
-        run: echo "::set-env name=TAG::$(date '+%Y%m%d').$GITHUB_RUN_ID"
+        run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
       - name: Build Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: dockerPush -PextraTag=$TAG
+          arguments: dockerPush -PextraTag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/fake-backend
 
   issue:

--- a/.github/workflows/publish-smoke-test-grpc-images.yml
+++ b/.github/workflows/publish-smoke-test-grpc-images.yml
@@ -31,30 +31,30 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Tag
-        run: echo "::set-env name=TAG::$(date '+%Y%m%d').$GITHUB_RUN_ID"
+        run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
       - name: Build Java 8 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/grpc
 
       - name: Build Java 11 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/grpc
 
       - name: Build Java 17 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/grpc
 
       - name: Build Java 18 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/grpc
 
   issue:

--- a/.github/workflows/publish-smoke-test-play-images.yml
+++ b/.github/workflows/publish-smoke-test-play-images.yml
@@ -31,18 +31,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Tag
-        run: echo "::set-env name=TAG::$(date '+%Y%m%d').$GITHUB_RUN_ID"
+        run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
       - name: Build Java 8 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/play
 
       - name: Build Java 11 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/play
 
         # Play doesn't support Java 16 (or 17) yet
@@ -50,7 +50,7 @@ jobs:
       - name: Build Java 15 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=15 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=15 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/play
 
   issue:

--- a/.github/workflows/publish-smoke-test-quarkus-images.yml
+++ b/.github/workflows/publish-smoke-test-quarkus-images.yml
@@ -31,25 +31,25 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Tag
-        run: echo "::set-env name=TAG::$(date '+%Y%m%d').$GITHUB_RUN_ID"
+        run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
         # Quarkus 2.0+ does not support Java 8
       - name: Build Java 11 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/quarkus
 
       - name: Build Java 17 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/quarkus
 
       - name: Build Java 18 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/quarkus
 
   issue:

--- a/.github/workflows/publish-smoke-test-servlet-images.yml
+++ b/.github/workflows/publish-smoke-test-servlet-images.yml
@@ -55,20 +55,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Tag
-        run: echo "::set-env name=TAG::$(date '+%Y%m%d').$GITHUB_RUN_ID"
+        run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
       - name: Build Linux docker images
         if: matrix.os != 'windows-latest'
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: buildLinuxTestImages pushMatrix -PextraTag=$TAG -PsmokeTestServer=${{ matrix.smoke-test-server }}
+          arguments: buildLinuxTestImages pushMatrix -PextraTag=${{ env.TAG }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
           working-directory: smoke-tests/images/servlet
 
       - name: Build Windows docker images
         if: matrix.os == 'windows-latest'
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: buildWindowsTestImages pushMatrix -PextraTag=$TAG -PsmokeTestServer=${{ matrix.smoke-test-server }}
+          arguments: buildWindowsTestImages pushMatrix -PextraTag=${{ env.TAG }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
           working-directory: smoke-tests/images/servlet
 
   issue:

--- a/.github/workflows/publish-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/publish-smoke-test-spring-boot-images.yml
@@ -31,30 +31,30 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Tag
-        run: echo "::set-env name=TAG::$(date '+%Y%m%d').$GITHUB_RUN_ID"
+        run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
       - name: Build Java 8 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/spring-boot
 
       - name: Build Java 11 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/spring-boot
 
       - name: Build Java 17 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/spring-boot
 
       - name: Build Java 18 Docker Image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=$TAG
+          arguments: jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
           build-root-directory: smoke-tests/images/spring-boot
 
   issue:


### PR DESCRIPTION
Fixing #5089

```
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```