### PR TITLE
Add more sleep to weak gauge test

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractGaugeTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractGaugeTest.java
@@ -138,6 +138,7 @@ public abstract class AbstractGaugeTest {
     GcUtils.awaitGc(numWeakRef);
 
     // then
+    Thread.sleep(100); // interval of the test metrics exporter
     testing().clearData();
     Thread.sleep(100); // interval of the test metrics exporter
     testing()


### PR DESCRIPTION
Sleep a bit before clearing data to give in transit data a change to arrive.
https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.javaagent.instrumentation.micrometer.v1_5.GaugeTest&tests.sortField=FLAKY&tests.test=testWeakRefGauge()&tests.unstableOnly=true