### PR TITLE
Exclude sporadically failing link check

### DIFF
--- a/.github/scripts/markdown_link_check_config.json
+++ b/.github/scripts/markdown_link_check_config.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "^https://mvnrepository\\.com/artifact/io\\.opentelemetry$"
+    },
+    {
+      "pattern": "^http://code\\.google\\.com/p/concurrentlinkedhashmap$"
     }
   ],
   "retryOn429": true


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/runs/5396032631:

 [✖] http://code.google.com/p/concurrentlinkedhashmap → Status: 500
