### PR TITLE
Fix release notes automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           EOF
 
           sed -n '/^## Version ${{ steps.set-versions.outputs.release-version }}/,/^## Version /p' CHANGELOG.md \
+            | tail -n +2 \
             | head -n -1 \
             | perl -0pe 's/^\n+//g' \
             | perl -0pe 's/\n+$/\n/g' \


### PR DESCRIPTION
Same as https://github.com/open-telemetry/opentelemetry-java-contrib/pull/256

`tail -n +2` to start printing from the second line, prevent it from copying over the starting `## Version` header (and the `head -n -1` prevents it from copying over the ending `## Version` header)