### PR TITLE
Increase delay in attempt to fix flaky test in AbstractAws1ClientTest

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
@@ -209,8 +209,8 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
   def "timeout and retry errors not captured"() {
     setup:
     // One retry so two requests.
-    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(500)))
-    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(500)))
+    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(5000)))
+    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(5000)))
     AmazonS3Client client = configureClient(AmazonS3ClientBuilder.standard())
       .withClientConfiguration(new ClientConfiguration()
         .withRequestTimeout(50 /* ms */)


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P7D&search.tags=CI&search.tags=not:v1.11.x&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.javaagent.instrumentation.awssdk.v1_11.Aws1ClientTest&tests.sortField=FLAKY&tests.test=timeout%20and%20retry%20errors%20not%20captured&tests.unstableOnly=true