### PR TITLE
Use repository interface name in spring data operation name

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -81,7 +81,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          name "CrudRepository.findAll"
+          name "DocRepository.findAll"
           kind INTERNAL
           attributes {
           }
@@ -117,7 +117,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          name "ElasticsearchRepository.index"
+          name "DocRepository.index"
           kind INTERNAL
           attributes {
           }
@@ -166,7 +166,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          name "CrudRepository.findById"
+          name "DocRepository.findById"
           kind INTERNAL
           attributes {
           }
@@ -201,7 +201,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
     assertTraces(2) {
       trace(0, 3) {
         span(0) {
-          name "ElasticsearchRepository.index"
+          name "DocRepository.index"
           kind INTERNAL
           attributes {
           }
@@ -242,7 +242,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
       }
       trace(1, 2) {
         span(0) {
-          name "CrudRepository.findById"
+          name "DocRepository.findById"
           kind INTERNAL
           attributes {
           }
@@ -276,7 +276,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
     assertTraces(2) {
       trace(0, 3) {
         span(0) {
-          name "CrudRepository.deleteById"
+          name "DocRepository.deleteById"
           kind INTERNAL
           attributes {
           }
@@ -317,7 +317,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
 
       trace(1, 2) {
         span(0) {
-          name "CrudRepository.findAll"
+          name "DocRepository.findAll"
           kind INTERNAL
           attributes {
           }

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataInstrumentationModule.java
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataInstrumentationModule.java
@@ -100,10 +100,7 @@ public class SpringDataInstrumentationModule extends InstrumentationModule {
       Method method = methodInvocation.getMethod();
       // Since this interceptor is the outermost interceptor, non-Repository methods
       // including Object methods will also flow through here.  Don't create spans for those.
-      boolean isRepositoryOp =
-          !Object.class.equals(
-              method
-                  .getDeclaringClass());
+      boolean isRepositoryOp = !Object.class.equals(method.getDeclaringClass());
       ClassAndMethod classAndMethod = ClassAndMethod.create(repositoryInterface, method.getName());
       if (!isRepositoryOp || !instrumenter().shouldStart(parentContext, classAndMethod)) {
         return methodInvocation.proceed();

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataInstrumentationModule.java
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataInstrumentationModule.java
@@ -103,7 +103,7 @@ public class SpringDataInstrumentationModule extends InstrumentationModule {
       boolean isRepositoryOp =
           !Object.class.equals(
               method
-                  .getDeclaringClass()); // Repository.class.isAssignableFrom(method.getDeclaringClass());
+                  .getDeclaringClass());
       ClassAndMethod classAndMethod = ClassAndMethod.create(repositoryInterface, method.getName());
       if (!isRepositoryOp || !instrumenter().shouldStart(parentContext, classAndMethod)) {
         return methodInvocation.proceed();

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataSingletons.java
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataSingletons.java
@@ -8,16 +8,16 @@ package io.opentelemetry.javaagent.instrumentation.spring.data;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNames;
-import java.lang.reflect.Method;
+import io.opentelemetry.instrumentation.api.util.ClassAndMethod;
 
 public final class SpringDataSingletons {
 
-  private static final Instrumenter<Method, Void> INSTRUMENTER =
-      Instrumenter.<Method, Void>builder(
+  private static final Instrumenter<ClassAndMethod, Void> INSTRUMENTER =
+      Instrumenter.<ClassAndMethod, Void>builder(
               GlobalOpenTelemetry.get(), "io.opentelemetry.spring-data-1.8", SpanNames::fromMethod)
           .newInstrumenter();
 
-  public static Instrumenter<Method, Void> instrumenter() {
+  public static Instrumenter<ClassAndMethod, Void> instrumenter() {
     return INSTRUMENTER;
   }
 

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/test/java/spring/jpa/JpaCustomerRepository.java
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/test/java/spring/jpa/JpaCustomerRepository.java
@@ -8,6 +8,7 @@ package spring.jpa;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JpaCustomerRepository extends JpaRepository<JpaCustomer, Long> {
+public interface JpaCustomerRepository
+    extends JpaRepository<JpaCustomer, Long>, JpaCustomerRepositoryCustom {
   List<JpaCustomer> findByLastName(String lastName);
 }

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/test/java/spring/jpa/JpaCustomerRepositoryCustom.java
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/test/java/spring/jpa/JpaCustomerRepositoryCustom.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package spring.jpa;
+
+import java.util.List;
+
+public interface JpaCustomerRepositoryCustom {
+  List<JpaCustomer> findSpecialCustomers();
+}

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/test/java/spring/jpa/JpaCustomerRepositoryImpl.java
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/test/java/spring/jpa/JpaCustomerRepositoryImpl.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package spring.jpa;
+
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class JpaCustomerRepositoryImpl implements JpaCustomerRepositoryCustom {
+  @Autowired private EntityManager entityManager;
+
+  @Override
+  public List<JpaCustomer> findSpecialCustomers() {
+    return entityManager.createQuery("from JpaCustomer", JpaCustomer.class).getResultList();
+  }
+}


### PR DESCRIPTION
Currently spring data operation name uses the declaring class of the invoked method. The problem with this is that some of these methods are defined in multiple interfaces and which makes the test flaky. https://ge.opentelemetry.io/s/xd5i7f7go3hh2/tests/:instrumentation:spring:spring-data-1.8:javaagent:test/SpringJpaTest/test%20CRUD?top-execution=1
Additionally both `JpaRepository` and `CrudRepository` that are usually used in operation name are really spring data classes which makes the operation name a bit useless. This pr changes the repository name to use the actual repository interface.