### PR TITLE
Use CLA approved user

### DIFF
--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Setup git name
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name trask
+          git config user.email trask.stalnaker@gmail.com
 
       - name: Create pull request
         env:
@@ -78,8 +78,8 @@ jobs:
 
       - name: Setup git name
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name trask
+          git config user.email trask.stalnaker@gmail.com
 
       - name: Create pull request
         env:


### PR DESCRIPTION
Based on @anuraaga's observation that we can set arbitrary user on the commit, don't need a Personal Access Token after all.

Will replace this with @opentelemetry-java-bot once github unflags the account I created and CNCF whitelists it for EasyCLA.