### PR TITLE
Avoid conflicts in Micrometer description mapping

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -37,6 +37,7 @@ final class Bridging {
     return namingConvention.name(id.getName(), id.getType(), id.getBaseUnit());
   }
 
+  // TODO: remove the cache usage once the SDK is able to handle different descriptions
   static String description(String name, Meter.Id id) {
     return descriptionsCache.computeIfAbsent(
         name,

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -17,6 +17,7 @@ import io.opentelemetry.instrumentation.api.cache.Cache;
 final class Bridging {
 
   private static final Cache<String, AttributeKey<String>> tagsCache = Cache.bounded(1024);
+  private static final Cache<String, String> descriptionsCache = Cache.bounded(1024);
 
   static Attributes tagsAsAttributes(Meter.Id id, NamingConvention namingConvention) {
     Iterable<Tag> tags = id.getTagsAsIterable();
@@ -36,9 +37,12 @@ final class Bridging {
     return namingConvention.name(id.getName(), id.getType(), id.getBaseUnit());
   }
 
-  static String description(Meter.Id id) {
-    String description = id.getDescription();
-    return description == null ? "" : description;
+  static String description(String name, Meter.Id id) {
+    return descriptionsCache.computeIfAbsent(
+        name, n -> {
+          String description = id.getDescription();
+          return description == null ? "" : description;
+        });
   }
 
   static String baseUnit(Meter.Id id) {

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -39,7 +39,8 @@ final class Bridging {
 
   static String description(String name, Meter.Id id) {
     return descriptionsCache.computeIfAbsent(
-        name, n -> {
+        name,
+        n -> {
           String description = id.getDescription();
           return description == null ? "" : description;
         });

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
@@ -34,10 +34,11 @@ final class OpenTelemetryCounter implements Counter, RemovableMeter {
     this.id = id;
 
     this.attributes = tagsAsAttributes(id, namingConvention);
+    String conventionName = name(id, namingConvention);
     this.otelCounter =
         otelMeter
-            .counterBuilder(name(id, namingConvention))
-            .setDescription(description(id))
+            .counterBuilder(conventionName)
+            .setDescription(description(conventionName, id))
             .setUnit(baseUnit(id))
             .ofDoubles()
             .build();

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
@@ -62,13 +62,13 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
     this.otelHistogram =
         otelMeter
             .histogramBuilder(conventionName)
-            .setDescription(description(id))
+            .setDescription(description(conventionName, id))
             .setUnit(baseUnit(id))
             .build();
     this.maxHandle =
         asyncInstrumentRegistry.buildGauge(
             conventionName + ".max",
-            description(id),
+            description(conventionName, id),
             baseUnit(id),
             attributes,
             max,

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
@@ -5,10 +5,7 @@
 
 package io.opentelemetry.instrumentation.micrometer.v1_5;
 
-import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.baseUnit;
-import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.description;
-import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.name;
-import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.tagsAsAttributes;
+import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.*;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Measurement;
@@ -34,10 +31,11 @@ final class OpenTelemetryFunctionCounter<T> implements FunctionCounter, Removabl
       AsyncInstrumentRegistry asyncInstrumentRegistry) {
     this.id = id;
 
+    String conventionName = name(id, namingConvention);
     countMeasurementHandle =
         asyncInstrumentRegistry.buildDoubleCounter(
-            name(id, namingConvention),
-            description(id),
+            conventionName,
+            description(conventionName, id),
             baseUnit(id),
             tagsAsAttributes(id, namingConvention),
             obj,

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
@@ -5,7 +5,10 @@
 
 package io.opentelemetry.instrumentation.micrometer.v1_5;
 
-import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.*;
+import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.baseUnit;
+import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.description;
+import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.name;
+import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.tagsAsAttributes;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Measurement;

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
@@ -45,18 +45,22 @@ final class OpenTelemetryFunctionTimer<T> implements FunctionTimer, RemovableMet
     this.id = id;
     this.baseTimeUnit = baseTimeUnit;
 
-    String countMeterName = name(id, namingConvention) + ".count";
-    String totalTimeMeterName = name(id, namingConvention) + ".sum";
+    String conventionName = name(id, namingConvention);
     Attributes attributes = tagsAsAttributes(id, namingConvention);
 
     countMeasurementHandle =
         asyncInstrumentRegistry.buildLongCounter(
-            countMeterName, description(id), /* baseUnit = */ "1", attributes, obj, countFunction);
+            conventionName + ".count",
+            description(conventionName, id),
+            /* baseUnit = */ "1",
+            attributes,
+            obj,
+            countFunction);
 
     totalTimeMeasurementHandle =
         asyncInstrumentRegistry.buildDoubleCounter(
-            totalTimeMeterName,
-            description(id),
+            conventionName + ".sum",
+            description(conventionName, id),
             getUnitString(baseTimeUnit),
             attributes,
             obj,

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
@@ -35,10 +35,11 @@ final class OpenTelemetryGauge<T> implements Gauge, RemovableMeter {
 
     this.id = id;
 
+    String conventionName = name(id, namingConvention);
     gaugeMeasurementHandle =
         asyncInstrumentRegistry.buildGauge(
-            name(id, namingConvention),
-            description(id),
+            conventionName,
+            description(conventionName, id),
             baseUnit(id),
             tagsAsAttributes(id, namingConvention),
             obj,

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
@@ -43,7 +43,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer implements R
     this.activeTasksHandle =
         asyncInstrumentRegistry.buildUpDownLongCounter(
             conventionName + ".active",
-            description(id),
+            description(conventionName, id),
             "tasks",
             attributes,
             this,
@@ -51,7 +51,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer implements R
     this.durationHandle =
         asyncInstrumentRegistry.buildUpDownDoubleCounter(
             conventionName + ".duration",
-            description(id),
+            description(conventionName, id),
             getUnitString(baseTimeUnit),
             attributes,
             this,

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
@@ -39,7 +39,7 @@ final class OpenTelemetryMeter implements Meter, RemovableMeter {
     List<AsyncMeasurementHandle> measurementHandles = new ArrayList<>();
     for (Measurement measurement : measurements) {
       String name = statisticInstrumentName(id, measurement.getStatistic(), namingConvention);
-      String description = description(id);
+      String description = description(name, id);
       String baseUnit = baseUnit(id);
 
       switch (measurement.getStatistic()) {

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
@@ -65,13 +65,13 @@ final class OpenTelemetryTimer extends AbstractTimer implements RemovableMeter {
     this.otelHistogram =
         otelMeter
             .histogramBuilder(conventionName)
-            .setDescription(description(id))
+            .setDescription(description(conventionName, id))
             .setUnit(getUnitString(baseTimeUnit))
             .build();
     this.maxHandle =
         asyncInstrumentRegistry.buildGauge(
             conventionName + ".max",
-            description(id),
+            description(conventionName, id),
             getUnitString(baseTimeUnit),
             attributes,
             max,


### PR DESCRIPTION
**Background: How PrometheusMeterRegistry Maps Descriptions**

The following shows an example of metrics in Prometheus format as produced by Micrometer's `PrometheusMeterRegistry`:

```
# HELP logback_events_total Number of error level events that made it to the logs
# TYPE logback_events_total counter
logback_events_total{level="warn"} 2.0
logback_events_total{level="debug"} 0.0
logback_events_total{level="error"} 2.0
logback_events_total{level="trace"} 0.0
logback_events_total{level="info"} 6.0
```

If you look closely at the `HELP` text, you will see a slight mismatch: The description is specific to `level="error"` and not to other attribute values.

The reason is that in Micrometer you can define descriptions per set of attributes. It is not very common to have different descriptions per set of attributes, but there are a few real-world examples like Micrometer's built-in `LogbackMetrics`

https://github.com/micrometer-metrics/micrometer/blob/fc9c4eed843f02f00cc6f3c9621aed5d4797e29d/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java#L139-L169

As Prometheus supports only one description per metric, Micrometer's `PrometheusMeterRegistry` maintains a `collectorMap` that caches the description per metric name, so metrics with the same name will get the same description. As a result, all metrics named `logback_events_total` will get the first description that was registered, which happens to be the description for `level="error"` in the example above.

https://github.com/fstab/micrometer/blob/31488cc4ca1232f6599f9479ddb6b8445ece3d06/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java#L482-L502

**This PR: Make OpenTelemetryMeterRegistry use The Same Strategy as PrometheusMeterRegistry**

The `OpenTelemetryMeterRegistry` has the same mismatch with Micrometer, as OTel metrics also don't support different descriptions for different attribute values. However, the current implementation does not handle this, and eventually the SDK throws a `DuplicateMetricStorageException` when Micrometer's `LogbackMetrics` register metrics with the same name but different descriptions:

https://github.com/open-telemetry/opentelemetry-java/blob/b19157ed98ffc81d5083752631b04e4074ea71f6/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/MetricStorageRegistry.java#L61-L67

This will happen whenever you use the `OpenTelemetryMeterRegistry` in a Spring application and Spring's Micrometer auto-detects `Logback`.

This PR introduces a `descriptionsCache` to mimic the behavior of the Micrometer -> Prometheus mapping. We cache the first description seen for each metric name and re-use it for all attributes.

This will result in descriptions that don't fit to the attributes (as in the example above). However, in practice this slight mismatch in the description has never been reported as an issue by Prometheus users (to my knowledge), and I think it is better than throwing a `DuplicateMetricStorageException` when Spring detects `Logback`.