### PR TITLE
Limit redisson version to 3.16.7

### DIFF
--- a/instrumentation/redisson-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/redisson-3.0/javaagent/build.gradle.kts
@@ -6,7 +6,9 @@ muzzle {
   pass {
     group.set("org.redisson")
     module.set("redisson")
-    versions.set("[3.0.0,)")
+    // in 3.16.8 CommandsData#getPromise() and CommandData#getPromise() return type was changed in
+    // a backwards-incompatible way from RPromise to CompletableStage
+    versions.set("[3.0.0,3.16.8)")
   }
 }
 
@@ -15,6 +17,8 @@ dependencies {
 
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
+
+  latestDepTestLibrary("org.redisson:redisson:3.16.8")
 }
 
 tasks.test {

--- a/instrumentation/redisson-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/redisson-3.0/javaagent/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 
-  latestDepTestLibrary("org.redisson:redisson:3.16.8")
+  latestDepTestLibrary("org.redisson:redisson:3.16.7")
 }
 
 tasks.test {


### PR DESCRIPTION
Release [3.16.8](https://github.com/redisson/redisson/releases/tag/redisson-3.16.8) has changed the return type of `getPromise()` methods 