### PR TITLE
Enable java lint

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -43,7 +43,32 @@ java {
 tasks.withType<JavaCompile>().configureEach {
   with(options) {
     release.set(otelJava.minJavaVersionSupported.map { it.majorVersion.toInt() })
-    compilerArgs.add("-Werror")
+
+    if (name != "jmhCompileGeneratedClasses") {
+      compilerArgs.addAll(
+        listOf(
+          "-Xlint:all",
+          // We suppress the "try" warning because it disallows managing an auto-closeable with
+          // try-with-resources without referencing the auto-closeable within the try block.
+          "-Xlint:-try",
+          // We suppress the "processing" warning as suggested in
+          // https://groups.google.com/forum/#!topic/bazel-discuss/_R3A9TJSoPM
+          "-Xlint:-processing",
+          // We suppress the "options" warning because it prevents compilation on modern JDKs
+          "-Xlint:-options",
+
+          // Fail build on any warning
+          "-Werror"
+        )
+      )
+    }
+
+    encoding = "UTF-8"
+
+    if (name.contains("Test")) {
+      // serialVersionUID is basically guaranteed to be useless in tests
+      compilerArgs.add("-Xlint:-serial")
+    }
   }
 }
 

--- a/instrumentation/internal/internal-lambda-java9/javaagent/build.gradle.kts
+++ b/instrumentation/internal/internal-lambda-java9/javaagent/build.gradle.kts
@@ -3,5 +3,19 @@ plugins {
 }
 
 otelJava {
+  // Fails with no error message :crying_cat_face:
   minJavaVersionSupported.set(JavaVersion.VERSION_1_9)
+  // Works:
+  // minJavaVersionSupported.set(JavaVersion.VERSION_11)
+}
+
+tasks {
+  compileJava {
+    with(options) {
+      // Because this module targets Java 9, we trigger this compiler bug which was fixed but not
+      // backported to Java 9 compilation.
+      // https://bugs.openjdk.java.net/browse/JDK-8209058
+      compilerArgs.add("-Xlint:none")
+    }
+  }
 }

--- a/instrumentation/vertx/vertx-reactive-3.5/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-reactive-3.5/javaagent/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
   compileOnly("io.vertx:vertx-web:$vertxVersion")
   compileOnly("io.vertx:vertx-rx-java2:$vertxVersion")
 
+  testCompileOnly("io.vertx:vertx-codegen:$vertxVersion")
+
   testInstrumentation(project(":instrumentation:jdbc:javaagent"))
   testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
   testInstrumentation(project(":instrumentation:rxjava:rxjava-2.0:javaagent"))

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/build.gradle.kts
@@ -35,7 +35,10 @@ dependencies {
 
   add("version3TestImplementation", "io.vertx:vertx-web:3.0.0")
   add("version3TestImplementation", "io.vertx:vertx-jdbc-client:3.0.0")
+  add("version3TestImplementation", "io.vertx:vertx-codegen:3.0.0")
+  add("version3TestImplementation", "io.vertx:vertx-docgen:3.0.0")
 
   add("latestDepTestImplementation", "io.vertx:vertx-web:4.+")
   add("latestDepTestImplementation", "io.vertx:vertx-jdbc-client:4.+")
+  add("latestDepTestImplementation", "io.vertx:vertx-codegen:4.+")
 }


### PR DESCRIPTION
Need help! I get the same lint warning as javaagent-tooling-java9, but after suppressing it, the lint failure goes away and instead it just fails to compile with absolutely no error message even with `--debug` 😿 

Bumping to Java 11 does succeed.

Can anyone help debug this? I have no leads