### PR TITLE
Only set read timeout for requests to /read-timeout

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/groovy/ApacheHttpClientTest.groovy
@@ -41,7 +41,7 @@ abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTes
       HttpConnectionParams.setSoTimeout(httpParams, READ_TIMEOUT_MS)
     }
     httpParams.setParameter(ClientPNames.CONNECTION_MANAGER_FACTORY_CLASS_NAME, ThreadSafeClientConnManagerFactory.getName())
-    client = new DefaultHttpClient(httpParams)
+    return new DefaultHttpClient(httpParams)
   }
 
   DefaultHttpClient getClient(URI uri) {


### PR DESCRIPTION
Setting read timeout for all requests causes occasional failures
https://ge.opentelemetry.io/s/cm5oxzwfgnzhs/tests/:instrumentation:apache-httpclient:apache-httpclient-4.0:javaagent:test/ApacheClientHostAbsoluteUriRequest/basic%20GET%20request%20%2Fsuccess?top-execution=1