### PR TITLE
Bump muzzle retry interval

### DIFF
--- a/.github/workflows/muzzle.yml
+++ b/.github/workflows/muzzle.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           # timing out has not been a problem, these jobs typically finish in 2-3 minutes
           timeout_minutes: 15
-          # give maven central some time to hopefully recover
-          retry_wait_seconds: 120
+          # give maven central some time to hopefully recover (120 seconds has not proven to be enough)
+          retry_wait_seconds: 300
           max_attempts: 5
           command: ./gradlew ${{ matrix.module }}:muzzle


### PR DESCRIPTION
Could end up taking a while, but better than having to re-run the entire build (if it eventually passes).