### PR TITLE
Wait for kafka to start

### DIFF
--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/groovy/SpringKafkaInstrumentationTest.groovy
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/groovy/SpringKafkaInstrumentationTest.groovy
@@ -7,6 +7,7 @@ import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.testing.GlobalTraceUtil
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import java.time.Duration
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.springframework.boot.SpringApplication
@@ -20,6 +21,7 @@ import org.springframework.kafka.config.TopicBuilder
 import org.springframework.kafka.core.ConsumerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.containers.wait.strategy.Wait
 import spock.lang.Shared
 
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER
@@ -34,6 +36,8 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
 
   def setupSpec() {
     kafka = new KafkaContainer()
+      .waitingFor(Wait.forLogMessage(".*started \\(kafka.server.KafkaServer\\).*", 1))
+      .withStartupTimeout(Duration.ofMinutes(1))
     kafka.start()
 
     def app = new SpringApplication(ConsumerConfig)


### PR DESCRIPTION
Some of our kafka tests are a bit flaky and get timeouts, for example https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.instrumentation.kafkaclients.KafkaClientPropagationDisabledTest&tests.sortField=FLAKY&tests.test=initializationError&tests.unstableOnly=true This pr adds waiting for the kafka to start in the hopes that it will reduce the chance of timing out on the first operation (which is creating a topic).