### PR TITLE
Fix flaky micrometer tests

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractFunctionCounterTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractFunctionCounterTest.java
@@ -22,6 +22,9 @@ public abstract class AbstractFunctionCounterTest {
 
   protected abstract InstrumentationExtension testing();
 
+  final AtomicLong num = new AtomicLong(12);
+  final AtomicLong anotherNum = new AtomicLong(13);
+
   @BeforeEach
   void cleanupMeters() {
     Metrics.globalRegistry.forEachMeter(Metrics.globalRegistry::remove);
@@ -30,8 +33,6 @@ public abstract class AbstractFunctionCounterTest {
   @Test
   void testFunctionCounter() throws InterruptedException {
     // when
-    AtomicLong num = new AtomicLong(12);
-
     FunctionCounter counter =
         FunctionCounter.builder("testFunctionCounter", num, AtomicLong::get)
             .description("This is a test function counter")
@@ -75,15 +76,12 @@ public abstract class AbstractFunctionCounterTest {
   @Test
   void functionCountersWithSameNameAndDifferentTags() {
     // when
-    AtomicLong num1 = new AtomicLong(12);
-    AtomicLong num2 = new AtomicLong(13);
-
-    FunctionCounter.builder("testFunctionCounterWithTags", num1, AtomicLong::get)
+    FunctionCounter.builder("testFunctionCounterWithTags", num, AtomicLong::get)
         .description("First description wins")
         .tags("tag", "1")
         .baseUnit("items")
         .register(Metrics.globalRegistry);
-    FunctionCounter.builder("testFunctionCounterWithTags", num2, AtomicLong::get)
+    FunctionCounter.builder("testFunctionCounterWithTags", anotherNum, AtomicLong::get)
         .description("ignored")
         .tags("tag", "2")
         .baseUnit("items")

--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractFunctionTimerTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractFunctionTimerTest.java
@@ -22,16 +22,19 @@ public abstract class AbstractFunctionTimerTest {
 
   protected abstract InstrumentationExtension testing();
 
+  final MyTimer timerObj = new MyTimer();
+  final MyTimer anotherTimerObj = new MyTimer();
+
   @BeforeEach
   void cleanupMeters() {
+    timerObj.reset();
+    anotherTimerObj.reset();
     Metrics.globalRegistry.forEachMeter(Metrics.globalRegistry::remove);
   }
 
   @Test
   void testFunctionTimer() throws InterruptedException {
     // given
-    MyTimer timerObj = new MyTimer();
-
     FunctionTimer functionTimer =
         FunctionTimer.builder(
                 "testFunctionTimer",
@@ -103,8 +106,6 @@ public abstract class AbstractFunctionTimerTest {
   @Test
   void testNanoPrecision() {
     // given
-    MyTimer timerObj = new MyTimer();
-
     FunctionTimer.builder(
             "testNanoFunctionTimer",
             timerObj,
@@ -135,12 +136,9 @@ public abstract class AbstractFunctionTimerTest {
   @Test
   void functionTimersWithSameNameAndDifferentTags() {
     // given
-    MyTimer timerObj1 = new MyTimer();
-    MyTimer timerObj2 = new MyTimer();
-
     FunctionTimer.builder(
             "testFunctionTimerWithTags",
-            timerObj1,
+            timerObj,
             MyTimer::getCount,
             MyTimer::getTotalTimeNanos,
             TimeUnit.NANOSECONDS)
@@ -149,7 +147,7 @@ public abstract class AbstractFunctionTimerTest {
 
     FunctionTimer.builder(
             "testFunctionTimerWithTags",
-            timerObj2,
+            anotherTimerObj,
             MyTimer::getCount,
             MyTimer::getTotalTimeNanos,
             TimeUnit.NANOSECONDS)
@@ -157,8 +155,8 @@ public abstract class AbstractFunctionTimerTest {
         .register(Metrics.globalRegistry);
 
     // when
-    timerObj1.add(12, TimeUnit.SECONDS);
-    timerObj2.add(42, TimeUnit.SECONDS);
+    timerObj.add(12, TimeUnit.SECONDS);
+    anotherTimerObj.add(42, TimeUnit.SECONDS);
 
     // then
     testing()
@@ -195,12 +193,17 @@ public abstract class AbstractFunctionTimerTest {
       totalTimeNanos += unit.toNanos(time);
     }
 
-    public int getCount() {
+    int getCount() {
       return count;
     }
 
-    public double getTotalTimeNanos() {
+    double getTotalTimeNanos() {
       return totalTimeNanos;
+    }
+
+    void reset() {
+      count = 0;
+      totalTimeNanos = 0;
     }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5163

Looks like on OpenJ9 JVMs these local variables were GC'd just after creating a meter, and it resulted in nulled-out weak refs and no measurements being observed.