### PR TITLE
Revert "Always set parent of agent class loader to bootstrap class loader (#5169)"

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentClassLoader.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentClassLoader.java
@@ -69,9 +69,10 @@ public class AgentClassLoader extends URLClassLoader {
    *
    * @param javaagentFile Used for resource lookups.
    * @param internalJarFileName File name of the internal jar
+   * @param parent Classloader parent. Should null (bootstrap), or the platform classloader for java
    */
-  public AgentClassLoader(File javaagentFile, String internalJarFileName) {
-    super(new URL[] {}, null);
+  public AgentClassLoader(File javaagentFile, String internalJarFileName, ClassLoader parent) {
+    super(new URL[] {}, parent);
     if (javaagentFile == null) {
       throw new IllegalArgumentException("Agent jar location should be set");
     }

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
@@ -8,6 +8,8 @@ package io.opentelemetry.javaagent.bootstrap;
 import java.io.File;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import javax.annotation.Nullable;
 
 /**
@@ -98,8 +100,31 @@ public final class AgentInitializer {
    *     classloader
    * @return Agent Classloader
    */
-  private static ClassLoader createAgentClassLoader(String innerJarFilename, File javaagentFile) {
-    return new AgentClassLoader(javaagentFile, innerJarFilename);
+  private static ClassLoader createAgentClassLoader(String innerJarFilename, File javaagentFile)
+      throws Exception {
+    ClassLoader agentParent;
+    if (isJavaBefore9()) {
+      agentParent = null; // bootstrap
+    } else {
+      // platform classloader is parent of system in java 9+
+      agentParent = getPlatformClassLoader();
+    }
+
+    return new AgentClassLoader(javaagentFile, innerJarFilename, agentParent);
+  }
+
+  private static ClassLoader getPlatformClassLoader()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    /*
+     Must invoke ClassLoader.getPlatformClassLoader by reflection to remain
+     compatible with java 8.
+    */
+    Method method = ClassLoader.class.getDeclaredMethod("getPlatformClassLoader");
+    return (ClassLoader) method.invoke(null);
+  }
+
+  public static boolean isJavaBefore9() {
+    return System.getProperty("java.version").startsWith("1.");
   }
 
   private static AgentStarter createAgentStarter(

--- a/javaagent-bootstrap/src/test/groovy/io/opentelemetry/javaagent/bootstrap/AgentClassLoaderTest.groovy
+++ b/javaagent-bootstrap/src/test/groovy/io/opentelemetry/javaagent/bootstrap/AgentClassLoaderTest.groovy
@@ -19,7 +19,7 @@ class AgentClassLoaderTest extends Specification {
     def className2 = 'some/class/Name2'
     // any jar would do, use opentelemety sdk
     URL testJarLocation = JavaVersionSpecific.getProtectionDomain().getCodeSource().getLocation()
-    AgentClassLoader loader = new AgentClassLoader(new File(testJarLocation.toURI()), "")
+    AgentClassLoader loader = new AgentClassLoader(new File(testJarLocation.toURI()), "", null)
     Phaser threadHoldLockPhase = new Phaser(2)
     Phaser acquireLockFromMainThreadPhase = new Phaser(2)
 
@@ -58,7 +58,7 @@ class AgentClassLoaderTest extends Specification {
     boolean jdk8 = "1.8" == System.getProperty("java.specification.version")
     // sdk is a multi release jar
     URL multiReleaseJar = JavaVersionSpecific.getProtectionDomain().getCodeSource().getLocation()
-    AgentClassLoader loader = new AgentClassLoader(new File(multiReleaseJar.toURI()), "") {
+    AgentClassLoader loader = new AgentClassLoader(new File(multiReleaseJar.toURI()), "", null) {
       @Override
       protected String getClassSuffix() {
         return ""

--- a/javaagent-tooling/javaagent-tooling-java9/src/test/groovy/UnsafeTest.groovy
+++ b/javaagent-tooling/javaagent-tooling-java9/src/test/groovy/UnsafeTest.groovy
@@ -14,7 +14,7 @@ class UnsafeTest extends Specification {
     setup:
     ByteBuddyAgent.install()
     URL testJarLocation = AgentClassLoader.getProtectionDomain().getCodeSource().getLocation()
-    AgentClassLoader loader = new AgentClassLoader(new File(testJarLocation.toURI()), "")
+    AgentClassLoader loader = new AgentClassLoader(new File(testJarLocation.toURI()), "", null)
     UnsafeInitializer.initialize(ByteBuddyAgent.getInstrumentation(), loader, false)
 
     expect:

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.tooling;
 
+import static io.opentelemetry.javaagent.bootstrap.AgentInitializer.isJavaBefore9;
 import static io.opentelemetry.javaagent.tooling.OpenTelemetryInstaller.installOpenTelemetrySdk;
 import static io.opentelemetry.javaagent.tooling.SafeServiceLoader.load;
 import static io.opentelemetry.javaagent.tooling.SafeServiceLoader.loadOrdered;
@@ -254,10 +255,6 @@ public class AgentInstaller {
         agentListener.afterAgent(config, autoConfiguredSdk);
       }
     }
-  }
-
-  private static boolean isJavaBefore9() {
-    return System.getProperty("java.version").startsWith("1.");
   }
 
   private static void addByteBuddyRawSetting() {


### PR DESCRIPTION
Resolves #5401 by reverting #5169. I will re-open #5156. I would open an issue to create a smoke test for the prometheus exporter, but we already have one #4516 😞.

Unfortunately, this PR is creating a regression to fix a regression 😞. But the regression it's fixing is a high-priority long existing use case, while the regression its causing is a more recently discovered issue related to JPMS support.