### PR TITLE
Remove duplicate gradle build cache

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -59,6 +59,9 @@ jobs:
           arguments: check -PtestJavaVersion=${{ matrix.test-java-version }} -PtestJavaVM=${{ matrix.vm }} -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false ${{ inputs.no-build-cache && ' --no-build-cache' || '' }}
           # only push cache for one matrix option since github action cache space is limited
           cache-read-only: ${{ inputs.cache-read-only || matrix.test-java-version != 11 || matrix.vm != 'hotspot' }}
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: |
+            caches/build-cache-1
 
       - name: Upload deadlock detector artifacts if any
         if: always()


### PR DESCRIPTION
Since we use gradle enterprise for build cache, I think we can save space on github action cache.

@anuraaga I looked into using `actions/cache` to have more control over cache keys as we discussed last week, but `actions/cache` has no support for read-only mode in PRs which could make our problem worse. I still want to revisit, but I'd like to confirm with this PR that we aren't really using build cache from github actions anyways.