### PR TITLE
Fix artifactID in log4j-context-data-2.16 documentation

### DIFF
--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.16/library-autoconfigure/README.md
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.16/library-autoconfigure/README.md
@@ -15,7 +15,7 @@ stable [release](https://search.maven.org/search?q=g:io.opentelemetry.instrument
 <dependencies>
   <dependency>
     <groupId>io.opentelemetry.instrumentation</groupId>
-    <artifactId>opentelemetry-log4j-2.16-autoconfigure</artifactId>
+    <artifactId>opentelemetry-log4j-context-data-2.16-autoconfigure</artifactId>
     <version>OPENTELEMETRY_VERSION</version>
   </dependency>
 </dependencies>
@@ -25,7 +25,7 @@ stable [release](https://search.maven.org/search?q=g:io.opentelemetry.instrument
 
 ```kotlin
 dependencies {
-  runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-2.16-autoconfigure:OPENTELEMETRY_VERSION")
+  runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-log4j-context-data-2.16-autoconfigure:OPENTELEMETRY_VERSION")
 }
 ```
 


### PR DESCRIPTION
This PR updates the `artifactId` for the Log4j2 Autoconfigure Integration to the current one, as it seems to have changed with [`1.10.0`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.10.0).

- old artifact: https://search.maven.org/search?q=a:opentelemetry-log4j-2.13.2
- new artifact: https://search.maven.org/search?q=a:opentelemetry-log4j-context-data-2.16-autoconfigure
