### PR TITLE
Avoid having two tasks producing the same file

### DIFF
--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -145,12 +145,7 @@ tasks {
   val shadowJar by existing(ShadowJar::class) {
     configurations = listOf(bootstrapLibs)
 
-    // without an explicit dependency on jar here, :javaagent:test fails on CI because :javaagent:jar
-    // runs after :javaagent:shadowJar and loses (at least) the manifest entries
-    //
-    // (also, note that we cannot disable the jar task completely, because it is necessary to produce
-    // javadoc and sources artifacts which maven central requires)
-    dependsOn(jar, relocateJavaagentLibs, relocateExporterLibs)
+    dependsOn(relocateJavaagentLibs, relocateExporterLibs)
     isolateClasses(relocateJavaagentLibs.get().outputs.files)
     isolateClasses(relocateExporterLibs.get().outputs.files)
 
@@ -186,6 +181,11 @@ tasks {
     }
   }
 
+  jar {
+    // Empty jar that cannot be used for anything and isn't published.
+    archiveClassifier.set("dontuse")
+  }
+
   val baseJar by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false
@@ -217,6 +217,25 @@ tasks {
 
   named("generateLicenseReport").configure {
     dependsOn(cleanLicenses)
+  }
+
+  // Because we reconfigure publishing to only include the shadow jar, the Gradle metadata is not correct.
+  // Since we are fully bundled and have no dependencies, Gradle metadata wouldn't provide any advantage over
+  // the POM anyways so in practice we shouldn't be losing anything.
+  withType<GenerateModuleMetadata>().configureEach {
+    enabled = false
+  }
+}
+
+// Don't publish non-shadowed jar (shadowJar is in shadowRuntimeElements)
+with(components["java"] as AdhocComponentWithVariants) {
+  configurations.forEach {
+    withVariantsFromConfiguration(configurations["apiElements"]) {
+      skip()
+    }
+    withVariantsFromConfiguration(configurations["runtimeElements"]) {
+      skip()
+    }
   }
 }
 


### PR DESCRIPTION
As #5333 already reduces the chance of a successful release, doesn't hurt to reduce it even further!

Note, `publishToMavenLocal` looks reasonable except for the lack of `-base`. But as far as I can tell, `-base` wasn't working before this PR as well

https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/1.10.1/