### PR TITLE
Fix regression in spring-scheduling span name

### DIFF
--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingCodeAttributesGetter.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingCodeAttributesGetter.java
@@ -14,7 +14,7 @@ public class SpringSchedulingCodeAttributesGetter implements CodeAttributesGette
   public Class<?> codeClass(Runnable runnable) {
     if (runnable instanceof ScheduledMethodRunnable) {
       ScheduledMethodRunnable scheduledMethodRunnable = (ScheduledMethodRunnable) runnable;
-      return scheduledMethodRunnable.getTarget().getClass();
+      return scheduledMethodRunnable.getMethod().getDeclaringClass();
     } else {
       return runnable.getClass();
     }

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/java/EnhancedClassTaskConfig.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/java/EnhancedClassTaskConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import java.util.concurrent.CountDownLatch;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@EnableScheduling
+public class EnhancedClassTaskConfig {
+
+  private final CountDownLatch latch = new CountDownLatch(1);
+
+  @Scheduled(fixedRate = 5000)
+  public void run() {
+    latch.countDown();
+  }
+
+  @Bean
+  public CountDownLatch countDownLatch() {
+    return latch;
+  }
+}


### PR DESCRIPTION
This fixes (and adds test for) a small (unreleased) regression introduced in #5342.