### PR TITLE
Move reactor context propagation operator instrumentation to separate…

### DIFF
--- a/instrumentation/reactor/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/ReactorInstrumentationModule.java
+++ b/instrumentation/reactor/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/ReactorInstrumentationModule.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.reactor;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -21,6 +21,6 @@ public class ReactorInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(new HooksInstrumentation(), new ContextPropagationOperatorInstrumentation());
+    return singletonList(new HooksInstrumentation());
   }
 }

--- a/instrumentation/reactor/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/operator/ContextPropagationOperatorInstrumentation.java
+++ b/instrumentation/reactor/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/operator/ContextPropagationOperatorInstrumentation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.reactor;
+package io.opentelemetry.javaagent.instrumentation.reactor.operator;
 
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;

--- a/instrumentation/reactor/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/operator/ContextPropagationOperatorInstrumentationModule.java
+++ b/instrumentation/reactor/reactor-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/operator/ContextPropagationOperatorInstrumentationModule.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.reactor.operator;
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static java.util.Collections.singletonList;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(InstrumentationModule.class)
+public class ContextPropagationOperatorInstrumentationModule extends InstrumentationModule {
+
+  public ContextPropagationOperatorInstrumentationModule() {
+    super("reactor", "reactor-3.1", "reactor-context-propagation-operator");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("application.io.opentelemetry.context.Context");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new ContextPropagationOperatorInstrumentation());
+  }
+}


### PR DESCRIPTION
… instrumentation module
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5186
Context propagation operator instrumentation depends on the presence of opentelemetry api. Move it to separate instrumentation module so that muzzle wouldn't fail for the whole reactor instrumentation when opentelemetry api isn't present.