### PR TITLE
Add gradle cache to muzzle jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,6 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: ${{ matrix.module }}:muzzle
-          cache-read-only: true
 
   examples:
     runs-on: ubuntu-latest
@@ -236,7 +235,6 @@ jobs:
       - name: Run muzzle check against extension
         uses: gradle/gradle-build-action@v2
         with:
-          cache-read-only: true
           arguments: muzzle --init-script ../../.github/scripts/local.init.gradle.kts
           build-root-directory: examples/extension
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -186,7 +186,6 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: ${{ matrix.module }}:muzzle
-          cache-read-only: true
 
   examples:
     runs-on: ubuntu-latest
@@ -227,7 +226,6 @@ jobs:
       - name: Run muzzle check against extension
         uses: gradle/gradle-build-action@v2
         with:
-          cache-read-only: true
           arguments: muzzle --init-script ../../.github/scripts/local.init.gradle.kts
           build-root-directory: examples/extension
 


### PR DESCRIPTION
Still seeing occasional muzzle failure due to maven central downloads: #5453

Closes #5440

I think this is worth trying, but need to monitor CI build times closely for a while to make sure this doesn't cause problems with overflowing the github action cache size limit.