### PR TITLE
Apply conventions to custom-checks project

### DIFF
--- a/custom-checks/src/main/java/io/opentelemetry/javaagent/customchecks/InternalJavadoc.java
+++ b/custom-checks/src/main/java/io/opentelemetry/javaagent/customchecks/InternalJavadoc.java
@@ -30,6 +30,8 @@ import javax.lang.model.element.Modifier;
     severity = WARNING)
 public class InternalJavadoc extends BugChecker implements BugChecker.ClassTreeMatcher {
 
+  private static final long serialVersionUID = 1L;
+
   private static final Pattern INTERNAL_PACKAGE_PATTERN = Pattern.compile("\\binternal\\b");
 
   private static final Pattern EXCLUDE_PACKAGE_PATTERN =
@@ -60,8 +62,9 @@ public class InternalJavadoc extends BugChecker implements BugChecker.ClassTreeM
     if (packageTree == null) {
       return false;
     }
-    String packageName = packageTree.getPackageName().toString();
-    return INTERNAL_PACKAGE_PATTERN.matcher(packageName).find()
+    String packageName = state.getSourceForNode(packageTree.getPackageName());
+    return packageName != null
+        && INTERNAL_PACKAGE_PATTERN.matcher(packageName).find()
         && !EXCLUDE_PACKAGE_PATTERN.matcher(packageName).find();
   }
 

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -52,7 +52,7 @@ val DEPENDENCY_SETS = listOf(
   DependencySet(
     "com.google.errorprone",
     "2.10.0",
-    listOf("error_prone_annotations", "error_prone_core")
+    listOf("error_prone_annotations", "error_prone_core", "error_prone_test_helpers")
   ),
   DependencySet(
     "io.prometheus",


### PR DESCRIPTION
The custom-checks project is missing important conventions such as the `release` version of the artifact, so currently the project doesn't build when running the build with a newer version of Java than 11.

Luckily it's not too tedious to solve the circular reference.