### PR TITLE
Set jackson.databind as 'implementation' dep for Lambda Instrumentation

### DIFF
--- a/instrumentation/aws-lambda-1.0/library/build.gradle.kts
+++ b/instrumentation/aws-lambda-1.0/library/build.gradle.kts
@@ -16,10 +16,10 @@ dependencies {
   // in public API.
   library("com.amazonaws:aws-lambda-java-events:2.2.1")
 
-  compileOnly("com.fasterxml.jackson.core:jackson-databind")
   compileOnly("commons-io:commons-io:2.2")
   compileOnly("org.slf4j:slf4j-api")
 
+  implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("io.opentelemetry:opentelemetry-extension-aws")
 
   // allows to get the function ARN


### PR DESCRIPTION
## Description

https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4254 added new imports but missed including them as `compileOnly` dependencies in the `io.opentelemetry.instrumentation:opentelemetry-aws-lambda-1.0` instrumentation package.

We add them here so downstream packages which pull it don't have to add them explicitly.

cc @kubawach

Fixes #5285