### PR TITLE
Change the way Micrometer LongTaskTimer is bridged

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -33,11 +33,7 @@ final class Bridging {
   }
 
   static String name(Meter.Id id, NamingConvention namingConvention) {
-    return name(id.getName(), id, namingConvention);
-  }
-
-  private static String name(String name, Meter.Id id, NamingConvention namingConvention) {
-    return namingConvention.name(name, id.getType(), id.getBaseUnit());
+    return namingConvention.name(id.getName(), id.getType(), id.getBaseUnit());
   }
 
   static String description(Meter.Id id) {
@@ -56,7 +52,7 @@ final class Bridging {
     // use "total_time" instead of "total" to avoid clashing with Statistic.TOTAL
     String statisticStr =
         statistic == Statistic.TOTAL_TIME ? "total_time" : statistic.getTagValueRepresentation();
-    return name(prefix + statisticStr, id, namingConvention);
+    return namingConvention.name(prefix + statisticStr, id.getType(), id.getBaseUnit());
   }
 
   private Bridging() {}

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
@@ -8,14 +8,12 @@ package io.opentelemetry.instrumentation.micrometer.v1_5;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.baseUnit;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.description;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.name;
-import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.statisticInstrumentName;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.tagsAsAttributes;
 
 import io.micrometer.core.instrument.AbstractDistributionSummary;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Measurement;
-import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.NoopHistogram;
@@ -59,15 +57,17 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
     max = new TimeWindowMax(clock, distributionStatisticConfig);
 
     this.attributes = tagsAsAttributes(id, namingConvention);
+
+    String conventionName = name(id, namingConvention);
     this.otelHistogram =
         otelMeter
-            .histogramBuilder(name(id, namingConvention))
+            .histogramBuilder(conventionName)
             .setDescription(description(id))
             .setUnit(baseUnit(id))
             .build();
     this.maxHandle =
         asyncInstrumentRegistry.buildGauge(
-            statisticInstrumentName(id, Statistic.MAX, namingConvention),
+            conventionName + ".max",
             description(id),
             baseUnit(id),
             attributes,

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
@@ -6,13 +6,12 @@
 package io.opentelemetry.instrumentation.micrometer.v1_5;
 
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.description;
-import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.statisticInstrumentName;
+import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.name;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.tagsAsAttributes;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.TimeUnitHelper.getUnitString;
 
 import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.Measurement;
-import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.instrument.util.TimeUtils;
@@ -46,8 +45,8 @@ final class OpenTelemetryFunctionTimer<T> implements FunctionTimer, RemovableMet
     this.id = id;
     this.baseTimeUnit = baseTimeUnit;
 
-    String countMeterName = statisticInstrumentName(id, Statistic.COUNT, namingConvention);
-    String totalTimeMeterName = statisticInstrumentName(id, Statistic.TOTAL_TIME, namingConvention);
+    String countMeterName = name(id, namingConvention) + ".count";
+    String totalTimeMeterName = name(id, namingConvention) + ".sum";
     Attributes attributes = tagsAsAttributes(id, namingConvention);
 
     countMeasurementHandle =

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
@@ -87,7 +87,7 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
             clock,
             getBaseTimeUnit(),
             distributionStatisticConfig,
-            otelMeter);
+            asyncInstrumentRegistry);
     if (timer.isUsingMicrometerHistograms()) {
       HistogramGauges.registerWithCommonFormat(timer, this);
     }

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
@@ -7,14 +7,12 @@ package io.opentelemetry.instrumentation.micrometer.v1_5;
 
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.description;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.name;
-import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.statisticInstrumentName;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.tagsAsAttributes;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.TimeUnitHelper.getUnitString;
 
 import io.micrometer.core.instrument.AbstractTimer;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Measurement;
