### PR TITLE
Fix flaky executor test

### DIFF
--- a/instrumentation/executors/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorServiceTest.java
+++ b/instrumentation/executors/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/javaconcurrent/AbstractExecutorServiceTest.java
@@ -150,7 +150,7 @@ public abstract class AbstractExecutorServiceTest<T extends ExecutorService, U e
             // we do not really have a good way for attributing work to correct parent span
             // if we reuse Callable/Runnable.
             // Solution for now is to never reuse a Callable/Runnable.
-            U child = newTask(true, true);
+            U child = newTask(false, true);
             children.add(child);
             Future<?> f = task.apply(child);
             jobFutures.add(f);


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.javaagent.instrumentation.javaconcurrent.ExecutorInstrumentationTest$ForkJoinPoolTest&tests.sortField=FLAKY&tests.test=submitCallableAndCancel()&tests.unstableOnly=true
https://ge.opentelemetry.io/s/exd67nuddwccg/tests/:instrumentation:akka:akka-actor-fork-join-2.5:javaagent:test/io.opentelemetry.instrumentation.akkaactor.AkkaExecutorInstrumentationTest/submitCallableAndCancel()?top-execution=1
Change the behaviour back to how it was before the test was converted to java https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/2ce764bd2a8a03b410d4855d50d6b6c02e7d7db1/instrumentation/executors/javaagent/src/test/groovy/ExecutorInstrumentationTest.groovy#L213
I guess the problem is that canceling the task clears propagated context. If the canceled task still manages to execute we'll have more than one trace.