### PR TITLE
Read response body in jax-rs client and google http client tests

### DIFF
--- a/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/AbstractGoogleHttpClientTest.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/AbstractGoogleHttpClientTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractGoogleHttpClientTest extends AbstractHttpClientTes
   protected final int sendRequest(
       HttpRequest request, String method, URI uri, Map<String, String> headers) throws Exception {
     HttpResponse response = sendRequest(request);
-    // read request body
+    // read request body to avoid broken pipe errors on the server side
     response.parseAsString();
     return response.getStatusCode();
   }

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/AbstractGoogleHttpClientTest.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/AbstractGoogleHttpClientTest.java
@@ -73,7 +73,10 @@ public abstract class AbstractGoogleHttpClientTest extends AbstractHttpClientTes
   @Override
   protected final int sendRequest(
       HttpRequest request, String method, URI uri, Map<String, String> headers) throws Exception {
-    return sendRequest(request).getStatusCode();
+    HttpResponse response = sendRequest(request);
+    // read request body
+    response.parseAsString();
+    return response.getStatusCode();
   }
 
   protected abstract HttpResponse sendRequest(HttpRequest request) throws Exception;

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/src/test/groovy/JaxRsClientTest.groovy
@@ -44,6 +44,8 @@ abstract class JaxRsClientTest extends HttpClientTest<Invocation.Builder> implem
     try {
       def body = BODY_METHODS.contains(method) ? Entity.text("") : null
       def response = request.build(method, body).invoke()
+      // read response body
+      response.readEntity(String)
       try {
         response.close()
       } catch (IOException ignore) {
@@ -61,6 +63,8 @@ abstract class JaxRsClientTest extends HttpClientTest<Invocation.Builder> implem
     request.async().method(method, (Entity) body, new InvocationCallback<Response>() {
       @Override
       void completed(Response response) {
+        // read response body
+        response.readEntity(String)
         requestResult.complete(response.status)
       }
 

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/src/test/groovy/JaxRsClientTest.groovy
@@ -44,7 +44,7 @@ abstract class JaxRsClientTest extends HttpClientTest<Invocation.Builder> implem
     try {
       def body = BODY_METHODS.contains(method) ? Entity.text("") : null
       def response = request.build(method, body).invoke()
-      // read response body
+      // read response body to avoid broken pipe errors on the server side
       response.readEntity(String)
       try {
         response.close()


### PR DESCRIPTION
There is a strange flake in concurrency test for some http client where some requests have double span for `test-http-server`. For the request that has the double server span there is always a matching warning
```
05:01:45.959 [armeria-common-worker-epoll-2-1] WARN  i.o.t.i.a.s.logging.LoggingService - [sreqId=2aa9a6ac, chanId=b229bb7c, raddr=127.0.0.1:49166, laddr=127.0.0.1:33525][h1c://fv-az204-530/success#GET] Request: {startTime=2022-03-20T05:01:45.919Z(1647752505919000), length=0B, duration=17901µs(17901140ns), cause=io.opentelemetry.testing.internal.io.netty.channel.unix.Errors$NativeIoException: writevAddresses(..) failed: Broken pipe, scheme=none+h1c, name=GET, headers=[:method=GET, :path=/success, :scheme=http, accept-encoding=gzip, user-agent=Google-HTTP-Java-Client/1.19.0 (gzip), test-request-id=25, traceparent=00-ea070902a2a6eb42afebcd043e990368-4698e51253b9d189-01, host=localhost:33525, accept=text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2]}
```
I believe these broken pipes happen because client close the response before server has managed to completely send the body.
I wasn't able to reproduce the double spans locally. I did try to increase the rate of broken pipes by using a response body but that wasn't able to trigger the failure on github. Perhaps I didn't rerun the tests enough times. It seems easier to just add reading the response body to a couple of tests and see if this gets rid of the failure, and if it does do the same change to other http client tests with the same issue (not all of them seem to have it).

For example of the failure see https://ge.opentelemetry.io/s/cii3nazylwp3y/tests/:instrumentation:google-http-client-1.19:javaagent:test/io.opentelemetry.javaagent.instrumentation.googlehttpclient.GoogleHttpClientAsyncTest/highConcurrency()?top-execution=1