### PR TITLE
Add code attributes to spring-scheduling spans

### DIFF
--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingCodeAttributesExtractor.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingCodeAttributesExtractor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.scheduling;
+
+import io.opentelemetry.instrumentation.api.instrumenter.code.CodeAttributesExtractor;
+import javax.annotation.Nullable;
+import org.springframework.scheduling.support.ScheduledMethodRunnable;
+
+public class SpringSchedulingCodeAttributesExtractor
+    extends CodeAttributesExtractor<Runnable, Void> {
+
+  @Override
+  protected Class<?> codeClass(Runnable runnable) {
+    if (runnable instanceof ScheduledMethodRunnable) {
+      ScheduledMethodRunnable scheduledMethodRunnable = (ScheduledMethodRunnable) runnable;
+      return scheduledMethodRunnable.getTarget().getClass();
+    } else {
+      return runnable.getClass();
+    }
+  }
+
+  @Override
+  protected String methodName(Runnable runnable) {
+    if (runnable instanceof ScheduledMethodRunnable) {
+      ScheduledMethodRunnable scheduledMethodRunnable = (ScheduledMethodRunnable) runnable;
+      return scheduledMethodRunnable.getMethod().getName();
+    } else {
+      return "run";
+    }
+  }
+
+  @Override
+  @Nullable
+  protected String filePath(Runnable runnable) {
+    return null;
+  }
+
+  @Override
+  @Nullable
+  protected Long lineNumber(Runnable runnable) {
+    return null;
+  }
+}

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingSingletons.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingSingletons.java
@@ -17,6 +17,7 @@ public final class SpringSchedulingSingletons {
               GlobalOpenTelemetry.get(),
               "io.opentelemetry.spring-scheduling-3.1",
               SpringSchedulingSingletons::extractSpanName)
+          .addAttributesExtractor(new SpringSchedulingCodeAttributesExtractor())
           .newInstrumenter();
 
   private static String extractSpanName(Runnable runnable) {

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
@@ -25,6 +25,8 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
           name "TriggerTask.run"
           hasNoParent()
           attributes {
+            "code.namespace" "TriggerTask"
+            "code.function" "run"
           }
         }
       }
@@ -46,6 +48,8 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
           name "IntervalTask.run"
           hasNoParent()
           attributes {
+            "code.namespace" "IntervalTask"
+            "code.function" "run"
           }
         }
       }
@@ -67,6 +71,8 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
           nameContains "LambdaTaskConfigurer\$\$Lambda\$"
           hasNoParent()
           attributes {
+            "code.namespace" { it.contains("LambdaTaskConfigurer\$\$Lambda\$") }
+            "code.function" "run"
           }
         }
       }


### PR DESCRIPTION
Motivation is that these spans currently have no attributes, so there's no way to suppress them via an attribute-based sampler.

Similar was done for Quartz in #4332