### PR TITLE
Convert all logging statements from slf4j to jul - part 1

### DIFF
--- a/conventions/src/main/kotlin/otel.javaagent-testing.gradle.kts
+++ b/conventions/src/main/kotlin/otel.javaagent-testing.gradle.kts
@@ -11,7 +11,6 @@ evaluationDependsOn(":testing:agent-for-testing")
 dependencies {
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service")
-  compileOnly("org.slf4j:slf4j-api")
 
   testImplementation("org.testcontainers:testcontainers")
 }

--- a/instrumentation-api-annotation-support/build.gradle.kts
+++ b/instrumentation-api-annotation-support/build.gradle.kts
@@ -13,8 +13,6 @@ dependencies {
   api("io.opentelemetry:opentelemetry-api")
   api("io.opentelemetry:opentelemetry-semconv")
 
-  implementation("org.slf4j:slf4j-api")
-
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 

--- a/instrumentation-api/build.gradle.kts
+++ b/instrumentation-api/build.gradle.kts
@@ -17,8 +17,6 @@ dependencies {
   api("io.opentelemetry:opentelemetry-api")
   api("io.opentelemetry:opentelemetry-semconv")
 
-  implementation("org.slf4j:slf4j-api")
-
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
@@ -11,9 +11,9 @@ import com.google.auto.value.AutoValue;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents the global agent configuration consisting of system properties, environment variables,
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 @AutoValue
 public abstract class Config {
-  private static final Logger logger = LoggerFactory.getLogger(Config.class);
+  private static final Logger logger = Logger.getLogger(Config.class.getName());
 
   // lazy initialized, so that javaagent can set it, and library instrumentation can fall back and
   // read system properties
@@ -53,7 +53,7 @@ public abstract class Config {
    */
   public static void internalInitializeConfig(Config config) {
     if (instance != null) {
-      logger.warn("Config#INSTANCE was already set earlier");
+      logger.warning("Config#INSTANCE was already set earlier");
       return;
     }
     instance = requireNonNull(config);
@@ -166,7 +166,9 @@ public abstract class Config {
       T value = getTypedProperty(name, parser);
       return value == null ? defaultValue : value;
     } catch (RuntimeException t) {
-      logger.debug("Error occurred during parsing: {}", t.getMessage(), t);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE, "Error occurred during parsing: " + t.getMessage(), t);
+      }
       return defaultValue;
     }
   }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/Config.java
@@ -6,12 +6,12 @@
 package io.opentelemetry.instrumentation.api.config;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.logging.Level.FINE;
 
 import com.google.auto.value.AutoValue;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -166,8 +166,8 @@ public abstract class Config {
       T value = getTypedProperty(name, parser);
       return value == null ? defaultValue : value;
     } catch (RuntimeException t) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.log(Level.FINE, "Error occurred during parsing: " + t.getMessage(), t);
+      if (logger.isLoggable(FINE)) {
+        logger.log(FINE, "Error occurred during parsing: " + t.getMessage(), t);
       }
       return defaultValue;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
@@ -67,13 +67,10 @@ public final class HttpClientMetrics implements RequestListener {
   public void end(Context context, Attributes endAttributes, long endNanos) {
     State state = context.get(HTTP_CLIENT_REQUEST_METRICS_STATE);
     if (state == null) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.log(
-            Level.FINE,
-            "No state present when ending context "
-                + context
-                + ". Cannot record HTTP request metrics.");
-      }
+      logger.log(
+          Level.FINE,
+          "No state present when ending context {0}. Cannot record HTTP request metrics.",
+          context);
       return;
     }
     duration.record(

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
@@ -17,8 +17,8 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestListener;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestMetrics;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * {@link RequestListener} which keeps track of <a
@@ -33,7 +33,7 @@ public final class HttpClientMetrics implements RequestListener {
   private static final ContextKey<State> HTTP_CLIENT_REQUEST_METRICS_STATE =
       ContextKey.named("http-client-request-metrics-state");
 
-  private static final Logger logger = LoggerFactory.getLogger(HttpClientMetrics.class);
+  private static final Logger logger = Logger.getLogger(HttpClientMetrics.class.getName());
 
   /**
    * Returns a {@link RequestMetrics} which can be used to enable recording of {@link
@@ -67,8 +67,13 @@ public final class HttpClientMetrics implements RequestListener {
   public void end(Context context, Attributes endAttributes, long endNanos) {
     State state = context.get(HTTP_CLIENT_REQUEST_METRICS_STATE);
     if (state == null) {
-      logger.debug(
-          "No state present when ending context {}. Cannot record HTTP request metrics.", context);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(
+            Level.FINE,
+            "No state present when ending context "
+                + context
+                + ". Cannot record HTTP request metrics.");
+      }
       return;
     }
     duration.record(

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
 import static io.opentelemetry.instrumentation.api.instrumenter.http.TemporaryMetricsView.applyClientDurationView;
+import static java.util.logging.Level.FINE;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
@@ -17,7 +18,6 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestListener;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestMetrics;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -68,7 +68,7 @@ public final class HttpClientMetrics implements RequestListener {
     State state = context.get(HTTP_CLIENT_REQUEST_METRICS_STATE);
     if (state == null) {
       logger.log(
-          Level.FINE,
+          FINE,
           "No state present when ending context {0}. Cannot record HTTP request metrics.",
           context);
       return;

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
@@ -82,9 +82,8 @@ public final class HttpServerMetrics implements RequestListener {
       if (logger.isLoggable(Level.FINE)) {
         logger.log(
             Level.FINE,
-            "No state present when ending context "
-                + context
-                + ". Cannot record HTTP request metrics.");
+            "No state present when ending context {0}. Cannot record HTTP request metrics.",
+            context);
       }
       return;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
@@ -19,8 +19,8 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestListener;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestMetrics;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * {@link RequestListener} which keeps track of <a
@@ -35,7 +35,7 @@ public final class HttpServerMetrics implements RequestListener {
   private static final ContextKey<State> HTTP_SERVER_REQUEST_METRICS_STATE =
       ContextKey.named("http-server-request-metrics-state");
 
-  private static final Logger logger = LoggerFactory.getLogger(HttpServerMetrics.class);
+  private static final Logger logger = Logger.getLogger(HttpServerMetrics.class.getName());
 
   /**
    * Returns a {@link RequestMetrics} which can be used to enable recording of {@link
@@ -79,8 +79,13 @@ public final class HttpServerMetrics implements RequestListener {
   public void end(Context context, Attributes endAttributes, long endNanos) {
     State state = context.get(HTTP_SERVER_REQUEST_METRICS_STATE);
     if (state == null) {
-      logger.debug(
-          "No state present when ending context {}. Cannot reset HTTP request metrics.", context);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(
+            Level.FINE,
+            "No state present when ending context "
+                + context
+                + ". Cannot record HTTP request metrics.");
+      }
       return;
     }
     activeRequests.add(-1, applyActiveRequestsView(state.startAttributes()));

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.instrumenter.http;
 
 import static io.opentelemetry.instrumentation.api.instrumenter.http.TemporaryMetricsView.applyActiveRequestsView;
 import static io.opentelemetry.instrumentation.api.instrumenter.http.TemporaryMetricsView.applyServerDurationView;
+import static java.util.logging.Level.FINE;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
@@ -19,7 +20,6 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestListener;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestMetrics;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -79,12 +79,10 @@ public final class HttpServerMetrics implements RequestListener {
   public void end(Context context, Attributes endAttributes, long endNanos) {
     State state = context.get(HTTP_SERVER_REQUEST_METRICS_STATE);
     if (state == null) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.log(
-            Level.FINE,
-            "No state present when ending context {0}. Cannot record HTTP request metrics.",
-            context);
-      }
+      logger.log(
+          FINE,
+          "No state present when ending context {0}. Cannot record HTTP request metrics.",
+          context);
       return;
     }
     activeRequests.add(-1, applyActiveRequestsView(state.startAttributes()));

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientMetrics.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.instrumenter.rpc;
 
 import static io.opentelemetry.instrumentation.api.instrumenter.rpc.MetricsView.applyClientView;
+import static java.util.logging.Level.FINE;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
@@ -17,7 +18,6 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestListener;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestMetrics;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -67,12 +67,10 @@ public final class RpcClientMetrics implements RequestListener {
   public void end(Context context, Attributes endAttributes, long endNanos) {
     State state = context.get(RPC_CLIENT_REQUEST_METRICS_STATE);
     if (state == null) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.log(
-            Level.FINE,
-            "No state present when ending context {0}. Cannot record RPC request metrics.",
-            context);
-      }
+      logger.log(
+          FINE,
+          "No state present when ending context {0}. Cannot record RPC request metrics.",
+          context);
       return;
     }
     clientDurationHistogram.record(

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientMetrics.java
@@ -17,8 +17,8 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestListener;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestMetrics;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * {@link RequestListener} which keeps track of <a
@@ -33,7 +33,7 @@ public final class RpcClientMetrics implements RequestListener {
   private static final ContextKey<RpcClientMetrics.State> RPC_CLIENT_REQUEST_METRICS_STATE =
       ContextKey.named("rpc-client-request-metrics-state");
 
-  private static final Logger logger = LoggerFactory.getLogger(RpcClientMetrics.class);
+  private static final Logger logger = Logger.getLogger(RpcClientMetrics.class.getName());
 
   private final DoubleHistogram clientDurationHistogram;
 
@@ -67,8 +67,13 @@ public final class RpcClientMetrics implements RequestListener {
   public void end(Context context, Attributes endAttributes, long endNanos) {
     State state = context.get(RPC_CLIENT_REQUEST_METRICS_STATE);
     if (state == null) {
-      logger.debug(
-          "No state present when ending context {}. Cannot record RPC request metrics.", context);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(
+            Level.FINE,
+            "No state present when ending context "
+                + context
+                + ". Cannot record RPC request metrics.");
+      }
       return;
     }
     clientDurationHistogram.record(

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientMetrics.java
@@ -70,9 +70,8 @@ public final class RpcClientMetrics implements RequestListener {
       if (logger.isLoggable(Level.FINE)) {
         logger.log(
             Level.FINE,
-            "No state present when ending context "
-                + context
-                + ". Cannot record RPC request metrics.");
+            "No state present when ending context {0}. Cannot record RPC request metrics.",
+            context);
       }
       return;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetrics.java
@@ -70,9 +70,8 @@ public final class RpcServerMetrics implements RequestListener {
       if (logger.isLoggable(Level.FINE)) {
         logger.log(
             Level.FINE,
-            "No state present when ending context "
-                + context
-                + ". Cannot record RPC request metrics.");
+            "No state present when ending context {0}. Cannot record RPC request metrics.",
+            context);
       }
       return;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetrics.java
@@ -17,8 +17,8 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestListener;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestMetrics;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * {@link RequestListener} which keeps track of <a
@@ -33,7 +33,7 @@ public final class RpcServerMetrics implements RequestListener {
   private static final ContextKey<RpcServerMetrics.State> RPC_SERVER_REQUEST_METRICS_STATE =
       ContextKey.named("rpc-server-request-metrics-state");
 
-  private static final Logger logger = LoggerFactory.getLogger(RpcServerMetrics.class);
+  private static final Logger logger = Logger.getLogger(RpcServerMetrics.class.getName());
 
   private final DoubleHistogram serverDurationHistogram;
 
@@ -67,8 +67,13 @@ public final class RpcServerMetrics implements RequestListener {
   public void end(Context context, Attributes endAttributes, long endNanos) {
     State state = context.get(RPC_SERVER_REQUEST_METRICS_STATE);
     if (state == null) {
-      logger.debug(
-          "No state present when ending context {}. Cannot record RPC request metrics.", context);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(
+            Level.FINE,
+            "No state present when ending context "
+                + context
+                + ". Cannot record RPC request metrics.");
+      }
       return;
     }
     serverDurationHistogram.record(

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetrics.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.instrumenter.rpc;
 
 import static io.opentelemetry.instrumentation.api.instrumenter.rpc.MetricsView.applyServerView;
+import static java.util.logging.Level.FINE;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.common.Attributes;
@@ -17,7 +18,6 @@ import io.opentelemetry.instrumentation.api.annotations.UnstableApi;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestListener;
 import io.opentelemetry.instrumentation.api.instrumenter.RequestMetrics;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -67,12 +67,10 @@ public final class RpcServerMetrics implements RequestListener {
   public void end(Context context, Attributes endAttributes, long endNanos) {
     State state = context.get(RPC_SERVER_REQUEST_METRICS_STATE);
     if (state == null) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.log(
-            Level.FINE,
-            "No state present when ending context {0}. Cannot record RPC request metrics.",
-            context);
-      }
+      logger.log(
+          FINE,
+          "No state present when ending context {0}. Cannot record RPC request metrics.",
+          context);
       return;
     }
     serverDurationHistogram.record(

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/ContextPropagationDebug.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/ContextPropagationDebug.java
@@ -12,16 +12,15 @@ import io.opentelemetry.instrumentation.api.config.Config;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
 public final class ContextPropagationDebug {
-  private static final Logger logger = LoggerFactory.getLogger(ContextPropagationDebug.class);
+  private static final Logger logger = Logger.getLogger(ContextPropagationDebug.class.getName());
 
   // locations where the context was propagated to another thread (tracking multiple steps is
   // helpful in akka where there is so much recursive async spawning of new work)
@@ -71,10 +70,10 @@ public final class ContextPropagationDebug {
 
     Context current = Context.current();
     if (current != Context.root()) {
-      logger.error("Unexpected non-root current context found when extracting remote context!");
+      logger.severe("Unexpected non-root current context found when extracting remote context!");
       Span currentSpan = Span.fromContextOrNull(current);
       if (currentSpan != null) {
-        logger.error("It contains this span: {}", currentSpan);
+        logger.severe("It contains this span: " + currentSpan);
       }
 
       debugContextPropagation(current);
@@ -121,7 +120,7 @@ public final class ContextPropagationDebug {
           sb.append("\nwhich was propagated from:");
         }
       }
-      logger.error("a context leak was detected. it was propagated from:{}", sb);
+      logger.severe("a context leak was detected. it was propagated from: " + sb);
     }
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/ContextPropagationDebug.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/ContextPropagationDebug.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.internal;
 
+import static java.util.logging.Level.SEVERE;
+
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
@@ -73,7 +75,7 @@ public final class ContextPropagationDebug {
       logger.severe("Unexpected non-root current context found when extracting remote context!");
       Span currentSpan = Span.fromContextOrNull(current);
       if (currentSpan != null) {
-        logger.severe("It contains this span: " + currentSpan);
+        logger.log(SEVERE, "It contains this span: {0}", currentSpan);
       }
 
       debugContextPropagation(current);
@@ -120,7 +122,7 @@ public final class ContextPropagationDebug {
           sb.append("\nwhich was propagated from:");
         }
       }
-      logger.severe("a context leak was detected. it was propagated from: " + sb);
+      logger.log(SEVERE, "a context leak was detected. it was propagated from: {0}", sb);
     }
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
@@ -7,9 +7,8 @@ package io.opentelemetry.instrumentation.api.internal;
 
 import io.opentelemetry.instrumentation.api.cache.Cache;
 import io.opentelemetry.instrumentation.api.field.VirtualField;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -17,7 +16,8 @@ import org.slf4j.LoggerFactory;
  */
 public final class RuntimeVirtualFieldSupplier {
 
-  private static final Logger logger = LoggerFactory.getLogger(RuntimeVirtualFieldSupplier.class);
+  private static final Logger logger =
+      Logger.getLogger(RuntimeVirtualFieldSupplier.class.getName());
 
   /**
    * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -34,7 +34,7 @@ public final class RuntimeVirtualFieldSupplier {
   public static void set(VirtualFieldSupplier virtualFieldSupplier) {
     // only overwrite the default, cache-based supplier
     if (instance != DEFAULT) {
-      logger.warn(
+      logger.warning(
           "Runtime VirtualField supplier has already been set up, further set() calls are ignored");
       return;
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SupportabilityMetrics.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SupportabilityMetrics.java
@@ -13,15 +13,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
 public final class SupportabilityMetrics {
-  private static final Logger logger = LoggerFactory.getLogger(SupportabilityMetrics.class);
+  private static final Logger logger = Logger.getLogger(SupportabilityMetrics.class.getName());
   private final boolean agentDebugEnabled;
   private final Consumer<String> reporter;
 
@@ -29,7 +28,7 @@ public final class SupportabilityMetrics {
   private final ConcurrentMap<String, AtomicLong> counters = new ConcurrentHashMap<>();
 
   private static final SupportabilityMetrics INSTANCE =
-      new SupportabilityMetrics(Config.get(), logger::debug).start();
+      new SupportabilityMetrics(Config.get(), logger::fine).start();
 
   public static SupportabilityMetrics instance() {
     return INSTANCE;

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/log/LoggingContextConstants.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/log/LoggingContextConstants.java
@@ -10,8 +10,6 @@ import io.opentelemetry.api.trace.SpanContext;
 /**
  * This class contains several constants used in logging libraries' Mapped Diagnostic Context
  * instrumentations.
- *
- * @see org.slf4j.MDC
  */
 public final class LoggingContextConstants {
   /**

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/ActiveContextManager.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/ActiveContextManager.java
@@ -24,10 +24,10 @@
 package io.opentelemetry.javaagent.instrumentation.apachecamel;
 
 import static io.opentelemetry.javaagent.instrumentation.apachecamel.CamelSingletons.instrumenter;
+import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.camel.Exchange;
@@ -53,7 +53,7 @@ class ActiveContextManager {
     ContextWithScope parent = exchange.getProperty(ACTIVE_CONTEXT_PROPERTY, ContextWithScope.class);
     ContextWithScope contextWithScope = ContextWithScope.activate(parent, context, request);
     exchange.setProperty(ACTIVE_CONTEXT_PROPERTY, contextWithScope);
-    logger.log(Level.FINE, "Activated a span: {0}", contextWithScope);
+    logger.log(FINE, "Activated a span: {0}", contextWithScope);
   }
 
   /**
@@ -70,7 +70,7 @@ class ActiveContextManager {
     if (contextWithScope != null) {
       contextWithScope.deactivate(exchange.getException());
       exchange.setProperty(ACTIVE_CONTEXT_PROPERTY, contextWithScope.getParent());
-      logger.log(Level.FINE, "Deactivated span: {0}", contextWithScope);
+      logger.log(FINE, "Deactivated span: {0}", contextWithScope);
       return contextWithScope.context;
     }
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/ActiveContextManager.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/ActiveContextManager.java
@@ -53,9 +53,7 @@ class ActiveContextManager {
     ContextWithScope parent = exchange.getProperty(ACTIVE_CONTEXT_PROPERTY, ContextWithScope.class);
     ContextWithScope contextWithScope = ContextWithScope.activate(parent, context, request);
     exchange.setProperty(ACTIVE_CONTEXT_PROPERTY, contextWithScope);
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("Activated a span: " + contextWithScope);
-    }
+    logger.log(Level.FINE, "Activated a span: {0}", contextWithScope);
   }
 
   /**
@@ -72,9 +70,7 @@ class ActiveContextManager {
     if (contextWithScope != null) {
       contextWithScope.deactivate(exchange.getException());
       exchange.setProperty(ACTIVE_CONTEXT_PROPERTY, contextWithScope.getParent());
-      if (logger.isLoggable(Level.FINE)) {
-        logger.fine("Deactivated span: " + contextWithScope);
-      }
+      logger.log(Level.FINE, "Deactivated span: {0}", contextWithScope);
       return contextWithScope.context;
     }
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/ActiveContextManager.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/ActiveContextManager.java
@@ -27,17 +27,17 @@ import static io.opentelemetry.javaagent.instrumentation.apachecamel.CamelSingle
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.camel.Exchange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Utility class for managing active contexts as a stack associated with an exchange. */
 class ActiveContextManager {
 
   private static final String ACTIVE_CONTEXT_PROPERTY = "OpenTelemetry.activeContext";
 
-  private static final Logger logger = LoggerFactory.getLogger(ActiveContextManager.class);
+  private static final Logger logger = Logger.getLogger(ActiveContextManager.class.getName());
 
   private ActiveContextManager() {}
 
@@ -53,7 +53,9 @@ class ActiveContextManager {
     ContextWithScope parent = exchange.getProperty(ACTIVE_CONTEXT_PROPERTY, ContextWithScope.class);
     ContextWithScope contextWithScope = ContextWithScope.activate(parent, context, request);
     exchange.setProperty(ACTIVE_CONTEXT_PROPERTY, contextWithScope);
-    logger.debug("Activated a span: {}", contextWithScope);
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("Activated a span: " + contextWithScope);
+    }
   }
 
   /**
@@ -70,7 +72,9 @@ class ActiveContextManager {
     if (contextWithScope != null) {
       contextWithScope.deactivate(exchange.getException());
       exchange.setProperty(ACTIVE_CONTEXT_PROPERTY, contextWithScope.getParent());
-      logger.debug("Deactivated span: {}", contextWithScope);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.fine("Deactivated span: " + contextWithScope);
+      }
       return contextWithScope.context;
     }
 

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelEventNotifier.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelEventNotifier.java
@@ -28,15 +28,15 @@ import static io.opentelemetry.javaagent.instrumentation.apachecamel.CamelSingle
 
 import io.opentelemetry.context.Context;
 import java.util.EventObject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.camel.management.event.ExchangeSendingEvent;
 import org.apache.camel.management.event.ExchangeSentEvent;
 import org.apache.camel.support.EventNotifierSupport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class CamelEventNotifier extends EventNotifierSupport {
 
-  private static final Logger logger = LoggerFactory.getLogger(CamelEventNotifier.class);
+  private static final Logger logger = Logger.getLogger(CamelEventNotifier.class.getName());
 
   @Override
   public void notify(EventObject event) {
@@ -66,7 +66,9 @@ final class CamelEventNotifier extends EventNotifierSupport {
     ActiveContextManager.activate(context, request);
     CamelPropagationUtil.injectParent(context, ese.getExchange().getIn().getHeaders());
 
-    logger.debug("[Exchange sending] Initiator span started: {}", context);
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("[Exchange sending] Initiator span started: " + context);
+    }
   }
 
   private static Context startOnExchangeSending(CamelRequest request) {
@@ -85,7 +87,9 @@ final class CamelEventNotifier extends EventNotifierSupport {
     }
 
     Context context = ActiveContextManager.deactivate(event.getExchange());
-    logger.debug("[Exchange sent] Initiator span finished: {}", context);
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("[Exchange sent] Initiator span finished: " + context);
+    }
   }
 
   @Override

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelEventNotifier.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelEventNotifier.java
@@ -25,10 +25,10 @@ package io.opentelemetry.javaagent.instrumentation.apachecamel;
 
 import static io.opentelemetry.javaagent.instrumentation.apachecamel.CamelSingletons.getSpanDecorator;
 import static io.opentelemetry.javaagent.instrumentation.apachecamel.CamelSingletons.instrumenter;
+import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.context.Context;
 import java.util.EventObject;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.camel.management.event.ExchangeSendingEvent;
 import org.apache.camel.management.event.ExchangeSentEvent;
@@ -66,7 +66,7 @@ final class CamelEventNotifier extends EventNotifierSupport {
     ActiveContextManager.activate(context, request);
     CamelPropagationUtil.injectParent(context, ese.getExchange().getIn().getHeaders());
 
-    logger.log(Level.FINE, "[Exchange sending] Initiator span started: {0}", context);
+    logger.log(FINE, "[Exchange sending] Initiator span started: {0}", context);
   }
 
   private static Context startOnExchangeSending(CamelRequest request) {
@@ -85,7 +85,7 @@ final class CamelEventNotifier extends EventNotifierSupport {
     }
 
     Context context = ActiveContextManager.deactivate(event.getExchange());
-    logger.log(Level.FINE, "[Exchange sent] Initiator span finished: {0}", context);
+    logger.log(FINE, "[Exchange sent] Initiator span finished: {0}", context);
   }
 
   @Override

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelEventNotifier.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelEventNotifier.java
@@ -66,9 +66,7 @@ final class CamelEventNotifier extends EventNotifierSupport {
     ActiveContextManager.activate(context, request);
     CamelPropagationUtil.injectParent(context, ese.getExchange().getIn().getHeaders());
 
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("[Exchange sending] Initiator span started: " + context);
-    }
+    logger.log(Level.FINE, "[Exchange sending] Initiator span started: {0}", context);
   }
 
   private static Context startOnExchangeSending(CamelRequest request) {
@@ -87,9 +85,7 @@ final class CamelEventNotifier extends EventNotifierSupport {
     }
 
     Context context = ActiveContextManager.deactivate(event.getExchange());
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("[Exchange sent] Initiator span finished: " + context);
-    }
+    logger.log(Level.FINE, "[Exchange sent] Initiator span finished: {0}", context);
   }
 
   @Override

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelRoutePolicy.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelRoutePolicy.java
@@ -74,17 +74,13 @@ final class CamelRoutePolicy extends RoutePolicySupport {
     SpanDecorator sd = getSpanDecorator(route.getEndpoint());
     Context parentContext = Context.current();
     Context context = spanOnExchangeBegin(route, exchange, sd, parentContext);
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("[Route start] Receiver span started " + context);
-    }
+    logger.log(Level.FINE, "[Route start] Receiver span started {0}", context);
   }
 
   /** Route exchange done. Get active CAMEL span, finish, remove from CAMEL holder. */
   @Override
   public void onExchangeDone(Route route, Exchange exchange) {
     Context context = ActiveContextManager.deactivate(exchange);
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("[Route finished] Receiver span finished " + context);
-    }
+    logger.log(Level.FINE, "[Route finished] Receiver span finished {0}", context);
   }
 }

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelRoutePolicy.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelRoutePolicy.java
@@ -25,11 +25,11 @@ package io.opentelemetry.javaagent.instrumentation.apachecamel;
 
 import static io.opentelemetry.javaagent.instrumentation.apachecamel.CamelSingletons.getSpanDecorator;
 import static io.opentelemetry.javaagent.instrumentation.apachecamel.CamelSingletons.instrumenter;
+import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.camel.Exchange;
 import org.apache.camel.Route;
@@ -74,13 +74,13 @@ final class CamelRoutePolicy extends RoutePolicySupport {
     SpanDecorator sd = getSpanDecorator(route.getEndpoint());
     Context parentContext = Context.current();
     Context context = spanOnExchangeBegin(route, exchange, sd, parentContext);
-    logger.log(Level.FINE, "[Route start] Receiver span started {0}", context);
+    logger.log(FINE, "[Route start] Receiver span started {0}", context);
   }
 
   /** Route exchange done. Get active CAMEL span, finish, remove from CAMEL holder. */
   @Override
   public void onExchangeDone(Route route, Exchange exchange) {
     Context context = ActiveContextManager.deactivate(exchange);
-    logger.log(Level.FINE, "[Route finished] Receiver span finished {0}", context);
+    logger.log(FINE, "[Route finished] Receiver span finished {0}", context);
   }
 }

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelRoutePolicy.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelRoutePolicy.java
@@ -29,15 +29,15 @@ import static io.opentelemetry.javaagent.instrumentation.apachecamel.CamelSingle
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.camel.Exchange;
 import org.apache.camel.Route;
 import org.apache.camel.support.RoutePolicySupport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class CamelRoutePolicy extends RoutePolicySupport {
 
-  private static final Logger logger = LoggerFactory.getLogger(CamelRoutePolicy.class);
+  private static final Logger logger = Logger.getLogger(CamelRoutePolicy.class.getName());
 
   private static Context spanOnExchangeBegin(
       Route route, Exchange exchange, SpanDecorator sd, Context parentContext) {
@@ -74,13 +74,17 @@ final class CamelRoutePolicy extends RoutePolicySupport {
     SpanDecorator sd = getSpanDecorator(route.getEndpoint());
     Context parentContext = Context.current();
     Context context = spanOnExchangeBegin(route, exchange, sd, parentContext);
-    logger.debug("[Route start] Receiver span started {}", context);
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("[Route start] Receiver span started " + context);
+    }
   }
 
   /** Route exchange done. Get active CAMEL span, finish, remove from CAMEL holder. */
   @Override
   public void onExchangeDone(Route route, Exchange exchange) {
     Context context = ActiveContextManager.deactivate(exchange);
-    logger.debug("[Route finished] Receiver span finished {}", context);
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("[Route finished] Receiver span finished " + context);
+    }
   }
 }

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/RestSpanDecorator.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/RestSpanDecorator.java
@@ -23,9 +23,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel.decorators;
 
+import static java.util.logging.Level.FINE;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
@@ -52,7 +53,7 @@ class RestSpanDecorator extends HttpSpanDecorator {
         try {
           path = URLDecoder.decode(path, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-          logger.log(Level.FINE, "Failed to decode URL path '" + path + "', ignoring exception", e);
+          logger.log(FINE, "Failed to decode URL path '" + path + "', ignoring exception", e);
         }
       }
     }

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/RestSpanDecorator.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/RestSpanDecorator.java
@@ -25,14 +25,14 @@ package io.opentelemetry.javaagent.instrumentation.apachecamel.decorators;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class RestSpanDecorator extends HttpSpanDecorator {
 
-  private static final Logger logger = LoggerFactory.getLogger(RestSpanDecorator.class);
+  private static final Logger logger = Logger.getLogger(RestSpanDecorator.class.getName());
 
   @Override
   protected String getPath(Exchange exchange, Endpoint endpoint) {
@@ -52,7 +52,7 @@ class RestSpanDecorator extends HttpSpanDecorator {
         try {
           path = URLDecoder.decode(path, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-          logger.debug("Failed to decode URL path '{}', ignoring exception", path, e);
+          logger.log(Level.FINE, "Failed to decode URL path '" + path + "', ignoring exception", e);
         }
       }
     }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -19,6 +19,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import java.io.IOException;
+import java.util.logging.Logger;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -32,8 +33,6 @@ import org.apache.http.nio.IOControl;
 import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpCoreContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation {
 
@@ -146,7 +145,7 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
 
   public static class WrappedFutureCallback<T> implements FutureCallback<T> {
 
-    private static final Logger logger = LoggerFactory.getLogger(WrappedFutureCallback.class);
+    private static final Logger logger = Logger.getLogger(WrappedFutureCallback.class.getName());
 
     private final Context parentContext;
     private final HttpContext httpContext;
@@ -167,7 +166,7 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
     public void completed(T result) {
       if (context == null) {
         // this is unexpected
-        logger.debug("context was never set");
+        logger.fine("context was never set");
         completeDelegate(result);
         return;
       }
@@ -188,7 +187,7 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
     public void failed(Exception ex) {
       if (context == null) {
         // this is unexpected
-        logger.debug("context was never set");
+        logger.fine("context was never set");
         failDelegate(ex);
         return;
       }
@@ -210,7 +209,7 @@ public class ApacheHttpAsyncClientInstrumentation implements TypeInstrumentation
     public void cancelled() {
       if (context == null) {
         // this is unexpected
-        logger.debug("context was never set");
+        logger.fine("context was never set");
         cancelDelegate();
         return;
       }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
@@ -11,17 +11,17 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.ProtocolVersion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class ApacheHttpClientRequest {
 
-  private static final Logger logger = LoggerFactory.getLogger(ApacheHttpClientRequest.class);
+  private static final Logger logger = Logger.getLogger(ApacheHttpClientRequest.class.getName());
 
   @Nullable private final URI uri;
 
@@ -82,7 +82,9 @@ public final class ApacheHttpClientRequest {
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    logger.debug("unexpected http protocol version: " + protocolVersion);
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("unexpected http protocol version: " + protocolVersion);
+    }
     return null;
   }
 
@@ -104,7 +106,9 @@ public final class ApacheHttpClientRequest {
       case "https":
         return 443;
       default:
-        logger.debug("no default port mapping for scheme: {}", uri.getScheme());
+        if (logger.isLoggable(Level.FINE)) {
+          logger.fine("no default port mapping for scheme: " + uri.getScheme());
+        }
         return null;
     }
   }
@@ -115,7 +119,7 @@ public final class ApacheHttpClientRequest {
       // this can be relative or absolute
       return new URI(httpRequest.getRequestLine().getUri());
     } catch (URISyntaxException e) {
-      logger.debug(e.getMessage(), e);
+      logger.log(Level.FINE, e.getMessage(), e);
       return null;
     }
   }
@@ -138,7 +142,7 @@ public final class ApacheHttpClientRequest {
           uri.getQuery(),
           uri.getFragment());
     } catch (URISyntaxException e) {
-      logger.debug(e.getMessage(), e);
+      logger.log(Level.FINE, e.getMessage(), e);
       return null;
     }
   }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
@@ -5,13 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.http.Header;
@@ -82,7 +83,7 @@ public final class ApacheHttpClientRequest {
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    logger.log(Level.FINE, "unexpected http protocol version: {0}", protocolVersion);
+    logger.log(FINE, "unexpected http protocol version: {0}", protocolVersion);
     return null;
   }
 
@@ -104,7 +105,7 @@ public final class ApacheHttpClientRequest {
       case "https":
         return 443;
       default:
-        logger.log(Level.FINE, "no default port mapping for scheme: {0}", uri.getScheme());
+        logger.log(FINE, "no default port mapping for scheme: {0}", uri.getScheme());
         return null;
     }
   }
@@ -115,7 +116,7 @@ public final class ApacheHttpClientRequest {
       // this can be relative or absolute
       return new URI(httpRequest.getRequestLine().getUri());
     } catch (URISyntaxException e) {
-      logger.log(Level.FINE, e.getMessage(), e);
+      logger.log(FINE, e.getMessage(), e);
       return null;
     }
   }
@@ -138,7 +139,7 @@ public final class ApacheHttpClientRequest {
           uri.getQuery(),
           uri.getFragment());
     } catch (URISyntaxException e) {
-      logger.log(Level.FINE, e.getMessage(), e);
+      logger.log(FINE, e.getMessage(), e);
       return null;
     }
   }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
@@ -82,9 +82,7 @@ public final class ApacheHttpClientRequest {
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("unexpected http protocol version: " + protocolVersion);
-    }
+    logger.log(Level.FINE, "unexpected http protocol version: {0}", protocolVersion);
     return null;
   }
 
