### PR TITLE
Fix vaadin14 latest dep test

### DIFF
--- a/instrumentation/vaadin-14.2/javaagent/src/vaadin14LatestTest/resources/application.properties
+++ b/instrumentation/vaadin-14.2/javaagent/src/vaadin14LatestTest/resources/application.properties
@@ -1,0 +1,4 @@
+# overrides testing/src/main/resources/application.properties
+vaadin.whitelisted-packages=test/vaadin
+vaadin.devmode.liveReload.enabled=false
+vaadin.pnpm.enable=true

--- a/instrumentation/vaadin-14.2/testing/src/main/resources/application.properties
+++ b/instrumentation/vaadin-14.2/testing/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+# there is another copy of this file in javaagent/src/vaadin14LatestTest/resources/application.properties
 vaadin.whitelisted-packages=test/vaadin
 vaadin.devmode.liveReload.enabled=false
 vaadin.pnpm.enable=true


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5213
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5212
Latest vaadin 14 doesn't like `--host` in webpack options, probably because unlike earlier versions it already passes `--host=127.0.0.1`. If I remember correctly we added `--host` because otherwise it didn't work on @iNikem's computer.