### PR TITLE
Fix flaky scala test

### DIFF
--- a/instrumentation/scala-fork-join-2.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/scalaexecutors/ScalaInstrumentationTest.scala
+++ b/instrumentation/scala-fork-join-2.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/scalaexecutors/ScalaInstrumentationTest.scala
@@ -11,7 +11,12 @@ import io.opentelemetry.instrumentation.testing.junit.{
   InstrumentationExtension
 }
 import io.opentelemetry.javaagent.testing.common.Java8BytecodeBridge
-import io.opentelemetry.sdk.testing.assertj.{SpanDataAssert, TraceAssert}
+import io.opentelemetry.sdk.testing.assertj.{
+  OpenTelemetryAssertions,
+  SpanDataAssert,
+  TraceAssert
+}
+import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.function.Consumer
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -242,28 +247,32 @@ class ScalaInstrumentationTest {
     testing.waitAndAssertTraces(
       new Consumer[TraceAssert] {
         override def accept(trace: TraceAssert): Unit =
-          trace.hasSpansSatisfyingExactly(
-            new Consumer[SpanDataAssert] {
-              override def accept(span: SpanDataAssert): Unit =
-                span
+          trace.satisfiesExactlyInAnyOrder(
+            new Consumer[SpanData] {
+              override def accept(span: SpanData): Unit =
+                OpenTelemetryAssertions
+                  .assertThat(span)
                   .hasName("parent")
                   .hasNoParent()
             },
-            new Consumer[SpanDataAssert] {
-              override def accept(span: SpanDataAssert): Unit =
-                span
+            new Consumer[SpanData] {
+              override def accept(span: SpanData): Unit =
+                OpenTelemetryAssertions
+                  .assertThat(span)
                   .hasName("timeout1")
                   .hasParent(trace.getSpan(0))
             },
-            new Consumer[SpanDataAssert] {
-              override def accept(span: SpanDataAssert): Unit =
-                span
+            new Consumer[SpanData] {
+              override def accept(span: SpanData): Unit =
+                OpenTelemetryAssertions
+                  .assertThat(span)
                   .hasName("timeout2")
                   .hasParent(trace.getSpan(0))
             },
-            new Consumer[SpanDataAssert] {
-              override def accept(span: SpanDataAssert): Unit =
-                span
+            new Consumer[SpanData] {
+              override def accept(span: SpanData): Unit =
+                OpenTelemetryAssertions
+                  .assertThat(span)
                   .hasName("timeout3")
                   .hasParent(trace.getSpan(0))
             }


### PR DESCRIPTION
https://ge.opentelemetry.io/s/jgxqztcmxojos/tests/:instrumentation:scala-fork-join-2.8:javaagent:test/io.opentelemetry.javaagent.instrumentation.scalaexecutors.ScalaInstrumentationTest/firstCompletedFuture()?top-execution=1
`timeout` spans can appear in any oder.