-import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.NoopHistogram;
@@ -62,15 +60,17 @@ final class OpenTelemetryTimer extends AbstractTimer implements RemovableMeter {
 
     this.baseTimeUnit = baseTimeUnit;
     this.attributes = tagsAsAttributes(id, namingConvention);
+
+    String conventionName = name(id, namingConvention);
     this.otelHistogram =
         otelMeter
-            .histogramBuilder(name(id, namingConvention))
+            .histogramBuilder(conventionName)
             .setDescription(description(id))
             .setUnit(getUnitString(baseTimeUnit))
             .build();
     this.maxHandle =
         asyncInstrumentRegistry.buildGauge(
-            statisticInstrumentName(id, Statistic.MAX, namingConvention),
+            conventionName + ".max",
             description(id),
             getUnitString(baseTimeUnit),
             attributes,

--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractFunctionTimerSecondsTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractFunctionTimerSecondsTest.java
@@ -31,7 +31,7 @@ public abstract class AbstractFunctionTimerSecondsTest {
   }
 
   @Test
-  void testFunctionCounterWithBaseUnitSeconds() throws InterruptedException {
+  void testFunctionTimerWithBaseUnitSeconds() throws InterruptedException {
     // given
     FunctionTimer functionTimer =
         FunctionTimer.builder(
@@ -70,7 +70,7 @@ public abstract class AbstractFunctionTimerSecondsTest {
     testing()
         .waitAndAssertMetrics(
             INSTRUMENTATION_NAME,
-            "testFunctionTimerSeconds.total_time",
+            "testFunctionTimerSeconds.sum",
             metrics ->
                 metrics.anySatisfy(
                     metric ->
@@ -100,8 +100,6 @@ public abstract class AbstractFunctionTimerSecondsTest {
             AbstractIterableAssert::isEmpty);
     testing()
         .waitAndAssertMetrics(
-            INSTRUMENTATION_NAME,
-            "testFunctionTimerSeconds.total_time",
-            AbstractIterableAssert::isEmpty);
+            INSTRUMENTATION_NAME, "testFunctionTimerSeconds.sum", AbstractIterableAssert::isEmpty);
   }
 }

--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractFunctionTimerTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractFunctionTimerTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractFunctionTimerTest {
     testing()
         .waitAndAssertMetrics(
             INSTRUMENTATION_NAME,
-            "testFunctionTimer.total_time",
+            "testFunctionTimer.sum",
             metrics ->
                 metrics.anySatisfy(
                     metric ->
@@ -100,7 +100,7 @@ public abstract class AbstractFunctionTimerTest {
             INSTRUMENTATION_NAME, "testFunctionTimer.count", AbstractIterableAssert::isEmpty);
     testing()
         .waitAndAssertMetrics(
-            INSTRUMENTATION_NAME, "testFunctionTimer.total_time", AbstractIterableAssert::isEmpty);
+            INSTRUMENTATION_NAME, "testFunctionTimer.sum", AbstractIterableAssert::isEmpty);
   }
 
   @Test
@@ -121,7 +121,7 @@ public abstract class AbstractFunctionTimerTest {
     testing()
         .waitAndAssertMetrics(
             INSTRUMENTATION_NAME,
-            "testNanoFunctionTimer.total_time",
+            "testNanoFunctionTimer.sum",
             metrics ->
                 metrics.anySatisfy(
                     metric ->
@@ -162,7 +162,7 @@ public abstract class AbstractFunctionTimerTest {
     testing()
         .waitAndAssertMetrics(
             INSTRUMENTATION_NAME,
-            "testFunctionTimerWithTags.total_time",
+            "testFunctionTimerWithTags.sum",
             metrics ->
                 metrics.anySatisfy(
                     metric ->


### PR DESCRIPTION
I realized that the previous way of reporting `LongTaskTimer` measurements, the one using a histogram, was wrong. As the example from https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5292#issuecomment-1029164493 shows, for long running task you might want to set up a `LongTaskTimer` for currently running tasks and a separate `Timer` for ones that have already finished - so reporting metrics for finished tasks in `LongTaskTimer` would result in duplicate metrics; and would not show the durations of tasks in progress. I removed the OTel histogram usage from `LongTaskTimer`; now it only reports metrics for tasks in progress (which should be consistent with all other `LongTaskTimer` implementations).