### PR TITLE
Simplify smoke test image workfows

### DIFF
--- a/.github/workflows/pr-smoke-test-grpc-images.yml
+++ b/.github/workflows/pr-smoke-test-grpc-images.yml
@@ -18,30 +18,23 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Build Java 8 Docker Image
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jibDockerBuild -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/grpc
           cache-read-only: true
+
+      - name: Build Java 8 Docker Image
+        run: ./gradlew jibDockerBuild -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/grpc
 
       - name: Build Java 11 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/grpc
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/grpc
 
       - name: Build Java 17 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/grpc
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/grpc
 
       - name: Build Java 18 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/grpc
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/grpc

--- a/.github/workflows/pr-smoke-test-play-images.yml
+++ b/.github/workflows/pr-smoke-test-play-images.yml
@@ -18,25 +18,21 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Build Java 8 Docker Image
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jibDockerBuild -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/play
           cache-read-only: true
 
+      - name: Build Java 8 Docker Image
+        run: ./gradlew jibDockerBuild -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/play
+
       - name: Build Java 11 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/play
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/play
 
         # Play doesn't support Java 16 (or 17) yet
         # https://github.com/playframework/playframework/pull/10819
       - name: Build Java 15 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=15 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/play
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=15 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/play

--- a/.github/workflows/pr-smoke-test-quarkus-images.yml
+++ b/.github/workflows/pr-smoke-test-quarkus-images.yml
@@ -18,24 +18,20 @@ jobs:
           distribution: adopt
           java-version: 11
 
+      - name: Set up gradle cache
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: true
+
         # Quarkus 2.0+ does not support Java 8
       - name: Build Java 11 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/quarkus
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/quarkus
 
       - name: Build Java 17 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/quarkus
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/quarkus
 
       - name: Build Java 18 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/quarkus
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/quarkus

--- a/.github/workflows/pr-smoke-test-servlet-images.yml
+++ b/.github/workflows/pr-smoke-test-servlet-images.yml
@@ -39,18 +39,17 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Build Linux docker images
-        if: matrix.os != 'windows-2019'
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: buildLinuxTestImages -PsmokeTestServer=${{ matrix.smoke-test-server }}
-          build-root-directory: smoke-tests/images/servlet
           cache-read-only: true
+
+      - name: Build Linux docker images
+        if: matrix.os != 'windows-2019'
+        run: ./gradlew buildLinuxTestImages -PsmokeTestServer=${{ matrix.smoke-test-server }}
+        working-directory: smoke-tests/images/servlet
 
       - name: Build Windows docker images
         if: matrix.os == 'windows-2019'
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: buildWindowsTestImages -PsmokeTestServer=${{ matrix.smoke-test-server }}
-          build-root-directory: smoke-tests/images/servlet
-          cache-read-only: true
+        run: ./gradlew buildWindowsTestImages -PsmokeTestServer=${{ matrix.smoke-test-server }}
+        working-directory: smoke-tests/images/servlet

--- a/.github/workflows/pr-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/pr-smoke-test-spring-boot-images.yml
@@ -18,30 +18,23 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Build Java 8 Docker Image
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jibDockerBuild -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/spring-boot
           cache-read-only: true
+
+      - name: Build Java 8 Docker Image
+        run: ./gradlew jibDockerBuild -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/spring-boot
 
       - name: Build Java 11 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/spring-boot
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/spring-boot
 
       - name: Build Java 17 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/spring-boot
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/spring-boot
 
       - name: Build Java 18 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jibDockerBuild -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
-          build-root-directory: smoke-tests/images/spring-boot
-          cache-read-only: true
+        run: ./gradlew jibDockerBuild -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
+        working-directory: smoke-tests/images/spring-boot

--- a/.github/workflows/publish-smoke-test-grpc-images.yml
+++ b/.github/workflows/publish-smoke-test-grpc-images.yml
@@ -31,29 +31,24 @@ jobs:
       - name: Set Tag
         run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
-      - name: Build Java 8 Docker Image
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/grpc
+
+      - name: Build Java 8 Docker Image
+        run: ./gradlew jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/grpc
 
       - name: Build Java 11 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/grpc
