### PR TITLE
Fix testLatestDeps lint error

### DIFF
--- a/instrumentation/servlet/servlet-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/servlet/servlet-5.0/javaagent/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
   testLibrary("org.eclipse.jetty:jetty-servlet:11.0.0")
   testLibrary("org.apache.tomcat.embed:tomcat-embed-core:10.0.0")
   testLibrary("org.apache.tomcat.embed:tomcat-embed-jasper:10.0.0")
+
+  // Tomcat 10.1 requires Java 11
+  latestDepTestLibrary("org.apache.tomcat.embed:tomcat-embed-core:10.0.+")
+  latestDepTestLibrary("org.apache.tomcat.embed:tomcat-embed-jasper:10.0.+")
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
Fixes

```
:instrumentation:servlet:servlet-5.0:javaagent:compileTestJava FAILED	
/home/runner/.gradle/caches/modules-2/files-2.1/org.apache.tomcat.embed/tomcat-embed-core/10.1.0-M10/57096840f13a4d747b4c22e55455eacae2dea104/tomcat-embed-core-10.1.0-M10.jar(/jakarta/servlet/http/HttpServlet.class): warning: Cannot find annotation method 'forRemoval()' in type 'Deprecated'	
/home/runner/.gradle/caches/modules-2/files-2.1/org.apache.tomcat.embed/tomcat-embed-core/10.1.0-M10/57096840f13a4d747b4c22e55455eacae2dea104/tomcat-embed-core-10.1.0-M10.jar(/jakarta/servlet/http/HttpServlet.class): warning: Cannot find annotation method 'since()' in type 'Deprecated'	
error: warnings found and -Werror specified	
```

I'm not really sure how the Servlet 5 / Java 8 tests were currently passing though on Tomcat 10.1...

(https://tomcat.apache.org/whichversion.html)