@@ -106,9 +104,7 @@ public final class ApacheHttpClientRequest {
       case "https":
         return 443;
       default:
-        if (logger.isLoggable(Level.FINE)) {
-          logger.fine("no default port mapping for scheme: " + uri.getScheme());
-        }
+        logger.log(Level.FINE, "no default port mapping for scheme: {0}", uri.getScheme());
         return null;
     }
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
@@ -88,9 +88,7 @@ public final class ApacheHttpClientRequest {
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("unexpected http protocol version: " + protocolVersion);
-    }
+    logger.log(Level.FINE, "unexpected http protocol version: {0}", protocolVersion);
     return null;
   }
 
@@ -112,9 +110,7 @@ public final class ApacheHttpClientRequest {
       case "https":
         return 443;
       default:
-        if (logger.isLoggable(Level.FINE)) {
-          logger.fine("no default port mapping for scheme: " + uri.getScheme());
-        }
+        logger.log(Level.FINE, "no default port mapping for scheme: {0}", uri.getScheme());
         return null;
     }
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
@@ -5,13 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v4_0;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.http.Header;
@@ -88,7 +89,7 @@ public final class ApacheHttpClientRequest {
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    logger.log(Level.FINE, "unexpected http protocol version: {0}", protocolVersion);
+    logger.log(FINE, "unexpected http protocol version: {0}", protocolVersion);
     return null;
   }
 