+        run: ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/grpc
 
       - name: Build Java 17 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/grpc
+        run: ./gradlew jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/grpc
 
       - name: Build Java 18 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/grpc
+        run: ./gradlew jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/grpc
 
   issue:
     name: Open issue on failure

--- a/.github/workflows/publish-smoke-test-play-images.yml
+++ b/.github/workflows/publish-smoke-test-play-images.yml
@@ -31,25 +31,22 @@ jobs:
       - name: Set Tag
         run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
-      - name: Build Java 8 Docker Image
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/play
+
+      - name: Build Java 8 Docker Image
+        run: ./gradlew jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/play
 
       - name: Build Java 11 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/play
+        run: ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/play
 
         # Play doesn't support Java 16 (or 17) yet
         # https://github.com/playframework/playframework/pull/10819
       - name: Build Java 15 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=15 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/play
+        run: ./gradlew jib -PtargetJDK=15 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/play
 
   issue:
     name: Open issue on failure

--- a/.github/workflows/publish-smoke-test-quarkus-images.yml
+++ b/.github/workflows/publish-smoke-test-quarkus-images.yml
@@ -31,24 +31,21 @@ jobs:
       - name: Set Tag
         run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
+      - name: Set up gradle cache
+        uses: gradle/gradle-build-action@v2
+
         # Quarkus 2.0+ does not support Java 8
       - name: Build Java 11 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/quarkus
+        run: ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/quarkus
 
       - name: Build Java 17 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/quarkus
+        run: ./gradlew jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/quarkus
 
       - name: Build Java 18 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/quarkus
+        run: ./gradlew jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/quarkus
 
   issue:
     name: Open issue on failure

--- a/.github/workflows/publish-smoke-test-servlet-images.yml
+++ b/.github/workflows/publish-smoke-test-servlet-images.yml
@@ -55,19 +55,21 @@ jobs:
       - name: Set Tag
         run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
-      - name: Build Linux docker images
-        if: matrix.os != 'windows-2019'
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: buildLinuxTestImages pushMatrix -PextraTag=${{ env.TAG }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
-          build-root-directory: smoke-tests/images/servlet
+          # only push cache for one matrix option per OS since github action cache space is limited
+          cache-read-only: ${{ inputs.cache-read-only || matrix.smoke-test-suite != 'tomcat' }}
+
+      - name: Build Linux docker images
+        if: matrix.os != 'windows-2019'
+        run: ./gradlew buildLinuxTestImages pushMatrix -PextraTag=${{ env.TAG }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
+        working-directory: smoke-tests/images/servlet
 
       - name: Build Windows docker images
         if: matrix.os == 'windows-2019'
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: buildWindowsTestImages pushMatrix -PextraTag=${{ env.TAG }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
-          build-root-directory: smoke-tests/images/servlet
+        run: ./gradlew buildWindowsTestImages pushMatrix -PextraTag=${{ env.TAG }} -PsmokeTestServer=${{ matrix.smoke-test-server }}
+        working-directory: smoke-tests/images/servlet
 
   issue:
     name: Open issue on failure

--- a/.github/workflows/publish-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/publish-smoke-test-spring-boot-images.yml
@@ -31,29 +31,24 @@ jobs:
       - name: Set Tag
         run: echo "TAG=$(date '+%Y%m%d').$GITHUB_RUN_ID" >> $GITHUB_ENV
 
-      - name: Build Java 8 Docker Image
+      - name: Set up gradle cache
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/spring-boot
+
+      - name: Build Java 8 Docker Image
+        run: ./gradlew jib -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/spring-boot
 
       - name: Build Java 11 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/spring-boot
+        run: ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/spring-boot
 
       - name: Build Java 17 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/spring-boot
+        run: ./gradlew jib -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/spring-boot
 
       - name: Build Java 18 Docker Image
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
-          build-root-directory: smoke-tests/images/spring-boot
+        run: ./gradlew jib -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain -Ptag=${{ env.TAG }}
+        working-directory: smoke-tests/images/spring-boot
 
   issue:
     name: Open issue on failure


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5459#discussion_r815569904, I think it's best to use a single `gradle-build-action` per job. And ends up being less LOC.