### PR TITLE
Consolidate request listener lists

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -18,6 +18,7 @@ import io.opentelemetry.instrumentation.api.internal.SupportabilityMetrics;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -100,7 +101,6 @@ public class Instrumenter<REQUEST, RESPONSE> {
       attributesExtractors;
   private final List<? extends ContextCustomizer<? super REQUEST>> contextCustomizers;
   private final List<? extends RequestListener> requestListeners;
-  private final List<? extends RequestListener> requestMetricListeners;
   private final ErrorCauseExtractor errorCauseExtractor;
   @Nullable private final TimeExtractor<REQUEST, RESPONSE> timeExtractor;
   private final boolean disabled;
@@ -117,7 +117,6 @@ public class Instrumenter<REQUEST, RESPONSE> {
     this.attributesExtractors = new ArrayList<>(builder.attributesExtractors);
     this.contextCustomizers = new ArrayList<>(builder.contextCustomizers);
     this.requestListeners = new ArrayList<>(builder.requestListeners);
-    this.requestMetricListeners = new ArrayList<>(builder.requestMetricListeners);
     this.errorCauseExtractor = builder.errorCauseExtractor;
     this.timeExtractor = builder.timeExtractor;
     this.disabled = builder.disabled;
@@ -177,6 +176,10 @@ public class Instrumenter<REQUEST, RESPONSE> {
 
     Context context = parentContext;
 
+    spanBuilder.setAllAttributes(attributes);
+    Span span = spanBuilder.startSpan();
+    context = context.with(span);
+
     for (ContextCustomizer<? super REQUEST> contextCustomizer : contextCustomizers) {
       context = contextCustomizer.start(context, request, attributes);
     }
@@ -184,19 +187,6 @@ public class Instrumenter<REQUEST, RESPONSE> {
     if (!requestListeners.isEmpty()) {
       long startNanos = getNanos(startTime);
       for (RequestListener requestListener : requestListeners) {
-        context = requestListener.start(context, attributes, startNanos);
-      }
-    }
-
-    spanBuilder.setAllAttributes(attributes);
-    Span span = spanBuilder.startSpan();
-    context = context.with(span);
-
-    // request metric listeners need to run after the span has been added to the context in order
-    // for them to generate exemplars
-    if (!requestMetricListeners.isEmpty()) {
-      long startNanos = getNanos(startTime);
-      for (RequestListener requestListener : requestMetricListeners) {
         context = requestListener.start(context, attributes, startNanos);
       }
     }
@@ -230,14 +220,12 @@ public class Instrumenter<REQUEST, RESPONSE> {
       endTime = timeExtractor.extractEndTime(request, response, error);
     }
 
-    if (!requestListeners.isEmpty() || !requestMetricListeners.isEmpty()) {
+    if (!requestListeners.isEmpty()) {
       long endNanos = getNanos(endTime);
-      // TODO (trask) call end in the reverse order that start was called?
-      for (RequestListener requestListener : requestMetricListeners) {
-        requestListener.end(context, attributes, endNanos);
-      }
-      for (RequestListener requestListener : requestListeners) {
-        requestListener.end(context, attributes, endNanos);
+      ListIterator<? extends RequestListener> i =
+          requestListeners.listIterator(requestListeners.size());
+      while (i.hasPrevious()) {
+        i.previous().end(context, attributes, endNanos);
       }
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
@@ -53,7 +53,6 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
       new ArrayList<>();
   final List<ContextCustomizer<? super REQUEST>> contextCustomizers = new ArrayList<>();
   final List<RequestListener> requestListeners = new ArrayList<>();
-  final List<RequestListener> requestMetricListeners = new ArrayList<>();
 
   SpanKindExtractor<? super REQUEST> spanKindExtractor = SpanKindExtractor.alwaysInternal();
   SpanStatusExtractor<? super REQUEST, ? super RESPONSE> spanStatusExtractor =
@@ -134,7 +133,7 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
   /** Adds a {@link RequestMetrics} whose metrics will be recorded for request start and end. */
   @UnstableApi
   public InstrumenterBuilder<REQUEST, RESPONSE> addRequestMetrics(RequestMetrics factory) {
-    requestMetricListeners.add(factory.create(meter));
+    requestListeners.add(factory.create(meter));
     return this;
   }
 


### PR DESCRIPTION
follow-up from @mateuszrzeszutek's https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5655#discussion_r831930029

This PR moves context customizer execution and request listener start execution from right before the span is started until right after the span is started.

This makes the newly create span available in the Context, which the metric listeners need for generating exemplars, and seems like could be useful for other listeners.

I'm thinking it doesn't matter much one way or the other for context customizers, so seems to make some sense to me to keep them with the listeners (after span start), so we can think of all context updates happening after span start.