### PR TITLE
Add retry back to muzzle jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,11 +191,19 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Run muzzle
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: ${{ matrix.module }}:muzzle
           cache-read-only: true
+
+      - name: Run muzzle
+        # using retry because of sporadic gradle download failures
+        uses: nick-invision/retry@v2.6.0
+        with:
+          # timing out has not been a problem, these jobs typically finish in 2-3 minutes
+          timeout_minutes: 15
+          max_attempts: 3
+          command: ./gradlew ${{ matrix.module }}:muzzle
 
   examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -182,11 +182,19 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Run muzzle
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: ${{ matrix.module }}:muzzle
           cache-read-only: true
+
+      - name: Run muzzle
+        # using retry because of sporadic gradle download failures
+        uses: nick-invision/retry@v2.6.0
+        with:
+          # timing out has not been a problem, these jobs typically finish in 2-3 minutes
+          timeout_minutes: 15
+          max_attempts: 3
+          command: ./gradlew ${{ matrix.module }}:muzzle
 
   examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -242,11 +242,19 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Run muzzle
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: ${{ matrix.module }}:muzzle
           cache-read-only: true
+
+      - name: Run muzzle
+        # using retry because of sporadic gradle download failures
+        uses: nick-invision/retry@v2.6.0
+        with:
+          # timing out has not been a problem, these jobs typically finish in 2-3 minutes
+          timeout_minutes: 15
+          max_attempts: 3
+          command: ./gradlew ${{ matrix.module }}:muzzle
 
   examples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The muzzle jobs have been a bit more(?) flaky I think since #5444, probably b/c not retrying anymore.

From reading the [gradle-build-action docs](https://github.com/gradle/gradle-build-action#use-the-action-to-setup-gradle), it looks like we can still get benefit from gradle cache without using it to run the gradle commands.
