### PR TITLE
Add workflow to prepare release branch

### DIFF
--- a/.github/scripts/update-versions.sh
+++ b/.github/scripts/update-versions.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Bumps versions in these files
+# - version.gradle.kts
+# - examples/distro/build.gradle
+# - examples/extension/build.gradle
+
+current_version=$1
+current_alpha_version=$2
+new_version=$3
+new_alpha_version=$4
+
+echo "updating from $current_version to $new_version and from $current_alpha_version to $new_alpha_version"
+
+sed -ri "s/$current_version/$new_version/" version.gradle.kts
+sed -ri "s/$current_alpha_version/$new_alpha_version/" version.gradle.kts
+
+sed -ri "s/(opentelemetryJavaagent *: \")$current_version/\1$new_version/" examples/distro/build.gradle
+sed -ri "s/(opentelemetryJavaagentAlpha *: \")$current_alpha_version/\1$new_alpha_version/" examples/distro/build.gradle
+
+sed -ri "s/(opentelemetryJavaagent *: \")$current_version/\1$new_version/" examples/extension/build.gradle
+sed -ri "s/(opentelemetryJavaagentAlpha *: \")$current_alpha_version/\1$new_alpha_version/" examples/extension/build.gradle
+
+sed -ri "s/(io.opentelemetry.instrumentation.muzzle-generation\" version \")$current_alpha_version/\1$new_alpha_version/" examples/extension/build.gradle
+sed -ri "s/(io.opentelemetry.instrumentation.muzzle-check\" version \")$current_alpha_version/\1$new_alpha_version/" examples/extension/build.gradle

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -1,0 +1,77 @@
+name: Prepare Release Branch
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare-release-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      release-branch-name: ${{ steps.set-release-branch-name.outputs.release-branch-name }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Set release branch name
+        id: set-release-branch-name
+        run: |
+          release_branch_name=$(grep -Eo "[0-9.]+-SNAPSHOT" version.gradle.kts | sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+)-SNAPSHOT/v\1.\2.x/')
+          echo "::set-output name=release-branch-name::$release_branch_name"
+
+      - name: Create release branch
+        run: |
+          git checkout -b ${{ steps.set-release-branch-name.outputs.release-branch-name }}
+          git push origin ${{ steps.set-release-branch-name.outputs.release-branch-name }}
+
+  create-pull-request-against-release-branch:
+    needs: prepare-release-branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          ref: ${{ needs.prepare-release-branch.outputs.release-branch-name }}
+
+      - name: Remove SNAPSHOT from version
+        run: |
+          v=$(grep -Eo "[0-9]+.[0-9]+.[0-9]+-SNAPSHOT" version.gradle.kts | sed 's/-SNAPSHOT//')
+          .github/scripts/update-versions.sh "$v-SNAPSHOT" "$v-alpha-SNAPSHOT" "$v" "$v-alpha"
+
+      - name: Bump download link version
+        run: |
+          new_version=$(grep -Eo "[0-9]+.[0-9]+.[0-9]+" version.gradle.kts | head -1)
+          sed -Ei "s,https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v[0-9]+.[0-9]+.[0-9]+/,https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$new_version/," README.md
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Prepare release branch ${{ needs.prepare-release-branch.outputs.release-branch-name }}
+          branch: prepare-release-branch-${{ needs.prepare-release-branch.outputs.release-branch-name }}
+          delete-branch: true
+          title: Prepare release branch ${{ needs.prepare-release-branch.outputs.release-branch-name }}
+          body: Prepare release branch ${{ needs.prepare-release-branch.outputs.release-branch-name }}
+
+  create-pull-request-against-main:
+    needs: prepare-release-branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Bump SNAPSHOT version
+        run: |
+          v=$(grep -Eo "[0-9]+.[0-9]+.[0-9]+-SNAPSHOT" version.gradle.kts | sed 's/-SNAPSHOT//')
+          if [[ $v =~ ([0-9]+).([0-9]+).0 ]]; then
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+          else
+            echo "unexpected version: $v"
+            exit 1
+          fi
+          bump="$major.$((minor + 1)).0"
+          .github/scripts/update-versions.sh "$v-SNAPSHOT" "$v-alpha-SNAPSHOT" "$bump-SNAPSHOT" "$bump-alpha-SNAPSHOT"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Bump snapshot version
+          branch: bump-snapshot-version
+          delete-branch: true
+          title: Bump snapshot version
+          body: Bump snapshot version

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -41,12 +41,12 @@ jobs:
 
       - name: Setup git name
         run: |
-          git config user.name trask
-          git config user.email trask.stalnaker@gmail.com
+          git config user.name github-actions
+          git config user.email github-actions@github.com
 
       - name: Create pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.TRASK_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           msg="Prepare release branch ${{ needs.prepare-release-branch.outputs.release-branch-name }}"
           git add -u
@@ -78,12 +78,12 @@ jobs:
 
       - name: Setup git name
         run: |
-          git config user.name trask
-          git config user.email trask.stalnaker@gmail.com
+          git config user.name github-actions
+          git config user.email github-actions@github.com
 
       - name: Create pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.TRASK_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           msg="Bump snapshot version"
           git add -u

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -41,12 +41,12 @@ jobs:
 
       - name: Setup git name
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name trask
+          git config user.email trask.stalnaker@gmail.com
 
       - name: Create pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRASK_GITHUB_TOKEN }}
         run: |
           msg="Prepare release branch ${{ needs.prepare-release-branch.outputs.release-branch-name }}"
           git add -u
