### PR TITLE
[v1.10.x branch] Reduce release branch maintenance overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,10 @@ jobs:
 
   testLatestDeps:
     runs-on: ubuntu-latest
+    # release branches are excluded
+    # because any time a new library version is released to maven central it can fail
+    # which requires unnecessary release branch maintenance, especially for patches
+    if: ${{ !startsWith(github.ref_name, 'v') }}
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -153,6 +157,10 @@ jobs:
           arguments: ":smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}"
 
   setup-muzzle-matrix:
+    # release branches are excluded
+    # because any time a new library version is released to maven central it can fail
+    # which requires unnecessary release branch maintenance, especially for patches
+    if: ${{ !startsWith(github.ref_name, 'v') }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -178,6 +186,10 @@ jobs:
         run: echo "::set-output name=matrix::{\"module\":[\"$(./gradlew -q instrumentation:listInstrumentations | xargs echo | sed 's/ /","/g')\"]}"
 
   muzzle:
+    # release branches are excluded
+    # because any time a new library version is released to maven central it can fail
+    # which requires unnecessary release branch maintenance, especially for patches
+    if: ${{ !startsWith(github.ref_name, 'v') }}
     needs: setup-muzzle-matrix
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,10 +186,6 @@ jobs:
         run: echo "::set-output name=matrix::{\"module\":[\"$(./gradlew -q instrumentation:listInstrumentations | xargs echo | sed 's/ /","/g')\"]}"
 
   muzzle:
-    # release branches are excluded
-    # because any time a new library version is released to maven central it can fail
-    # which requires unnecessary release branch maintenance, especially for patches
-    if: ${{ !startsWith(github.ref_name, 'v') }}
     needs: setup-muzzle-matrix
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -170,6 +170,10 @@ jobs:
           arguments: ":smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}"
 
   setup-muzzle-matrix:
+    # release branches are excluded
+    # because any time a new library version is released to maven central it can fail
+    # which requires unnecessary release branch maintenance, especially for patches
+    if: ${{ !startsWith(github.base_ref_name, 'v') }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -195,6 +199,10 @@ jobs:
         run: echo "::set-output name=matrix::{\"module\":[\"$(./gradlew -q instrumentation:listInstrumentations | xargs echo | sed 's/ /","/g')\"]}"
 
   muzzle:
+    # release branches are excluded
+    # because any time a new library version is released to maven central it can fail
+    # which requires unnecessary release branch maintenance, especially for patches
+    if: ${{ !startsWith(github.base_ref_name, 'v') }}
     needs: setup-muzzle-matrix
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -199,10 +199,6 @@ jobs:
         run: echo "::set-output name=matrix::{\"module\":[\"$(./gradlew -q instrumentation:listInstrumentations | xargs echo | sed 's/ /","/g')\"]}"
 
   muzzle:
-    # release branches are excluded
-    # because any time a new library version is released to maven central it can fail
-    # which requires unnecessary release branch maintenance, especially for patches
-    if: ${{ !startsWith(github.base_ref, 'v') }}
     needs: setup-muzzle-matrix
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -173,7 +173,7 @@ jobs:
     # release branches are excluded
     # because any time a new library version is released to maven central it can fail
     # which requires unnecessary release branch maintenance, especially for patches
-    if: ${{ !startsWith(github.base_ref_name, 'v') }}
+    if: ${{ !startsWith(github.base_ref, 'v') }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -202,7 +202,7 @@ jobs:
     # release branches are excluded
     # because any time a new library version is released to maven central it can fail
     # which requires unnecessary release branch maintenance, especially for patches
-    if: ${{ !startsWith(github.base_ref_name, 'v') }}
+    if: ${{ !startsWith(github.base_ref, 'v') }}
     needs: setup-muzzle-matrix
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
#5245 tracks this change in `main`, but would like to merge this into v1.10.x branch sooner to fix the release branch CI (instead of merging in several testLatestDeps and muzzle fixes)

> Skip muzzle and testLatestDeps on release branch PRs and CI.
>
> They are requiring a lot of release branch maintenance which seems to have little value.
>
> These are already skipped on the release workflow itself.