### PR TITLE
Limit latest dep version in aws sdk library-autoconfigure module

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
@@ -12,7 +12,9 @@ dependencies {
 
   testImplementation(project(":instrumentation:aws-sdk:aws-sdk-2.2:testing"))
 
-  latestDepTestLibrary("software.amazon.awssdk:kinesis:+")
+  latestDepTestLibrary("software.amazon.awssdk:kinesis:2.17.114")
+  latestDepTestLibrary("software.amazon.awssdk:aws-core:2.17.114")
+  latestDepTestLibrary("software.amazon.awssdk:aws-json-protocol:2.17.114")
 }
 
 tasks {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5204
Rest of the modules were changed in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5202