@@ -78,12 +78,12 @@ jobs:
 
       - name: Setup git name
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name trask
+          git config user.email trask.stalnaker@gmail.com
 
       - name: Create pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRASK_GITHUB_TOKEN }}
         run: |
           msg="Bump snapshot version"
           git add -u

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -39,14 +39,23 @@ jobs:
           new_version=$(grep -Eo "[0-9]+.[0-9]+.[0-9]+" version.gradle.kts | head -1)
           sed -Ei "s,https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v[0-9]+.[0-9]+.[0-9]+/,https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$new_version/," README.md
 
+      - name: Setup git name
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          commit-message: Prepare release branch ${{ needs.prepare-release-branch.outputs.release-branch-name }}
-          branch: prepare-release-branch-${{ needs.prepare-release-branch.outputs.release-branch-name }}
-          delete-branch: true
-          title: Prepare release branch ${{ needs.prepare-release-branch.outputs.release-branch-name }}
-          body: Prepare release branch ${{ needs.prepare-release-branch.outputs.release-branch-name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          msg="Prepare release branch ${{ needs.prepare-release-branch.outputs.release-branch-name }}"
+          git add -u
+          git commit -m "$msg"
+          git push origin HEAD:prepare-release-branch-${{ needs.prepare-release-branch.outputs.release-branch-name }}
+          gh pr create --title "$msg" \
+                       --body "$msg" \
+                       --head prepare-release-branch-${{ needs.prepare-release-branch.outputs.release-branch-name }} \
+                       --base ${{ needs.prepare-release-branch.outputs.release-branch-name }}
 
   create-pull-request-against-main:
     needs: prepare-release-branch
@@ -67,11 +76,17 @@ jobs:
           bump="$major.$((minor + 1)).0"
           .github/scripts/update-versions.sh "$v-SNAPSHOT" "$v-alpha-SNAPSHOT" "$bump-SNAPSHOT" "$bump-alpha-SNAPSHOT"
 
+      - name: Setup git name
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          commit-message: Bump snapshot version
-          branch: bump-snapshot-version
-          delete-branch: true
-          title: Bump snapshot version
-          body: Bump snapshot version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          msg="Bump snapshot version"
+          git add -u
+          git commit -m "$msg"
+          git push origin HEAD:bump-snapshot-version
+          gh pr create --title "$msg" --body "$msg" --head bump-snapshot-version --base main

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,17 +14,8 @@ as the last step, which publishes a snapshot build to
 Before making the release:
 
 * Merge a PR to `main` updating the `CHANGELOG.md`
-* Create a release branch, e.g. `v1.9.x`
-  ```
-  git checkout -b v1.9.x upstream/main
-  git push upstream v1.9.x
-  ```
-* Merge a PR to the release branch with the following changes
-  * Remove `-SNAPSHOT` from the version in these files:
-    * version.gradle.kts
-    * examples/distro/build.gradle
-    * examples/extension/build.gradle
-  * Bump the version in the download link in the root `README.md` file
+* Run the [Prepare Release Branch workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/prepare-release-branch.yml).
+* Review and merge the two PRs that it creates (one is targeted to the release branch and one is targeted to the `main` branch)
 
 Open the release build workflow in your browser [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/release-build.yml).
 
@@ -40,11 +31,7 @@ and pushes a git tag with the version number.
 
 After making the release:
 
-* Merge a PR to `main` with the following changes
-  * Bump version in these files to the next `-SNAPSHOT` version (e.g. from `1.9.0-SNAPSHOT` to `1.10.0-SNAPSHOT`)
-    * version.gradle.kts
-    * examples/distro/build.gradle
-    * examples/extension/build.gradle
+* Merge a PR to `main` with the following change
   * Bump the version in the download link in the root `README.md` file
 
 ## Announcement

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,6 +16,7 @@ Before making the release:
 * Merge a PR to `main` updating the `CHANGELOG.md`
 * Run the [Prepare Release Branch workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/prepare-release-branch.yml).
 * Review and merge the two PRs that it creates (one is targeted to the release branch and one is targeted to the `main` branch)
+* Delete the branches from these two PRs since they are created in the main repo
 
 Open the release build workflow in your browser [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/release-build.yml).
 


### PR DESCRIPTION
Automate a couple of the manual release steps

I tested this on my fork, you can look there to see example of the two PRs that this workflow creates: https://github.com/trask/opentelemetry-java-instrumentation/pulls