@@ -110,7 +111,7 @@ public final class ApacheHttpClientRequest {
       case "https":
         return 443;
       default:
-        logger.log(Level.FINE, "no default port mapping for scheme: {0}", uri.getScheme());
+        logger.log(FINE, "no default port mapping for scheme: {0}", uri.getScheme());
         return null;
     }
   }
@@ -121,7 +122,7 @@ public final class ApacheHttpClientRequest {
       // this can be relative or absolute
       return new URI(httpRequest.getRequestLine().getUri());
     } catch (URISyntaxException e) {
-      logger.log(Level.FINE, e.getMessage(), e);
+      logger.log(FINE, e.getMessage(), e);
       return null;
     }
   }
@@ -138,7 +139,7 @@ public final class ApacheHttpClientRequest {
           uri.getQuery(),
           uri.getFragment());
     } catch (URISyntaxException e) {
-      logger.log(Level.FINE, e.getMessage(), e);
+      logger.log(FINE, e.getMessage(), e);
       return null;
     }
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
@@ -11,18 +11,18 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class ApacheHttpClientRequest {
 
-  private static final Logger logger = LoggerFactory.getLogger(ApacheHttpClientRequest.class);
+  private static final Logger logger = Logger.getLogger(ApacheHttpClientRequest.class.getName());
 
   @Nullable private final URI uri;
 
@@ -88,7 +88,9 @@ public final class ApacheHttpClientRequest {
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    logger.debug("unexpected http protocol version: " + protocolVersion);
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("unexpected http protocol version: " + protocolVersion);
+    }
     return null;
   }
 
@@ -110,7 +112,9 @@ public final class ApacheHttpClientRequest {
       case "https":
         return 443;
       default:
-        logger.debug("no default port mapping for scheme: {}", uri.getScheme());
+        if (logger.isLoggable(Level.FINE)) {
+          logger.fine("no default port mapping for scheme: " + uri.getScheme());
+        }
         return null;
     }
   }
@@ -121,7 +125,7 @@ public final class ApacheHttpClientRequest {
       // this can be relative or absolute
       return new URI(httpRequest.getRequestLine().getUri());
     } catch (URISyntaxException e) {
-      logger.debug(e.getMessage(), e);
+      logger.log(Level.FINE, e.getMessage(), e);
       return null;
     }
   }
@@ -138,7 +142,7 @@ public final class ApacheHttpClientRequest {
           uri.getQuery(),
           uri.getFragment());
     } catch (URISyntaxException e) {
-      logger.debug(e.getMessage(), e);
+      logger.log(Level.FINE, e.getMessage(), e);
       return null;
     }
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
 dependencies {
   library("org.apache.httpcomponents:httpclient:4.3")
 
-  implementation("org.slf4j:slf4j-api")
-
   testImplementation(project(":instrumentation:apache-httpclient:apache-httpclient-4.3:testing"))
 
   latestDepTestLibrary("org.apache.httpcomponents:httpclient:4.+") // see apache-httpclient-5.0 module

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
@@ -89,9 +89,7 @@ public final class ApacheHttpClientRequest {
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("unexpected http protocol version: " + protocolVersion);
-    }
+    logger.log(Level.FINE, "unexpected http protocol version: {0}", protocolVersion);
     return null;
   }
 
@@ -115,9 +113,7 @@ public final class ApacheHttpClientRequest {
       case "https":
         return 443;
       default:
-        if (logger.isLoggable(Level.FINE)) {
-          logger.fine("no default port mapping for scheme: " + uri.getScheme());
-        }
+        logger.log(Level.FINE, "no default port mapping for scheme: {0}", uri.getScheme());
         return null;
     }
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
@@ -11,17 +11,17 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.ProtocolVersion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class ApacheHttpClientRequest {
 
-  private static final Logger logger = LoggerFactory.getLogger(ApacheHttpClientRequest.class);
+  private static final Logger logger = Logger.getLogger(ApacheHttpClientRequest.class.getName());
 
   @Nullable private final URI uri;
 
@@ -89,7 +89,9 @@ public final class ApacheHttpClientRequest {
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    logger.debug("unexpected http protocol version: {}", protocolVersion);
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("unexpected http protocol version: " + protocolVersion);
+    }
     return null;
   }
 
@@ -113,7 +115,9 @@ public final class ApacheHttpClientRequest {
       case "https":
         return 443;
       default:
-        logger.debug("no default port mapping for scheme: {}", uri.getScheme());
+        if (logger.isLoggable(Level.FINE)) {
+          logger.fine("no default port mapping for scheme: " + uri.getScheme());
+        }
         return null;
     }
   }
@@ -124,7 +128,7 @@ public final class ApacheHttpClientRequest {
       // this can be relative or absolute
       return new URI(httpRequest.getRequestLine().getUri());
     } catch (URISyntaxException e) {
-      logger.debug(e.getMessage(), e);
+      logger.log(Level.FINE, e.getMessage(), e);
       return null;
     }
   }
@@ -141,7 +145,7 @@ public final class ApacheHttpClientRequest {
           uri.getQuery(),
           uri.getFragment());
     } catch (URISyntaxException e) {
-      logger.debug(e.getMessage(), e);
+      logger.log(Level.FINE, e.getMessage(), e);
       return null;
     }
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
@@ -5,13 +5,14 @@
 
 package io.opentelemetry.instrumentation.apachehttpclient.v4_3;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.http.Header;
@@ -89,7 +90,7 @@ public final class ApacheHttpClientRequest {
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    logger.log(Level.FINE, "unexpected http protocol version: {0}", protocolVersion);
+    logger.log(FINE, "unexpected http protocol version: {0}", protocolVersion);
     return null;
   }
 
@@ -113,7 +114,7 @@ public final class ApacheHttpClientRequest {
       case "https":
         return 443;
       default:
-        logger.log(Level.FINE, "no default port mapping for scheme: {0}", uri.getScheme());
+        logger.log(FINE, "no default port mapping for scheme: {0}", uri.getScheme());
         return null;
     }
   }
@@ -124,7 +125,7 @@ public final class ApacheHttpClientRequest {
       // this can be relative or absolute
       return new URI(httpRequest.getRequestLine().getUri());
     } catch (URISyntaxException e) {
-      logger.log(Level.FINE, e.getMessage(), e);
+      logger.log(FINE, e.getMessage(), e);
       return null;
     }
   }
@@ -141,7 +142,7 @@ public final class ApacheHttpClientRequest {
           uri.getQuery(),
           uri.getFragment());
     } catch (URISyntaxException e) {
-      logger.log(Level.FINE, e.getMessage(), e);
+      logger.log(FINE, e.getMessage(), e);
       return null;
     }
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
@@ -10,20 +10,20 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.net.URIAuthority;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class ApacheHttpClientHttpAttributesGetter
     implements HttpClientAttributesGetter<ClassicHttpRequest, HttpResponse> {
 
   private static final Logger logger =
-      LoggerFactory.getLogger(ApacheHttpClientHttpAttributesGetter.class);
+      Logger.getLogger(ApacheHttpClientHttpAttributesGetter.class.getName());
 
   @Override
   public String method(ClassicHttpRequest request) {
@@ -108,7 +108,9 @@ final class ApacheHttpClientHttpAttributesGetter
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    logger.debug("unexpected http protocol version: " + protocolVersion);
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("unexpected http protocol version: " + protocolVersion);
+    }
     return null;
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
@@ -108,9 +108,7 @@ final class ApacheHttpClientHttpAttributesGetter
     if (major == 2 && minor == 0) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("unexpected http protocol version: " + protocolVersion);
-    }
+    logger.log(Level.FINE, "unexpected http protocol version: {0}", protocolVersion);
     return null;
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v5_0;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -46,7 +47,7 @@ final class ApacheHttpClientNetAttributesGetter
       case "https":
         return 443;
       default:
-        logger.log(Level.FINE, "no default port mapping for scheme: {0}", scheme);
+        logger.log(FINE, "no default port mapping for scheme: {0}", scheme);
         return null;
     }
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
@@ -7,17 +7,17 @@ package io.opentelemetry.javaagent.instrumentation.apachehttpclient.v5_0;
 
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class ApacheHttpClientNetAttributesGetter
     implements NetClientAttributesGetter<ClassicHttpRequest, HttpResponse> {
 
   private static final Logger logger =
-      LoggerFactory.getLogger(ApacheHttpClientNetAttributesGetter.class);
+      Logger.getLogger(ApacheHttpClientNetAttributesGetter.class.getName());
 
   @Override
   public String transport(ClassicHttpRequest request, @Nullable HttpResponse response) {
@@ -46,7 +46,9 @@ final class ApacheHttpClientNetAttributesGetter
       case "https":
         return 443;
       default:
-        logger.debug("no default port mapping for scheme: {}", scheme);
+        if (logger.isLoggable(Level.FINE)) {
+          logger.fine("no default port mapping for scheme: " + scheme);
+        }
         return null;
     }
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
@@ -46,9 +46,7 @@ final class ApacheHttpClientNetAttributesGetter
       case "https":
         return 443;
       default:
-        if (logger.isLoggable(Level.FINE)) {
-          logger.fine("no default port mapping for scheme: " + scheme);
-        }
+        logger.log(Level.FINE, "no default port mapping for scheme: {0}", scheme);
         return null;
     }
   }

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/ApiGatewayProxyRequest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/ApiGatewayProxyRequest.java
@@ -13,9 +13,8 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -23,7 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ApiGatewayProxyRequest {
 
-  private static final Logger logger = LoggerFactory.getLogger(ApiGatewayProxyRequest.class);
+  private static final Logger logger = Logger.getLogger(ApiGatewayProxyRequest.class.getName());
 
   // TODO(anuraaga): We should create a RequestFactory type of class instead of evaluating this
   // for every request.
@@ -51,10 +50,10 @@ public abstract class ApiGatewayProxyRequest {
     // It is known that the Lambda runtime passes ByteArrayInputStream's to functions, so gracefully
     // handle this without propagating and revisit if getting user reports that expectations
     // changed.
-    logger.warn(
+    logger.warning(
         "HTTP propagation enabled but could not extract HTTP headers. "
-            + "This is a bug in the OpenTelemetry AWS Lambda instrumentation. Type of request stream {}",
-        source.getClass());
+            + "This is a bug in the OpenTelemetry AWS Lambda instrumentation. Type of request stream "
+            + source.getClass());
     return new NoopRequest(source);
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/ApiGatewayProxyRequest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/ApiGatewayProxyRequest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awslambdacore.v1_0.internal;
 
 import static io.opentelemetry.instrumentation.awslambdacore.v1_0.internal.HeadersFactory.ofStream;
+import static java.util.logging.Level.WARNING;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import java.io.IOException;
@@ -50,10 +51,12 @@ public abstract class ApiGatewayProxyRequest {
     // It is known that the Lambda runtime passes ByteArrayInputStream's to functions, so gracefully
     // handle this without propagating and revisit if getting user reports that expectations
     // changed.
-    logger.warning(
-        "HTTP propagation enabled but could not extract HTTP headers. "
-            + "This is a bug in the OpenTelemetry AWS Lambda instrumentation. Type of request stream "
-            + source.getClass());
+    logger.log(
+        WARNING,
+        "HTTP propagation enabled but could not extract HTTP headers."
+            + " This is a bug in the OpenTelemetry AWS Lambda instrumentation."
+            + " Type of request stream {0}",
+        source.getClass());
     return new NoopRequest(source);
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/HeadersFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/HeadersFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.awslambdacore.v1_0.internal;
 
+import static java.util.logging.Level.FINE;
+
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -12,7 +14,6 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 final class HeadersFactory {
@@ -51,7 +52,7 @@ final class HeadersFactory {
         return headers;
       }
     } catch (Exception e) {
-      logger.log(Level.FINE, "Could not get headers from request", e);
+      logger.log(FINE, "Could not get headers from request", e);
     }
     return Collections.emptyMap();
   }

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/HeadersFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/HeadersFactory.java
@@ -12,12 +12,12 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 final class HeadersFactory {
 
-  private static final Logger logger = LoggerFactory.getLogger(HeadersFactory.class);
+  private static final Logger logger = Logger.getLogger(HeadersFactory.class.getName());
 
   private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
@@ -26,7 +26,7 @@ final class HeadersFactory {
       parser.nextToken();
 
       if (!parser.isExpectedStartObjectToken()) {
-        logger.debug("Not a JSON object");
+        logger.fine("Not a JSON object");
         return Collections.emptyMap();
       }
       while (parser.nextToken() != JsonToken.END_OBJECT) {
@@ -37,7 +37,7 @@ final class HeadersFactory {
         }
 
         if (!parser.isExpectedStartObjectToken()) {
-          logger.debug("Invalid JSON for HTTP headers");
+          logger.fine("Invalid JSON for HTTP headers");
           return Collections.emptyMap();
         }
 
@@ -51,7 +51,7 @@ final class HeadersFactory {
         return headers;
       }
     } catch (Exception e) {
-      logger.debug("Could not get headers from request, ", e);
+      logger.log(Level.FINE, "Could not get headers from request", e);
     }
     return Collections.emptyMap();
   }

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.javaconcurrent;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
 import static java.util.Collections.emptyList;
+import static java.util.logging.Level.FINE;
 import static net.bytebuddy.matcher.ElementMatchers.any;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
@@ -18,7 +19,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -132,8 +132,7 @@ public abstract class AbstractExecutorInstrumentation implements TypeInstrumenta
                   }
 
                   if (!allowed && hasExecutorInterfaceMatcher.matches(target)) {
-                    logger.log(
-                        Level.FINE, "Skipping executor instrumentation for {0}", target.getName());
+                    logger.log(FINE, "Skipping executor instrumentation for {0}", target.getName());
                   }
                   return allowed;
                 }

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
@@ -131,10 +131,9 @@ public abstract class AbstractExecutorInstrumentation implements TypeInstrumenta
                     }
                   }
 
