### PR TITLE
Add option to run testLatestDeps on PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,12 +114,29 @@ jobs:
           path: "**/javacore.*.txt"
           if-no-files-found: ignore
 
-  # testLatestDeps is intentionally not included in the PR workflow
-  # because any time a new library version is released to maven central
-  # it can fail due to test code incompatibility with the new library version,
-  # or due to slight changes in emitted telemetry, which can be confusing for contributors
-  # (muzzle can also fail when a new library version is released to maven central
-  # but that happens much less often)
+  testLatestDeps:
+    runs-on: ubuntu-latest
+    # testLatestDeps is not included in the PR workflow by default
+    # because any time a new library version is released to maven central
+    # it can fail due to test code incompatibility with the new library version,
+    # or due to slight changes in emitted telemetry, which can be confusing for contributors
+    # (muzzle can also fail when a new library version is released to maven central
+    # but that happens much less often)
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test latest deps') }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Set up JDK 11 for running Gradle
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+      - name: Test
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: test -PtestLatestDeps=true
+          cache-read-only: true
 
   smoke-test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This will be helpful for the current testLatestDeps cleanup I'm working on.

And seems like a nice alternative on some PRs instead of merging and waiting to see if CI fails on `main`.

We could also use this on brand new instrumentations since we often find out that testLatestDeps fails on those once they are merged.