### PR TITLE
Change rxjava version that is used in hystrix tests

### DIFF
--- a/instrumentation/hystrix-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/hystrix-1.4/javaagent/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   implementation(project(":instrumentation:rxjava:rxjava-1.0:library"))
 
   library("com.netflix.hystrix:hystrix-core:1.4.0")
-  library("io.reactivex:rxjava:1.0.7")
+  library("io.reactivex:rxjava:1.0.8")
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
Hopefully resolves test flakyness https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=HystrixObservableTest&tests.sortField=FLAKY&tests.unstableOnly=true
I let the tests run in a loop, after changing rxjava version I wasn't able to reproduce the timeouts any more. With `1.0.7` timeouts were reproducible even without our hystrix instrumentation.