-                  if (!allowed
-                      && logger.isLoggable(Level.FINE)
-                      && hasExecutorInterfaceMatcher.matches(target)) {
-                    logger.fine("Skipping executor instrumentation for " + target.getName());
+                  if (!allowed && hasExecutorInterfaceMatcher.matches(target)) {
+                    logger.log(
+                        Level.FINE, "Skipping executor instrumentation for {0}", target.getName());
                   }
                   return allowed;
                 }

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
@@ -18,14 +18,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class AbstractExecutorInstrumentation implements TypeInstrumentation {
   private static final Logger logger =
-      LoggerFactory.getLogger(AbstractExecutorInstrumentation.class);
+      Logger.getLogger(AbstractExecutorInstrumentation.class.getName());
 
   private static final String EXECUTORS_INCLUDE_PROPERTY_NAME =
       "otel.instrumentation.executors.include";
@@ -132,9 +132,9 @@ public abstract class AbstractExecutorInstrumentation implements TypeInstrumenta
                   }
 
                   if (!allowed
-                      && logger.isDebugEnabled()
+                      && logger.isLoggable(Level.FINE)
                       && hasExecutorInterfaceMatcher.matches(target)) {
-                    logger.debug("Skipping executor instrumentation for {}", target.getName());
+                    logger.fine("Skipping executor instrumentation for " + target.getName());
                   }
                   return allowed;
                 }

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
@@ -19,14 +19,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class FutureInstrumentation implements TypeInstrumentation {
-  private static final Logger logger = LoggerFactory.getLogger(FutureInstrumentation.class);
+  private static final Logger logger = Logger.getLogger(FutureInstrumentation.class.getName());
 
   /**
    * Only apply executor instrumentation to allowed executors. In the future, this restriction may
@@ -79,8 +79,10 @@ public class FutureInstrumentation implements TypeInstrumentation {
       @Override
       public boolean matches(TypeDescription target) {
         boolean allowed = ALLOWED_FUTURES.contains(target.getName());
-        if (!allowed && logger.isDebugEnabled() && hasFutureInterfaceMatcher.matches(target)) {
-          logger.debug("Skipping future instrumentation for {}", target.getName());
+        if (!allowed
+            && logger.isLoggable(Level.FINE)
+            && hasFutureInterfaceMatcher.matches(target)) {
+          logger.fine("Skipping future instrumentation for " + target.getName());
         }
         return allowed;
       }

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.javaconcurrent;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
+import static java.util.logging.Level.FINE;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 
@@ -19,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.Future;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -80,7 +80,7 @@ public class FutureInstrumentation implements TypeInstrumentation {
       public boolean matches(TypeDescription target) {
         boolean allowed = ALLOWED_FUTURES.contains(target.getName());
         if (!allowed && hasFutureInterfaceMatcher.matches(target)) {
-          logger.log(Level.FINE, "Skipping future instrumentation for {0}", target.getName());
+          logger.log(FINE, "Skipping future instrumentation for {0}", target.getName());
         }
         return allowed;
       }

--- a/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
+++ b/instrumentation/executors/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/FutureInstrumentation.java
@@ -79,10 +79,8 @@ public class FutureInstrumentation implements TypeInstrumentation {
       @Override
       public boolean matches(TypeDescription target) {
         boolean allowed = ALLOWED_FUTURES.contains(target.getName());
-        if (!allowed
-            && logger.isLoggable(Level.FINE)
-            && hasFutureInterfaceMatcher.matches(target)) {
-          logger.fine("Skipping future instrumentation for " + target.getName());
+        if (!allowed && hasFutureInterfaceMatcher.matches(target)) {
+          logger.log(Level.FINE, "Skipping future instrumentation for {0}", target.getName());
         }
         return allowed;
       }

--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/ExternalAnnotationInstrumentation.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/ExternalAnnotationInstrumentation.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.ByteCodeElement;
@@ -116,10 +117,10 @@ public class ExternalAnnotationInstrumentation implements TypeInstrumentation {
     } else if (configString.isEmpty()) {
       return Collections.emptySet();
     } else if (!configString.matches(CONFIG_FORMAT)) {
-      logger.warning(
-          "Invalid trace annotations config '"
-              + configString
-              + "'. Must match 'package.Annotation$Name;*'.");
+      logger.log(
+          Level.WARNING,
+          "Invalid trace annotations config '{0}'. Must match 'package.Annotation$Name;*'.",
+          configString);
       return Collections.emptySet();
     } else {
       Set<String> annotations = new HashSet<>();

--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/ExternalAnnotationInstrumentation.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/ExternalAnnotationInstrumentation.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.ByteCodeElement;
 import net.bytebuddy.description.NamedElement;
@@ -36,13 +37,11 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ExternalAnnotationInstrumentation implements TypeInstrumentation {
 
   private static final Logger logger =
-      LoggerFactory.getLogger(ExternalAnnotationInstrumentationModule.class);
+      Logger.getLogger(ExternalAnnotationInstrumentationModule.class.getName());
 
   private static final String PACKAGE_CLASS_NAME_REGEX = "[\\w.$]+";
 
@@ -117,9 +116,10 @@ public class ExternalAnnotationInstrumentation implements TypeInstrumentation {
     } else if (configString.isEmpty()) {
       return Collections.emptySet();
     } else if (!configString.matches(CONFIG_FORMAT)) {
-      logger.warn(
-          "Invalid trace annotations config '{}'. Must match 'package.Annotation$Name;*'.",
-          configString);
+      logger.warning(
+          "Invalid trace annotations config '"
+              + configString
+              + "'. Must match 'package.Annotation$Name;*'.");
       return Collections.emptySet();
     } else {
       Set<String> annotations = new HashSet<>();

--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/ExternalAnnotationInstrumentation.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/ExternalAnnotationInstrumentation.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.extannotations;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType;
 import static io.opentelemetry.javaagent.instrumentation.extannotations.ExternalAnnotationSingletons.instrumenter;
+import static java.util.logging.Level.WARNING;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
@@ -29,7 +30,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.ByteCodeElement;
@@ -118,7 +118,7 @@ public class ExternalAnnotationInstrumentation implements TypeInstrumentation {
       return Collections.emptySet();
     } else if (!configString.matches(CONFIG_FORMAT)) {
       logger.log(
-          Level.WARNING,
+          WARNING,
           "Invalid trace annotations config '{0}'. Must match 'package.Annotation$Name;*'.",
           configString);
       return Collections.emptySet();

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/ContextStorageBridge.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/ContextStorageBridge.java
@@ -5,10 +5,11 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6.internal;
 
+import static java.util.logging.Level.SEVERE;
+
 import io.grpc.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.Scope;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -71,9 +72,7 @@ public final class ContextStorageBridge extends Context.Storage {
     Scope scope = OTEL_SCOPE.get(toRestore);
     if (scope == null) {
       logger.log(
-          Level.SEVERE,
-          "Detaching context which was not attached.",
-          new Throwable().fillInStackTrace());
+          SEVERE, "Detaching context which was not attached.", new Throwable().fillInStackTrace());
     } else {
       scope.close();
     }

--- a/instrumentation/internal/internal-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/BootDelegationInstrumentation.java
+++ b/instrumentation/internal/internal-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/BootDelegationInstrumentation.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.internal.classloader;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.extendsClass;
+import static java.util.logging.Level.WARNING;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isProtected;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -25,10 +26,10 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.List;
+import java.util.logging.Logger;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.slf4j.LoggerFactory;
 
 /**
  * Some class loaders do not delegate to their parent, so classes in those class loaders will not be
@@ -89,8 +90,8 @@ public class BootDelegationInstrumentation implements TypeInstrumentation {
         //noinspection unchecked
         return (List<String>) methodHandle.invokeExact();
       } catch (Throwable e) {
-        LoggerFactory.getLogger(Holder.class)
-            .warn("Unable to load bootstrap package prefixes from the bootstrap CL", e);
+        Logger.getLogger(Holder.class.getName())
+            .log(WARNING, "Unable to load bootstrap package prefixes from the bootstrap CL", e);
         return Constants.BOOTSTRAP_PACKAGE_PREFIXES;
       }
     }

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesGetter.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesGetter.java
@@ -9,14 +9,14 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributes
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class JdkHttpNetAttributesGetter
     implements NetClientAttributesGetter<HttpRequest, HttpResponse<?>> {
 
-  private static final Logger logger = LoggerFactory.getLogger(JdkHttpNetAttributesGetter.class);
+  private static final Logger logger = Logger.getLogger(JdkHttpNetAttributesGetter.class.getName());
 
   @Override
   public String transport(HttpRequest httpRequest, @Nullable HttpResponse<?> response) {
@@ -46,7 +46,9 @@ public class JdkHttpNetAttributesGetter
       case "https":
         return 443;
       default:
-        logger.debug("no default port mapping for scheme: {}", scheme);
+        if (logger.isLoggable(Level.FINE)) {
+          logger.fine("no default port mapping for scheme: " + scheme);
+        }
         return null;
     }
   }

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesGetter.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesGetter.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.httpclient;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -46,7 +47,7 @@ public class JdkHttpNetAttributesGetter
       case "https":
         return 443;
       default:
-        logger.log(Level.FINE, "no default port mapping for scheme: {0}", scheme);
+        logger.log(FINE, "no default port mapping for scheme: {0}", scheme);
         return null;
     }
   }

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesGetter.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesGetter.java
@@ -46,9 +46,7 @@ public class JdkHttpNetAttributesGetter
       case "https":
         return 443;
       default:
-        if (logger.isLoggable(Level.FINE)) {
-          logger.fine("no default port mapping for scheme: " + scheme);
-        }
+        logger.log(Level.FINE, "no default port mapping for scheme: {0}", scheme);
         return null;
     }
   }

--- a/instrumentation/jdbc/library/build.gradle.kts
+++ b/instrumentation/jdbc/library/build.gradle.kts
@@ -11,7 +11,5 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
 
-  implementation("org.slf4j:slf4j-api")
-
   testImplementation(project(":instrumentation:jdbc:testing"))
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -20,10 +20,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Structured as an enum instead of a class hierarchy to allow iterating through the parsers
@@ -295,7 +295,7 @@ public enum JdbcConnectionUrlParser {
         try {
           builder.port(Integer.parseInt(jdbcUrl.substring(portLoc + 1, dbLoc)));
         } catch (NumberFormatException e) {
-          logger.debug(e.getMessage(), e);
+          logger.log(Level.FINE, e.getMessage(), e);
         }
       } else {
         hostEndLoc = dbLoc;
@@ -336,7 +336,7 @@ public enum JdbcConnectionUrlParser {
         try {
           builder.port(Integer.parseInt(jdbcUrl.substring(portLoc + 1, portEndLoc)));
         } catch (NumberFormatException e) {
-          logger.debug(e.getMessage(), e);
+          logger.log(Level.FINE, e.getMessage(), e);
         }
       } else {
         hostEndLoc = clusterSepLoc > 0 ? clusterSepLoc : dbLoc;
@@ -485,7 +485,7 @@ public enum JdbcConnectionUrlParser {
             try {
               parsedPort = Integer.parseInt(portOrInstance);
             } catch (NumberFormatException e) {
-              logger.debug(e.getMessage(), e);
+              logger.log(Level.FINE, e.getMessage(), e);
             }
             if (parsedPort == null) {
               port = null;
@@ -794,7 +794,7 @@ public enum JdbcConnectionUrlParser {
     }
   };
 
-  private static final Logger logger = LoggerFactory.getLogger(JdbcConnectionUrlParser.class);
+  private static final Logger logger = Logger.getLogger(JdbcConnectionUrlParser.class.getName());
 
   private static final Map<String, JdbcConnectionUrlParser> typeParsers = new HashMap<>();
 
@@ -847,7 +847,7 @@ public enum JdbcConnectionUrlParser {
       }
       return withUrl(GENERIC_URL_LIKE.doParse(jdbcUrl, parsedProps), type);
     } catch (RuntimeException e) {
-      logger.debug("Error parsing URL", e);
+      logger.log(Level.FINE, "Error parsing URL", e);
       return parsedProps.build();
     }
   }
@@ -925,7 +925,9 @@ public enum JdbcConnectionUrlParser {
         try {
           builder.port(Integer.parseInt(portNumber));
         } catch (NumberFormatException e) {
-          logger.debug("Error parsing portnumber property: " + portNumber, e);
+          if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "Error parsing portnumber property: " + portNumber, e);
+          }
         }
       }
 
@@ -934,7 +936,9 @@ public enum JdbcConnectionUrlParser {
         try {
           builder.port(Integer.parseInt(portNumber));
         } catch (NumberFormatException e) {
-          logger.debug("Error parsing portNumber property: " + portNumber, e);
+          if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "Error parsing portNumber property: " + portNumber, e);
+          }
         }
       }
     }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.jdbc.internal;
 
 import static io.opentelemetry.instrumentation.jdbc.internal.DbInfo.DEFAULT;
+import static java.util.logging.Level.FINE;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DbSystemValues;
@@ -20,7 +21,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -295,7 +295,7 @@ public enum JdbcConnectionUrlParser {
         try {
           builder.port(Integer.parseInt(jdbcUrl.substring(portLoc + 1, dbLoc)));
         } catch (NumberFormatException e) {
-          logger.log(Level.FINE, e.getMessage(), e);
+          logger.log(FINE, e.getMessage(), e);
         }
       } else {
         hostEndLoc = dbLoc;
@@ -336,7 +336,7 @@ public enum JdbcConnectionUrlParser {
         try {
           builder.port(Integer.parseInt(jdbcUrl.substring(portLoc + 1, portEndLoc)));
         } catch (NumberFormatException e) {
-          logger.log(Level.FINE, e.getMessage(), e);
+          logger.log(FINE, e.getMessage(), e);
         }
       } else {
         hostEndLoc = clusterSepLoc > 0 ? clusterSepLoc : dbLoc;
@@ -485,7 +485,7 @@ public enum JdbcConnectionUrlParser {
             try {
               parsedPort = Integer.parseInt(portOrInstance);
             } catch (NumberFormatException e) {
-              logger.log(Level.FINE, e.getMessage(), e);
+              logger.log(FINE, e.getMessage(), e);
             }
             if (parsedPort == null) {
               port = null;
@@ -847,7 +847,7 @@ public enum JdbcConnectionUrlParser {
       }
       return withUrl(GENERIC_URL_LIKE.doParse(jdbcUrl, parsedProps), type);
     } catch (RuntimeException e) {
-      logger.log(Level.FINE, "Error parsing URL", e);
+      logger.log(FINE, "Error parsing URL", e);
       return parsedProps.build();
     }
   }
@@ -925,8 +925,8 @@ public enum JdbcConnectionUrlParser {
         try {
           builder.port(Integer.parseInt(portNumber));
         } catch (NumberFormatException e) {
-          if (logger.isLoggable(Level.FINE)) {
-            logger.log(Level.FINE, "Error parsing portnumber property: " + portNumber, e);
+          if (logger.isLoggable(FINE)) {
+            logger.log(FINE, "Error parsing portnumber property: " + portNumber, e);
           }
         }
       }
@@ -936,8 +936,8 @@ public enum JdbcConnectionUrlParser {
         try {
           builder.port(Integer.parseInt(portNumber));
         } catch (NumberFormatException e) {
-          if (logger.isLoggable(Level.FINE)) {
-            logger.log(Level.FINE, "Error parsing portNumber property: " + portNumber, e);
+          if (logger.isLoggable(FINE)) {
+            logger.log(FINE, "Error parsing portNumber property: " + portNumber, e);
           }
         }
       }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcUtils.java
@@ -10,9 +10,9 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class JdbcUtils {
 
-  private static final Logger logger = LoggerFactory.getLogger(JdbcUtils.class);
+  private static final Logger logger = Logger.getLogger(JdbcUtils.class.getName());
 
   @Nullable private static Field c3poField = null;
 
@@ -62,7 +62,7 @@ public final class JdbcUtils {
       }
     } catch (Throwable e) {
       // Had some problem getting the connection.
-      logger.debug("Could not get connection for StatementAdvice", e);
+      logger.log(Level.FINE, "Could not get connection for StatementAdvice", e);
       return null;
     }
     return connection;

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcUtils.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal;
 
+import static java.util.logging.Level.FINE;
+
 import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -62,7 +63,7 @@ public final class JdbcUtils {
       }
     } catch (Throwable e) {
       // Had some problem getting the connection.
-      logger.log(Level.FINE, "Could not get connection for StatementAdvice", e);
+      logger.log(FINE, "Could not get connection for StatementAdvice", e);
       return null;
     }
     return connection;

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/build.gradle.kts
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/build.gradle.kts
@@ -7,8 +7,8 @@ val jettyVers_base9 = "9.2.0.v20140526"
 
 dependencies {
   library("org.eclipse.jetty:jetty-client:$jettyVers_base9")
-  latestDepTestLibrary("org.eclipse.jetty:jetty-client:9.+")
+
   testImplementation(project(":instrumentation:jetty-httpclient::jetty-httpclient-9.2:testing"))
 
-  implementation("org.slf4j:slf4j-api")
+  latestDepTestLibrary("org.eclipse.jetty:jetty-client:9.+")
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
@@ -11,20 +11,20 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpF
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesGetter;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpVersion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Request, Response> {
   INSTANCE;
 
   private static final Logger logger =
-      LoggerFactory.getLogger(JettyClientHttpAttributesGetter.class);
+      Logger.getLogger(JettyClientHttpAttributesGetter.class.getName());
 
   @Override
   @Nullable
@@ -113,10 +113,13 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
     try {
       longFromField = httpField != null ? Long.getLong(httpField.getValue()) : null;
     } catch (NumberFormatException t) {
-      logger.debug(
-          "Value {} is not  not valid number format for header field: {}",
-          httpField.getValue(),
-          httpField.getName());
+      if (logger.isLoggable(Level.FINE)) {
+        logger.fine(
+            "Value "
+                + httpField.getValue()
+                + " is not valid number format for header field: "
+                + httpField.getName());
+      }
     }
     return longFromField;
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
@@ -8,10 +8,10 @@ package io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_1_0;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_1_1;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_2_0;
+import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesGetter;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.eclipse.jetty.client.api.Request;
@@ -113,12 +113,10 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
     try {
       longFromField = httpField != null ? Long.getLong(httpField.getValue()) : null;
     } catch (NumberFormatException t) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.log(
-            Level.FINE,
-            "Value {0} is not valid number format for header field: {1}",
-            new String[] {httpField.getValue(), httpField.getName()});
-      }
+      logger.log(
+          FINE,
+          "Value {0} is not valid number format for header field: {1}",
+          new String[] {httpField.getValue(), httpField.getName()});
     }
     return longFromField;
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
@@ -114,11 +114,10 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
       longFromField = httpField != null ? Long.getLong(httpField.getValue()) : null;
     } catch (NumberFormatException t) {
       if (logger.isLoggable(Level.FINE)) {
-        logger.fine(
-            "Value "
-                + httpField.getValue()
-                + " is not valid number format for header field: "
-                + httpField.getName());
+        logger.log(
+            Level.FINE,
+            "Value {0} is not valid number format for header field: {1}",
+            new String[] {httpField.getValue(), httpField.getName()});
       }
     }
     return longFromField;

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClient9TracingInterceptor.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClient9TracingInterceptor.java
@@ -14,14 +14,13 @@ import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * JettyHttpClient9TracingInterceptor does three jobs stimulated from the Jetty Request object from
@@ -40,7 +39,7 @@ public class JettyHttpClient9TracingInterceptor
         Response.CompleteListener {
 
   private static final Logger logger =
-      LoggerFactory.getLogger(JettyHttpClient9TracingInterceptor.class);
+      Logger.getLogger(JettyHttpClient9TracingInterceptor.class.getName());
 
   private static final Class<?>[] requestlistenerInterfaces = {
     Request.BeginListener.class,
@@ -74,7 +73,7 @@ public class JettyHttpClient9TracingInterceptor
         jettyRequest.getRequestListeners(JettyHttpClient9TracingInterceptor.class);
 
     if (!current.isEmpty()) {
-      logger.warn("A tracing interceptor is already in place for this request! ");
+      logger.warning("A tracing interceptor is already in place for this request!");
       return;
     }
     startSpan(jettyRequest);
@@ -174,7 +173,7 @@ public class JettyHttpClient9TracingInterceptor
     if (this.context != null) {
       instrumenter.end(this.context, response.getRequest(), response, null);
     } else {
-      logger.debug("onComplete - could not find an otel context");
+      logger.fine("onComplete - could not find an otel context");
     }
   }
 }

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageAttributesGetter.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageAttributesGetter.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.jms.JMSException;
@@ -62,7 +63,7 @@ enum JmsMessageAttributesGetter implements MessagingAttributesGetter<MessageWith
     try {
       return messageWithDestination.message().getJMSCorrelationID();
     } catch (JMSException e) {
-      logger.log(Level.FINE, "Failure getting JMS correlation id", e);
+      logger.log(FINE, "Failure getting JMS correlation id", e);
       return null;
     }
   }
@@ -85,7 +86,7 @@ enum JmsMessageAttributesGetter implements MessagingAttributesGetter<MessageWith
     try {
       return messageWithDestination.message().getJMSMessageID();
     } catch (JMSException e) {
-      logger.log(Level.FINE, "Failure getting JMS message id", e);
+      logger.log(FINE, "Failure getting JMS message id", e);
       return null;
     }
   }

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageAttributesGetter.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageAttributesGetter.java
@@ -6,15 +6,15 @@
 package io.opentelemetry.javaagent.instrumentation.jms;
 
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.jms.JMSException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 enum JmsMessageAttributesGetter implements MessagingAttributesGetter<MessageWithDestination, Void> {
   INSTANCE;
 
-  private static final Logger logger = LoggerFactory.getLogger(JmsMessageAttributesGetter.class);
+  private static final Logger logger = Logger.getLogger(JmsMessageAttributesGetter.class.getName());
 
   @Override
   public String system(MessageWithDestination messageWithDestination) {
@@ -62,7 +62,7 @@ enum JmsMessageAttributesGetter implements MessagingAttributesGetter<MessageWith
     try {
       return messageWithDestination.message().getJMSCorrelationID();
     } catch (JMSException e) {
-      logger.debug("Failure getting JMS correlation id", e);
+      logger.log(Level.FINE, "Failure getting JMS correlation id", e);
       return null;
     }
   }
@@ -85,7 +85,7 @@ enum JmsMessageAttributesGetter implements MessagingAttributesGetter<MessageWith
     try {
       return messageWithDestination.message().getJMSMessageID();
     } catch (JMSException e) {
-      logger.debug("Failure getting JMS message id", e);
+      logger.log(Level.FINE, "Failure getting JMS message id", e);
       return null;
     }
   }

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/MessagePropertySetter.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/MessagePropertySetter.java
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.context.propagation.TextMapSetter;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.jms.JMSException;
 
@@ -23,8 +24,8 @@ enum MessagePropertySetter implements TextMapSetter<MessageWithDestination> {
     try {
       carrier.message().setStringProperty(propName, value);
     } catch (JMSException e) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.log(Level.FINE, "Failure setting jms property: " + propName, e);
+      if (logger.isLoggable(FINE)) {
+        logger.log(FINE, "Failure setting jms property: " + propName, e);
       }
     }
   }

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/MessagePropertySetter.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/MessagePropertySetter.java
@@ -6,14 +6,14 @@
 package io.opentelemetry.javaagent.instrumentation.jms;
 
 import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.jms.JMSException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 enum MessagePropertySetter implements TextMapSetter<MessageWithDestination> {
   INSTANCE;
 
-  private static final Logger logger = LoggerFactory.getLogger(MessagePropertySetter.class);
+  private static final Logger logger = Logger.getLogger(MessagePropertySetter.class.getName());
 
   static final String DASH = "__dash__";
 
@@ -23,8 +23,8 @@ enum MessagePropertySetter implements TextMapSetter<MessageWithDestination> {
     try {
       carrier.message().setStringProperty(propName, value);
     } catch (JMSException e) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Failure setting jms property: {}", propName, e);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE, "Failure setting jms property: " + propName, e);
       }
     }
   }

--- a/instrumentation/jsp-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/HttpJspPageInstrumentationSingletons.java
+++ b/instrumentation/jsp-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/HttpJspPageInstrumentationSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jsp;
 
+import static java.util.logging.Level.WARNING;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
@@ -76,7 +78,7 @@ public class HttpJspPageInstrumentationSingletons {
             "jsp.requestURL", new URI(request.getRequestURL().toString()).normalize().toString());
       } catch (URISyntaxException e) {
         Logger.getLogger(HttpJspPage.class.getName())
-            .warning("Failed to get and normalize request URL: " + e.getMessage());
+            .log(WARNING, "Failed to get and normalize request URL: {0}", e.getMessage());
       }
     }
 

--- a/instrumentation/jsp-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/HttpJspPageInstrumentationSingletons.java
+++ b/instrumentation/jsp-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/HttpJspPageInstrumentationSingletons.java
@@ -14,11 +14,11 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.HttpJspPage;
-import org.slf4j.LoggerFactory;
 
 public class HttpJspPageInstrumentationSingletons {
   private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
@@ -75,8 +75,8 @@ public class HttpJspPageInstrumentationSingletons {
         attributes.put(
             "jsp.requestURL", new URI(request.getRequestURL().toString()).normalize().toString());
       } catch (URISyntaxException e) {
-        LoggerFactory.getLogger(HttpJspPage.class)
-            .warn("Failed to get and normalize request URL: " + e.getMessage());
+        Logger.getLogger(HttpJspPage.class.getName())
+            .warning("Failed to get and normalize request URL: " + e.getMessage());
       }
     }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/KafkaTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/KafkaTelemetry.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.kafkaclients;
 
+import static java.util.logging.Level.WARNING;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
@@ -17,6 +19,7 @@ import io.opentelemetry.instrumentation.kafka.internal.KafkaConsumerRecordGetter
 import io.opentelemetry.instrumentation.kafka.internal.KafkaHeadersSetter;
 import java.util.concurrent.Future;
 import java.util.function.BiFunction;
+import java.util.logging.Logger;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -25,11 +28,9 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.header.Headers;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class KafkaTelemetry {
-  private static final Logger logger = LoggerFactory.getLogger(KafkaTelemetry.class);
+  private static final Logger logger = Logger.getLogger(KafkaTelemetry.class.getName());
 
   private static final TextMapGetter<ConsumerRecord<?, ?>> GETTER =
       KafkaConsumerRecordGetter.INSTANCE;
@@ -93,7 +94,7 @@ public final class KafkaTelemetry {
         propagator().inject(current, record.headers(), SETTER);
       } catch (Throwable t) {
         // it can happen if headers are read only (when record is sent second time)
-        logger.error("failed to inject span context. sending record second time?", t);
+        logger.log(WARNING, "failed to inject span context. sending record second time?", t);
       }
     }
 

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/rx/LettuceFluxTerminationRunnable.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/rx/LettuceFluxTerminationRunnable.java
@@ -12,8 +12,8 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.config.Config;
 import java.util.function.Consumer;
+import java.util.logging.Logger;
 import org.reactivestreams.Subscription;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Signal;
 import reactor.core.publisher.SignalType;
@@ -46,8 +46,8 @@ public class LettuceFluxTerminationRunnable implements Consumer<Signal<?>>, Runn
       }
       instrumenter().end(context, onSubscribeConsumer.command, null, throwable);
     } else {
-      LoggerFactory.getLogger(Flux.class)
-          .error(
+      Logger.getLogger(Flux.class.getName())
+          .severe(
               "Failed to end this.context, LettuceFluxTerminationRunnable cannot find this.context "
                   + "because it probably wasn't started.");
     }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/rx/LettuceMonoDualConsumer.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/rx/LettuceMonoDualConsumer.java
@@ -11,7 +11,7 @@ import io.lettuce.core.protocol.RedisCommand;
 import io.opentelemetry.context.Context;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 import reactor.core.publisher.Mono;
 
 public class LettuceMonoDualConsumer<R, T> implements Consumer<R>, BiConsumer<T, Throwable> {
@@ -38,8 +38,8 @@ public class LettuceMonoDualConsumer<R, T> implements Consumer<R>, BiConsumer<T,
     if (context != null) {
       instrumenter().end(context, command, null, throwable);
     } else {
-      LoggerFactory.getLogger(Mono.class)
-          .error(
+      Logger.getLogger(Mono.class.getName())
+          .severe(
               "Failed to finish this.span, BiConsumer cannot find this.span because "
                   + "it probably wasn't started.");
     }

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/TimeUnitHelper.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/TimeUnitHelper.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.micrometer.v1_5;
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -43,12 +44,10 @@ final class TimeUnitHelper {
       case "days":
         return TimeUnit.DAYS;
       default:
-        logger.warning(
-            "Invalid base time unit: '"
-                + value
-                + "'; using '"
-                + getUnitString(defaultUnit)
-                + "' as the base time unit instead");
+        logger.log(
+            Level.WARNING,
+            "Invalid base time unit: '{0}'; using '{1}' as the base time unit instead",
+            new String[] {value, getUnitString(defaultUnit)});
         return defaultUnit;
     }
   }

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/TimeUnitHelper.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/TimeUnitHelper.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.instrumentation.micrometer.v1_5;
 
+import static java.util.logging.Level.WARNING;
+
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -45,7 +46,7 @@ final class TimeUnitHelper {
         return TimeUnit.DAYS;
       default:
         logger.log(
-            Level.WARNING,
+            WARNING,
             "Invalid base time unit: '{0}'; using '{1}' as the base time unit instead",
             new String[] {value, getUnitString(defaultUnit)});
         return defaultUnit;

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/TimeUnitHelper.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/TimeUnitHelper.java
@@ -7,13 +7,12 @@ package io.opentelemetry.instrumentation.micrometer.v1_5;
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class TimeUnitHelper {
 
-  private static final Logger logger = LoggerFactory.getLogger(OpenTelemetryMeterRegistry.class);
+  private static final Logger logger = Logger.getLogger(OpenTelemetryMeterRegistry.class.getName());
 
   static TimeUnit parseConfigValue(@Nullable String value, TimeUnit defaultUnit) {
     if (value == null) {
@@ -44,10 +43,12 @@ final class TimeUnitHelper {
       case "days":
         return TimeUnit.DAYS;
       default:
-        logger.warn(
-            "Invalid base time unit: '{}'; using '{}' as the base time unit instead",
-            value,
-            getUnitString(defaultUnit));
+        logger.warning(
+            "Invalid base time unit: '"
+                + value
+                + "'; using '"
+                + getUnitString(defaultUnit)
+                + "' as the base time unit instead");
         return defaultUnit;
     }
   }

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/UnsupportedReadLogger.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/UnsupportedReadLogger.java
@@ -5,14 +5,13 @@
 
 package io.opentelemetry.instrumentation.micrometer.v1_5;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 final class UnsupportedReadLogger {
 
   static {
-    Logger logger = LoggerFactory.getLogger(OpenTelemetryMeterRegistry.class);
-    logger.warn("OpenTelemetry metrics bridge does not support reading measurements");
+    Logger logger = Logger.getLogger(OpenTelemetryMeterRegistry.class.getName());
+    logger.warning("OpenTelemetry metrics bridge does not support reading measurements");
   }
 
   static void logWarning() {

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanSingletons.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanSingletons.java
@@ -12,14 +12,13 @@ import io.opentelemetry.instrumentation.api.annotation.support.MethodSpanAttribu
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNames;
 import java.lang.reflect.Method;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 public final class WithSpanSingletons {
   private static final String INSTRUMENTATION_NAME =
       "io.opentelemetry.opentelemetry-annotations-1.0";
 
-  private static final Logger logger = LoggerFactory.getLogger(WithSpanSingletons.class);
+  private static final Logger logger = Logger.getLogger(WithSpanSingletons.class.getName());
   private static final Instrumenter<Method, Object> INSTRUMENTER = createInstrumenter();
   private static final Instrumenter<MethodRequest, Object> INSTRUMENTER_WITH_ATTRIBUTES =
       createInstrumenterWithAttributes();
@@ -68,7 +67,7 @@ public final class WithSpanSingletons {
     try {
       return SpanKind.valueOf(applicationSpanKind.name());
     } catch (IllegalArgumentException e) {
-      logger.debug("unexpected span kind: {}", applicationSpanKind.name());
+      logger.fine("unexpected span kind: " + applicationSpanKind.name());
       return SpanKind.INTERNAL;
     }
   }

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanSingletons.java
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/otelannotations/WithSpanSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.otelannotations;
 
+import static java.util.logging.Level.FINE;
+
 import application.io.opentelemetry.extension.annotations.WithSpan;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.SpanKind;
@@ -67,7 +69,7 @@ public final class WithSpanSingletons {
     try {
       return SpanKind.valueOf(applicationSpanKind.name());
     } catch (IllegalArgumentException e) {
-      logger.fine("unexpected span kind: " + applicationSpanKind.name());
+      logger.log(FINE, "unexpected span kind: {0}", applicationSpanKind.name());
       return SpanKind.INTERNAL;
     }
   }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/OpenTelemetryInstrumentation.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/OpenTelemetryInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opentelemetryapi;
 
+import static java.util.logging.Level.WARNING;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -14,7 +15,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -70,7 +70,7 @@ public class OpenTelemetryInstrumentation implements TypeInstrumentation {
     public static void onEnter() {
       Logger.getLogger(application.io.opentelemetry.api.GlobalOpenTelemetry.class.getName())
           .log(
-              Level.WARNING,
+              WARNING,
               "You are currently using the OpenTelemetry Instrumentation Java Agent;"
                   + " all GlobalOpenTelemetry.set calls are ignored - the agent provides"
                   + " the global OpenTelemetry object used by your application.",

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/OpenTelemetryInstrumentation.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/OpenTelemetryInstrumentation.java
@@ -14,10 +14,11 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.slf4j.LoggerFactory;
 
 // Our convention for accessing agent package
 @SuppressWarnings("UnnecessarilyFullyQualified")
@@ -67,8 +68,9 @@ public class OpenTelemetryInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter() {
-      LoggerFactory.getLogger(application.io.opentelemetry.api.GlobalOpenTelemetry.class)
-          .warn(
+      Logger.getLogger(application.io.opentelemetry.api.GlobalOpenTelemetry.class.getName())
+          .log(
+              Level.WARNING,
               "You are currently using the OpenTelemetry Instrumentation Java Agent;"
                   + " all GlobalOpenTelemetry.set calls are ignored - the agent provides"
                   + " the global OpenTelemetry object used by your application.",

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/AgentContextStorage.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/AgentContextStorage.java
@@ -18,9 +18,9 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * {@link ContextStorage} which stores the {@link Context} in the user's application inside the
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("FieldMissingNullable")
 public class AgentContextStorage implements ContextStorage, AutoCloseable {
 
-  private static final Logger logger = LoggerFactory.getLogger(AgentContextStorage.class);
+  private static final Logger logger = Logger.getLogger(AgentContextStorage.class.getName());
 
   // MethodHandle for ContextStorage.root() that was added in 1.5
   private static final MethodHandle CONTEXT_STORAGE_ROOT_HANDLE = getContextStorageRootHandle();
@@ -121,9 +121,11 @@ public class AgentContextStorage implements ContextStorage, AutoCloseable {
     if (applicationContext instanceof AgentContextWrapper) {
       return ((AgentContextWrapper) applicationContext).toAgentContext();
     }
-    if (logger.isDebugEnabled()) {
-      logger.debug(
-          "unexpected context: {}", applicationContext, new Exception("unexpected context"));
+    if (logger.isLoggable(Level.FINE)) {
+      logger.log(
+          Level.FINE,
+          "unexpected context: " + applicationContext,
+          new Exception("unexpected context"));
     }
     return io.opentelemetry.context.Context.root();
   }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/AgentContextStorage.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/context/AgentContextStorage.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.context;
 
+import static java.util.logging.Level.FINE;
+
 import application.io.opentelemetry.api.baggage.Baggage;
 import application.io.opentelemetry.api.trace.Span;
 import application.io.opentelemetry.context.Context;
@@ -18,7 +20,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -121,11 +122,9 @@ public class AgentContextStorage implements ContextStorage, AutoCloseable {
     if (applicationContext instanceof AgentContextWrapper) {
       return ((AgentContextWrapper) applicationContext).toAgentContext();
     }
-    if (logger.isLoggable(Level.FINE)) {
+    if (logger.isLoggable(FINE)) {
       logger.log(
-          Level.FINE,
-          "unexpected context: " + applicationContext,
-          new Exception("unexpected context"));
+          FINE, "unexpected context: " + applicationContext, new Exception("unexpected context"));
     }
     return io.opentelemetry.context.Context.root();
   }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/Bridging.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/Bridging.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.opentelemetryapi.trace;
 
+import static java.util.logging.Level.FINE;
+
 import application.io.opentelemetry.api.common.AttributeKey;
 import application.io.opentelemetry.api.common.Attributes;
 import application.io.opentelemetry.api.trace.Span;
@@ -80,7 +82,7 @@ public class Bridging {
     try {
       return io.opentelemetry.api.trace.SpanKind.valueOf(applicationSpanKind.name());
     } catch (IllegalArgumentException e) {
-      logger.fine("unexpected span kind: " + applicationSpanKind.name());
+      logger.log(FINE, "unexpected span kind: {0}", applicationSpanKind.name());
       return null;
     }
   }
@@ -137,7 +139,7 @@ public class Bridging {
       case DOUBLE_ARRAY:
         return io.opentelemetry.api.common.AttributeKey.doubleArrayKey(applicationKey.getKey());
     }
-    logger.fine("unexpected attribute key type: " + applicationKey.getType());
+    logger.log(FINE, "unexpected attribute key type: {0}", applicationKey.getType());
     return null;
   }
 
@@ -146,7 +148,7 @@ public class Bridging {
     try {
       agentCanonicalCode = io.opentelemetry.api.trace.StatusCode.valueOf(applicationStatus.name());
     } catch (IllegalArgumentException e) {
-      logger.fine("unexpected status canonical code: " + applicationStatus.name());
+      logger.log(FINE, "unexpected status canonical code: {0}", applicationStatus.name());
       return io.opentelemetry.api.trace.StatusCode.UNSET;
     }
     return agentCanonicalCode;

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/Bridging.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/Bridging.java
@@ -13,8 +13,7 @@ import application.io.opentelemetry.api.trace.SpanKind;
 import application.io.opentelemetry.api.trace.StatusCode;
 import application.io.opentelemetry.api.trace.TraceState;
 import application.io.opentelemetry.api.trace.TraceStateBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 /**
  * This class translates between the (unshaded) OpenTelemetry API that the application brings and
@@ -33,7 +32,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("UnnecessarilyFullyQualified")
 public class Bridging {
 
-  private static final Logger logger = LoggerFactory.getLogger(Bridging.class);
+  private static final Logger logger = Logger.getLogger(Bridging.class.getName());
 
   public static Span toApplication(io.opentelemetry.api.trace.Span agentSpan) {
     if (!agentSpan.getSpanContext().isValid()) {
@@ -81,7 +80,7 @@ public class Bridging {
     try {
       return io.opentelemetry.api.trace.SpanKind.valueOf(applicationSpanKind.name());
     } catch (IllegalArgumentException e) {
-      logger.debug("unexpected span kind: {}", applicationSpanKind.name());
+      logger.fine("unexpected span kind: " + applicationSpanKind.name());
       return null;
     }
   }
@@ -138,7 +137,7 @@ public class Bridging {
       case DOUBLE_ARRAY:
         return io.opentelemetry.api.common.AttributeKey.doubleArrayKey(applicationKey.getKey());
     }
-    logger.debug("unexpected attribute key type: {}", applicationKey.getType());
+    logger.fine("unexpected attribute key type: " + applicationKey.getType());
     return null;
   }
 
@@ -147,7 +146,7 @@ public class Bridging {
     try {
       agentCanonicalCode = io.opentelemetry.api.trace.StatusCode.valueOf(applicationStatus.name());
     } catch (IllegalArgumentException e) {
-      logger.debug("unexpected status canonical code: {}", applicationStatus.name());
+      logger.fine("unexpected status canonical code: " + applicationStatus.name());
       return io.opentelemetry.api.trace.StatusCode.UNSET;
     }
     return agentCanonicalCode;

--- a/instrumentation/play/play-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/RequestCompleteCallback.java
+++ b/instrumentation/play/play-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/RequestCompleteCallback.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.javaagent.instrumentation.play.v2_4;
 
 import static io.opentelemetry.javaagent.instrumentation.play.v2_4.Play24Singletons.instrumenter;
+import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.context.Context;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import play.api.mvc.Result;
 import scala.runtime.AbstractFunction1;
@@ -29,7 +29,7 @@ public class RequestCompleteCallback extends AbstractFunction1<Try<Result>, Obje
     try {
       instrumenter().end(context, null, null, result.isFailure() ? result.failed().get() : null);
     } catch (Throwable t) {
-      logger.log(Level.FINE, "error in play instrumentation", t);
+      logger.log(FINE, "error in play instrumentation", t);
     }
     return null;
   }

--- a/instrumentation/play/play-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/RequestCompleteCallback.java
+++ b/instrumentation/play/play-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/RequestCompleteCallback.java
@@ -8,15 +8,15 @@ package io.opentelemetry.javaagent.instrumentation.play.v2_4;
 import static io.opentelemetry.javaagent.instrumentation.play.v2_4.Play24Singletons.instrumenter;
 
 import io.opentelemetry.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import play.api.mvc.Result;
 import scala.runtime.AbstractFunction1;
 import scala.util.Try;
 
 public class RequestCompleteCallback extends AbstractFunction1<Try<Result>, Object> {
 
-  private static final Logger logger = LoggerFactory.getLogger(RequestCompleteCallback.class);
+  private static final Logger logger = Logger.getLogger(RequestCompleteCallback.class.getName());
 
   private final Context context;
 
@@ -29,7 +29,7 @@ public class RequestCompleteCallback extends AbstractFunction1<Try<Result>, Obje
     try {
       instrumenter().end(context, null, null, result.isFailure() ? result.failed().get() : null);
     } catch (Throwable t) {
-      logger.debug("error in play instrumentation", t);
+      logger.log(Level.FINE, "error in play instrumentation", t);
     }
     return null;
   }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryFallbackErrorHandler.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryFallbackErrorHandler.java
@@ -22,7 +22,8 @@
 
 package io.opentelemetry.instrumentation.ratpack;
 
-import java.util.logging.Level;
+import static java.util.logging.Level.WARNING;
+
 import java.util.logging.Logger;
 import ratpack.error.ClientErrorHandler;
 import ratpack.error.ServerErrorHandler;
@@ -42,7 +43,7 @@ final class OpenTelemetryFallbackErrorHandler implements ClientErrorHandler, Ser
 
   @Override
   public void error(Context context, int statusCode) {
-    if (logger.isLoggable(Level.WARNING)) {
+    if (logger.isLoggable(WARNING)) {
       WarnOnce.execute();
       logger.warning(getMsg(ClientErrorHandler.class, "client error", context));
     }
@@ -51,12 +52,10 @@ final class OpenTelemetryFallbackErrorHandler implements ClientErrorHandler, Ser
 
   @Override
   public void error(Context context, Throwable throwable) {
-    if (logger.isLoggable(Level.WARNING)) {
+    if (logger.isLoggable(WARNING)) {
       WarnOnce.execute();
       logger.log(
-          Level.WARNING,
-          getMsg(ServerErrorHandler.class, "server error", context) + "\n",
-          throwable);
+          WARNING, getMsg(ServerErrorHandler.class, "server error", context) + "\n", throwable);
     }
     context.getResponse().status(500).send();
   }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryFallbackErrorHandler.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryFallbackErrorHandler.java
@@ -22,8 +22,8 @@
 
 package io.opentelemetry.instrumentation.ratpack;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import ratpack.error.ClientErrorHandler;
 import ratpack.error.ServerErrorHandler;
 import ratpack.handling.Context;
@@ -36,24 +36,27 @@ final class OpenTelemetryFallbackErrorHandler implements ClientErrorHandler, Ser
   static final OpenTelemetryFallbackErrorHandler INSTANCE = new OpenTelemetryFallbackErrorHandler();
 
   private static final Logger logger =
-      LoggerFactory.getLogger(OpenTelemetryFallbackErrorHandler.class);
+      Logger.getLogger(OpenTelemetryFallbackErrorHandler.class.getName());
 
   OpenTelemetryFallbackErrorHandler() {}
 
   @Override
   public void error(Context context, int statusCode) {
-    if (logger.isWarnEnabled()) {
+    if (logger.isLoggable(Level.WARNING)) {
       WarnOnce.execute();
-      logger.warn(getMsg(ClientErrorHandler.class, "client error", context));
+      logger.warning(getMsg(ClientErrorHandler.class, "client error", context));
     }
     context.getResponse().status(statusCode).send();
   }
 
   @Override
   public void error(Context context, Throwable throwable) {
-    if (logger.isWarnEnabled()) {
+    if (logger.isLoggable(Level.WARNING)) {
       WarnOnce.execute();
-      logger.warn(getMsg(ServerErrorHandler.class, "server error", context) + "\n", throwable);
+      logger.log(
+          Level.WARNING,
+          getMsg(ServerErrorHandler.class, "server error", context) + "\n",
+          throwable);
     }
     context.getResponse().status(500).send();
   }
@@ -73,7 +76,7 @@ final class OpenTelemetryFallbackErrorHandler implements ClientErrorHandler, Ser
 
   private static class WarnOnce {
     static {
-      logger.warn(
+      logger.warning(
           "Logging error using OpenTelemetryFallbackErrorHandler. This indicates "
               + "OpenTelemetry could not find a registered error handler which is not expected. "
               + "Log messages will only be outputted to console.");

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/ContextPayload.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/ContextPayload.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.rmi.context;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
@@ -14,7 +16,6 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /** ContextPayload wraps context information shared between client and server. */
@@ -49,7 +50,7 @@ public class ContextPayload {
         return new ContextPayload(map);
       }
     } catch (ClassCastException | ClassNotFoundException ex) {
-      logger.log(Level.FINE, "Error reading object", ex);
+      logger.log(FINE, "Error reading object", ex);
     }
 
     return null;

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/ContextPayload.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/ContextPayload.java
@@ -14,13 +14,13 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** ContextPayload wraps context information shared between client and server. */
 public class ContextPayload {
 
-  private static final Logger logger = LoggerFactory.getLogger(ContextPayload.class);
+  private static final Logger logger = Logger.getLogger(ContextPayload.class.getName());
 
   private final Map<String, String> context;
 
@@ -49,7 +49,7 @@ public class ContextPayload {
         return new ContextPayload(map);
       }
     } catch (ClassCastException | ClassNotFoundException ex) {
-      logger.debug("Error reading object", ex);
+      logger.log(Level.FINE, "Error reading object", ex);
     }
 
     return null;

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/ContextPropagator.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/ContextPropagator.java
@@ -11,15 +11,15 @@ import java.io.IOException;
 import java.io.ObjectOutput;
 import java.rmi.NoSuchObjectException;
 import java.rmi.server.ObjID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import sun.rmi.transport.Connection;
 import sun.rmi.transport.StreamRemoteCall;
 import sun.rmi.transport.TransportConstants;
 
 public class ContextPropagator {
 
-  private static final Logger logger = LoggerFactory.getLogger(ContextPropagator.class);
+  private static final Logger logger = Logger.getLogger(ContextPropagator.class.getName());
 
   // Internal RMI object ids that we don't want to trace
   private static final ObjID ACTIVATOR_ID = new ObjID(ObjID.ACTIVATOR_ID);
@@ -51,7 +51,7 @@ public class ContextPropagator {
       VirtualField<Connection, Boolean> knownConnections, Connection c, Context context) {
     if (checkIfContextCanBePassed(knownConnections, c)) {
       if (!syntheticCall(c, ContextPayload.from(context), CONTEXT_PAYLOAD_OPERATION_ID)) {
-        logger.debug("Couldn't send context payload");
+        logger.fine("Couldn't send context payload");
       }
     }
   }
@@ -99,10 +99,10 @@ public class ContextPropagator {
           if (ex instanceof NoSuchObjectException) {
             return false;
           } else {
-            logger.debug("Server error when executing synthetic call", ex);
+            logger.log(Level.FINE, "Server error when executing synthetic call", ex);
           }
         } else {
-          logger.debug("Error executing synthetic call", e);
+          logger.log(Level.FINE, "Error executing synthetic call", e);
         }
         return false;
       } finally {
@@ -110,7 +110,7 @@ public class ContextPropagator {
       }
 
     } catch (IOException e) {
-      logger.debug("Communication error executing synthetic call", e);
+      logger.log(Level.FINE, "Communication error executing synthetic call", e);
       return false;
     }
     return true;

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/ContextPropagator.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/ContextPropagator.java
@@ -5,13 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.rmi.context;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.field.VirtualField;
 import java.io.IOException;
 import java.io.ObjectOutput;
 import java.rmi.NoSuchObjectException;
 import java.rmi.server.ObjID;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import sun.rmi.transport.Connection;
 import sun.rmi.transport.StreamRemoteCall;
