### PR TITLE
Setting bean class name overwrites bean class

### DIFF
--- a/instrumentation/spring/spring-web-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springweb/WebApplicationContextInstrumentation.java
+++ b/instrumentation/spring/spring-web-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springweb/WebApplicationContextInstrumentation.java
@@ -77,7 +77,6 @@ public class WebApplicationContextInstrumentation implements TypeInstrumentation
           GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
           beanDefinition.setScope(SCOPE_SINGLETON);
           beanDefinition.setBeanClass(clazz);
-          beanDefinition.setBeanClassName(clazz.getName());
 
           ((BeanDefinitionRegistry) beanFactory)
               .registerBeanDefinition("otelAutoDispatcherFilter", beanDefinition);


### PR DESCRIPTION
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5381
Spring bean definition keeps bean class and bean class name in the same field and uses instanceof to figure out which it has.