### PR TITLE
Fix resteasy muzzle

### DIFF
--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-3.0/javaagent/build.gradle.kts
@@ -6,7 +6,7 @@ muzzle {
   pass {
     group.set("org.jboss.resteasy")
     module.set("resteasy-client")
-    versions.set("[3.0.0.Final,)")
+    versions.set("[3.0.0.Final,6)")
   }
 }
 
@@ -14,4 +14,6 @@ dependencies {
   library("org.jboss.resteasy:resteasy-client:3.0.0.Final")
 
   implementation(project(":instrumentation:jaxrs-client:jaxrs-client-2.0:jaxrs-client-2.0-common:javaagent"))
+
+  latestDepTestLibrary("org.jboss.resteasy:resteasy-client:5+")
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/javaagent/build.gradle.kts
@@ -18,7 +18,7 @@ muzzle {
   pass {
     group.set("org.jboss.resteasy")
     module.set("resteasy-core")
-    versions.set("[4.0.0.Final,)")
+    versions.set("[4.0.0.Final,6)")
   }
 }
 


### PR DESCRIPTION
Resteasy has released a new v6.0.0 version tonight: https://github.com/resteasy/resteasy/releases/tag/6.0.0.Final
It's based on Jakarta REST 3.0, and completely incompatible with JAX-RS 1-2. 