### PR TITLE
Fix flaky micrometer tests

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AsyncInstrumentRegistry.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AsyncInstrumentRegistry.java
@@ -26,7 +26,10 @@ final class AsyncInstrumentRegistry {
 
   // using a weak ref so that the AsyncInstrumentRegistry (which is stored in a static maps) does
   // not hold strong references to Meter (and thus make it impossible to collect Meter garbage).
-  // in practice this should never return null
+  // in practice this should never return null - OpenTelemetryMeterRegistry maintains a strong
+  // reference to both Meter and AsyncInstrumentRegistry; if the meter registry is GC'd then its
+  // corresponding AsyncInstrumentRegistry cannot possibly be used; and Meter cannot be GC'd until
+  // OpentelemetryMeterRegistry is GC'd
   private final WeakReference<Meter> meter;
 
   // we're always locking lock on the whole instrument map; the add/remove methods aren't called

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramGauges;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.cache.Cache;
 import java.util.concurrent.TimeUnit;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
@@ -48,13 +49,20 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
     return new OpenTelemetryMeterRegistryBuilder(openTelemetry);
   }
 
+  // we need to re-use instrument registries per OpenTelemetry instance so that async instruments
+  // that were created by other OpenTelemetryMeterRegistries can be reused; otherwise the SDK will
+  // start logging errors and async measurements will not be recorded
+  private static final Cache<io.opentelemetry.api.metrics.Meter, AsyncInstrumentRegistry>
+      asyncInstrumentRegistries = Cache.weak();
+
   private final io.opentelemetry.api.metrics.Meter otelMeter;
   private final AsyncInstrumentRegistry asyncInstrumentRegistry;
 
   OpenTelemetryMeterRegistry(Clock clock, io.opentelemetry.api.metrics.Meter otelMeter) {
     super(clock);
     this.otelMeter = otelMeter;
-    this.asyncInstrumentRegistry = new AsyncInstrumentRegistry(otelMeter);
+    this.asyncInstrumentRegistry =
+        asyncInstrumentRegistries.computeIfAbsent(otelMeter, AsyncInstrumentRegistry::new);
     this.config().onMeterRemoved(OpenTelemetryMeterRegistry::onMeterRemoved);
   }
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5103

This PR presents yet another reason why we'd like to be able to use multiple callbacks in async instruments (https://github.com/open-telemetry/opentelemetry-specification/issues/2249) -- turns out the library instrumentation tests were randomly failing because each of them created a new `OpenTelemetryMeterRegistry`, and they did not share state - and the `OpenTelemetry` used in library tests is shared between all test classes.