### PR TITLE
Use VirtualField for associating netty listener with wrapper

### DIFF
--- a/instrumentation/internal/internal-lambda-java9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/lambda/Java9LambdaTransformer.java
+++ b/instrumentation/internal/internal-lambda-java9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/lambda/Java9LambdaTransformer.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.internal.lambda;
 
+import io.opentelemetry.javaagent.bootstrap.InjectedHelperClassDetector;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 
@@ -19,6 +20,10 @@ public final class Java9LambdaTransformer {
       String slashClassName,
       Class<?> targetClass)
       throws IllegalClassFormatException {
+    // Skip transforming lambdas of injected helper classes.
+    if (InjectedHelperClassDetector.isHelperClass(targetClass)) {
+      return classBytes;
+    }
     return transformer.transform(
         targetClass.getModule(),
         targetClass.getClassLoader(),

--- a/instrumentation/internal/internal-lambda-java9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/lambda/Java9LambdaTransformer.java
+++ b/instrumentation/internal/internal-lambda-java9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/lambda/Java9LambdaTransformer.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.internal.lambda;
 
-import io.opentelemetry.javaagent.bootstrap.InjectedHelperClassDetector;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 
@@ -20,10 +19,6 @@ public final class Java9LambdaTransformer {
       String slashClassName,
       Class<?> targetClass)
       throws IllegalClassFormatException {
-    // Skip transforming lambdas of injected helper classes.
-    if (InjectedHelperClassDetector.isHelperClass(targetClass)) {
-      return classBytes;
-    }
     return transformer.transform(
         targetClass.getModule(),
         targetClass.getClassLoader(),

--- a/instrumentation/internal/internal-lambda/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/lambda/LambdaTransformer.java
+++ b/instrumentation/internal/internal-lambda/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/lambda/LambdaTransformer.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.internal.lambda;
 
 import io.opentelemetry.javaagent.bootstrap.ClassFileTransformerHolder;
+import io.opentelemetry.javaagent.bootstrap.InjectedHelperClassDetector;
 import java.lang.instrument.ClassFileTransformer;
 
 /** Helper class for transforming lambda class bytes. */
@@ -29,6 +30,11 @@ public final class LambdaTransformer {
    */
   @SuppressWarnings("unused")
   public static byte[] transform(byte[] classBytes, String slashClassName, Class<?> targetClass) {
+    // Skip transforming lambdas of injected helper classes.
+    if (InjectedHelperClassDetector.isHelperClass(targetClass)) {
+      return classBytes;
+    }
+
     ClassFileTransformer transformer = ClassFileTransformerHolder.getClassFileTransformer();
     if (transformer != null) {
       try {

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/InjectedHelperClassDetector.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/InjectedHelperClassDetector.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.bootstrap;
+
+import java.util.function.Function;
+
+/** Helper class for detecting whether given class is an injected helper class. */
+public final class InjectedHelperClassDetector {
+
+  private InjectedHelperClassDetector() {}
+
+  private static volatile Function<Class<?>, Boolean> helperClassDetector;
+
+  /** Sets the {@link Function} for detecting injected helper classes. */
+  public static void internalSetHelperClassDetector(
+      Function<Class<?>, Boolean> helperClassDetector) {
+    if (InjectedHelperClassDetector.helperClassDetector != null) {
+      // Only possible by misuse of this API, just ignore.
+      return;
+    }
+    InjectedHelperClassDetector.helperClassDetector = helperClassDetector;
+  }
+
+  public static boolean isHelperClass(Class<?> clazz) {
+    if (helperClassDetector == null) {
+      return false;
+    }
+    return helperClassDetector.apply(clazz);
+  }
+}

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.tooling;
 import io.opentelemetry.instrumentation.api.cache.Cache;
 import io.opentelemetry.javaagent.bootstrap.DefineClassContext;
 import io.opentelemetry.javaagent.bootstrap.HelperResources;
+import io.opentelemetry.javaagent.bootstrap.InjectedHelperClassDetector;
 import io.opentelemetry.javaagent.tooling.muzzle.HelperResource;
 import java.io.File;
 import java.io.IOException;
@@ -49,6 +50,10 @@ public class HelperInjector implements Transformer {
 
   private static final TransformSafeLogger logger =
       TransformSafeLogger.getLogger(HelperInjector.class);
+
+  static {
+    InjectedHelperClassDetector.internalSetHelperClassDetector(HelperInjector::isInjectedClass);
+  }
 
   // Need this because we can't put null into the injectedClassLoaders map.
   private static final ClassLoader BOOTSTRAP_CLASSLOADER_PLACEHOLDER =


### PR DESCRIPTION
Probably resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5265
To support removing netty listeners we need to be able to find the wrapper that we register instead of the original listener from the original listener. Currently we use a static weak cache for it. Removal of the elements from this cache depends on the gc, which might confuse users who inspect the heap dump and make them suspect that there is a memory leak.