### PR TITLE
Only publish snaphots from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
     # it can fail due to test code incompatibility with the new library version,
     # or due to slight changes in emitted telemetry
     needs: [ build, test, smoke-test, examples, muzzle ]
-    if: github.repository == 'open-telemetry/opentelemetry-java-instrumentation'
+    if: ${{ github.ref_name == 'main' && github.repository == 'open-telemetry/opentelemetry-java-instrumentation' }}
     steps:
       - uses: actions/checkout@v2.3.4
 


### PR DESCRIPTION
I noticed we have a couple of open staging repos because I added CI to the release branches yesterday (and release branch version doesn't end with -SNAPSHOT) 😬.

Will cherry-pick this to the v1.10.x branch in case there's a 1.10.2.