### PR TITLE
Fix WeakConcurrentMap memory leak

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/cache/internal/weaklockfree/WeakConcurrentMap.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/cache/internal/weaklockfree/WeakConcurrentMap.java
@@ -216,6 +216,12 @@ public class WeakConcurrentMap<K, V>
     }
 
     @Override
+    public V getIfPresent(K key) {
+      expungeStaleEntries();
+      return super.getIfPresent(key);
+    }
+
+    @Override
     public boolean containsKey(K key) {
       expungeStaleEntries();
       return super.containsKey(key);
@@ -225,6 +231,12 @@ public class WeakConcurrentMap<K, V>
     public V put(K key, V value) {
       expungeStaleEntries();
       return super.put(key, value);
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+      expungeStaleEntries();
+      return super.putIfAbsent(key, value);
     }
 
     @Override


### PR DESCRIPTION
We noticed that opentelemetry javaagent produces a memory leak and root class for this is `io.opentelemetry.javaagent.tooling.muzzle.AgentCachingPoolStrategy` as you can see from heap dump analysis:

<img width="1057" alt="Screenshot 2022-02-07 at 16 28 09" src="https://user-images.githubusercontent.com/7068169/152807058-dc2577c2-a472-4199-b04c-5f70286f7863.png">

From what can see in the code `AgentCachingPoolStrategy` uses `WeakLockFreeCache`
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/f6bcd76219283048c6be6a728d362c070e265aca/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategy.java#L52

and it only calls the method `computeIfAbsent()` on it
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/f6bcd76219283048c6be6a728d362c070e265aca/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategy.java#L71

`computeIfAbsent()` makes calls to only two methods of the underlying `WeekConcurrentMap.WithInlinedExpunction delegate` object: `getIfPresent()` and `putIfAbsent()`
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/f6bcd76219283048c6be6a728d362c070e265aca/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/cache/WeakLockFreeCache.java#L21
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/f6bcd76219283048c6be6a728d362c070e265aca/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/cache/WeakLockFreeCache.java#L46
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/f6bcd76219283048c6be6a728d362c070e265aca/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/cache/WeakLockFreeCache.java#L36

But `WeekConcurrentMap.WithInlinedExpunction` doesn't override those two methods and, thus, the `expungeStaleEntries()` method is not called and the weak keys are not removed from the map. 

We think the described issue is the root cause of the observed memory leak and this pull request should fix it.

---
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5265
