### PR TITLE
Remove fetch-depth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -33,8 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -62,8 +58,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - id: setup-test-java
         name: Set up JDK ${{ matrix.test-java-version }}-${{ matrix.vm }} for running tests
@@ -91,8 +85,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -135,8 +127,6 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -160,8 +150,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -187,8 +175,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -215,8 +201,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -266,8 +250,6 @@ jobs:
     if: github.repository == 'open-telemetry/opentelemetry-java-instrumentation'
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -13,7 +13,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - uses: gradle/wrapper-validation-action@v1.0.4

--- a/.github/workflows/nightly-benchmark-overhead.yml
+++ b/.github/workflows/nightly-benchmark-overhead.yml
@@ -48,8 +48,6 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v2.2
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - uses: JasonEtco/create-an-issue@v2.6
         if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure

--- a/.github/workflows/nightly-codeql-analysis.yml
+++ b/.github/workflows/nightly-codeql-analysis.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
@@ -43,8 +41,6 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v2.2
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - uses: JasonEtco/create-an-issue@v2.6
         if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure

--- a/.github/workflows/nightly-no-cache.yml
+++ b/.github/workflows/nightly-no-cache.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -31,8 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -60,8 +56,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - id: setup-test-java
         name: Set up JDK ${{ matrix.test-java-version }}-${{ matrix.vm }} for running tests
@@ -87,8 +81,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -129,8 +121,6 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -152,8 +142,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -203,8 +191,6 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v2.2
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - uses: JasonEtco/create-an-issue@v2.6
         if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -33,8 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -62,8 +58,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - id: setup-test-java
         name: Set up JDK ${{ matrix.test-java-version }}-${{ matrix.vm }} for running tests
@@ -91,8 +85,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -135,8 +127,6 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -160,8 +150,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -187,8 +175,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -215,8 +201,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -267,8 +251,6 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v2.2
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - uses: JasonEtco/create-an-issue@v2.6
         if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - id: setup-test-java
         name: Set up JDK ${{ matrix.test-java-version }} for running tests
@@ -76,7 +75,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -99,7 +97,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -146,7 +143,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/pr-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/pr-smoke-test-fake-backend-images.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -37,8 +35,6 @@ jobs:
         run: git config --system core.longpaths true
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/pr-smoke-test-grpc-images.yml
+++ b/.github/workflows/pr-smoke-test-grpc-images.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/pr-smoke-test-play-images.yml
+++ b/.github/workflows/pr-smoke-test-play-images.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/pr-smoke-test-quarkus-images.yml
+++ b/.github/workflows/pr-smoke-test-quarkus-images.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/pr-smoke-test-servlet-images.yml
+++ b/.github/workflows/pr-smoke-test-servlet-images.yml
@@ -32,8 +32,6 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/pr-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/pr-smoke-test-spring-boot-images.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -49,8 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -79,8 +75,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - id: setup-test-java
         name: Set up JDK ${{ matrix.test-java-version }}-${{ matrix.vm }} for running tests
@@ -153,8 +147,6 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -202,8 +194,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -224,8 +214,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/publish-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/publish-smoke-test-fake-backend-images.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -49,8 +47,6 @@ jobs:
         run: git config --system core.longpaths true
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -85,8 +81,6 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v2.2
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - uses: JasonEtco/create-an-issue@v2.6
         if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure

--- a/.github/workflows/publish-smoke-test-grpc-images.yml
+++ b/.github/workflows/publish-smoke-test-grpc-images.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -68,8 +66,6 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v2.2
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - uses: JasonEtco/create-an-issue@v2.6
         if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure

--- a/.github/workflows/publish-smoke-test-play-images.yml
+++ b/.github/workflows/publish-smoke-test-play-images.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -64,8 +62,6 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v2.2
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - uses: JasonEtco/create-an-issue@v2.6
         if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure

--- a/.github/workflows/publish-smoke-test-quarkus-images.yml
+++ b/.github/workflows/publish-smoke-test-quarkus-images.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -63,8 +61,6 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v2.2
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - uses: JasonEtco/create-an-issue@v2.6
         if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure

--- a/.github/workflows/publish-smoke-test-servlet-images.yml
+++ b/.github/workflows/publish-smoke-test-servlet-images.yml
@@ -38,8 +38,6 @@ jobs:
         if: matrix.os == 'windows-latest'
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -82,8 +80,6 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v2.2
 
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - uses: JasonEtco/create-an-issue@v2.6
         if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure

--- a/.github/workflows/publish-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/publish-smoke-test-spring-boot-images.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - id: setup-test-java
         name: Set up JDK ${{ matrix.test-java-version }} for running tests
@@ -76,7 +75,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -99,7 +97,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -146,7 +143,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2

--- a/.github/workflows/release-gradle-plugins.yml
+++ b/.github/workflows/release-gradle-plugins.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - id: setup-test-java
         name: Set up JDK ${{ matrix.test-java-version }} for running tests
@@ -76,7 +75,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -99,7 +97,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2
@@ -152,7 +149,6 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           ref: ${{ github.event.inputs.release-branch-name }}
-          fetch-depth: 0
 
       - name: Set up JDK 11 for running Gradle
         uses: actions/setup-java@v2


### PR DESCRIPTION
I thought `fetch-depth: 0` meant fetch only the most recent commit, but it means fetch all history for all branches, which seems unnecessary. Not sure if there's a reason to keep it?