### PR TITLE
Fix markdown links

### DIFF
--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -11,8 +11,7 @@ Please report any bugs or unexpected behavior you find.
 
 * [SDK Autoconfiguration](#sdk-autoconfiguration)
 * [Configuring the agent](#configuring-the-agent)
-* [Peer service name](#peer-service-name)
-* [DB statement sanitization](#db-statement-sanitization)
+* [Common instrumentation configuration](#common-instrumentation-configuration)
 * [Suppressing specific auto-instrumentation](#suppressing-specific-auto-instrumentation)
 
 ## SDK Autoconfiguration


### PR DESCRIPTION
Interesting (and good) that the anchor links just started getting checked.

(CI just started failing: https://github.com/open-telemetry/opentelemetry-java-instrumentation/runs/5614114096)

EDIT Resolves #5640