### PR TITLE
Factor out NetServerAttributesGetter

### DIFF
--- a/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
+++ b/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
@@ -10,7 +10,8 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeaders;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
 import java.util.Collections;
@@ -41,7 +42,8 @@ public class InstrumenterBenchmark {
               "benchmark",
               HttpSpanNameExtractor.create(ConstantHttpAttributesExtractor.INSTANCE))
           .addAttributesExtractor(ConstantHttpAttributesExtractor.INSTANCE)
-          .addAttributesExtractor(new ConstantNetAttributesExtractor())
+          .addAttributesExtractor(
+              NetServerAttributesExtractor.create(new ConstantNetAttributesGetter()))
           .newInstrumenter();
 
   @Benchmark
@@ -126,8 +128,8 @@ public class InstrumenterBenchmark {
     }
   }
 
-  static class ConstantNetAttributesExtractor
-      extends InetSocketAddressNetServerAttributesExtractor<Void, Void> {
+  static class ConstantNetAttributesGetter
+      extends InetSocketAddressNetServerAttributesGetter<Void> {
 
     private static final InetSocketAddress ADDRESS =
         InetSocketAddress.createUnresolved("localhost", 8080);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetter.java
@@ -16,8 +16,8 @@ import javax.annotation.Nullable;
  * {@link InetSocketAddress} so this is a convenient alternative to {@link
  * NetServerAttributesExtractor}. There is no meaning to implement both in the same instrumentation.
  */
-public abstract class InetSocketAddressNetServerAttributesExtractor<REQUEST, RESPONSE>
-    extends NetServerAttributesExtractor<REQUEST, RESPONSE> {
+public abstract class InetSocketAddressNetServerAttributesGetter<REQUEST>
+    implements NetServerAttributesGetter<REQUEST> {
 
   @Nullable
   public abstract InetSocketAddress getAddress(REQUEST request);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
@@ -14,45 +14,44 @@ import javax.annotation.Nullable;
  * Extractor of <a
  * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes">Network
  * attributes</a>. It is common to have access to {@link java.net.InetSocketAddress}, in which case
- * it is more convenient to use {@link InetSocketAddressNetServerAttributesExtractor}.
+ * it is more convenient to use {@link InetSocketAddressNetServerAttributesGetter}.
  */
-public abstract class NetServerAttributesExtractor<REQUEST, RESPONSE>
+public final class NetServerAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {
+
+  private final NetServerAttributesGetter<REQUEST> getter;
+
+  public static <REQUEST, RESPONSE> NetServerAttributesExtractor<REQUEST, RESPONSE> create(
+      NetServerAttributesGetter<REQUEST> getter) {
+    return new NetServerAttributesExtractor<>(getter);
+  }
+
+  private NetServerAttributesExtractor(NetServerAttributesGetter<REQUEST> getter) {
+    this.getter = getter;
+  }
 
   @Override
   public final void onStart(AttributesBuilder attributes, REQUEST request) {
-    set(attributes, SemanticAttributes.NET_TRANSPORT, transport(request));
+    set(attributes, SemanticAttributes.NET_TRANSPORT, getter.transport(request));
 
-    String peerIp = peerIp(request);
-    String peerName = peerName(request);
+    String peerIp = getter.peerIp(request);
+    String peerName = getter.peerName(request);
 
     if (peerName != null && !peerName.equals(peerIp)) {
       set(attributes, SemanticAttributes.NET_PEER_NAME, peerName);
     }
     set(attributes, SemanticAttributes.NET_PEER_IP, peerIp);
 
-    Integer peerPort = peerPort(request);
+    Integer peerPort = getter.peerPort(request);
     if (peerPort != null && peerPort > 0) {
       set(attributes, SemanticAttributes.NET_PEER_PORT, (long) peerPort);
     }
   }
 
   @Override
-  public final void onEnd(
+  public void onEnd(
       AttributesBuilder attributes,
       REQUEST request,
       @Nullable RESPONSE response,
       @Nullable Throwable error) {}
-
-  @Nullable
-  public abstract String transport(REQUEST request);
-
-  @Nullable
-  public abstract String peerName(REQUEST request);
-
-  @Nullable
-  public abstract Integer peerPort(REQUEST request);
-
-  @Nullable
-  public abstract String peerIp(REQUEST request);
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
@@ -12,8 +12,8 @@ import javax.annotation.Nullable;
  * type into the 4 common attributes (transport, peerName, peerPort, peerIp).
  *
  * <p>Instrumentation authors will create implementations of this interface for their specific
- * server library/framework. It will be used by the {@link NetServerAttributesExtractor} to obtain the
- * various network attributes in a type-generic way.
+ * server library/framework. It will be used by the {@link NetServerAttributesExtractor} to obtain
+ * the various network attributes in a type-generic way.
  */
 public interface NetServerAttributesGetter<REQUEST> {
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.net;
+
+import javax.annotation.Nullable;
+
+/**
+ * An interface for getting server-based network attributes. It adapts a vendor-specific request
+ * type into the 4 common attributes (transport, peerName, peerPort, peerIp).
+ *
+ * <p>Instrumentation authors will create implementations of this interface for their specific
+ * server library/framework. It will be used by the NetServerAttributesExtractor to obtain the
+ * various network attributes in a type-generic way.
+ */
+public interface NetServerAttributesGetter<REQUEST> {
+
+  @Nullable
+  String transport(REQUEST request);
+
+  @Nullable
+  String peerName(REQUEST request);
+
+  @Nullable
+  Integer peerPort(REQUEST request);
+
+  @Nullable
+  String peerIp(REQUEST request);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
  * type into the 4 common attributes (transport, peerName, peerPort, peerIp).
  *
  * <p>Instrumentation authors will create implementations of this interface for their specific
- * server library/framework. It will be used by the NetServerAttributesExtractor to obtain the
+ * server library/framework. It will be used by the {@link NetServerAttributesExtractor} to obtain the
  * various network attributes in a type-generic way.
  */
 public interface NetServerAttributesGetter<REQUEST> {

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -30,6 +30,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttribut
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.rpc.RpcAttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -290,7 +291,7 @@ class InstrumenterTest {
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addAttributesExtractors(
                 mockHttpServerAttributes,
-                new ConstantNetPeerIpExtractor<>("2.2.2.2"),
+                NetServerAttributesExtractor.create(new ConstantNetPeerIpGetter<>("2.2.2.2")),
                 new AttributesExtractor1(),
                 new AttributesExtractor2())
             .addSpanLinksExtractor(new LinksExtractor())
@@ -765,12 +766,12 @@ class InstrumenterTest {
             LINK_TRACE_ID, LINK_SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault()));
   }
 
-  private static final class ConstantNetPeerIpExtractor<REQUEST, RESPONSE>
-      extends NetServerAttributesExtractor<REQUEST, RESPONSE> {
+  private static final class ConstantNetPeerIpGetter<REQUEST>
+      implements NetServerAttributesGetter<REQUEST> {
 
     private final String peerIp;
 
-    private ConstantNetPeerIpExtractor(String peerIp) {
+    private ConstantNetPeerIpGetter(String peerIp) {
       this.peerIp = peerIp;
     }
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
@@ -17,12 +17,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class InetSocketAddressNetServerAttributesExtractorTest {
+class InetSocketAddressNetServerAttributesGetterTest {
 
-  private final InetSocketAddressNetServerAttributesExtractor<InetSocketAddress, InetSocketAddress>
-      extractor =
-          new InetSocketAddressNetServerAttributesExtractor<
-              InetSocketAddress, InetSocketAddress>() {
+  private final NetServerAttributesExtractor<InetSocketAddress, InetSocketAddress> extractor =
+      NetServerAttributesExtractor.create(
+          new InetSocketAddressNetServerAttributesGetter<InetSocketAddress>() {
             @Override
             public InetSocketAddress getAddress(InetSocketAddress request) {
               return request;
@@ -32,7 +31,7 @@ class InetSocketAddressNetServerAttributesExtractorTest {
             public String transport(InetSocketAddress request) {
               return SemanticAttributes.NetTransportValues.IP_TCP;
             }
-          };
+          });
 
   @Test
   void noInetSocketAddress() {

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.Test;
 
 class NetServerAttributesExtractorTest {
 
-  static class TestNetServerAttributesExtractor
-      extends NetServerAttributesExtractor<Map<String, String>, Map<String, String>> {
+  static class TestNetServerAttributesGetter
+      implements NetServerAttributesGetter<Map<String, String>> {
 
     @Override
     public String transport(Map<String, String> request) {
@@ -55,7 +55,8 @@ class NetServerAttributesExtractorTest {
     response.put("peerPort", "42");
     response.put("peerIp", "4.3.2.1");
 
-    TestNetServerAttributesExtractor extractor = new TestNetServerAttributesExtractor();
+    NetServerAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+        createTestExtractor();
 
     // when
     AttributesBuilder startAttributes = Attributes.builder();
@@ -89,7 +90,8 @@ class NetServerAttributesExtractorTest {
     response.put("peerPort", "42");
     response.put("peerIp", "4.3.2.1");
 
-    TestNetServerAttributesExtractor extractor = new TestNetServerAttributesExtractor();
+    NetServerAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+        createTestExtractor();
 
     // when
     AttributesBuilder startAttributes = Attributes.builder();
@@ -117,7 +119,8 @@ class NetServerAttributesExtractorTest {
     Map<String, String> response = new HashMap<>();
     response.put("peerPort", "-1");
 
-    TestNetServerAttributesExtractor extractor = new TestNetServerAttributesExtractor();
+    NetServerAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+        createTestExtractor();
 
     // when
     AttributesBuilder startAttributes = Attributes.builder();
@@ -129,5 +132,10 @@ class NetServerAttributesExtractorTest {
     // then
     assertThat(startAttributes.build()).isEmpty();
     assertThat(endAttributes.build()).isEmpty();
+  }
+
+  private NetServerAttributesExtractor<Map<String, String>, Map<String, String>>
+      createTestExtractor() {
+    return NetServerAttributesExtractor.create(new TestNetServerAttributesGetter());
   }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorTest.java
@@ -134,7 +134,7 @@ class NetServerAttributesExtractorTest {
     assertThat(endAttributes.build()).isEmpty();
   }
 
-  private NetServerAttributesExtractor<Map<String, String>, Map<String, String>>
+  private static NetServerAttributesExtractor<Map<String, String>, Map<String, String>>
       createTestExtractor() {
     return NetServerAttributesExtractor.create(new TestNetServerAttributesGetter());
   }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTracingBuilder.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTracingBuilder.java
@@ -7,13 +7,14 @@ package io.opentelemetry.instrumentation.apachedubbo.v2_7;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboNetClientAttributesGetter;
-import io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboNetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboNetServerAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.PeerServiceAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.rpc.RpcSpanNameExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.ArrayList;
@@ -73,7 +74,8 @@ public final class DubboTracingBuilder {
                     .addAttributesExtractors(rpcAttributesExtractor)
                     .addAttributesExtractors(attributesExtractors));
 
-    serverInstrumenterBuilder.addAttributesExtractor(new DubboNetServerAttributesExtractor());
+    serverInstrumenterBuilder.addAttributesExtractor(
+        NetServerAttributesExtractor.create(new DubboNetServerAttributesGetter()));
     clientInstrumenterBuilder.addAttributesExtractor(netClientAttributesExtractor);
 
     if (peerService != null) {

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetServerAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetServerAttributesGetter.java
@@ -6,13 +6,12 @@
 package io.opentelemetry.instrumentation.apachedubbo.v2_7.internal;
 
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboRequest;
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
-import org.apache.dubbo.rpc.Result;
 
-public final class DubboNetServerAttributesExtractor
-    extends InetSocketAddressNetServerAttributesExtractor<DubboRequest, Result> {
+public final class DubboNetServerAttributesGetter
+    extends InetSocketAddressNetServerAttributesGetter<DubboRequest> {
 
   @Override
   @Nullable

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
@@ -6,15 +6,14 @@
 package io.opentelemetry.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.logging.RequestLog;
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-final class ArmeriaNetServerAttributesExtractor
-    extends InetSocketAddressNetServerAttributesExtractor<RequestContext, RequestLog> {
+final class ArmeriaNetServerAttributesGetter
+    extends InetSocketAddressNetServerAttributesGetter<RequestContext> {
 
   @Override
   public String transport(RequestContext ctx) {

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTracingBuilder.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTracingBuilder.java
@@ -22,6 +22,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.server.ServerSpanNaming;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.ArrayList;
@@ -137,7 +138,8 @@ public final class ArmeriaTracingBuilder {
         .setSpanStatusExtractor(
             statusExtractorTransformer.apply(
                 HttpSpanStatusExtractor.create(serverAttributesExtractor)))
-        .addAttributesExtractor(new ArmeriaNetServerAttributesExtractor())
+        .addAttributesExtractor(
+            NetServerAttributesExtractor.create(new ArmeriaNetServerAttributesGetter()))
         .addAttributesExtractor(serverAttributesExtractor)
         .addRequestMetrics(HttpServerMetrics.get())
         .addContextCustomizer(ServerSpanNaming.get());

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
@@ -5,13 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.grizzly;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import javax.annotation.Nullable;
 import org.glassfish.grizzly.http.HttpRequestPacket;
-import org.glassfish.grizzly.http.HttpResponsePacket;
 
-final class GrizzlyNetAttributesExtractor
-    extends NetServerAttributesExtractor<HttpRequestPacket, HttpResponsePacket> {
+final class GrizzlyNetAttributesGetter implements NetServerAttributesGetter<HttpRequestPacket> {
 
   @Nullable
   @Override

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlySingletons.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlySingletons.java
@@ -10,6 +10,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.server.ServerSpanNaming;
 import org.glassfish.grizzly.http.HttpRequestPacket;
 import org.glassfish.grizzly.http.HttpResponsePacket;
@@ -20,7 +21,7 @@ public final class GrizzlySingletons {
 
   static {
     GrizzlyHttpAttributesExtractor httpAttributesExtractor = new GrizzlyHttpAttributesExtractor();
-    GrizzlyNetAttributesExtractor netAttributesExtractor = new GrizzlyNetAttributesExtractor();
+    GrizzlyNetAttributesGetter netAttributesGetter = new GrizzlyNetAttributesGetter();
 
     INSTRUMENTER =
         Instrumenter.<HttpRequestPacket, HttpResponsePacket>builder(
@@ -29,7 +30,7 @@ public final class GrizzlySingletons {
                 HttpSpanNameExtractor.create(httpAttributesExtractor))
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesExtractor))
             .addAttributesExtractor(httpAttributesExtractor)
-            .addAttributesExtractor(netAttributesExtractor)
+            .addAttributesExtractor(NetServerAttributesExtractor.create(netAttributesGetter))
             .addRequestMetrics(HttpServerMetrics.get())
             .addContextCustomizer(
                 (context, httpRequestPacket, startAttributes) -> GrizzlyErrorHolder.init(context))

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTracingBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTracingBuilder.java
@@ -13,8 +13,9 @@ import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.PeerServiceAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.grpc.v1_6.internal.GrpcNetClientAttributesGetter;
-import io.opentelemetry.instrumentation.grpc.v1_6.internal.GrpcNetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.grpc.v1_6.internal.GrpcNetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.ArrayList;
 import java.util.List;
@@ -85,7 +86,8 @@ public final class GrpcTracingBuilder {
 
     clientInstrumenterBuilder.addAttributesExtractor(
         NetClientAttributesExtractor.create(netClientAttributesExtractor));
-    serverInstrumenterBuilder.addAttributesExtractor(new GrpcNetServerAttributesExtractor());
+    serverInstrumenterBuilder.addAttributesExtractor(
+        NetServerAttributesExtractor.create(new GrpcNetServerAttributesGetter()));
 
     if (peerService != null) {
       clientInstrumenterBuilder.addAttributesExtractor(

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetServerAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetServerAttributesGetter.java
@@ -5,16 +5,15 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6.internal;
 
-import io.grpc.Status;
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcRequest;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-public final class GrpcNetServerAttributesExtractor
-    extends InetSocketAddressNetServerAttributesExtractor<GrpcRequest, Status> {
+public final class GrpcNetServerAttributesGetter
+    extends InetSocketAddressNetServerAttributesGetter<GrpcRequest> {
   @Override
   @Nullable
   public InetSocketAddress getAddress(GrpcRequest request) {

--- a/instrumentation/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorNetServerAttributesGetter.kt
+++ b/instrumentation/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorNetServerAttributesGetter.kt
@@ -7,10 +7,10 @@ package io.opentelemetry.instrumentation.ktor.v1_0
 
 import io.ktor.request.*
 import io.ktor.response.*
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
-internal class KtorNetServerAttributesExtractor : NetServerAttributesExtractor<ApplicationRequest, ApplicationResponse>() {
+internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<ApplicationRequest> {
   override fun transport(request: ApplicationRequest): String {
     return SemanticAttributes.NetTransportValues.IP_TCP
   }

--- a/instrumentation/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorServerTracing.kt
+++ b/instrumentation/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorServerTracing.kt
@@ -22,6 +22,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeader
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor
 import io.opentelemetry.instrumentation.api.server.ServerSpanNaming
 import kotlinx.coroutines.withContext
 
@@ -98,7 +99,7 @@ class KtorServerTracing private constructor(
 
       with(instrumenterBuilder) {
         setSpanStatusExtractor(configuration.statusExtractor(HttpSpanStatusExtractor.create(httpAttributesExtractor)))
-        addAttributesExtractor(KtorNetServerAttributesExtractor())
+        addAttributesExtractor(NetServerAttributesExtractor.create(KtorNetServerAttributesGetter()))
         addAttributesExtractor(httpAttributesExtractor)
         addRequestMetrics(HttpServerMetrics.get())
         addContextCustomizer(ServerSpanNaming.get())

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.liberty.dispatcher;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.annotation.Nullable;
 
-public class LibertyDispatcherNetAttributesExtractor
-    extends NetServerAttributesExtractor<LibertyRequest, LibertyResponse> {
+public class LibertyDispatcherNetAttributesGetter
+    implements NetServerAttributesGetter<LibertyRequest> {
 
   @Override
   public String transport(LibertyRequest libertyRequest) {

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherSingletons.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherSingletons.java
@@ -29,7 +29,7 @@ public final class LibertyDispatcherSingletons {
     SpanStatusExtractor<LibertyRequest, LibertyResponse> spanStatusExtractor =
         HttpSpanStatusExtractor.create(httpAttributesExtractor);
     NetServerAttributesExtractor<LibertyRequest, LibertyResponse> netAttributesExtractor =
-        new LibertyDispatcherNetAttributesExtractor();
+        NetServerAttributesExtractor.create(new LibertyDispatcherNetAttributesGetter());
 
     INSTRUMENTER =
         Instrumenter.<LibertyRequest, LibertyResponse>builder(

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
@@ -3,21 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.netty.common.server;
+package io.opentelemetry.javaagent.instrumentation.netty.v3_8.server;
 
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_UDP;
 
-import io.netty.channel.socket.DatagramChannel;
-import io.netty.handler.codec.http.HttpResponse;
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesExtractor;
-import io.opentelemetry.javaagent.instrumentation.netty.common.HttpRequestAndChannel;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
+import io.opentelemetry.javaagent.instrumentation.netty.v3_8.HttpRequestAndChannel;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
+import org.jboss.netty.channel.socket.DatagramChannel;
 
-final class NettyNetServerAttributesExtractor
-    extends InetSocketAddressNetServerAttributesExtractor<HttpRequestAndChannel, HttpResponse> {
+final class NettyNetServerAttributesGetter
+    extends InetSocketAddressNetServerAttributesGetter<HttpRequestAndChannel> {
 
   @Override
   @Nullable
@@ -28,7 +27,7 @@ final class NettyNetServerAttributesExtractor
   @Override
   @Nullable
   public InetSocketAddress getAddress(HttpRequestAndChannel requestAndChannel) {
-    SocketAddress address = requestAndChannel.remoteAddress();
+    SocketAddress address = requestAndChannel.channel().getRemoteAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;
     }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyServerSingletons.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyServerSingletons.java
@@ -10,6 +10,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.server.ServerSpanNaming;
 import io.opentelemetry.javaagent.instrumentation.netty.common.NettyErrorHolder;
 import io.opentelemetry.javaagent.instrumentation.netty.v3_8.HttpRequestAndChannel;
@@ -30,7 +31,8 @@ final class NettyServerSingletons {
                 HttpSpanNameExtractor.create(httpServerAttributesExtractor))
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpServerAttributesExtractor))
             .addAttributesExtractor(httpServerAttributesExtractor)
-            .addAttributesExtractor(new NettyNetServerAttributesExtractor())
+            .addAttributesExtractor(
+                NetServerAttributesExtractor.create(new NettyNetServerAttributesGetter()))
             .addRequestMetrics(HttpServerMetrics.get())
             .addContextCustomizer(
                 (context, requestAndChannel, startAttributes) -> NettyErrorHolder.init(context))

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/common/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/common/server/NettyNetServerAttributesGetter.java
@@ -3,21 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.netty.v3_8.server;
+package io.opentelemetry.javaagent.instrumentation.netty.common.server;
 
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_UDP;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesExtractor;
-import io.opentelemetry.javaagent.instrumentation.netty.v3_8.HttpRequestAndChannel;
+import io.netty.channel.socket.DatagramChannel;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
+import io.opentelemetry.javaagent.instrumentation.netty.common.HttpRequestAndChannel;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
-import org.jboss.netty.channel.socket.DatagramChannel;
-import org.jboss.netty.handler.codec.http.HttpResponse;
 
-final class NettyNetServerAttributesExtractor
-    extends InetSocketAddressNetServerAttributesExtractor<HttpRequestAndChannel, HttpResponse> {
+final class NettyNetServerAttributesGetter
+    extends InetSocketAddressNetServerAttributesGetter<HttpRequestAndChannel> {
 
   @Override
   @Nullable
@@ -28,7 +27,7 @@ final class NettyNetServerAttributesExtractor
   @Override
   @Nullable
   public InetSocketAddress getAddress(HttpRequestAndChannel requestAndChannel) {
-    SocketAddress address = requestAndChannel.channel().getRemoteAddress();
+    SocketAddress address = requestAndChannel.remoteAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;
     }

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/common/server/NettyServerInstrumenterFactory.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/common/server/NettyServerInstrumenterFactory.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.server.ServerSpanNaming;
 import io.opentelemetry.javaagent.instrumentation.netty.common.HttpRequestAndChannel;
 import io.opentelemetry.javaagent.instrumentation.netty.common.NettyErrorHolder;
@@ -29,7 +30,8 @@ public final class NettyServerInstrumenterFactory {
             HttpSpanNameExtractor.create(httpAttributesExtractor))
         .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesExtractor))
         .addAttributesExtractor(httpAttributesExtractor)
-        .addAttributesExtractor(new NettyNetServerAttributesExtractor())
+        .addAttributesExtractor(
+            NetServerAttributesExtractor.create(new NettyNetServerAttributesGetter()))
         .addRequestMetrics(HttpServerMetrics.get())
         .addContextCustomizer((context, request, attributes) -> NettyErrorHolder.init(context))
         .addContextCustomizer(ServerSpanNaming.get())

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracingBuilder.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTracingBuilder.java
@@ -14,8 +14,9 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.ratpack.internal.RatpackHttpNetAttributesGetter;
-import io.opentelemetry.instrumentation.ratpack.internal.RatpackNetAttributesExtractor;
+import io.opentelemetry.instrumentation.ratpack.internal.RatpackNetAttributesGetter;
 import java.util.ArrayList;
 import java.util.List;
 import ratpack.http.Request;
@@ -71,7 +72,7 @@ public final class RatpackTracingBuilder {
 
   /** Returns a new {@link RatpackTracing} with the configuration of this builder. */
   public RatpackTracing build() {
-    RatpackNetAttributesExtractor netAttributes = new RatpackNetAttributesExtractor();
+    RatpackNetAttributesGetter netAttributes = new RatpackNetAttributesGetter();
     RatpackHttpAttributesExtractor httpAttributes =
         new RatpackHttpAttributesExtractor(capturedHttpHeaders);
 
@@ -79,7 +80,7 @@ public final class RatpackTracingBuilder {
         Instrumenter.<Request, Response>builder(
                 openTelemetry, INSTRUMENTATION_NAME, HttpSpanNameExtractor.create(httpAttributes))
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributes))
-            .addAttributesExtractor(netAttributes)
+            .addAttributesExtractor(NetServerAttributesExtractor.create(netAttributes))
             .addAttributesExtractor(httpAttributes)
             .addAttributesExtractors(additionalExtractors)
             .addRequestMetrics(HttpServerMetrics.get())

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/internal/RatpackNetAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/internal/RatpackNetAttributesGetter.java
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.restlet.v2_0.internal;
+package io.opentelemetry.instrumentation.ratpack.internal;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.annotation.Nullable;
-import org.restlet.Request;
-import org.restlet.Response;
+import ratpack.http.Request;
 
-final class RestletNetAttributesExtractor extends NetServerAttributesExtractor<Request, Response> {
+public final class RatpackNetAttributesGetter implements NetServerAttributesGetter<Request> {
   @Override
+  @Nullable
   public String transport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
@@ -25,12 +25,12 @@ final class RestletNetAttributesExtractor extends NetServerAttributesExtractor<R
 
   @Override
   public Integer peerPort(Request request) {
-    return request.getClientInfo().getPort();
+    return request.getRemoteAddress().getPort();
   }
 
   @Override
   @Nullable
   public String peerIp(Request request) {
-    return request.getClientInfo().getAddress();
+    return null;
   }
 }

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletNetAttributesGetter.java
@@ -3,18 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.ratpack.internal;
+package io.opentelemetry.instrumentation.restlet.v1_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.annotation.Nullable;
-import ratpack.http.Request;
-import ratpack.http.Response;
+import org.restlet.data.Request;
 
-public final class RatpackNetAttributesExtractor
-    extends NetServerAttributesExtractor<Request, Response> {
+final class RestletNetAttributesGetter implements NetServerAttributesGetter<Request> {
   @Override
-  @Nullable
   public String transport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
@@ -27,12 +24,12 @@ public final class RatpackNetAttributesExtractor
 
   @Override
   public Integer peerPort(Request request) {
-    return request.getRemoteAddress().getPort();
+    return request.getClientInfo().getPort();
   }
 
   @Override
   @Nullable
   public String peerIp(Request request) {
-    return null;
+    return request.getClientInfo().getAddress();
   }
 }

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletTracingBuilder.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletTracingBuilder.java
@@ -68,7 +68,7 @@ public final class RestletTracingBuilder {
     SpanStatusExtractor<Request, Response> spanStatusExtractor =
         HttpSpanStatusExtractor.create(httpAttributesExtractor);
     NetServerAttributesExtractor<Request, Response> netAttributesExtractor =
-        new RestletNetAttributesExtractor();
+        NetServerAttributesExtractor.create(new RestletNetAttributesGetter());
 
     Instrumenter<Request, Response> instrumenter =
         Instrumenter.<Request, Response>builder(

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletInstrumenterFactory.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletInstrumenterFactory.java
@@ -43,7 +43,7 @@ public class RestletInstrumenterFactory {
     SpanStatusExtractor<Request, Response> spanStatusExtractor =
         HttpSpanStatusExtractor.create(httpAttributesExtractor);
     NetServerAttributesExtractor<Request, Response> netAttributesExtractor =
-        new RestletNetAttributesExtractor();
+        NetServerAttributesExtractor.create(new RestletNetAttributesGetter());
 
     return Instrumenter.<Request, Response>builder(
             openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletNetAttributesGetter.java
@@ -3,15 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.restlet.v1_0;
+package io.opentelemetry.instrumentation.restlet.v2_0.internal;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.annotation.Nullable;
-import org.restlet.data.Request;
-import org.restlet.data.Response;
+import org.restlet.Request;
 
-final class RestletNetAttributesExtractor extends NetServerAttributesExtractor<Request, Response> {
+final class RestletNetAttributesGetter implements NetServerAttributesGetter<Request> {
   @Override
   public String transport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletInstrumenterBuilder.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletInstrumenterBuilder.java
@@ -16,6 +16,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttribut
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.server.ServerSpanNaming;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,8 +48,8 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
 
     SpanStatusExtractor<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
         spanStatusExtractor = HttpSpanStatusExtractor.create(httpAttributesExtractor);
-    ServletNetAttributesExtractor<REQUEST, RESPONSE> netAttributesExtractor =
-        new ServletNetAttributesExtractor<>(accessor);
+    ServletNetAttributesGetter<REQUEST, RESPONSE> netAttributesGetter =
+        new ServletNetAttributesGetter<>(accessor);
     ServletErrorCauseExtractor<REQUEST, RESPONSE> errorCauseExtractor =
         new ServletErrorCauseExtractor<>(accessor);
     AttributesExtractor<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
@@ -60,7 +61,7 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
             .setSpanStatusExtractor(spanStatusExtractor)
             .setErrorCauseExtractor(errorCauseExtractor)
             .addAttributesExtractor(httpAttributesExtractor)
-            .addAttributesExtractor(netAttributesExtractor)
+            .addAttributesExtractor(NetServerAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractor(additionalAttributesExtractor)
             .addRequestMetrics(HttpServerMetrics.get())
             .addContextCustomizer(ServerSpanNaming.get());

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesGetter.java
@@ -5,16 +5,15 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.annotation.Nullable;
 
-public class ServletNetAttributesExtractor<REQUEST, RESPONSE>
-    extends NetServerAttributesExtractor<
-        ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>> {
+public class ServletNetAttributesGetter<REQUEST, RESPONSE>
+    implements NetServerAttributesGetter<ServletRequestContext<REQUEST>> {
   private final ServletAccessor<REQUEST, RESPONSE> accessor;
 
-  public ServletNetAttributesExtractor(ServletAccessor<REQUEST, RESPONSE> accessor) {
+  public ServletNetAttributesGetter(ServletAccessor<REQUEST, RESPONSE> accessor) {
     this.accessor = accessor;
   }
 

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebNetAttributesGetter.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebNetAttributesGetter.java
@@ -5,14 +5,12 @@
 
 package io.opentelemetry.instrumentation.spring.web;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.annotation.Nullable;
 import org.springframework.http.HttpRequest;
-import org.springframework.http.client.ClientHttpResponse;
 
-final class SpringWebNetAttributesExtractor
-    extends NetServerAttributesExtractor<HttpRequest, ClientHttpResponse> {
+final class SpringWebNetAttributesGetter implements NetServerAttributesGetter<HttpRequest> {
   @Override
   public String transport(HttpRequest httpRequest) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebTracingBuilder.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebTracingBuilder.java
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeader
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.http.HttpRequest;
@@ -60,7 +61,7 @@ public final class SpringWebTracingBuilder {
   public SpringWebTracing build() {
     SpringWebHttpAttributesExtractor httpAttributesExtractor =
         new SpringWebHttpAttributesExtractor(capturedHttpHeaders);
-    SpringWebNetAttributesExtractor netAttributesExtractor = new SpringWebNetAttributesExtractor();
+    SpringWebNetAttributesGetter netAttributesGetter = new SpringWebNetAttributesGetter();
 
     Instrumenter<HttpRequest, ClientHttpResponse> instrumenter =
         Instrumenter.<HttpRequest, ClientHttpResponse>builder(
@@ -69,7 +70,7 @@ public final class SpringWebTracingBuilder {
                 HttpSpanNameExtractor.create(httpAttributesExtractor))
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesExtractor))
             .addAttributesExtractor(httpAttributesExtractor)
-            .addAttributesExtractor(netAttributesExtractor)
+            .addAttributesExtractor(NetServerAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractors(additionalExtractors)
             .addRequestMetrics(HttpClientMetrics.get())
             .newClientInstrumenter(HttpRequestSetter.INSTANCE);

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcNetAttributesGetter.java
@@ -5,14 +5,13 @@
 
 package io.opentelemetry.instrumentation.spring.webmvc;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-final class SpringWebMvcNetAttributesExtractor
-    extends NetServerAttributesExtractor<HttpServletRequest, HttpServletResponse> {
+final class SpringWebMvcNetAttributesGetter
+    implements NetServerAttributesGetter<HttpServletRequest> {
   @Override
   public String transport(HttpServletRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcTracingBuilder.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcTracingBuilder.java
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.CapturedHttpHeader
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.server.ServerSpanNaming;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +72,8 @@ public final class SpringWebMvcTracingBuilder {
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesExtractor))
             .addAttributesExtractor(httpAttributesExtractor)
             .addAttributesExtractor(new StatusCodeExtractor())
-            .addAttributesExtractor(new SpringWebMvcNetAttributesExtractor())
+            .addAttributesExtractor(
+                NetServerAttributesExtractor.create(new SpringWebMvcNetAttributesGetter()))
             .addAttributesExtractors(additionalExtractors)
             .addRequestMetrics(HttpServerMetrics.get())
             .addContextCustomizer(ServerSpanNaming.get())

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatInstrumenterFactory.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatInstrumenterFactory.java
@@ -37,7 +37,7 @@ public final class TomcatInstrumenterFactory {
     SpanStatusExtractor<Request, Response> spanStatusExtractor =
         HttpSpanStatusExtractor.create(httpAttributesExtractor);
     NetServerAttributesExtractor<Request, Response> netAttributesExtractor =
-        new TomcatNetAttributesExtractor();
+        NetServerAttributesExtractor.create(new TomcatNetAttributesGetter());
     AttributesExtractor<Request, Response> additionalAttributeExtractor =
         new TomcatAdditionalAttributesExtractor<>(accessor, servletEntityProvider);
 

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesGetter.java
@@ -5,14 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.common;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.annotation.Nullable;
 import org.apache.coyote.ActionCode;
 import org.apache.coyote.Request;
-import org.apache.coyote.Response;
 
-public class TomcatNetAttributesExtractor extends NetServerAttributesExtractor<Request, Response> {
+public class TomcatNetAttributesGetter implements NetServerAttributesGetter<Request> {
 
   @Override
   @Nullable

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.undertow;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import io.undertow.server.HttpServerExchange;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
-public class UndertowNetAttributesExtractor
-    extends InetSocketAddressNetServerAttributesExtractor<HttpServerExchange, HttpServerExchange> {
+public class UndertowNetAttributesGetter
+    extends InetSocketAddressNetServerAttributesGetter<HttpServerExchange> {
 
   @Override
   @Nullable

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowSingletons.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowSingletons.java
@@ -32,7 +32,7 @@ public final class UndertowSingletons {
     SpanStatusExtractor<HttpServerExchange, HttpServerExchange> spanStatusExtractor =
         HttpSpanStatusExtractor.create(httpAttributesExtractor);
     NetServerAttributesExtractor<HttpServerExchange, HttpServerExchange> netAttributesExtractor =
-        new UndertowNetAttributesExtractor();
+        NetServerAttributesExtractor.create(new UndertowNetAttributesGetter());
 
     INSTRUMENTER =
         Instrumenter.<HttpServerExchange, HttpServerExchange>builder(


### PR DESCRIPTION
Continuing our series on favoring composition over inheritance. This is a follow-up from #5030, but geared at the server attributes.