### PR TITLE
Update Log4j appender example to follow the spec

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.16/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.16/library/README.md
@@ -38,7 +38,7 @@ The following demonstrates how you might configure the appender in your `log4j.x
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout
-          pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} traceId: %X{trace_id} spanId: %X{span_id} flags: %X{trace_flags} - %msg%n"/>
+          pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} trace_id: %X{trace_id} span_id: %X{span_id} trace_flags: %X{trace_flags} - %msg%n"/>
     </Console>
     <OpenTelemetry name="OpenTelemetryAppender"/>
   </Appenders>


### PR DESCRIPTION
In https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/logs/overview.md#trace-context-in-legacy-formats the spec defines how a Trace Context should be represented for logging in text formats:

> [OTEP0114](https://github.com/open-telemetry/oteps/pull/114) defines how the trace context should be recorded in logs.
To summarize, the following field names should be used in legacy formats:
> 
> - "trace_id" for [TraceId](data-model.md#field-traceid), hex-encoded.
> - "span_id" for [SpanId](data-model.md#field-spanid), hex-encoded.
> - "trace_flags" for [trace flags](data-model.md#field-traceflags), formatted according to W3C traceflags format.

I adapted the keys in the example provided in the Log4j appender readme to match that.