### PR TITLE
Add possibility to configure Resource from Spring Boot properties / environment

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
@@ -21,7 +21,6 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -61,7 +60,7 @@ public class OpenTelemetryAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnBean(SdkTracerProvider.class)
+    @ConditionalOnMissingBean
     public Resource openTelemetryResource(ResourceProperties resourceProperties) {
       AttributesBuilder customAttributesBuilder = Attributes.builder();
       resourceProperties

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/ResourceProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/ResourceProperties.java
@@ -8,17 +8,19 @@ package io.opentelemetry.instrumentation.spring.autoconfigure;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "otel.resource")
+@ConstructorBinding
 public class ResourceProperties {
 
-  private Map<String, String> attributes = new HashMap<>();
+  private final Map<String, String> attributes;
+
+  public ResourceProperties(Map<String, String> attributes) {
+    this.attributes = attributes == null ? new HashMap<>() : attributes;
+  }
 
   public Map<String, String> getAttributes() {
     return attributes;
-  }
-
-  public void setAttributes(Map<String, String> attributes) {
-    this.attributes = attributes;
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/ResourceProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/ResourceProperties.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.autoconfigure;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "otel.resource")
+public class ResourceProperties {
+
+  private Map<String, String> attributes = new HashMap<>();
+
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+  }
+}


### PR DESCRIPTION
Would resolve #5414.

Added possibility to configure `Resource` with Spring boot properties so that I can change the service name for example so that it is exported to Jaeger. For example : 
```
otel:
  resource:
    attributes:
      service:
        name: test
```
Or through environment variable like : `OTEL_RESOURCE_ATTRIBUTES_SERVICE_NAME=test`
All properties under `otel.resource.attributes` will be passed to configured `Resource`.

If this change is ok I can also modify README and add information about this.