### PR TITLE
Add JBoss java.util.logging support

### DIFF
--- a/instrumentation/java-util-logging/javaagent/build.gradle.kts
+++ b/instrumentation/java-util-logging/javaagent/build.gradle.kts
@@ -7,6 +7,10 @@ dependencies {
 
   compileOnly(project(":instrumentation-appender-api-internal"))
 
+  // the JBoss instrumentation in this artifact is needed
+  // for jboss-logmanager versions 1.1.0.GA through latest 2.x
+  testLibrary("org.jboss.logmanager:jboss-logmanager:1.1.0.GA")
+
   testImplementation("org.awaitility:awaitility")
 }
 

--- a/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingHelper.java
+++ b/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingHelper.java
@@ -36,7 +36,7 @@ public final class JavaUtilLoggingHelper {
       return;
     }
 
-    String instrumentationName = logRecord.getLoggerName();
+    String instrumentationName = logger.getName();
     if (instrumentationName == null || instrumentationName.isEmpty()) {
       instrumentationName = "ROOT";
     }

--- a/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingInstrumentation.java
+++ b/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingInstrumentation.java
@@ -38,6 +38,13 @@ class JavaUtilLoggingInstrumentation implements TypeInstrumentation {
             .and(takesArguments(1))
             .and(takesArgument(0, named("java.util.logging.LogRecord"))),
         JavaUtilLoggingInstrumentation.class.getName() + "$LogAdvice");
+    transformer.applyAdviceToMethod(
+        isMethod()
+            .and(isPublic())
+            .and(named("logRaw"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("org.jboss.logmanager.ExtLogRecord"))),
+        JavaUtilLoggingInstrumentation.class.getName() + "$LogAdvice");
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/java-util-logging/javaagent/src/test/groovy/JBossJavaUtilLoggingTest.groovy
+++ b/instrumentation/java-util-logging/javaagent/src/test/groovy/JBossJavaUtilLoggingTest.groovy
@@ -1,0 +1,14 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import org.jboss.logmanager.LogContext
+
+class JBossJavaUtilLoggingTest extends JavaUtilLoggingTest {
+
+  @Override
+  Object createLogger(String name) {
+    LogContext.create().getLogger(name)
+  }
+}

--- a/instrumentation/java-util-logging/javaagent/src/test/groovy/JavaUtilLoggingTest.groovy
+++ b/instrumentation/java-util-logging/javaagent/src/test/groovy/JavaUtilLoggingTest.groovy
@@ -6,6 +6,7 @@
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.sdk.logs.data.Severity
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import spock.lang.Shared
 import spock.lang.Unroll
 
 import java.util.logging.Level
@@ -16,7 +17,12 @@ import static org.awaitility.Awaitility.await
 
 class JavaUtilLoggingTest extends AgentInstrumentationSpecification {
 
-  private static final Logger logger = Logger.getLogger("abc")
+  @Shared
+  private final Object logger = createLogger("abc")
+
+  Object createLogger(String name) {
+    Logger.getLogger(name)
+  }
 
   @Unroll
   def "test method=#testMethod with exception=#exception and parent=#parent"() {

--- a/instrumentation/java-util-logging/shaded-stub-for-instrumenting/src/main/java/application/java/util/logging/Logger.java
+++ b/instrumentation/java-util-logging/shaded-stub-for-instrumenting/src/main/java/application/java/util/logging/Logger.java
@@ -12,6 +12,10 @@ import java.util.logging.Level;
 // after java.util.logging.Logger is shaded to the "PatchLogger"
 public class Logger {
 
+  public String getName() {
+    throw new UnsupportedOperationException();
+  }
+
   public boolean isLoggable(@SuppressWarnings("unused") Level level) {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
I didn't upstream this part originally because the JBoss test I included was working both with and without the extra instrumentation, but found the problem, that I was running the test against JBoss Logging 1.0.0, and the extra instrumentation is only needed starting from 1.1.0.