### PR TITLE
Run CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v*
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Side effect of this is to push gradle cache from release branch so that hopefully the release branch PR builds won't be so slow.