@@ -99,10 +100,10 @@ public class ContextPropagator {
           if (ex instanceof NoSuchObjectException) {
             return false;
           } else {
-            logger.log(Level.FINE, "Server error when executing synthetic call", ex);
+            logger.log(FINE, "Server error when executing synthetic call", ex);
           }
         } else {
-          logger.log(Level.FINE, "Error executing synthetic call", e);
+          logger.log(FINE, "Error executing synthetic call", e);
         }
         return false;
       } finally {
@@ -110,7 +111,7 @@ public class ContextPropagator {
       }
 
     } catch (IOException e) {
-      logger.log(Level.FINE, "Communication error executing synthetic call", e);
+      logger.log(FINE, "Communication error executing synthetic call", e);
       return false;
     }
     return true;

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/jpms/ExposeRmiModuleInstrumentation.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/jpms/ExposeRmiModuleInstrumentation.java
@@ -13,16 +13,15 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.loading.ClassInjector;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.utility.JavaModule;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ExposeRmiModuleInstrumentation implements TypeInstrumentation {
   private static final Logger logger =
-      LoggerFactory.getLogger(ExposeRmiModuleInstrumentation.class);
+      Logger.getLogger(ExposeRmiModuleInstrumentation.class.getName());
 
   private final AtomicBoolean instrumented = new AtomicBoolean();
 
@@ -71,8 +70,8 @@ public class ExposeRmiModuleInstrumentation implements TypeInstrumentation {
                 Collections.emptyMap());
 
             instrumented.set(true);
-            logger.debug(
-                "Exposed package \"sun.rmi.server\" in module {} to unnamed module", module);
+            logger.fine(
+                "Exposed package \"sun.rmi.server\" in module " + module + " to unnamed module");
           }
           return builder;
         });

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/jpms/ExposeRmiModuleInstrumentation.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/jpms/ExposeRmiModuleInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.rmi.context.jpms;
 
