### PR TITLE
More gradle build action cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,10 @@ jobs:
           java-version: 11
 
       - name: Build
-        run: ../gradlew build
-        working-directory: gradle-plugins
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+          build-root-directory: gradle-plugins
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-benchmark-overhead.yml
+++ b/.github/workflows/nightly-benchmark-overhead.yml
@@ -20,8 +20,10 @@ jobs:
         run: |
           rsync -avv gh-pages/benchmark-overhead/results/ benchmark-overhead/results/
       - name: run tests
-        working-directory: benchmark-overhead
-        run: ./gradlew test
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: test
+          build-root-directory: benchmark-overhead
       - name: inspect the results dir
         working-directory: benchmark-overhead
         run: ls -lR results

--- a/.github/workflows/nightly-no-cache.yml
+++ b/.github/workflows/nightly-no-cache.yml
@@ -20,12 +20,6 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Build
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -46,15 +40,11 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Build
-        run: ../gradlew build --no-build-cache
-        working-directory: gradle-plugins
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build --no-build-cache
+          build-root-directory: gradle-plugins
 
   test:
     runs-on: ubuntu-latest
@@ -86,12 +76,6 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Test
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -111,12 +95,6 @@ jobs:
         with:
           distribution: adopt
           java-version: 11
-
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Test
         env:
@@ -159,12 +137,6 @@ jobs:
         with:
           distribution: adopt
           java-version: 11
-
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Test
         env:

--- a/.github/workflows/nightly-no-cache.yml
+++ b/.github/workflows/nightly-no-cache.yml
@@ -161,32 +161,36 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('examples/distro/gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Local publish of artifacts
-        # javadoc task fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
-        run: ./gradlew publishToMavenLocal -x javadoc
+        uses: gradle/gradle-build-action@v2
+        with:
+          # javadoc task fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
+          arguments: publishToMavenLocal -x javadoc
 
       - name: Local publish of gradle plugins
-        # javadoc task fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
-        run: ../gradlew publishToMavenLocal -x javadoc
-        working-directory: gradle-plugins
+        uses: gradle/gradle-build-action@v2
+        with:
+          # javadoc task fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
+          arguments: publishToMavenLocal -x javadoc
+          build-root-directory: gradle-plugins
 
       - name: Build distro
-        run: ./gradlew build --init-script ../../.github/scripts/local.init.gradle.kts --no-build-cache
-        working-directory: examples/distro
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build --init-script ../../.github/scripts/local.init.gradle.kts --no-build-cache
+          build-root-directory: examples/distro
 
       - name: Build extension
-        run: ./gradlew build --init-script ../../.github/scripts/local.init.gradle.kts --no-build-cache
-        working-directory: examples/extension
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build --init-script ../../.github/scripts/local.init.gradle.kts --no-build-cache
+          build-root-directory: examples/extension
 
       - name: Run muzzle check against extension
-        run: ./gradlew muzzle --init-script ../../.github/scripts/local.init.gradle.kts
-        working-directory: examples/extension
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: muzzle --init-script ../../.github/scripts/local.init.gradle.kts
+          build-root-directory: examples/extension
 
   issue:
     name: Open issue on failure

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,8 +43,10 @@ jobs:
           java-version: 11
 
       - name: Build
-        run: ../gradlew build
-        working-directory: gradle-plugins
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+          root-build-directory: gradle-plugins
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -107,12 +107,6 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('examples/distro/gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Local publish of artifacts
         uses: gradle/gradle-build-action@v2
         with:
@@ -172,13 +166,14 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
-        # TODO (trask) cache gradle wrapper?
       - name: Build and publish gradle plugins
+        uses: gradle/gradle-build-action@v2
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-        run: ../gradlew build publishPlugins
-        working-directory: gradle-plugins
+        with:
+          arguments: build publishPlugins
+          build-root-directory: gradle-plugins
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -107,12 +107,6 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('examples/distro/gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Local publish of artifacts
         uses: gradle/gradle-build-action@v2
         with:
@@ -172,13 +166,14 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
-        # TODO (trask) cache gradle wrapper?
       - name: Build and publish gradle plugins
+        uses: gradle/gradle-build-action@v2
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-        run: ../gradlew build publishPlugins
-        working-directory: gradle-plugins
+        with:
+          arguments: build publishPlugins
+          build-root-directory: gradle-plugins
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
Applies `actions/gradle-build-action` to more places, and removes now unnecessary gradle wrapper caching since that's now taken care of by `actions/gradle-build-action`.