### PR TITLE
Don't run testLatestDeps on alpha/beta/rc versions

### DIFF
--- a/instrumentation/logback/logback-appender-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/build.gradle.kts
@@ -21,8 +21,6 @@ dependencies {
 
   implementation(project(":instrumentation:logback:logback-appender-1.0:library"))
 
-  latestDepTestLibrary("ch.qos.logback:logback-classic:1.2.+")
-
   testImplementation("org.awaitility:awaitility")
 }
 

--- a/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
@@ -8,8 +8,6 @@ dependencies {
 
   library("ch.qos.logback:logback-classic:0.9.16")
 
-  latestDepTestLibrary("ch.qos.logback:logback-classic:1.2.+")
-
   testImplementation("io.opentelemetry:opentelemetry-sdk-logs")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 

--- a/instrumentation/logback/logback-mdc-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/logback/logback-mdc-1.0/javaagent/build.gradle.kts
@@ -16,7 +16,4 @@ dependencies {
   library("ch.qos.logback:logback-classic:1.0.0")
 
   testImplementation(project(":instrumentation:logback:logback-mdc-1.0:testing"))
-
-  // 1.3+ contains breaking changes, check back after it stabilizes.
-  latestDepTestLibrary("ch.qos.logback:logback-classic:1.2.+")
 }

--- a/instrumentation/logback/logback-mdc-1.0/library/build.gradle.kts
+++ b/instrumentation/logback/logback-mdc-1.0/library/build.gradle.kts
@@ -6,7 +6,4 @@ dependencies {
   library("ch.qos.logback:logback-classic:1.0.0")
 
   testImplementation(project(":instrumentation:logback:logback-mdc-1.0:testing"))
-
-  // 1.3+ contains breaking changes, check back after it stabilizes.
-  latestDepTestLibrary("ch.qos.logback:logback-classic:1.2.+")
 }


### PR DESCRIPTION
Resolves #5225

Will apply to more places as part of reviewing all testLatestDeps caps in #5227.

Sources for gradle magic:
* https://stackoverflow.com/questions/24995517/how-to-use-gradles-dynamic-versions-and-avoid-betas
* https://docs.gradle.org/current/userguide/component_metadata_rules.html#sec:custom_status_scheme