+import static java.util.logging.Level.FINE;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 
 import io.opentelemetry.instrumentation.api.InstrumentationVersion;
@@ -13,7 +14,6 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.loading.ClassInjector;
@@ -72,9 +72,7 @@ public class ExposeRmiModuleInstrumentation implements TypeInstrumentation {
 
             instrumented.set(true);
             logger.log(
-                Level.FINE,
-                "Exposed package \"sun.rmi.server\" in module {0} to unnamed module",
-                module);
+                FINE, "Exposed package \"sun.rmi.server\" in module {0} to unnamed module", module);
           }
           return builder;
         });

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/jpms/ExposeRmiModuleInstrumentation.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/context/jpms/ExposeRmiModuleInstrumentation.java
@@ -13,6 +13,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.loading.ClassInjector;
@@ -70,8 +71,10 @@ public class ExposeRmiModuleInstrumentation implements TypeInstrumentation {
                 Collections.emptyMap());
 
             instrumented.set(true);
-            logger.fine(
-                "Exposed package \"sun.rmi.server\" in module " + module + " to unnamed module");
+            logger.log(
+                Level.FINE,
+                "Exposed package \"sun.rmi.server\" in module {0} to unnamed module",
+                module);
           }
           return builder;
         });

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/CompositeTextMapPropagatorFactory.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/CompositeTextMapPropagatorFactory.java
@@ -15,8 +15,7 @@ import io.opentelemetry.extension.trace.propagation.OtTracePropagator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.util.ClassUtils;
 
