### PR TITLE
Fix flaky OpenTelemetryInstallerTest

### DIFF
--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/OpenTelemetryInstallerTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/OpenTelemetryInstallerTest.groovy
@@ -8,16 +8,19 @@ package io.opentelemetry.javaagent.tooling
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.extension.noopapi.NoopOpenTelemetry
 import io.opentelemetry.instrumentation.api.config.Config
+import io.opentelemetry.javaagent.instrumentation.api.appender.internal.AgentLogEmitterProvider
 import spock.lang.Specification
 
 class OpenTelemetryInstallerTest extends Specification {
 
   void setup() {
     GlobalOpenTelemetry.resetForTest()
+    AgentLogEmitterProvider.resetForTest()
   }
 
   void cleanup() {
     GlobalOpenTelemetry.resetForTest()
+    AgentLogEmitterProvider.resetForTest()
   }
 
   def "should initialize GlobalOpenTelemetry"() {


### PR DESCRIPTION
https://ge.opentelemetry.io/s/7z2k4qkeciacq/tests/:javaagent-tooling:test/io.opentelemetry.javaagent.tooling.OpenTelemetryInstallerTest/should%20initialize%20GlobalOpenTelemetry?top-execution=1