### PR TITLE
Fix publishing gradle plugins

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
@@ -4,6 +4,8 @@ plugins {
   id("com.github.johnrengelman.shadow")
 }
 
+// NOTE: any modifications below should also be made in
+//       io.opentelemetry.instrumentation.muzzle-check.gradle.kts
 tasks.withType<ShadowJar>().configureEach {
   mergeServiceFiles()
   // Merge any AWS SDK service files that may be present (too bad they didn't just use normal

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -29,7 +29,7 @@ import java.util.stream.StreamSupport
 plugins {
   `java-library`
 
-  id("io.opentelemetry.instrumentation.javaagent-shadowing")
+  id("com.github.johnrengelman.shadow")
 }
 
 // Select a random set of versions to test
@@ -67,6 +67,42 @@ val shadowMuzzleBootstrap by tasks.registering(ShadowJar::class) {
   configurations = listOf(muzzleBootstrap)
 
   archiveFileName.set("bootstrap-for-muzzle-check.jar")
+}
+
+// this is a copied from io.opentelemetry.instrumentation.javaagent-shadowing for now at least to
+// avoid publishing io.opentelemetry.instrumentation.javaagent-shadowing publicly
+tasks.withType<ShadowJar>().configureEach {
+  mergeServiceFiles()
+  // Merge any AWS SDK service files that may be present (too bad they didn't just use normal
+  // service loader...)
+  mergeServiceFiles("software/amazon/awssdk/global/handlers")
+
+  exclude("**/module-info.class")
+
+  // Prevents conflict with other SLF4J instances. Important for premain.
+  relocate("org.slf4j", "io.opentelemetry.javaagent.slf4j")
+  // rewrite dependencies calling Logger.getLogger
+  relocate("java.util.logging.Logger", "io.opentelemetry.javaagent.bootstrap.PatchLogger")
+
+  // prevents conflict with library instrumentation
+  relocate("io.opentelemetry.instrumentation", "io.opentelemetry.javaagent.shaded.instrumentation")
+
+  // relocate(OpenTelemetry API)
+  relocate("io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api")
+  relocate("io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv")
+  relocate("io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context")
+
+  // relocate(the OpenTelemetry extensions that are used by instrumentation modules)
+  // these extensions live in the AgentClassLoader, and are injected into the user's class loader
+  // by the instrumentation modules that use them
+  relocate("io.opentelemetry.extension.aws", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.aws")
+  relocate("io.opentelemetry.extension.kotlin", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.kotlin")
+
+  // this is for instrumentation on opentelemetry-api itself
+  relocate("application.io.opentelemetry", "io.opentelemetry")
+
+  // this is for instrumentation on java.util.logging (since java.util.logging itself is shaded above)
+  relocate("application.java.util.logging", "java.util.logging")
 }
 
 val compileMuzzle by tasks.registering {


### PR DESCRIPTION
I'm not sure if we should publish io.opentelemetry.instrumentation.javaagent-shadowing publicly. It's just needed here as an implementation dependency of the public `muzzle-check` gradle plugin. "Vendoring" it in for now.

EDIT: this was already merged into v1.10.x branch in #5133