@@ -24,7 +23,7 @@ import org.springframework.util.ClassUtils;
 public final class CompositeTextMapPropagatorFactory {
 
   private static final Logger logger =
-      LoggerFactory.getLogger(CompositeTextMapPropagatorFactory.class);
+      Logger.getLogger(CompositeTextMapPropagatorFactory.class.getName());
 
   static TextMapPropagator getCompositeTextMapPropagator(
       BeanFactory beanFactory, List<String> types) {
@@ -80,7 +79,7 @@ public final class CompositeTextMapPropagatorFactory {
           propagators.add(W3CBaggagePropagator.getInstance());
           break;
         default:
-          logger.warn("Unsupported type of propagator: {}", type);
+          logger.warning("Unsupported type of propagator: " + type);
           break;
       }
     }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/CompositeTextMapPropagatorFactory.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/CompositeTextMapPropagatorFactory.java
@@ -15,6 +15,7 @@ import io.opentelemetry.extension.trace.propagation.OtTracePropagator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.util.ClassUtils;
@@ -79,7 +80,7 @@ public final class CompositeTextMapPropagatorFactory {
           propagators.add(W3CBaggagePropagator.getInstance());
           break;
         default:
-          logger.warning("Unsupported type of propagator: " + type);
+          logger.log(Level.WARNING, "Unsupported type of propagator: {0}", type);
           break;
       }
     }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/CompositeTextMapPropagatorFactory.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/CompositeTextMapPropagatorFactory.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.spring.autoconfigure.propagators;
 
+import static java.util.logging.Level.WARNING;
+
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.TextMapPropagator;
@@ -15,7 +17,6 @@ import io.opentelemetry.extension.trace.propagation.OtTracePropagator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.util.ClassUtils;
@@ -80,7 +81,7 @@ public final class CompositeTextMapPropagatorFactory {
           propagators.add(W3CBaggagePropagator.getInstance());
           break;
         default:
-          logger.log(Level.WARNING, "Unsupported type of propagator: {0}", type);
+          logger.log(WARNING, "Unsupported type of propagator: {0}", type);
           break;
       }
     }

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SyncCompletionListener.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SyncCompletionListener.java
@@ -9,14 +9,13 @@ import static io.opentelemetry.javaagent.instrumentation.spymemcached.Spymemcach
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import net.spy.memcached.MemcachedConnection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SyncCompletionListener extends CompletionListener<Void> {
 
-  private static final Logger logger = LoggerFactory.getLogger(SyncCompletionListener.class);
+  private static final Logger logger = Logger.getLogger(SyncCompletionListener.class.getName());
 
   private SyncCompletionListener(Context parentContext, SpymemcachedRequest request) {
     super(parentContext, request);
@@ -34,7 +33,7 @@ public class SyncCompletionListener extends CompletionListener<Void> {
 
   @Override
   protected void processResult(Span span, Void future) {
-    logger.error("processResult was called on SyncCompletionListener. This should never happen. ");
+    logger.severe("processResult was called on SyncCompletionListener. This should never happen.");
   }
 
   public void done(Throwable thrown) {

--- a/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioExperimentalAttributesExtractor.java
+++ b/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioExperimentalAttributesExtractor.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.twilio;
 
+import static java.util.logging.Level.FINE;
+
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.twilio.rest.api.v2010.account.Call;
@@ -14,7 +16,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -44,7 +45,7 @@ class TwilioExperimentalAttributesExtractor implements AttributesExtractor<Strin
             Uninterruptibles.getUninterruptibly(
                 (ListenableFuture<?>) result, 0, TimeUnit.MICROSECONDS);
       } catch (Exception e) {
-        logger.log(Level.FINE, "Error unwrapping result", e);
+        logger.log(FINE, "Error unwrapping result", e);
       }
     }
 

--- a/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioExperimentalAttributesExtractor.java
+++ b/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioExperimentalAttributesExtractor.java
@@ -14,14 +14,14 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class TwilioExperimentalAttributesExtractor implements AttributesExtractor<String, Object> {
 
   private static final Logger logger =
-      LoggerFactory.getLogger(TwilioExperimentalAttributesExtractor.class);
+      Logger.getLogger(TwilioExperimentalAttributesExtractor.class.getName());
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, String s) {}
@@ -44,7 +44,7 @@ class TwilioExperimentalAttributesExtractor implements AttributesExtractor<Strin
             Uninterruptibles.getUninterruptibly(
                 (ListenableFuture<?>) result, 0, TimeUnit.MICROSECONDS);
       } catch (Exception e) {
-        logger.debug("Error unwrapping result", e);
+        logger.log(Level.FINE, "Error unwrapping result", e);
       }
     }
 

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultConsumerWrapper.java
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultConsumerWrapper.java
@@ -10,12 +10,12 @@ import io.opentelemetry.context.Scope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import java.util.function.Consumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class AsyncResultConsumerWrapper implements Consumer<Handler<AsyncResult<?>>> {
 
-  private static final Logger logger = LoggerFactory.getLogger(AsyncResultConsumerWrapper.class);
+  private static final Logger logger = Logger.getLogger(AsyncResultConsumerWrapper.class.getName());
 
   private final Consumer<Handler<AsyncResult<?>>> delegate;
   private final Context executionContext;
@@ -40,7 +40,9 @@ public class AsyncResultConsumerWrapper implements Consumer<Handler<AsyncResult<
   public static Consumer<Handler<AsyncResult<?>>> wrapIfNeeded(
       Consumer<Handler<AsyncResult<?>>> delegate, Context executionContext) {
     if (!(delegate instanceof AsyncResultConsumerWrapper)) {
-      logger.debug("Wrapping consumer {}", delegate);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.fine("Wrapping consumer " + delegate);
+      }
       return new AsyncResultConsumerWrapper(delegate, executionContext);
     }
     return delegate;

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultConsumerWrapper.java
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultConsumerWrapper.java
@@ -40,9 +40,7 @@ public class AsyncResultConsumerWrapper implements Consumer<Handler<AsyncResult<
   public static Consumer<Handler<AsyncResult<?>>> wrapIfNeeded(
       Consumer<Handler<AsyncResult<?>>> delegate, Context executionContext) {
     if (!(delegate instanceof AsyncResultConsumerWrapper)) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.fine("Wrapping consumer " + delegate);
-      }
+      logger.log(Level.FINE, "Wrapping consumer {0}", delegate);
       return new AsyncResultConsumerWrapper(delegate, executionContext);
     }
     return delegate;

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultConsumerWrapper.java
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultConsumerWrapper.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.reactive;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import java.util.function.Consumer;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class AsyncResultConsumerWrapper implements Consumer<Handler<AsyncResult<?>>> {
@@ -40,7 +41,7 @@ public class AsyncResultConsumerWrapper implements Consumer<Handler<AsyncResult<
   public static Consumer<Handler<AsyncResult<?>>> wrapIfNeeded(
       Consumer<Handler<AsyncResult<?>>> delegate, Context executionContext) {
     if (!(delegate instanceof AsyncResultConsumerWrapper)) {
-      logger.log(Level.FINE, "Wrapping consumer {0}", delegate);
+      logger.log(FINE, "Wrapping consumer {0}", delegate);
       return new AsyncResultConsumerWrapper(delegate, executionContext);
     }
     return delegate;

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultHandlerWrapper.java
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultHandlerWrapper.java
@@ -9,12 +9,12 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class AsyncResultHandlerWrapper implements Handler<Handler<AsyncResult<?>>> {
 
-  private static final Logger logger = LoggerFactory.getLogger(AsyncResultHandlerWrapper.class);
+  private static final Logger logger = Logger.getLogger(AsyncResultHandlerWrapper.class.getName());
 
   private final Handler<Handler<AsyncResult<?>>> delegate;
   private final Context executionContext;
@@ -39,7 +39,9 @@ public class AsyncResultHandlerWrapper implements Handler<Handler<AsyncResult<?>
   public static Handler<Handler<AsyncResult<?>>> wrapIfNeeded(
       Handler<Handler<AsyncResult<?>>> delegate, Context executionContext) {
     if (!(delegate instanceof AsyncResultHandlerWrapper)) {
-      logger.debug("Wrapping handler {}", delegate);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.fine("Wrapping handler " + delegate);
+      }
       return new AsyncResultHandlerWrapper(delegate, executionContext);
     }
     return delegate;

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultHandlerWrapper.java
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultHandlerWrapper.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.reactive;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class AsyncResultHandlerWrapper implements Handler<Handler<AsyncResult<?>>> {
@@ -39,7 +40,7 @@ public class AsyncResultHandlerWrapper implements Handler<Handler<AsyncResult<?>
   public static Handler<Handler<AsyncResult<?>>> wrapIfNeeded(
       Handler<Handler<AsyncResult<?>>> delegate, Context executionContext) {
     if (!(delegate instanceof AsyncResultHandlerWrapper)) {
-      logger.log(Level.FINE, "Wrapping handler {0}", delegate);
+      logger.log(FINE, "Wrapping handler {0}", delegate);
       return new AsyncResultHandlerWrapper(delegate, executionContext);
     }
     return delegate;

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultHandlerWrapper.java
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/reactive/AsyncResultHandlerWrapper.java
@@ -39,9 +39,7 @@ public class AsyncResultHandlerWrapper implements Handler<Handler<AsyncResult<?>
   public static Handler<Handler<AsyncResult<?>>> wrapIfNeeded(
       Handler<Handler<AsyncResult<?>>> delegate, Context executionContext) {
     if (!(delegate instanceof AsyncResultHandlerWrapper)) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.fine("Wrapping handler " + delegate);
-      }
+      logger.log(Level.FINE, "Wrapping handler {0}", delegate);
       return new AsyncResultHandlerWrapper(delegate, executionContext);
     }
     return delegate;

--- a/javaagent-extension-api/build.gradle.kts
+++ b/javaagent-extension-api/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
 
   implementation(project(":instrumentation-api"))
   implementation(project(":javaagent-instrumentation-api"))
-  implementation("org.slf4j:slf4j-api")
 
   // metrics are unstable, do not expose as api
   implementation("io.opentelemetry:opentelemetry-sdk-metrics")

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeErasureMatcher.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeErasureMatcher.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.javaagent.extension.matcher;
 
 import static io.opentelemetry.javaagent.extension.matcher.Utils.safeTypeDefinitionName;
+import static java.util.logging.Level.FINE;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import net.bytebuddy.description.type.TypeDefinition;
@@ -56,7 +56,7 @@ class SafeErasureMatcher<T extends TypeDefinition> extends ElementMatcher.Juncti
       return typeDefinition.asErasure();
     } catch (Throwable e) {
       logger.log(
-          Level.FINE,
+          FINE,
           "{0} trying to get erasure for target {1}: {2}",
           new String[] {
             e.getClass().getSimpleName(), safeTypeDefinitionName(typeDefinition), e.getMessage()

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeErasureMatcher.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeErasureMatcher.java
@@ -7,12 +7,12 @@ package io.opentelemetry.javaagent.extension.matcher;
 
 import static io.opentelemetry.javaagent.extension.matcher.Utils.safeTypeDefinitionName;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import net.bytebuddy.description.type.TypeDefinition;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * An element matcher that matches its argument's {@link TypeDescription.Generic} raw type against
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 class SafeErasureMatcher<T extends TypeDefinition> extends ElementMatcher.Junction.AbstractBase<T> {
 
-  private static final Logger logger = LoggerFactory.getLogger(SafeErasureMatcher.class);
+  private static final Logger logger = Logger.getLogger(SafeErasureMatcher.class.getName());
 
   /** The matcher to apply to the raw type of the matched element. */
   private final ElementMatcher<TypeDescription> matcher;
@@ -55,12 +55,13 @@ class SafeErasureMatcher<T extends TypeDefinition> extends ElementMatcher.Juncti
     try {
       return typeDefinition.asErasure();
     } catch (Throwable e) {
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "{} trying to get erasure for target {}: {}",
-            e.getClass().getSimpleName(),
-            safeTypeDefinitionName(typeDefinition),
-            e.getMessage());
+      if (logger.isLoggable(Level.FINE)) {
+        logger.fine(
+            e.getClass().getSimpleName()
+                + " trying to get erasure for target "
+                + safeTypeDefinitionName(typeDefinition)
+                + ": "
+                + e.getMessage());
       }
       return null;
     }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeErasureMatcher.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeErasureMatcher.java
@@ -55,14 +55,12 @@ class SafeErasureMatcher<T extends TypeDefinition> extends ElementMatcher.Juncti
     try {
       return typeDefinition.asErasure();
     } catch (Throwable e) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.fine(
-            e.getClass().getSimpleName()
-                + " trying to get erasure for target "
-                + safeTypeDefinitionName(typeDefinition)
-                + ": "
-                + e.getMessage());
-      }
+      logger.log(
+          Level.FINE,
+          "{0} trying to get erasure for target {1}: {2}",
+          new String[] {
+            e.getClass().getSimpleName(), safeTypeDefinitionName(typeDefinition), e.getMessage()
+          });
       return null;
     }
   }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeHasSuperTypeMatcher.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeHasSuperTypeMatcher.java
@@ -11,12 +11,12 @@ import static io.opentelemetry.javaagent.extension.matcher.Utils.safeTypeDefinit
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import net.bytebuddy.description.type.TypeDefinition;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * An element matcher that matches a super type. This is different from {@link
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 class SafeHasSuperTypeMatcher extends ElementMatcher.Junction.AbstractBase<TypeDescription> {
 
-  private static final Logger logger = LoggerFactory.getLogger(SafeHasSuperTypeMatcher.class);
+  private static final Logger logger = Logger.getLogger(SafeHasSuperTypeMatcher.class.getName());
 
   /** The matcher to apply to any super type of the matched type. */
   private final ElementMatcher<TypeDescription.Generic> matcher;
@@ -102,12 +102,13 @@ class SafeHasSuperTypeMatcher extends ElementMatcher.Junction.AbstractBase<TypeD
     try {
       return typeDefinition.getSuperClass();
     } catch (Throwable e) {
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "{} trying to get super class for target {}: {}",
-            e.getClass().getSimpleName(),
-            safeTypeDefinitionName(typeDefinition),
-            e.getMessage());
+      if (logger.isLoggable(Level.FINE)) {
+        logger.fine(
+            e.getClass().getSimpleName()
+                + " trying to get super class for target "
+                + safeTypeDefinitionName(typeDefinition)
+                + ": "
+                + e.getMessage());
       }
       return null;
     }
@@ -192,12 +193,13 @@ class SafeHasSuperTypeMatcher extends ElementMatcher.Junction.AbstractBase<TypeD
     }
 
     private static void logException(TypeDefinition typeDefinition, Throwable e) {
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "{} trying to get interfaces for target {}: {}",
-            e.getClass().getSimpleName(),
-            safeTypeDefinitionName(typeDefinition),
-            e.getMessage());
+      if (logger.isLoggable(Level.FINE)) {
+        logger.fine(
+            e.getClass().getSimpleName()
+                + " trying to get interfaces for target "
+                + safeTypeDefinitionName(typeDefinition)
+                + ": "
+                + e.getMessage());
       }
     }
   }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeHasSuperTypeMatcher.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeHasSuperTypeMatcher.java
@@ -7,11 +7,11 @@ package io.opentelemetry.javaagent.extension.matcher;
 
 import static io.opentelemetry.javaagent.extension.matcher.SafeErasureMatcher.safeAsErasure;
 import static io.opentelemetry.javaagent.extension.matcher.Utils.safeTypeDefinitionName;
+import static java.util.logging.Level.FINE;
 
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import net.bytebuddy.description.type.TypeDefinition;
@@ -103,7 +103,7 @@ class SafeHasSuperTypeMatcher extends ElementMatcher.Junction.AbstractBase<TypeD
       return typeDefinition.getSuperClass();
     } catch (Throwable e) {
       logger.log(
-          Level.FINE,
+          FINE,
           "{0} trying to get super class for target {1}: {2}",
           new String[] {
             e.getClass().getSimpleName(), safeTypeDefinitionName(typeDefinition), e.getMessage()
@@ -192,7 +192,7 @@ class SafeHasSuperTypeMatcher extends ElementMatcher.Junction.AbstractBase<TypeD
 
     private static void logException(TypeDefinition typeDefinition, Throwable e) {
       logger.log(
-          Level.FINE,
+          FINE,
           "{0} trying to get interfaces for target {1}: {2}",
           new String[] {
             e.getClass().getSimpleName(), safeTypeDefinitionName(typeDefinition), e.getMessage()

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeHasSuperTypeMatcher.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/SafeHasSuperTypeMatcher.java
@@ -102,14 +102,12 @@ class SafeHasSuperTypeMatcher extends ElementMatcher.Junction.AbstractBase<TypeD
     try {
       return typeDefinition.getSuperClass();
     } catch (Throwable e) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.fine(
-            e.getClass().getSimpleName()
-                + " trying to get super class for target "
-                + safeTypeDefinitionName(typeDefinition)
-                + ": "
-                + e.getMessage());
-      }
+      logger.log(
+          Level.FINE,
+          "{0} trying to get super class for target {1}: {2}",
+          new String[] {
+            e.getClass().getSimpleName(), safeTypeDefinitionName(typeDefinition), e.getMessage()
+          });
       return null;
     }
   }
@@ -193,14 +191,12 @@ class SafeHasSuperTypeMatcher extends ElementMatcher.Junction.AbstractBase<TypeD
     }
 
     private static void logException(TypeDefinition typeDefinition, Throwable e) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.fine(
-            e.getClass().getSimpleName()
-                + " trying to get interfaces for target "
-                + safeTypeDefinitionName(typeDefinition)
-                + ": "
-                + e.getMessage());
-      }
+      logger.log(
+          Level.FINE,
+          "{0} trying to get interfaces for target {1}: {2}",
+          new String[] {
+            e.getClass().getSimpleName(), safeTypeDefinitionName(typeDefinition), e.getMessage()
+          });
     }
   }
 }

