### PR TITLE
Reduce muzzle sporadic failures

### DIFF
--- a/.github/workflows/muzzle.yml
+++ b/.github/workflows/muzzle.yml
@@ -51,5 +51,7 @@ jobs:
         with:
           # timing out has not been a problem, these jobs typically finish in 2-3 minutes
           timeout_minutes: 15
-          max_attempts: 3
+          # give maven central a minute to hopefully recover
+          retry_wait_seconds: 60
+          max_attempts: 5
           command: ./gradlew ${{ matrix.module }}:muzzle


### PR DESCRIPTION
Muzzle jobs have been sporadically failing a lot lately on maven central.

I think #5488 is going to help.

I think this will help too.