### PR TITLE
Add vm name to deadlock detector file name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: deadlock-detector-test-${{ matrix.test-java-version }}
+          name: deadlock-detector-test-${{ matrix.test-java-version }}-${{ matrix.vm }}
           path: /tmp/deadlock-detector-*
           if-no-files-found: ignore
 


### PR DESCRIPTION
otherwise hotspot and openj9 will use the same file name