--- a/javaagent-instrumentation-api/build.gradle.kts
+++ b/javaagent-instrumentation-api/build.gradle.kts
@@ -10,8 +10,6 @@ group = "io.opentelemetry.javaagent"
 dependencies {
   api(project(":instrumentation-api"))
 
-  implementation("org.slf4j:slf4j-api")
-
   compileOnly(project(":instrumentation-appender-api-internal"))
 
   compileOnly("com.google.auto.value:auto-value-annotations")

--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/PropagatedContext.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/PropagatedContext.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.api.concurrent;
 
+import static java.util.logging.Level.FINE;
+
 import io.opentelemetry.context.Context;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /** Represents a {@link Context} attached to a concurrent task instance. */
@@ -29,12 +30,10 @@ public final class PropagatedContext {
     if (!result) {
       Context currentPropagatedContext = contextUpdater.get(this);
       if (currentPropagatedContext != context) {
-        if (logger.isLoggable(Level.FINE)) {
-          logger.log(
-              Level.FINE,
-              "Failed to propagate context because previous propagated context is already set; new: {0}, old: {1}",
-              new Object[] {context, currentPropagatedContext});
-        }
+        logger.log(
+            FINE,
+            "Failed to propagate context because previous propagated context is already set; new: {0}, old: {1}",
+            new Object[] {context, currentPropagatedContext});
       }
     }
   }

--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/PropagatedContext.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/PropagatedContext.java
@@ -30,11 +30,10 @@ public final class PropagatedContext {
       Context currentPropagatedContext = contextUpdater.get(this);
       if (currentPropagatedContext != context) {
         if (logger.isLoggable(Level.FINE)) {
-          logger.fine(
-              "Failed to propagate context because previous propagated context is already set; new: "
-                  + context
-                  + ", old: "
-                  + currentPropagatedContext);
+          logger.log(
+              Level.FINE,
+              "Failed to propagate context because previous propagated context is already set; new: {0}, old: {1}",
+              new Object[] {context, currentPropagatedContext});
         }
       }
     }

--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/PropagatedContext.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/concurrent/PropagatedContext.java
@@ -7,13 +7,13 @@ package io.opentelemetry.javaagent.instrumentation.api.concurrent;
 
 import io.opentelemetry.context.Context;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** Represents a {@link Context} attached to a concurrent task instance. */
 public final class PropagatedContext {
 
-  private static final Logger logger = LoggerFactory.getLogger(PropagatedContext.class);
+  private static final Logger logger = Logger.getLogger(PropagatedContext.class.getName());
 
   private static final AtomicReferenceFieldUpdater<PropagatedContext, Context> contextUpdater =
       AtomicReferenceFieldUpdater.newUpdater(PropagatedContext.class, Context.class, "context");
@@ -29,13 +29,12 @@ public final class PropagatedContext {
     if (!result) {
       Context currentPropagatedContext = contextUpdater.get(this);
       if (currentPropagatedContext != context) {
-        if (logger.isDebugEnabled()) {
-          logger.debug(
-              "Failed to propagate context because previous propagated context is "
-                  + "already set {}: new: {}, old: {}",
-              this,
-              context,
-              currentPropagatedContext);
+        if (logger.isLoggable(Level.FINE)) {
+          logger.fine(
+              "Failed to propagate context because previous propagated context is already set; new: "
+                  + context
+                  + ", old: "
+                  + currentPropagatedContext);
         }
       }
     }

--- a/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/internal/InstrumentedTaskClasses.java
+++ b/javaagent-instrumentation-api/src/main/java/io/opentelemetry/javaagent/instrumentation/api/internal/InstrumentedTaskClasses.java
@@ -7,8 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.api.internal;
 
 import io.opentelemetry.instrumentation.api.config.Config;
 import java.util.function.Predicate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -16,7 +15,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class InstrumentedTaskClasses {
 
-  private static final Logger logger = LoggerFactory.getLogger(Config.class);
+  private static final Logger logger = Logger.getLogger(Config.class.getName());
 
   private static final String AGENT_CLASSLOADER_NAME =
       "io.opentelemetry.javaagent.bootstrap.AgentClassLoader";
@@ -50,7 +49,7 @@ public final class InstrumentedTaskClasses {
    */
   public static void setIgnoredTaskClassesPredicate(Predicate<String> ignoredTasksTriePredicate) {
     if (InstrumentedTaskClasses.ignoredTaskClassesPredicate != null) {
-      logger.warn("Ignored task classes were already set earlier; returning.");
+      logger.warning("Ignored task classes were already set earlier; returning.");
       return;
     }
     InstrumentedTaskClasses.ignoredTaskClassesPredicate = ignoredTasksTriePredicate;

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ExtendsClassMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ExtendsClassMatcherTest.groovy
@@ -56,7 +56,9 @@ class ExtendsClassMatcherTest extends Specification {
     noExceptionThrown()
     1 * type.getModifiers() >> Opcodes.ACC_ABSTRACT
     1 * type.asGenericType() >> typeGeneric
+    1 * type.getTypeName() >> "type-name"
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
+    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     0 * _
   }

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ExtendsClassMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ExtendsClassMatcherTest.groovy
@@ -14,6 +14,7 @@ import net.bytebuddy.description.type.TypeDescription
 import org.objectweb.asm.Opcodes
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.extendsClass
 import static net.bytebuddy.matcher.ElementMatchers.named
@@ -24,6 +25,7 @@ class ExtendsClassMatcherTest extends Specification {
     AgentTooling.poolStrategy()
       .typePool(AgentTooling.locationStrategy().classFileLocator(this.class.classLoader, null), this.class.classLoader)
 
+  @Unroll
   def "test matcher #matcherClass.simpleName -> #type.simpleName"() {
     expect:
     extendsClass(matcher).matches(argument) == result
@@ -54,9 +56,7 @@ class ExtendsClassMatcherTest extends Specification {
     noExceptionThrown()
     1 * type.getModifiers() >> Opcodes.ACC_ABSTRACT
     1 * type.asGenericType() >> typeGeneric
-    1 * type.getTypeName() >> "type-name"
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
-    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     0 * _
   }

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
@@ -15,6 +15,7 @@ import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.description.type.TypeList
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface
 import static net.bytebuddy.matcher.ElementMatchers.named
@@ -25,6 +26,7 @@ class HasInterfaceMatcherTest extends Specification {
     AgentTooling.poolStrategy()
       .typePool(AgentTooling.locationStrategy().classFileLocator(this.class.classLoader, null), this.class.classLoader)
 
+  @Unroll
   def "test matcher #matcherClass.simpleName -> #type.simpleName"() {
     expect:
     implementsInterface(matcher).matches(argument) == result
@@ -62,11 +64,9 @@ class HasInterfaceMatcherTest extends Specification {
     1 * type.isInterface() >> true
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
-    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
     1 * type.getInterfaces() >> interfaces
     1 * interfaces.iterator() >> it
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
-    2 * type.getTypeName() >> "type-name"
     0 * _
   }
 }

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
@@ -64,9 +64,11 @@ class HasInterfaceMatcherTest extends Specification {
     1 * type.isInterface() >> true
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
+    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
     1 * type.getInterfaces() >> interfaces
     1 * interfaces.iterator() >> it
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
+    2 * type.getTypeName() >> "type-name"
     0 * _
   }
 }

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
@@ -62,8 +62,10 @@ class ImplementsInterfaceMatcherTest extends Specification {
     1 * type.isInterface() >> true
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
+    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
     1 * type.getInterfaces() >> { throw new Exception("getInterfaces exception") }
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
+    2 * type.getTypeName() >> "type-name"
     0 * _
   }
 
@@ -84,8 +86,10 @@ class ImplementsInterfaceMatcherTest extends Specification {
     1 * type.isInterface() >> true
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
+    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
     1 * type.getInterfaces() >> interfaces
     1 * interfaces.iterator() >> it
+    2 * type.getTypeName() >> "type-name"
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     0 * _
   }

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
@@ -15,6 +15,7 @@ import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.description.type.TypeList
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface
 import static net.bytebuddy.matcher.ElementMatchers.named
@@ -25,6 +26,7 @@ class ImplementsInterfaceMatcherTest extends Specification {
     AgentTooling.poolStrategy()
       .typePool(AgentTooling.locationStrategy().classFileLocator(this.class.classLoader, null), this.class.classLoader)
 
+  @Unroll
   def "test matcher #matcherClass.simpleName -> #type.simpleName"() {
     expect:
     implementsInterface(matcher).matches(argument) == result
@@ -60,10 +62,8 @@ class ImplementsInterfaceMatcherTest extends Specification {
     1 * type.isInterface() >> true
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
-    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
     1 * type.getInterfaces() >> { throw new Exception("getInterfaces exception") }
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
-    2 * type.getTypeName() >> "type-name"
     0 * _
   }
 
@@ -84,10 +84,8 @@ class ImplementsInterfaceMatcherTest extends Specification {
     1 * type.isInterface() >> true
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
-    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
     1 * type.getInterfaces() >> interfaces
     1 * interfaces.iterator() >> it
-    2 * type.getTypeName() >> "type-name"
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
     0 * _
   }

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
@@ -61,8 +61,10 @@ class SafeHasSuperTypeMatcherTest extends Specification {
     noExceptionThrown()
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
+    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
     1 * type.getInterfaces() >> { throw new Exception("getInterfaces exception") }
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
+    2 * type.getTypeName() >> "type-name"
     0 * _
   }
 
@@ -84,5 +86,6 @@ class SafeHasSuperTypeMatcherTest extends Specification {
     1 * interfaces.iterator() >> it
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
+    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
   }
 }

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
@@ -15,6 +15,7 @@ import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.description.type.TypeList
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType
 import static net.bytebuddy.matcher.ElementMatchers.named
@@ -25,6 +26,7 @@ class SafeHasSuperTypeMatcherTest extends Specification {
     AgentTooling.poolStrategy()
       .typePool(AgentTooling.locationStrategy().classFileLocator(this.class.classLoader, null), this.class.classLoader)
 
+  @Unroll
   def "test matcher #matcherClass.simpleName -> #type.simpleName"() {
     expect:
     hasSuperType(matcher).matches(argument) == result
@@ -59,10 +61,8 @@ class SafeHasSuperTypeMatcherTest extends Specification {
     noExceptionThrown()
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
-    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
     1 * type.getInterfaces() >> { throw new Exception("getInterfaces exception") }
     1 * type.getSuperClass() >> { throw new Exception("getSuperClass exception") }
-    2 * type.getTypeName() >> "type-name"
     0 * _
   }
 
@@ -84,6 +84,5 @@ class SafeHasSuperTypeMatcherTest extends Specification {
     1 * interfaces.iterator() >> it
     1 * type.asGenericType() >> typeGeneric
     1 * typeGeneric.asErasure() >> { throw new Exception("asErasure exception") }
-    1 * typeGeneric.getTypeName() >> "typeGeneric-name"
   }
 }

--- a/testing/agent-exporter/build.gradle.kts
+++ b/testing/agent-exporter/build.gradle.kts
@@ -20,5 +20,4 @@ dependencies {
 
   implementation("io.opentelemetry:opentelemetry-exporter-otlp-common")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  compileOnly("org.slf4j:slf4j-api")
 }

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.testing.bytebuddy;
 
+import static java.util.logging.Level.SEVERE;
+
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
 import io.opentelemetry.javaagent.tooling.SafeServiceLoader;
@@ -22,7 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
@@ -150,7 +151,7 @@ public class TestAgentListener implements AgentBuilder.Listener {
     }
     if (!(throwable instanceof AbortTransformationException)) {
       logger.log(
-          Level.SEVERE,
+          SEVERE,
           "Unexpected instrumentation error when instrumenting " + typeName + " on " + classLoader,
           throwable);
       instrumentationErrorCount.incrementAndGet();

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
@@ -22,16 +22,16 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.utility.JavaModule;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestAgentListener implements AgentBuilder.Listener {
 
-  private static final Logger logger = LoggerFactory.getLogger(TestAgentListener.class);
+  private static final Logger logger = Logger.getLogger(TestAgentListener.class.getName());
 
   private static final Trie<IgnoreAllow> ADDITIONAL_LIBRARIES_TRIE;
   private static final Trie<IgnoreAllow> OTHER_IGNORES_TRIE;
@@ -149,10 +149,9 @@ public class TestAgentListener implements AgentBuilder.Listener {
       }
     }
     if (!(throwable instanceof AbortTransformationException)) {
-      logger.error(
-          "Unexpected instrumentation error when instrumenting {} on {}",
-          typeName,
-          classLoader,
+      logger.log(
+          Level.SEVERE,
+          "Unexpected instrumentation error when instrumenting " + typeName + " on " + classLoader,
           throwable);
       instrumentationErrorCount.incrementAndGet();
     }

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryLogExporter.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryLogExporter.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.testing.exporter;
 
+import static java.util.logging.Level.INFO;
+
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.data.LogData;
@@ -36,7 +38,7 @@ class OtlpInMemoryLogExporter implements LogExporter {
   @Override
   public CompletableResultCode export(Collection<LogData> logs) {
     for (LogData log : logs) {
-      logger.info("Exporting log " + log);
+      logger.log(INFO, "Exporting log {0}", log);
     }
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     try {

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryLogExporter.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryLogExporter.java
@@ -17,12 +17,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 class OtlpInMemoryLogExporter implements LogExporter {
 
-  private static final Logger logger = LoggerFactory.getLogger(OtlpInMemoryLogExporter.class);
+  private static final Logger logger = Logger.getLogger(OtlpInMemoryLogExporter.class.getName());
 
   private final Queue<byte[]> collectedRequests = new ConcurrentLinkedQueue<>();
 
@@ -37,7 +36,7 @@ class OtlpInMemoryLogExporter implements LogExporter {
   @Override
   public CompletableResultCode export(Collection<LogData> logs) {
     for (LogData log : logs) {
-      logger.info("Exporting log {}", log);
+      logger.info("Exporting log " + log);
     }
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     try {

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryMetricExporter.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryMetricExporter.java
@@ -17,12 +17,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class OtlpInMemoryMetricExporter implements MetricExporter {
-
-  private static final Logger logger = LoggerFactory.getLogger(OtlpInMemoryMetricExporter.class);
 
   private final Queue<byte[]> collectedRequests = new ConcurrentLinkedQueue<>();
 

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemorySpanExporter.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemorySpanExporter.java
@@ -17,12 +17,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 class OtlpInMemorySpanExporter implements SpanExporter {
 
-  private static final Logger logger = LoggerFactory.getLogger(OtlpInMemorySpanExporter.class);
+  private static final Logger logger = Logger.getLogger(OtlpInMemorySpanExporter.class.getName());
 
   private final Queue<byte[]> collectedRequests = new ConcurrentLinkedQueue<>();
 
@@ -37,7 +36,7 @@ class OtlpInMemorySpanExporter implements SpanExporter {
   @Override
   public CompletableResultCode export(Collection<SpanData> spans) {
     for (SpanData span : spans) {
-      logger.info("Exporting span {}", span);
+      logger.info("Exporting span " + span);
     }
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     try {

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemorySpanExporter.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemorySpanExporter.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.testing.exporter;
 
+import static java.util.logging.Level.INFO;
+
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -36,7 +38,7 @@ class OtlpInMemorySpanExporter implements SpanExporter {
   @Override
   public CompletableResultCode export(Collection<SpanData> spans) {
     for (SpanData span : spans) {
-      logger.info("Exporting span " + span);
+      logger.log(INFO, "Exporting span {0}", span);
     }
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     try {


### PR DESCRIPTION
Half of #5077

Not included in this PR:
- tooling, muzzle -- will do that in the next PR
- testing modules -- as far as I understand, we'll probably want to keep using slf4j here; in many tests, we're using testcontainers' built-in facilities to redirect container logs to slf4j logger