### PR TITLE
Bump more checkout action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
   markdown-misspell-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
 
       - name: Check markdown for common misspellings
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -165,7 +165,7 @@ jobs:
   markdown-misspell-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
 
       - name: Check markdown for common misspellings
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -214,7 +214,7 @@ jobs:
   markdown-misspell-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
 
       - name: Check markdown for common misspellings
         run: |


### PR DESCRIPTION
Dependabot wasn't able to update its PR to catch these new ones: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5473#issuecomment-1056116726