### PR TITLE
Use windows-2019 for smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - ubuntu-latest
         smoke-test-suite:
           - jetty
@@ -124,13 +124,13 @@ jobs:
           - wildfly
           - other
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             smoke-test-suite: websphere
       fail-fast: false
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - uses: actions/checkout@v2.3.4
 

--- a/.github/workflows/nightly-no-cache.yml
+++ b/.github/workflows/nightly-no-cache.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - ubuntu-latest
         smoke-test-suite:
           - jetty
@@ -113,13 +113,13 @@ jobs:
           - wildfly
           - other
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             smoke-test-suite: websphere
       fail-fast: false
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - uses: actions/checkout@v2.3.4
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - ubuntu-latest
         smoke-test-suite:
           - jetty
@@ -119,13 +119,13 @@ jobs:
           - wildfly
           - other
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             smoke-test-suite: websphere
       fail-fast: false
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - uses: actions/checkout@v2.3.4
 

--- a/.github/workflows/pr-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/pr-smoke-test-fake-backend-images.yml
@@ -26,7 +26,7 @@ jobs:
           cache-read-only: true
 
   buildWindows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pr-smoke-test-servlet-images.yml
+++ b/.github/workflows/pr-smoke-test-servlet-images.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - ubuntu-latest
         smoke-test-server:
           - jetty
@@ -23,13 +23,13 @@ jobs:
           - websphere
           - wildfly
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             smoke-test-server: websphere
       fail-fast: false
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - uses: actions/checkout@v2.3.4
 
@@ -40,7 +40,7 @@ jobs:
           java-version: 11
 
       - name: Build Linux docker images
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2019'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: buildLinuxTestImages -PsmokeTestServer=${{ matrix.smoke-test-server }}
@@ -48,7 +48,7 @@ jobs:
           cache-read-only: true
 
       - name: Build Windows docker images
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: buildWindowsTestImages -PsmokeTestServer=${{ matrix.smoke-test-server }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - ubuntu-latest
         smoke-test-suite:
           - jetty
@@ -156,13 +156,13 @@ jobs:
           - wildfly
           - other
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             smoke-test-suite: websphere
       fail-fast: false
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - uses: actions/checkout@v2.3.4
 

--- a/.github/workflows/publish-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/publish-smoke-test-fake-backend-images.yml
@@ -38,7 +38,7 @@ jobs:
           build-root-directory: smoke-tests/images/fake-backend
 
   publishWindows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-smoke-test-servlet-images.yml
+++ b/.github/workflows/publish-smoke-test-servlet-images.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - ubuntu-latest
         smoke-test-server:
           - jetty
@@ -29,13 +29,13 @@ jobs:
           - websphere
           - wildfly
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             smoke-test-server: websphere
       fail-fast: false
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - uses: actions/checkout@v2.3.4
 
@@ -56,14 +56,14 @@ jobs:
         run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
       - name: Build Linux docker images
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2019'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: buildLinuxTestImages pushMatrix -PextraTag=${{ env.TAG }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
           build-root-directory: smoke-tests/images/servlet
 
       - name: Build Windows docker images
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: buildWindowsTestImages pushMatrix -PextraTag=${{ env.TAG }} -PsmokeTestServer=${{ matrix.smoke-test-server }}

--- a/.github/workflows/release-gradle-plugins.yml
+++ b/.github/workflows/release-gradle-plugins.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - ubuntu-latest
         smoke-test-suite:
           - jetty
@@ -65,12 +65,12 @@ jobs:
           - wildfly
           - other
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             smoke-test-suite: websphere
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - ubuntu-latest
         smoke-test-suite:
           - jetty
@@ -57,12 +57,12 @@ jobs:
           - wildfly
           - other
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             smoke-test-suite: websphere
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5390
`windows-latest` seems to have changed to windows 2022