### PR TITLE
Publish gradle-plugins to Maven Central

### DIFF
--- a/.github/workflows/release-gradle-plugins.yml
+++ b/.github/workflows/release-gradle-plugins.yml
@@ -156,7 +156,6 @@ jobs:
           distribution: adopt
           java-version: 11
 
-        # TODO (trask) cache gradle wrapper?
       - name: Build and publish gradle plugins
         uses: gradle/gradle-build-action@v2
         env:

--- a/.github/workflows/release-gradle-plugins.yml
+++ b/.github/workflows/release-gradle-plugins.yml
@@ -158,8 +158,15 @@ jobs:
 
         # TODO (trask) cache gradle wrapper?
       - name: Build and publish gradle plugins
+        uses: gradle/gradle-build-action@v2
         env:
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-        run: ../gradlew build publishPlugins
-        working-directory: gradle-plugins
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+        with:
+          # Don't use publishToSonatype since we don't want to publish the marker artifact
+          arguments: build publishPlugins publishPluginMavenPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
+          build-root-directory: gradle-plugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,10 +157,15 @@ jobs:
       - name: Build and publish gradle plugins
         uses: gradle/gradle-build-action@v2
         env:
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
         with:
-          arguments: build publishPlugins
+          # Don't use publishToSonatype since we don't want to publish the marker artifact
+          arguments: build publishPlugins publishPluginMavenPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
           build-root-directory: gradle-plugins
 
       - name: Set release version


### PR DESCRIPTION
Also makes sure to target Java 8 bytecode so the plugin doesn't require other builds to be using Java 11

Fixes #5330 