### PR TITLE
Sort netty RESOLVE, CONNECT and SSL handshake spans

### DIFF
--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ConnectionSpanTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ConnectionSpanTest.groovy
@@ -95,6 +95,8 @@ class Netty41ConnectionSpanTest extends InstrumentationSpecification implements 
     responseCode == 200
     assertTraces(1) {
       trace(0, 5) {
+        def list = Arrays.asList("RESOLVE", "CONNECT")
+        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL
@@ -149,6 +151,8 @@ class Netty41ConnectionSpanTest extends InstrumentationSpecification implements 
     and:
     assertTraces(1) {
       trace(0, 3) {
+        def list = Arrays.asList("RESOLVE", "CONNECT")
+        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL

--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.groovy
@@ -51,6 +51,8 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
     responseCode == 200
     assertTraces(1) {
       trace(0, 5) {
+        def list = Arrays.asList("RESOLVE", "CONNECT")
+        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL
@@ -111,6 +113,8 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
     and:
     assertTraces(1) {
       trace(0, 3) {
+        def list = Arrays.asList("RESOLVE", "CONNECT")
+        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyClientSslTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyClientSslTest.groovy
@@ -57,6 +57,8 @@ class ReactorNettyClientSslTest extends AgentInstrumentationSpecification {
 
     assertTraces(1) {
       trace(0, 5) {
+        def list = Arrays.asList("RESOLVE", "CONNECT", "SSL handshake")
+        spans.subList(2, 5).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           status ERROR
@@ -132,6 +134,8 @@ class ReactorNettyClientSslTest extends AgentInstrumentationSpecification {
     then:
     assertTraces(1) {
       trace(0, 6) {
+        def list = Arrays.asList("RESOLVE", "CONNECT", "SSL handshake")
+        spans.subList(2, 5).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
         }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.groovy
@@ -55,6 +55,8 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
     responseCode == 200
     assertTraces(1) {
       trace(0, 5) {
+        def list = Arrays.asList("RESOLVE", "CONNECT")
+        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL
@@ -127,6 +129,8 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
     and:
     assertTraces(1) {
       trace(0, 4) {
+        def list = Arrays.asList("RESOLVE", "CONNECT")
+        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL


### PR DESCRIPTION
These spans seem to occasionally appear out of order on when running on jdk8. For example see https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9.ReactorNettyConnectionSpanTest&tests.expandedTests=WzBd&tests.sortField=FLAKY&tests.test=test%20failing%20request&tests.unstableOnly=true