### PR TITLE
Remove unnecessary destroyMethod

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Config.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Config.groovy
@@ -29,7 +29,7 @@ class Config {
     return new NodeBuilder()
   }
 
-  @Bean(destroyMethod = "close")
+  @Bean
   Node elasticSearchNode() {
     def tmpDir = File.createTempFile("test-es-working-dir-", "")
     tmpDir.delete()

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
@@ -37,7 +37,7 @@ public class OpenTelemetryAutoConfiguration {
   @ConditionalOnMissingBean(OpenTelemetry.class)
   public static class OpenTelemetryBeanConfig {
 
-    @Bean(destroyMethod = "close")
+    @Bean
     @ConditionalOnMissingBean
     public SdkTracerProvider sdkTracerProvider(
         SamplerProperties samplerProperties,


### PR DESCRIPTION
as pointed out by @anuraaga in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5125#discussion_r785610192

EDIT and confirmed by google 😂 

> As a convenience to the user, the container will attempt to infer a destroy method against an object returned from the @Bean method. For example, given an @Bean method returning an Apache Commons DBCP BasicDataSource, the container will notice the close() method available on that object and automatically register it as the destroyMethod. This 'destroy method inference' is currently limited to detecting only public, no-arg methods named 'close' or 'shutdown'

https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Bean.html#destroyMethod--

EDIT EDIT I feel bad just thinking about the github user bean's notifications 😭