### PR TITLE
Wait before clearing metrics

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractLongTaskTimerTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractLongTaskTimerTest.java
@@ -118,10 +118,11 @@ public abstract class AbstractLongTaskTimerTest {
                                         .hasValue(0)
                                         .attributes()
                                         .containsOnly(attributeEntry("tag", "value")))));
-    testing().clearData();
 
     // when timer is removed from the registry
     Metrics.globalRegistry.remove(timer);
+    Thread.sleep(10); // give time for any in flight metric export to be received
+    testing().clearData();
     timer.start();
 
     // then no tasks are active after starting a new sample


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.instrumentation.micrometer.v1_5.LongTaskTimerSecondsTest&tests.sortField=FLAKY&tests.test=testLongTaskTimerWithBaseUnitSeconds()&tests.unstableOnly=true
Similarly to other micrometer tests wait for in flight data before clearing metrics.