### PR TITLE
Elasticsearch rest client low cardinality span name

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Singletons.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Singletons.java
@@ -7,14 +7,15 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v5_0;
 
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestInstrumenterFactory;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestRequest;
 import org.elasticsearch.client.Response;
 
 public final class ElasticsearchRest5Singletons {
 
-  private static final Instrumenter<String, Response> INSTRUMENTER =
+  private static final Instrumenter<ElasticsearchRestRequest, Response> INSTRUMENTER =
       ElasticsearchRestInstrumenterFactory.create("io.opentelemetry.elasticsearch-rest-5.0");
 
-  public static Instrumenter<String, Response> instrumenter() {
+  public static Instrumenter<ElasticsearchRestRequest, Response> instrumenter() {
     return INSTRUMENTER;
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/RestClientInstrumentation.java
@@ -17,6 +17,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestRequest;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.RestResponseListener;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -48,13 +49,13 @@ public class RestClientInstrumentation implements TypeInstrumentation {
     public static void onEnter(
         @Advice.Argument(0) String method,
         @Advice.Argument(1) String endpoint,
-        @Advice.Local("otelRequest") String request,
+        @Advice.Local("otelRequest") ElasticsearchRestRequest request,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope,
         @Advice.Argument(value = 5, readOnly = false) ResponseListener responseListener) {
 
       Context parentContext = currentContext();
-      request = method + " " + endpoint;
+      request = ElasticsearchRestRequest.create(method, endpoint);
       if (!instrumenter().shouldStart(parentContext, request)) {
         return;
       }
@@ -70,7 +71,7 @@ public class RestClientInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelRequest") String request,
+        @Advice.Local("otelRequest") ElasticsearchRestRequest request,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/ElasticsearchRest5Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/ElasticsearchRest5Test.groovy
@@ -71,12 +71,13 @@ class ElasticsearchRest5Test extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          name "GET _cluster/health"
+          name "GET"
           kind CLIENT
           hasNoParent()
           attributes {
             "$SemanticAttributes.DB_SYSTEM" "elasticsearch"
-            "$SemanticAttributes.DB_OPERATION" "GET _cluster/health"
+            "$SemanticAttributes.DB_OPERATION" "GET"
+            "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
             "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
             "$SemanticAttributes.NET_PEER_PORT" httpHost.port
@@ -130,12 +131,13 @@ class ElasticsearchRest5Test extends AgentInstrumentationSpecification {
           hasNoParent()
         }
         span(1) {
-          name "GET _cluster/health"
+          name "GET"
           kind CLIENT
           childOf(span(0))
           attributes {
             "$SemanticAttributes.DB_SYSTEM" "elasticsearch"
-            "$SemanticAttributes.DB_OPERATION" "GET _cluster/health"
+            "$SemanticAttributes.DB_OPERATION" "GET"
+            "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
             "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
             "$SemanticAttributes.NET_PEER_PORT" httpHost.port

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Singletons.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Singletons.java
@@ -7,14 +7,15 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v6_4;
 
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestInstrumenterFactory;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestRequest;
 import org.elasticsearch.client.Response;
 
 public final class ElasticsearchRest6Singletons {
 
-  private static final Instrumenter<String, Response> INSTRUMENTER =
+  private static final Instrumenter<ElasticsearchRestRequest, Response> INSTRUMENTER =
       ElasticsearchRestInstrumenterFactory.create("io.opentelemetry.elasticsearch-rest-6.4");
 
-  public static Instrumenter<String, Response> instrumenter() {
+  public static Instrumenter<ElasticsearchRestRequest, Response> instrumenter() {
     return INSTRUMENTER;
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/RestClientInstrumentation.java
@@ -16,6 +16,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestRequest;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.RestResponseListener;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -47,12 +48,12 @@ public class RestClientInstrumentation implements TypeInstrumentation {
     public static void onEnter(
         @Advice.Argument(0) Request request,
         @Advice.Argument(value = 1, readOnly = false) ResponseListener responseListener,
-        @Advice.Local("otelRequest") String otelRequest,
+        @Advice.Local("otelRequest") ElasticsearchRestRequest otelRequest,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
 
       Context parentContext = currentContext();
-      otelRequest = request.getMethod() + " " + request.getEndpoint();
+      otelRequest = ElasticsearchRestRequest.create(request.getMethod(), request.getEndpoint());
       if (!instrumenter().shouldStart(parentContext, otelRequest)) {
         return;
       }
@@ -68,7 +69,7 @@ public class RestClientInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelRequest") String otelRequest,
+        @Advice.Local("otelRequest") ElasticsearchRestRequest otelRequest,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/ElasticsearchRest6Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/ElasticsearchRest6Test.groovy
@@ -66,12 +66,13 @@ class ElasticsearchRest6Test extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          name "GET _cluster/health"
+          name "GET"
           kind CLIENT
           hasNoParent()
           attributes {
             "$SemanticAttributes.DB_SYSTEM" "elasticsearch"
-            "$SemanticAttributes.DB_OPERATION" "GET _cluster/health"
+            "$SemanticAttributes.DB_OPERATION" "GET"
+            "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
             "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
             "$SemanticAttributes.NET_PEER_PORT" httpHost.port
@@ -124,12 +125,13 @@ class ElasticsearchRest6Test extends AgentInstrumentationSpecification {
           hasNoParent()
         }
         span(1) {
-          name "GET _cluster/health"
+          name "GET"
           kind CLIENT
           childOf(span(0))
           attributes {
             "$SemanticAttributes.DB_SYSTEM" "elasticsearch"
-            "$SemanticAttributes.DB_OPERATION" "GET _cluster/health"
+            "$SemanticAttributes.DB_OPERATION" "GET"
+            "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
             "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
             "$SemanticAttributes.NET_PEER_PORT" httpHost.port

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Singletons.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Singletons.java
@@ -7,14 +7,15 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v7_0;
 
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestInstrumenterFactory;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestRequest;
 import org.elasticsearch.client.Response;
 
 public final class ElasticsearchRest7Singletons {
 
-  private static final Instrumenter<String, Response> INSTRUMENTER =
+  private static final Instrumenter<ElasticsearchRestRequest, Response> INSTRUMENTER =
       ElasticsearchRestInstrumenterFactory.create("io.opentelemetry.elasticsearch-rest-7.0");
 
-  public static Instrumenter<String, Response> instrumenter() {
+  public static Instrumenter<ElasticsearchRestRequest, Response> instrumenter() {
     return INSTRUMENTER;
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/RestClientInstrumentation.java
@@ -16,6 +16,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.ElasticsearchRestRequest;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.RestResponseListener;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -53,12 +54,12 @@ public class RestClientInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
         @Advice.Argument(0) Request request,
-        @Advice.Local("otelRequest") String otelRequest,
+        @Advice.Local("otelRequest") ElasticsearchRestRequest otelRequest,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
 
       Context parentContext = currentContext();
-      otelRequest = request.getMethod() + " " + request.getEndpoint();
+      otelRequest = ElasticsearchRestRequest.create(request.getMethod(), request.getEndpoint());
       if (!instrumenter().shouldStart(parentContext, otelRequest)) {
         return;
       }
@@ -71,7 +72,7 @@ public class RestClientInstrumentation implements TypeInstrumentation {
     public static void stopSpan(
         @Advice.Return(readOnly = false) Response response,
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelRequest") String otelRequest,
+        @Advice.Local("otelRequest") ElasticsearchRestRequest otelRequest,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
 
@@ -91,12 +92,12 @@ public class RestClientInstrumentation implements TypeInstrumentation {
     public static void onEnter(
         @Advice.Argument(0) Request request,
         @Advice.Argument(value = 1, readOnly = false) ResponseListener responseListener,
-        @Advice.Local("otelRequest") String otelRequest,
+        @Advice.Local("otelRequest") ElasticsearchRestRequest otelRequest,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
 
       Context parentContext = currentContext();
-      otelRequest = request.getMethod() + " " + request.getEndpoint();
+      otelRequest = ElasticsearchRestRequest.create(request.getMethod(), request.getEndpoint());
       if (!instrumenter().shouldStart(parentContext, otelRequest)) {
         return;
       }
@@ -112,7 +113,7 @@ public class RestClientInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Thrown Throwable throwable,
-        @Advice.Local("otelRequest") String otelRequest,
+        @Advice.Local("otelRequest") ElasticsearchRestRequest otelRequest,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/groovy/ElasticsearchRest7Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/groovy/ElasticsearchRest7Test.groovy
@@ -65,12 +65,13 @@ class ElasticsearchRest7Test extends AgentInstrumentationSpecification {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          name "GET _cluster/health"
+          name "GET"
           kind CLIENT
           hasNoParent()
           attributes {
             "$SemanticAttributes.DB_SYSTEM" "elasticsearch"
-            "$SemanticAttributes.DB_OPERATION" "GET _cluster/health"
+            "$SemanticAttributes.DB_OPERATION" "GET"
+            "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
             "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
             "$SemanticAttributes.NET_PEER_PORT" httpHost.port
@@ -123,12 +124,13 @@ class ElasticsearchRest7Test extends AgentInstrumentationSpecification {
           hasNoParent()
         }
         span(1) {
-          name "GET _cluster/health"
+          name "GET"
           kind CLIENT
           childOf(span(0))
           attributes {
             "$SemanticAttributes.DB_SYSTEM" "elasticsearch"
-            "$SemanticAttributes.DB_OPERATION" "GET _cluster/health"
+            "$SemanticAttributes.DB_OPERATION" "GET"
+            "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
             "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
             "$SemanticAttributes.NET_PEER_PORT" httpHost.port

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/build.gradle.kts
@@ -4,4 +4,7 @@ plugins {
 
 dependencies {
   compileOnly("org.elasticsearch.client:rest:5.0.0")
+  compileOnly("com.google.auto.value:auto-value-annotations")
+
+  annotationProcessor("com.google.auto.value:auto-value")
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestAttributesGetter.java
@@ -9,40 +9,41 @@ import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientAttributesGe
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import javax.annotation.Nullable;
 
-final class ElasticsearchRestAttributesGetter implements DbClientAttributesGetter<String> {
+final class ElasticsearchRestAttributesGetter
+    implements DbClientAttributesGetter<ElasticsearchRestRequest> {
 
   @Override
-  public String system(String operation) {
+  public String system(ElasticsearchRestRequest request) {
     return SemanticAttributes.DbSystemValues.ELASTICSEARCH;
   }
 
   @Override
   @Nullable
-  public String user(String operation) {
+  public String user(ElasticsearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(String operation) {
+  public String name(ElasticsearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String connectionString(String operation) {
+  public String connectionString(ElasticsearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String statement(String operation) {
-    return null;
+  public String statement(ElasticsearchRestRequest request) {
+    return request.getMethod() + " " + request.getOperation();
   }
 
   @Override
   @Nullable
-  public String operation(String operation) {
-    return operation;
+  public String operation(ElasticsearchRestRequest request) {
+    return request.getMethod();
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestInstrumenterFactory.java
@@ -16,13 +16,14 @@ import org.elasticsearch.client.Response;
 
 public final class ElasticsearchRestInstrumenterFactory {
 
-  public static Instrumenter<String, Response> create(String instrumentationName) {
+  public static Instrumenter<ElasticsearchRestRequest, Response> create(
+      String instrumentationName) {
     ElasticsearchRestAttributesGetter dbClientAttributesGetter =
         new ElasticsearchRestAttributesGetter();
     ElasticsearchRestNetResponseAttributesGetter netAttributesGetter =
         new ElasticsearchRestNetResponseAttributesGetter();
 
-    return Instrumenter.<String, Response>builder(
+    return Instrumenter.<ElasticsearchRestRequest, Response>builder(
             GlobalOpenTelemetry.get(),
             instrumentationName,
             DbClientSpanNameExtractor.create(dbClientAttributesGetter))

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestNetResponseAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestNetResponseAttributesGetter.java
@@ -11,16 +11,16 @@ import javax.annotation.Nullable;
 import org.elasticsearch.client.Response;
 
 final class ElasticsearchRestNetResponseAttributesGetter
-    implements NetClientAttributesGetter<String, Response> {
+    implements NetClientAttributesGetter<ElasticsearchRestRequest, Response> {
 
   @Override
-  public String transport(String operation, Response response) {
+  public String transport(ElasticsearchRestRequest request, Response response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(String operation, @Nullable Response response) {
+  public String peerName(ElasticsearchRestRequest request, @Nullable Response response) {
     if (response != null) {
       return response.getHost().getHostName();
     }
@@ -29,7 +29,7 @@ final class ElasticsearchRestNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public Integer peerPort(String operation, @Nullable Response response) {
+  public Integer peerPort(ElasticsearchRestRequest request, @Nullable Response response) {
     if (response != null) {
       return response.getHost().getPort();
     }
@@ -38,7 +38,7 @@ final class ElasticsearchRestNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String peerIp(String operation, @Nullable Response response) {
+  public String peerIp(ElasticsearchRestRequest request, @Nullable Response response) {
     if (response != null && response.getHost().getAddress() != null) {
       return response.getHost().getAddress().getHostAddress();
     }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestRequest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestRequest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class ElasticsearchRestRequest {
+
+  public static ElasticsearchRestRequest create(String method, String endpoint) {
+    return new AutoValue_ElasticsearchRestRequest(method, endpoint);
+  }
+
+  public abstract String getMethod();
+
+  public abstract String getOperation();
+}

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/RestResponseListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/RestResponseListener.java
@@ -15,16 +15,16 @@ public final class RestResponseListener implements ResponseListener {
 
   private final ResponseListener listener;
   private final Context parentContext;
-  private final Instrumenter<String, Response> instrumenter;
+  private final Instrumenter<ElasticsearchRestRequest, Response> instrumenter;
   private final Context context;
-  private final String request;
+  private final ElasticsearchRestRequest request;
 
   public RestResponseListener(
       ResponseListener listener,
       Context parentContext,
-      Instrumenter<String, Response> instrumenter,
+      Instrumenter<ElasticsearchRestRequest, Response> instrumenter,
       Context context,
-      String request) {
+      ElasticsearchRestRequest request) {
     this.listener = listener;
     this.parentContext = parentContext;
     this.instrumenter = instrumenter;


### PR DESCRIPTION
This pr changes elasticsearch rest client to use a low cardinality span name. The endpoint that is currently used in span name is the path that was requested, so each request for a different document produces a unique span name event when the document doesn't exist.