### PR TITLE
chore: add bin directories to .gitignore for vsc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ out/
 # Visual Studio Code #
 ######################
 .vscode
+**/bin/
 
 # Others #
 ##########


### PR DESCRIPTION
I cloned to repo and just opened it in visual studio code.
I have [this extention](https://code.visualstudio.com/docs/java/extensions) installed in vsc, and it seems to create files in `bin` directories that are not in `.gitignore`. 

![image](https://user-images.githubusercontent.com/22870745/149799210-67d5d710-dbf0-456d-bfdf-6ce02bf13a65.png)

Found this similar rule in `.gitignore` for eclipse:
```
# Eclipse is odd in assuming in can use bin to put temp files into it
# This assumes we do not have sub-projects that actually need bin files committed
*/bin/
```

But it doesn't work for VSC as [An asterisk "*" matches anything except a slash](https://git-scm.com/docs/gitignore).
Adding `**/bin/` fixed the issue in my setup
