### PR TITLE
Retry elasticsearch start on BindTransportException

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -12,6 +12,7 @@ import org.elasticsearch.http.BindHttpException
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.Node
 import org.elasticsearch.node.internal.InternalSettingsPreparer
+import org.elasticsearch.transport.BindTransportException
 import org.elasticsearch.transport.Netty3Plugin
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -56,9 +57,14 @@ class Elasticsearch5NodeClientTest extends AbstractElasticsearchNodeClientTest {
     // retry when starting elasticsearch fails with
     // org.elasticsearch.http.BindHttpException: Failed to resolve host [[]]
     // Caused by: java.net.SocketException: No such device (getFlags() failed)
+    // or
+    // org.elasticsearch.transport.BindTransportException: Failed to resolve host null
+    // Caused by: java.net.SocketException: No such device (getFlags() failed)
     await()
       .atMost(10, TimeUnit.SECONDS)
-      .ignoreException(BindHttpException)
+      .ignoreExceptionsMatching({
+        BindHttpException.isInstance(it) || BindTransportException.isInstance(it)
+      })
       .until({
         testNode.start()
         true

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -13,6 +13,7 @@ import org.elasticsearch.http.BindHttpException
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.Node
 import org.elasticsearch.node.internal.InternalSettingsPreparer
+import org.elasticsearch.transport.BindTransportException
 import org.elasticsearch.transport.Netty3Plugin
 import org.elasticsearch.transport.RemoteTransportException
 import org.elasticsearch.transport.TransportService
@@ -60,9 +61,14 @@ class Elasticsearch5TransportClientTest extends AbstractElasticsearchTransportCl
     // retry when starting elasticsearch fails with
     // org.elasticsearch.http.BindHttpException: Failed to resolve host [[]]
     // Caused by: java.net.SocketException: No such device (getFlags() failed)
+    // or
+    // org.elasticsearch.transport.BindTransportException: Failed to resolve host null
+    // Caused by: java.net.SocketException: No such device (getFlags() failed)
     await()
       .atMost(10, TimeUnit.SECONDS)
-      .ignoreException(BindHttpException)
+      .ignoreExceptionsMatching({
+        BindHttpException.isInstance(it) || BindTransportException.isInstance(it)
+      })
       .until({
         testNode.start()
         true

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -13,6 +13,7 @@ import org.elasticsearch.http.BindHttpException
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.InternalSettingsPreparer
 import org.elasticsearch.node.Node
+import org.elasticsearch.transport.BindTransportException
 import org.elasticsearch.transport.Netty3Plugin
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -57,9 +58,14 @@ class Elasticsearch53NodeClientTest extends AbstractElasticsearchNodeClientTest 
     // retry when starting elasticsearch fails with
     // org.elasticsearch.http.BindHttpException: Failed to resolve host [[]]
     // Caused by: java.net.SocketException: No such device (getFlags() failed)
+    // or
+    // org.elasticsearch.transport.BindTransportException: Failed to resolve host null
+    // Caused by: java.net.SocketException: No such device (getFlags() failed)
     await()
       .atMost(10, TimeUnit.SECONDS)
-      .ignoreException(BindHttpException)
+      .ignoreExceptionsMatching({
+        BindHttpException.isInstance(it) || BindTransportException.isInstance(it)
+      })
       .until({
         testNode.start()
         true

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -14,6 +14,7 @@ import org.elasticsearch.http.BindHttpException
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.node.InternalSettingsPreparer
 import org.elasticsearch.node.Node
+import org.elasticsearch.transport.BindTransportException
 import org.elasticsearch.transport.Netty3Plugin
 import org.elasticsearch.transport.RemoteTransportException
 import org.elasticsearch.transport.TransportService
@@ -62,9 +63,14 @@ class Elasticsearch53TransportClientTest extends AbstractElasticsearchTransportC
     // retry when starting elasticsearch fails with
     // org.elasticsearch.http.BindHttpException: Failed to resolve host [[]]
     // Caused by: java.net.SocketException: No such device (getFlags() failed)
+    // or
+    // org.elasticsearch.transport.BindTransportException: Failed to resolve host null
+    // Caused by: java.net.SocketException: No such device (getFlags() failed)
     await()
       .atMost(10, TimeUnit.SECONDS)
-      .ignoreException(BindHttpException)
+      .ignoreExceptionsMatching({
+        BindHttpException.isInstance(it) || BindTransportException.isInstance(it)
+      })
       .until({
         testNode.start()
         true


### PR DESCRIPTION
https://ge.opentelemetry.io/s/sw6gxvd3mqotm/tests/:instrumentation:elasticsearch:elasticsearch-transport-5.0:javaagent:test/Elasticsearch5TransportClientTest/initializationError?top-execution=1