### PR TITLE
Increase ready timeout for couchbase31

### DIFF
--- a/instrumentation/couchbase/couchbase-3.1/javaagent/src/test/groovy/CouchbaseClient31Test.groovy
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/src/test/groovy/CouchbaseClient31Test.groovy
@@ -41,7 +41,7 @@ class CouchbaseClient31Test extends AgentInstrumentationSpecification {
     cluster = Cluster.connect(couchbase.connectionString, couchbase.username, couchbase.password)
     def bucket = cluster.bucket("test")
     collection = bucket.defaultCollection()
-    bucket.waitUntilReady(Duration.ofSeconds(10))
+    bucket.waitUntilReady(Duration.ofSeconds(30))
   }
 
   def cleanupSpec() {


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.relativeStartTime=P28D&search.tags=CI&search.tags=not:v1.11.x&search.timeZoneId=Europe/Tallinn&tests.container=CouchbaseClient31Test&tests.sortField=FLAKY&tests.unstableOnly=true
`CouchbaseClient316Test` and `CouchbaseClient32Test` already use a 30s timeout