### PR TITLE
[v1.10.x branch] Run CI on release branches (#5230)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v*
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I'm interested to test this out and see if it improves release branch PR builds (and patch release times themselves)