### PR TITLE
More restrictive branch match

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - v*
+      - v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
ran into this problem on a fork with it running CI on branches that coincidentally start with `v`