### PR TITLE
Limit aws-sdk version for latest dep tests

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -23,8 +23,9 @@ dependencies {
   testImplementation(project(":instrumentation:apache-httpclient:apache-httpclient-4.0:javaagent"))
   testImplementation(project(":instrumentation:netty:netty-4.1:javaagent"))
 
-  latestDepTestLibrary("software.amazon.awssdk:aws-json-protocol:+")
-  latestDepTestLibrary("software.amazon.awssdk:kinesis:+")
+  latestDepTestLibrary("software.amazon.awssdk:aws-json-protocol:2.17.114")
+  latestDepTestLibrary("software.amazon.awssdk:kinesis:2.17.114")
+  latestDepTestLibrary("software.amazon.awssdk:aws-core:2.17.114")
 }
 
 tasks.withType<Test>().configureEach {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -13,7 +13,9 @@ dependencies {
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-core")
 
-  latestDepTestLibrary("software.amazon.awssdk:kinesis:+")
+  latestDepTestLibrary("software.amazon.awssdk:kinesis:2.17.114")
+  latestDepTestLibrary("software.amazon.awssdk:aws-core:2.17.114")
+  latestDepTestLibrary("software.amazon.awssdk:aws-json-protocol:2.17.114")
 }
 
 tasks {


### PR DESCRIPTION
to fix CI for now until proper fix can be made