### PR TITLE
Handle failed request in http server concurrency tests

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -374,7 +374,10 @@ public abstract class AbstractHttpServerTest<SERVER> {
           () -> {
             Span.current().setAttribute(ServerEndpoint.ID_ATTRIBUTE_NAME, index);
             propagator.inject(Context.current(), request, setter);
-            client.execute(request.build()).aggregate().thenRun(latch::countDown);
+            client
+                .execute(request.build())
+                .aggregate()
+                .whenComplete((result, throwable) -> latch.countDown());
           });
     }
     latch.await();


### PR DESCRIPTION
Count down the latch even for failed request to ensure that the test doesn't completely hang in case there is a failed request. Probably this cause the test to time out in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5595