### PR TITLE
Fix flaky jdk http client test

### DIFF
--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/CompletableFutureWrapper.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/CompletableFutureWrapper.java
@@ -14,10 +14,6 @@ public final class CompletableFutureWrapper {
   private CompletableFutureWrapper() {}
 
   public static <T> CompletableFuture<T> wrap(CompletableFuture<T> future, Context context) {
-    if (context == Context.root()) {
-      return future;
-    }
-
     CompletableFuture<T> result = new CompletableFuture<>();
     future.whenComplete(
         (T value, Throwable throwable) -> {


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=JdkHttpClientTest&tests.sortField=FLAKY&tests.test=trace%20request%20with%20callback%20and%20no%20parent&tests.unstableOnly=true
Apparently sometimes http client call context is propagated to callback so we need to always set the context for the callback. 