### PR TITLE
[v1.10.x branch] Limit redisson version to 3.16.7 (#5198)

### DIFF
--- a/instrumentation/redisson-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/redisson-3.0/javaagent/build.gradle.kts
@@ -6,7 +6,9 @@ muzzle {
   pass {
     group.set("org.redisson")
     module.set("redisson")
-    versions.set("[3.0.0,)")
+    // in 3.16.8 CommandsData#getPromise() and CommandData#getPromise() return type was changed in
+    // a backwards-incompatible way from RPromise to CompletableStage
+    versions.set("[3.0.0,3.16.8)")
   }
 }
 
@@ -15,6 +17,8 @@ dependencies {
 
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
+
+  latestDepTestLibrary("org.redisson:redisson:3.16.7")
 }
 
 tasks.test {


### PR DESCRIPTION
Clean cherry-pick of #5198 into the `v1.10.x` branch.

We don't run testLatestDeps in patch branch, but we do run muzzle, so we don't need to cherry-pick things that cause testLatestDeps to fail (which is more common), but we do need to cherry-pick things that cause muzzle to fail.