### PR TITLE
[v1.10.x branch] Fix release failure

### DIFF
--- a/conventions/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -9,10 +9,8 @@ publishing {
       plugins.withId("java-platform") {
         from(components["javaPlatform"])
       }
-      if (project.path != ":javaagent") {
-        plugins.withId("java-library") {
-          from(components["java"])
-        }
+      plugins.withId("java-library") {
+        from(components["java"])
       }
 
       versionMapping {

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -162,6 +162,9 @@ tasks {
 
     // without an explicit dependency on jar here, :javaagent:test fails on CI because :javaagent:jar
     // runs after :javaagent:shadowJar and loses (at least) the manifest entries
+    //
+    // (also, note that we cannot disable the jar task completely, because it is necessary to produce
+    // javadoc and sources artifacts which maven central requires)
     dependsOn(jar, relocateJavaagentLibs, relocateExporterLibs)
     isolateClasses(relocateJavaagentLibs.get().outputs.files)
     isolateClasses(relocateExporterLibs.get().outputs.files)

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -160,7 +160,9 @@ tasks {
   val shadowJar by existing(ShadowJar::class) {
     configurations = listOf(bootstrapLibs)
 
-    dependsOn(relocateJavaagentLibs, relocateExporterLibs)
+    // without an explicit dependency on jar here, :javaagent:test fails on CI because :javaagent:jar
+    // runs after :javaagent:shadowJar and loses (at least) the manifest entries
+    dependsOn(jar, relocateJavaagentLibs, relocateExporterLibs)
     isolateClasses(relocateJavaagentLibs.get().outputs.files)
     isolateClasses(relocateExporterLibs.get().outputs.files)
 
@@ -220,10 +222,6 @@ tasks {
     add("baseJar", baseJavaagentJar)
   }
 
-  jar {
-    enabled = false
-  }
-
   assemble {
     dependsOn(shadowJar, slimShadowJar, baseJavaagentJar)
   }
@@ -252,7 +250,6 @@ tasks {
     publications {
       named<MavenPublication>("maven") {
         artifact(slimShadowJar)
-        project.shadow.component(this)
       }
     }
   }


### PR DESCRIPTION
Reverts #4765, and adds a comment why we can't get rid of the `jar` task.

(same as #5129, which applies this change to `main`)