### PR TITLE
Sort spans in Netty41ClientSslTest

### DIFF
--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientSslTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientSslTest.groovy
@@ -81,6 +81,8 @@ class Netty41ClientSslTest extends AgentInstrumentationSpecification {
 
     assertTraces(1) {
       trace(0, 4) {
+        def list = Arrays.asList("RESOLVE", "CONNECT", "SSL handshake")
+        spans.subList(1, 4).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           status ERROR
@@ -149,6 +151,8 @@ class Netty41ClientSslTest extends AgentInstrumentationSpecification {
     then:
     assertTraces(1) {
       trace(0, 6) {
+        def list = Arrays.asList("RESOLVE", "CONNECT", "SSL handshake")
+        spans.subList(1, 4).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
         }


### PR DESCRIPTION
Same as https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5394
https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=Netty41ClientSslTest&tests.sortField=FLAKY&tests.test=should%20successfully%20establish%20SSL%20handshake&tests.unstableOnly=true