### PR TITLE
Run muzzle with read-only github cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,20 +192,11 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Run muzzle
-        # using retry because of sporadic gradle download failures
-        uses: nick-invision/retry@v2.6.0
+        uses: gradle/gradle-build-action@v2
         with:
-          # timing out has not been a problem, these jobs typically finish in 2-3 minutes
-          timeout_minutes: 15
-          max_attempts: 3
-          command: ./gradlew ${{ matrix.module }}:muzzle
+          arguments: ${{ matrix.module }}:muzzle
+          cache-read-only: true
 
   examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -183,20 +183,11 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Run muzzle
-        # using retry because of sporadic gradle download failures
-        uses: nick-invision/retry@v2.6.0
+        uses: gradle/gradle-build-action@v2
         with:
-          # timing out has not been a problem, these jobs typically finish in 2-3 minutes
-          timeout_minutes: 15
-          max_attempts: 3
-          command: ./gradlew ${{ matrix.module }}:muzzle
+          arguments: ${{ matrix.module }}:muzzle
+          cache-read-only: true
 
   examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -243,13 +243,10 @@ jobs:
           java-version: 11
 
       - name: Run muzzle
-        # using retry because of sporadic gradle download failures
-        uses: nick-invision/retry@v2.6.0
+        uses: gradle/gradle-build-action@v2
         with:
-          # timing out has not been a problem, these jobs typically finish in 2-3 minutes
-          timeout_minutes: 15
-          max_attempts: 3
-          command: ./gradlew ${{ matrix.module }}:muzzle
+          arguments: ${{ matrix.module }}:muzzle
+          cache-read-only: true
 
   examples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5440
Sometimes download fails for stuff that we should have in cache like
```
* What went wrong:
A problem occurred configuring root project 'opentelemetry-java-instrumentation'.
> Could not determine the dependencies of task ':conventions:compileKotlin'.
   > Could not resolve all task dependencies for configuration ':conventions:kotlinCompilerClasspath'.
      > Could not resolve org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.31.
        Required by:
            project :conventions
         > Could not resolve org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.31.
            > Could not get resource 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.5.31/kotlin-compiler-embeddable-1.5.31.pom'.
               > Could not HEAD 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/1.5.31/kotlin-compiler-embeddable-1.5.31.pom'.
                  > Connect to repo.maven.apache.org:443 [repo.maven.apache.org/146.75.28.215] failed: connect timed out
```
Other time if fails when downloading a specific library version for muzzle where this change won't help.