### PR TITLE
Fix http concurrency test with large responses

### DIFF
--- a/instrumentation/executors/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorServiceTest.java
+++ b/instrumentation/executors/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorServiceTest.java
@@ -161,8 +161,7 @@ public abstract class AbstractExecutorServiceTest<T extends ExecutorService, U e
         });
 
     // Just check there is a single trace, this test is primarily to make sure that scopes aren't
-    // leak on
-    // cancellation.
+    // leaked on cancellation.
     testing.waitAndAssertTraces(trace -> {});
   }
 }

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
@@ -72,7 +72,7 @@ class Netty38ClientTest extends HttpClientTest<Request> implements AgentTestTrai
 
   @Override
   void sendRequestWithCallback(Request request, String method, URI uri, Map<String, String> headers, AbstractHttpClientTest.RequestResult requestResult) {
-    // TODO: context propagation into callbacks is not implemented
+    // TODO: context is not automatically propagated into callbacks
     Context context = Context.current()
     // TODO(anuraaga): Do we also need to test ListenableFuture callback?
     client.executeRequest(request, new AsyncCompletionHandler<Void>() {

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/groovy/Netty38ClientTest.groovy
@@ -10,6 +10,8 @@ import com.ning.http.client.Request
 import com.ning.http.client.RequestBuilder
 import com.ning.http.client.Response
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.Scope
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
@@ -70,17 +72,23 @@ class Netty38ClientTest extends HttpClientTest<Request> implements AgentTestTrai
 
   @Override
   void sendRequestWithCallback(Request request, String method, URI uri, Map<String, String> headers, AbstractHttpClientTest.RequestResult requestResult) {
+    // TODO: context propagation into callbacks is not implemented
+    Context context = Context.current()
     // TODO(anuraaga): Do we also need to test ListenableFuture callback?
     client.executeRequest(request, new AsyncCompletionHandler<Void>() {
       @Override
       Void onCompleted(Response response) throws Exception {
-        requestResult.complete(response.statusCode)
+        try (Scope scope = context.makeCurrent()) {
+          requestResult.complete(response.statusCode)
+        }
         return null
       }
 
       @Override
       void onThrowable(Throwable throwable) {
-        requestResult.complete(throwable)
+        try (Scope scope = context.makeCurrent()) {
+          requestResult.complete(throwable)
+        }
       }
     })
   }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/client/SpringWebFluxSingleConnection.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/client/SpringWebFluxSingleConnection.groovy
@@ -61,7 +61,7 @@ class SpringWebFluxSingleConnection implements SingleConnection {
 
     def response = request.exchange().block()
     // read response body, this will close the request and release the connection so that it can be reused
-    response.bodyToMono(String.class).block()
+    response.bodyToMono(String).block()
 
     String responseId = response.headers().asHttpHeaders().getFirst(REQUEST_ID_HEADER)
     if (requestId != responseId) {

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/client/SpringWebFluxSingleConnection.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/client/SpringWebFluxSingleConnection.groovy
@@ -60,7 +60,7 @@ class SpringWebFluxSingleConnection implements SingleConnection {
       .headers { h -> headers.forEach({ key, value -> h.add(key, value) }) }
 
     def response = request.exchange().block()
-    // read response body, this will close the request and release the connection so that it can be reused
+    // read response body, this seems to be needed to ensure that the connection can be reused
     response.bodyToMono(String).block()
 
     String responseId = response.headers().asHttpHeaders().getFirst(REQUEST_ID_HEADER)

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -832,19 +832,21 @@ public abstract class AbstractHttpClientTest<REQUEST> {
             } catch (InterruptedException e) {
               throw new AssertionError(e);
             }
-            Integer result = testing.runWithSpan(
-                "Parent span " + index,
-                () -> {
-                  Span.current().setAttribute("test.request.id", index);
-                  try {
-                    return singleConnection.doRequest(
-                        path, Collections.singletonMap("test-request-id", String.valueOf(index)));
-                  } catch (InterruptedException e) {
-                    throw new AssertionError(e);
-                  } catch (Exception e) {
-                    throw new AssertionError(e);
-                  }
-                });
+            Integer result =
+                testing.runWithSpan(
+                    "Parent span " + index,
+                    () -> {
+                      Span.current().setAttribute("test.request.id", index);
+                      try {
+                        return singleConnection.doRequest(
+                            path,
+                            Collections.singletonMap("test-request-id", String.valueOf(index)));
+                      } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                      } catch (Exception e) {
+                        throw new AssertionError(e);
+                      }
+                    });
             assertThat(result).isEqualTo(200);
           };
       pool.submit(job);

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -680,17 +680,22 @@ public abstract class AbstractHttpClientTest<REQUEST> {
               throw new AssertionError(e);
             }
             try {
-              testing.runWithSpan(
-                  "Parent span " + index,
-                  () -> {
-                    Span.current().setAttribute("test.request.id", index);
-                    doRequest(
-                        method,
-                        uri,
-                        Collections.singletonMap("test-request-id", String.valueOf(index)));
-                  });
-            } catch (Exception e) {
-              throw new AssertionError(e);
+              Integer result =
+                  testing.runWithSpan(
+                      "Parent span " + index,
+                      () -> {
+                        Span.current().setAttribute("test.request.id", index);
+                        return doRequest(
+                            method,
+                            uri,
+                            Collections.singletonMap("test-request-id", String.valueOf(index)));
+                      });
+              assertThat(result).isEqualTo(200);
+            } catch (Throwable throwable) {
+              if (throwable instanceof AssertionError) {
+                throw (AssertionError) throwable;
+              }
+              throw new AssertionError(throwable);
             }
           };
       pool.submit(job);
@@ -832,22 +837,23 @@ public abstract class AbstractHttpClientTest<REQUEST> {
             } catch (InterruptedException e) {
               throw new AssertionError(e);
             }
-            Integer result =
-                testing.runWithSpan(
-                    "Parent span " + index,
-                    () -> {
-                      Span.current().setAttribute("test.request.id", index);
-                      try {
+            try {
+              Integer result =
+                  testing.runWithSpan(
+                      "Parent span " + index,
+                      () -> {
+                        Span.current().setAttribute("test.request.id", index);
                         return singleConnection.doRequest(
                             path,
                             Collections.singletonMap("test-request-id", String.valueOf(index)));
-                      } catch (InterruptedException e) {
-                        throw new AssertionError(e);
-                      } catch (Exception e) {
-                        throw new AssertionError(e);
-                      }
-                    });
-            assertThat(result).isEqualTo(200);
+                      });
+              assertThat(result).isEqualTo(200);
+            } catch (Throwable throwable) {
+              if (throwable instanceof AssertionError) {
+                throw (AssertionError) throwable;
+              }
+              throw new AssertionError(throwable);
+            }
           };
       pool.submit(job);
     }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -832,12 +832,12 @@ public abstract class AbstractHttpClientTest<REQUEST> {
             } catch (InterruptedException e) {
               throw new AssertionError(e);
             }
-            testing.runWithSpan(
+            Integer result = testing.runWithSpan(
                 "Parent span " + index,
                 () -> {
                   Span.current().setAttribute("test.request.id", index);
                   try {
-                    singleConnection.doRequest(
+                    return singleConnection.doRequest(
                         path, Collections.singletonMap("test-request-id", String.valueOf(index)));
                   } catch (InterruptedException e) {
                     throw new AssertionError(e);
@@ -845,6 +845,7 @@ public abstract class AbstractHttpClientTest<REQUEST> {
                     throw new AssertionError(e);
                   }
                 });
+            assertThat(result).isEqualTo(200);
           };
       pool.submit(job);
     }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
@@ -65,8 +65,11 @@ public final class HttpClientTestServer extends ServerExtension {
               if (testRequestId != null) {
                 headers.set("test-request-id", testRequestId);
               }
-              // return HttpResponse.of(headers.build(), HttpData.ofAscii("Hello."));
-              return HttpResponse.of(headers.build(), HttpData.ofAscii(LONG_STRING));
+              if (testRequestId != null) {
+                return HttpResponse.of(headers.build(), HttpData.ofAscii(LONG_STRING));
+              } else {
+                return HttpResponse.of(headers.build(), HttpData.ofAscii("Hello."));
+              }
             })
         .service(
             "/client-error",

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
@@ -28,15 +28,6 @@ import java.time.Duration;
 import javax.net.ssl.KeyManagerFactory;
 
 public final class HttpClientTestServer extends ServerExtension {
-  private static final String LONG_STRING;
-
-  static {
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < 100_000; i++) {
-      sb.append("1234567890");
-    }
-    LONG_STRING = sb.toString();
-  }
 
   private final OpenTelemetry openTelemetry;
   private final Tracer tracer;
@@ -66,11 +57,7 @@ public final class HttpClientTestServer extends ServerExtension {
               if (testRequestId != null) {
                 headers.set("test-request-id", testRequestId);
               }
-              if (testRequestId != null) {
-                return HttpResponse.of(headers.build(), HttpData.ofAscii(LONG_STRING));
-              } else {
-                return HttpResponse.of(headers.build(), HttpData.ofAscii("Hello."));
-              }
+              return HttpResponse.of(headers.build(), HttpData.ofAscii("Hello."));
             })
         .service(
             "/client-error",

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
@@ -29,6 +29,7 @@ import javax.net.ssl.KeyManagerFactory;
 
 public final class HttpClientTestServer extends ServerExtension {
   private static final String LONG_STRING;
+
   static {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < 100_000; i++) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
@@ -28,6 +28,14 @@ import java.time.Duration;
 import javax.net.ssl.KeyManagerFactory;
 
 public final class HttpClientTestServer extends ServerExtension {
+  private static final String LONG_STRING;
+  static {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 100_000; i++) {
+      sb.append("1234567890");
+    }
+    LONG_STRING = sb.toString();
+  }
 
   private final OpenTelemetry openTelemetry;
   private final Tracer tracer;
@@ -57,7 +65,8 @@ public final class HttpClientTestServer extends ServerExtension {
               if (testRequestId != null) {
                 headers.set("test-request-id", testRequestId);
               }
-              return HttpResponse.of(headers.build(), HttpData.ofAscii("Hello."));
+              // return HttpResponse.of(headers.build(), HttpData.ofAscii("Hello."));
+              return HttpResponse.of(headers.build(), HttpData.ofAscii(LONG_STRING));
             })
         .service(
             "/client-error",


### PR DESCRIPTION
While trying to reproduce https://ge.opentelemetry.io/s/cii3nazylwp3y/tests/:instrumentation:google-http-client-1.19:javaagent:test/io.opentelemetry.javaagent.instrumentation.googlehttpclient.GoogleHttpClientAsyncTest/highConcurrency() I made http concurrency tests use a large response which caused some test to fail. Hopefully these changes will make it easier in case a similar test needs to be carried out in the future.