### PR TITLE
Prefix opentelemetry-java-bot branch names

### DIFF
--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -44,7 +44,7 @@ jobs:
           msg="Prepare patch release ${{ steps.set-versions.outputs.release-version }}"
           git add -u
           git commit -m "$msg"
-          git push origin HEAD:prepare-patch-release-${{ steps.set-versions.outputs.release-version }}
+          git push origin HEAD:opentelemetry-java-bot/prepare-patch-release-${{ steps.set-versions.outputs.release-version }}
           gh pr create --title "$msg" \
                        --body "$msg" \
                        --head prepare-patch-release-${{ steps.set-versions.outputs.release-version }} \

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -51,7 +51,7 @@ jobs:
           msg="Prepare release branch ${{ needs.prepare-release-branch.outputs.release-branch-name }}"
           git add -u
           git commit -m "$msg"
-          git push origin HEAD:prepare-release-branch-${{ needs.prepare-release-branch.outputs.release-branch-name }}
+          git push origin HEAD:opentelemetry-java-bot/prepare-release-branch-${{ needs.prepare-release-branch.outputs.release-branch-name }}
           gh pr create --title "$msg" \
                        --body "$msg" \
                        --head prepare-release-branch-${{ needs.prepare-release-branch.outputs.release-branch-name }} \
@@ -88,5 +88,5 @@ jobs:
           msg="Bump snapshot version"
           git add -u
           git commit -m "$msg"
-          git push origin HEAD:bump-snapshot-version
+          git push origin HEAD:opentelemetry-java-bot/bump-snapshot-version
           gh pr create --title "$msg" --body "$msg" --head bump-snapshot-version --base main


### PR DESCRIPTION
So that we can configure branch protection rule on `opentelemetry-java-bot/*` to allow deleting the branches