### PR TITLE
Use gradle cache for setup-muzzle-matrix job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,14 +167,13 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
+      - name: List instrumentations to file
+        uses: gradle/gradle-build-action@v2
         with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          arguments: instrumentation:listInstrumentations
 
       - id: set-matrix
-        run: echo "::set-output name=matrix::{\"module\":[\"$(./gradlew -q instrumentation:listInstrumentations | xargs echo | sed 's/ /","/g')\"]}"
+        run: echo "::set-output name=matrix::{\"module\":[\"$(cat instrumentation-list.txt | xargs echo | sed 's/ /","/g')\"]}"
 
   muzzle:
     needs: setup-muzzle-matrix

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,14 +158,13 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
+      - name: List instrumentations to file
+        uses: gradle/gradle-build-action@v2
         with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          arguments: instrumentation:listInstrumentations
 
       - id: set-matrix
-        run: echo "::set-output name=matrix::{\"module\":[\"$(./gradlew -q instrumentation:listInstrumentations | xargs echo | sed 's/ /","/g')\"]}"
+        run: echo "::set-output name=matrix::{\"module\":[\"$(cat instrumentation-list.txt | xargs echo | sed 's/ /","/g')\"]}"
 
   muzzle:
     needs: setup-muzzle-matrix

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -217,14 +217,14 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
+      - name: List instrumentations to file
+        uses: gradle/gradle-build-action@v2
         with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          arguments: instrumentation:listInstrumentations
+          cache-read-only: true
 
       - id: set-matrix
-        run: echo "::set-output name=matrix::{\"module\":[\"$(./gradlew -q instrumentation:listInstrumentations | xargs echo | sed 's/ /","/g')\"]}"
+        run: echo "::set-output name=matrix::{\"module\":[\"$(cat instrumentation-list.txt | xargs echo | sed 's/ /","/g')\"]}"
 
   muzzle:
     needs: setup-muzzle-matrix

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -25,10 +25,12 @@ tasks {
     group = "Help"
     description = "List all available instrumentation modules"
     doFirst {
-      subprojects
-        .filter { it.plugins.hasPlugin("io.opentelemetry.instrumentation.muzzle-check") }
-        .map { it.path }
-        .forEach { println(it) }
+      File("instrumentation-list.txt").printWriter().use { out ->
+        subprojects
+          .filter { it.plugins.hasPlugin("io.opentelemetry.instrumentation.muzzle-check") }
+          .map { it.path }
+          .forEach { out.println(it) }
+      }
     }
   }
 }


### PR DESCRIPTION
mainly for consistency to use `gradle/gradle-build-action` everywhere