### PR TITLE
Increase finatra startup timeout

### DIFF
--- a/instrumentation/finatra-2.9/javaagent/src/latestDepTest/scala/io/opentelemetry/javaagent/instrumentation/finatra/FinatraServer.scala
+++ b/instrumentation/finatra-2.9/javaagent/src/latestDepTest/scala/io/opentelemetry/javaagent/instrumentation/finatra/FinatraServer.scala
@@ -29,7 +29,7 @@ class FinatraServer extends HttpServer {
   }
 
   def awaitReady(): FinatraServer = {
-    latch.await(10, TimeUnit.SECONDS)
+    latch.await(1, TimeUnit.MINUTES)
     this
   }
 }

--- a/instrumentation/finatra-2.9/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/finatra/FinatraServer.scala
+++ b/instrumentation/finatra-2.9/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/finatra/FinatraServer.scala
@@ -29,7 +29,7 @@ class FinatraServer extends HttpServer {
   }
 
   def awaitReady(): FinatraServer = {
-    latch.await(10, TimeUnit.SECONDS)
+    latch.await(1, TimeUnit.MINUTES)
     this
   }
 }


### PR DESCRIPTION
There have been a lot of finatra timeouts lately like https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5595 I believe this happens because during scala conversion timeout was reduced.