### PR TITLE
Parameterize VirtualField field type

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/field/VirtualField.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/field/VirtualField.java
@@ -36,7 +36,8 @@ public abstract class VirtualField<T, F> {
    * @param type The type that will contain the new virtual field.
    * @param fieldType The field type that will be added to {@code type}.
    */
-  public static <U extends T, T, F> VirtualField<U, F> find(Class<T> type, Class<F> fieldType) {
+  public static <U extends T, V extends F, T, F> VirtualField<U, V> find(
+      Class<T> type, Class<F> fieldType) {
     return RuntimeVirtualFieldSupplier.get().find(type, fieldType);
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
@@ -16,7 +16,7 @@ public final class RuntimeVirtualFieldSupplier {
   private static final Logger logger = LoggerFactory.getLogger(RuntimeVirtualFieldSupplier.class);
 
   public interface VirtualFieldSupplier {
-    <U extends T, T, F> VirtualField<U, F> find(Class<T> type, Class<F> fieldType);
+    <U extends T, V extends F, T, F> VirtualField<U, V> find(Class<T> type, Class<F> fieldType);
   }
 
   private static final VirtualFieldSupplier DEFAULT = new CacheBasedVirtualFieldSupplier();
@@ -44,8 +44,9 @@ public final class RuntimeVirtualFieldSupplier {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <U extends T, T, F> VirtualField<U, F> find(Class<T> type, Class<F> fieldType) {
-      return (VirtualField<U, F>)
+    public <U extends T, V extends F, T, F> VirtualField<U, V> find(
+        Class<T> type, Class<F> fieldType) {
+      return (VirtualField<U, V>)
           ownerToFieldToImplementationMap
               .computeIfAbsent(type, c -> Cache.weak())
               .computeIfAbsent(fieldType, c -> new CacheBasedVirtualField<>());

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/AbstractMessageListenerContainerInstrumentation.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/AbstractMessageListenerContainerInstrumentation.java
@@ -41,11 +41,13 @@ public class AbstractMessageListenerContainerInstrumentation implements TypeInst
   @SuppressWarnings("unused")
   public static class GetBatchInterceptorAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void onExit(@Advice.Return(readOnly = false) BatchInterceptor<?, ?> interceptor) {
+    public static <K, V> void onExit(
+        @Advice.Return(readOnly = false) BatchInterceptor<K, V> interceptor) {
       if (!(interceptor instanceof InstrumentedBatchInterceptor)) {
-        VirtualField receiveContextVirtualField =
+        VirtualField<ConsumerRecords<K, V>, Context> receiveContextVirtualField =
             VirtualField.find(ConsumerRecords.class, Context.class);
-        VirtualField stateStore = VirtualField.find(ConsumerRecords.class, State.class);
+        VirtualField<ConsumerRecords<K, V>, State<K, V>> stateStore =
+            VirtualField.find(ConsumerRecords.class, State.class);
         interceptor =
             new InstrumentedBatchInterceptor<>(receiveContextVirtualField, stateStore, interceptor);
       }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/RuntimeFieldBasedImplementationSupplier.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/RuntimeFieldBasedImplementationSupplier.java
@@ -16,14 +16,15 @@ final class RuntimeFieldBasedImplementationSupplier
     implements RuntimeVirtualFieldSupplier.VirtualFieldSupplier {
 
   @Override
-  public <U extends T, T, F> VirtualField<U, F> find(Class<T> type, Class<F> fieldType) {
+  public <U extends T, V extends F, T, F> VirtualField<U, V> find(
+      Class<T> type, Class<F> fieldType) {
     try {
       String virtualFieldImplClassName =
           getVirtualFieldImplementationClassName(type.getName(), fieldType.getName());
       Class<?> contextStoreClass = Class.forName(virtualFieldImplClassName, false, null);
       Method method = contextStoreClass.getMethod("getVirtualField", Class.class, Class.class);
       @SuppressWarnings("unchecked")
-      VirtualField<U, F> field = (VirtualField<U, F>) method.invoke(null, type, fieldType);
+      VirtualField<U, V> field = (VirtualField<U, V>) method.invoke(null, type, fieldType);
       return field;
     } catch (ClassNotFoundException exception) {
       throw new IllegalStateException("VirtualField not found", exception);


### PR DESCRIPTION
While fixing some java lint warnings, I noticed that `VirtualField` only supports parameterized holder type and not field type. Given a field of type `Foo` can always have `? extends Foo` assigned to it, it seems to make sense to parameterize it too.