### PR TITLE
Disable connection pooling in netty38 tests

### DIFF
--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
@@ -27,6 +27,8 @@ class Netty38ClientTest extends HttpClientTest<Request> implements AgentTestTrai
   def getClientConfig() {
     def builder = new AsyncHttpClientConfig.Builder()
       .setUserAgent("test-user-agent")
+      // with connection pooling is enabled there are occasional failures in high concurrency test
+      .setAllowPoolingConnection(false)
 
     if (builder.metaClass.getMetaMethod("setConnectTimeout", int) != null) {
       builder.setConnectTimeout(CONNECT_TIMEOUT_MS)


### PR DESCRIPTION
Hopefully resolves flakiness in high concurrency test https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=Netty38ClientTest&tests.sortField=FLAKY&tests.test=high%20concurrency%20test&tests.unstableOnly=true
To handle connection pooling we'd probably need to have instrumentation for the async http client version that is used in netty38 tests.