### PR TITLE
Allows passing an OpenTelemetry instance to registerObservers() methods.

### DIFF
--- a/instrumentation/oshi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/MetricsRegistration.java
+++ b/instrumentation/oshi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/MetricsRegistration.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.oshi;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.oshi.ProcessMetrics;
 import io.opentelemetry.instrumentation.oshi.SystemMetrics;
@@ -16,12 +17,12 @@ public final class MetricsRegistration {
 
   public static void register() {
     if (registered.compareAndSet(false, true)) {
-      SystemMetrics.registerObservers();
+      SystemMetrics.registerObservers(GlobalOpenTelemetry.get());
 
       // ProcessMetrics don't follow the spec
       if (Config.get()
           .getBoolean("otel.instrumentation.oshi.experimental-metrics.enabled", false)) {
-        ProcessMetrics.registerObservers();
+        ProcessMetrics.registerObservers(GlobalOpenTelemetry.get());
       }
     }
   }

--- a/instrumentation/oshi/library/src/main/java/io/opentelemetry/instrumentation/oshi/ProcessMetrics.java
+++ b/instrumentation/oshi/library/src/main/java/io/opentelemetry/instrumentation/oshi/ProcessMetrics.java
@@ -20,10 +20,16 @@ public class ProcessMetrics {
 
   private ProcessMetrics() {}
 
-  /** Register observers for java runtime metrics. */
+  /**
+   * Register observers for java runtime metrics.
+   *
+   * @deprecated use {@link #registerObservers(OpenTelemetry openTelemetry)}
+   */
+  @Deprecated
   public static void registerObservers() {
     registerObservers(GlobalOpenTelemetry.get());
   }
+
   public static void registerObservers(OpenTelemetry openTelemetry) {
     Meter meter = openTelemetry.getMeterProvider().get("io.opentelemetry.oshi");
     SystemInfo systemInfo = new SystemInfo();

--- a/instrumentation/oshi/library/src/main/java/io/opentelemetry/instrumentation/oshi/ProcessMetrics.java
+++ b/instrumentation/oshi/library/src/main/java/io/opentelemetry/instrumentation/oshi/ProcessMetrics.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.oshi;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
@@ -21,8 +22,10 @@ public class ProcessMetrics {
 
   /** Register observers for java runtime metrics. */
   public static void registerObservers() {
-    // TODO(anuraaga): registerObservers should accept an OpenTelemetry instance
-    Meter meter = GlobalOpenTelemetry.get().getMeterProvider().get("io.opentelemetry.oshi");
+    registerObservers(GlobalOpenTelemetry.get());
+  }
+  public static void registerObservers(OpenTelemetry openTelemetry) {
+    Meter meter = openTelemetry.getMeterProvider().get("io.opentelemetry.oshi");
     SystemInfo systemInfo = new SystemInfo();
     OperatingSystem osInfo = systemInfo.getOperatingSystem();
     OSProcess processInfo = osInfo.getProcess(osInfo.getProcessId());

--- a/instrumentation/oshi/library/src/main/java/io/opentelemetry/instrumentation/oshi/SystemMetrics.java
+++ b/instrumentation/oshi/library/src/main/java/io/opentelemetry/instrumentation/oshi/SystemMetrics.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.oshi;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
@@ -29,8 +30,10 @@ public class SystemMetrics {
 
   /** Register observers for system metrics. */
   public static void registerObservers() {
-    // TODO(anuraaga): registerObservers should accept an OpenTelemetry instance
-    Meter meter = GlobalOpenTelemetry.get().getMeterProvider().get("io.opentelemetry.oshi");
+    registerObservers(GlobalOpenTelemetry.get());
+  }
+  public static void registerObservers(OpenTelemetry openTelemetry) {
+    Meter meter = openTelemetry.getMeterProvider().get("io.opentelemetry.oshi");
     SystemInfo systemInfo = new SystemInfo();
     HardwareAbstractionLayer hal = systemInfo.getHardware();
 

--- a/instrumentation/oshi/library/src/main/java/io/opentelemetry/instrumentation/oshi/SystemMetrics.java
+++ b/instrumentation/oshi/library/src/main/java/io/opentelemetry/instrumentation/oshi/SystemMetrics.java
@@ -28,10 +28,16 @@ public class SystemMetrics {
 
   private SystemMetrics() {}
 
-  /** Register observers for system metrics. */
+  /**
+   * Register observers for system metrics.
+   *
+   * @deprecated use {@link #registerObservers(OpenTelemetry openTelemetry)}
+   */
+  @Deprecated
   public static void registerObservers() {
     registerObservers(GlobalOpenTelemetry.get());
   }
+
   public static void registerObservers(OpenTelemetry openTelemetry) {
     Meter meter = openTelemetry.getMeterProvider().get("io.opentelemetry.oshi");
     SystemInfo systemInfo = new SystemInfo();

--- a/instrumentation/oshi/library/src/test/java/io/opentelemetry/instrumentation/oshi/ProcessMetricsTest.java
+++ b/instrumentation/oshi/library/src/test/java/io/opentelemetry/instrumentation/oshi/ProcessMetricsTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.oshi;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -16,7 +17,7 @@ class ProcessMetricsTest extends AbstractProcessMetricsTest {
 
   @Override
   protected void registerMetrics() {
-    ProcessMetrics.registerObservers();
+    ProcessMetrics.registerObservers(GlobalOpenTelemetry.get());
   }
 
   @Override

--- a/instrumentation/oshi/library/src/test/java/io/opentelemetry/instrumentation/oshi/SystemMetricsTest.java
+++ b/instrumentation/oshi/library/src/test/java/io/opentelemetry/instrumentation/oshi/SystemMetricsTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.oshi;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -16,7 +17,7 @@ class SystemMetricsTest extends AbstractSystemMetricsTest {
 
   @Override
   protected void registerMetrics() {
-    SystemMetrics.registerObservers();
+    SystemMetrics.registerObservers(GlobalOpenTelemetry.get());
   }
 
   @Override

--- a/instrumentation/runtime-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsInstaller.java
+++ b/instrumentation/runtime-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsInstaller.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.javaagent.runtimemetrics;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.runtimemetrics.GarbageCollector;
 import io.opentelemetry.instrumentation.runtimemetrics.MemoryPools;
@@ -20,8 +21,8 @@ public class RuntimeMetricsInstaller implements AgentListener {
   public void afterAgent(Config config, AutoConfiguredOpenTelemetrySdk unused) {
     if (config.isInstrumentationEnabled(
         Collections.singleton("runtime-metrics"), /* defaultEnabled= */ true)) {
-      GarbageCollector.registerObservers();
-      MemoryPools.registerObservers();
+      GarbageCollector.registerObservers(GlobalOpenTelemetry.get());
+      MemoryPools.registerObservers(GlobalOpenTelemetry.get());
     }
   }
 }

--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
@@ -21,7 +21,7 @@ import java.util.List;
  * <p>Example usage:
  *
  * <pre>{@code
- * GarbageCollector.registerObservers();
+ * GarbageCollector.registerObservers(GlobalOpenTelemetry.get());
  * }</pre>
  *
  * <p>Example metrics being exported:
@@ -34,15 +34,19 @@ import java.util.List;
 public final class GarbageCollector {
   private static final AttributeKey<String> GC_KEY = AttributeKey.stringKey("gc");
 
-  /** Register all observers provided by this module. */
+  /**
+   * Register all observers provided by this module.
+   *
+   * @deprecated use {@link #registerObservers(OpenTelemetry openTelemetry)}
+   */
+  @Deprecated
   public static void registerObservers() {
     registerObservers(GlobalOpenTelemetry.get());
   }
 
   public static void registerObservers(OpenTelemetry openTelemetry) {
     List<GarbageCollectorMXBean> garbageCollectors = ManagementFactory.getGarbageCollectorMXBeans();
-    Meter meter =
-        openTelemetry.getMeterProvider().get(GarbageCollector.class.getName());
+    Meter meter = openTelemetry.getMeterProvider().get(GarbageCollector.class.getName());
     List<Attributes> labelSets = new ArrayList<>(garbageCollectors.size());
     for (GarbageCollectorMXBean gc : garbageCollectors) {
       labelSets.add(Attributes.of(GC_KEY, gc.getName()));

--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.runtimemetrics;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
@@ -35,10 +36,13 @@ public final class GarbageCollector {
 
   /** Register all observers provided by this module. */
   public static void registerObservers() {
-    // TODO(anuraaga): registerObservers should accept an OpenTelemetry instance
+    registerObservers(GlobalOpenTelemetry.get());
+  }
+
+  public static void registerObservers(OpenTelemetry openTelemetry) {
     List<GarbageCollectorMXBean> garbageCollectors = ManagementFactory.getGarbageCollectorMXBeans();
     Meter meter =
-        GlobalOpenTelemetry.get().getMeterProvider().get(GarbageCollector.class.getName());
+        openTelemetry.getMeterProvider().get(GarbageCollector.class.getName());
     List<Attributes> labelSets = new ArrayList<>(garbageCollectors.size());
     for (GarbageCollectorMXBean gc : garbageCollectors) {
       labelSets.add(Attributes.of(GC_KEY, gc.getName()));

--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/MemoryPools.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/MemoryPools.java
@@ -24,7 +24,7 @@ import java.util.List;
  * <p>Example usage:
  *
  * <pre>{@code
- * MemoryPools.registerObservers();
+ * MemoryPools.registerObservers(GlobalOpenTelemetry.get());
  * }</pre>
  *
  * <p>Example metrics being exported: Component
@@ -59,6 +59,7 @@ public final class MemoryPools {
   private static final Attributes MAX_NON_HEAP = Attributes.of(TYPE_KEY, MAX, AREA_KEY, NON_HEAP);
 
   /** Register only the "area" measurements. */
+  @Deprecated
   public static void registerMemoryAreaObservers() {
     registerMemoryPoolObservers(GlobalOpenTelemetry.get());
   }
@@ -78,6 +79,7 @@ public final class MemoryPools {
   }
 
   /** Register only the "pool" measurements. */
+  @Deprecated
   public static void registerMemoryPoolObservers() {
     registerMemoryPoolObservers(GlobalOpenTelemetry.get());
   }
@@ -113,7 +115,12 @@ public final class MemoryPools {
             });
   }
 
-  /** Register all measurements provided by this module. */
+  /**
+   * Register all measurements provided by this module.
+   *
+   * @deprecated use {@link #registerObservers(OpenTelemetry openTelemetry)}
+   */
+  @Deprecated
   public static void registerObservers() {
     registerMemoryAreaObservers();
     registerMemoryPoolObservers();

--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/MemoryPools.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/MemoryPools.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.runtimemetrics;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
@@ -59,9 +60,12 @@ public final class MemoryPools {
 
   /** Register only the "area" measurements. */
   public static void registerMemoryAreaObservers() {
-    // TODO(anuraaga): registerObservers should accept an OpenTelemetry instance
+    registerMemoryPoolObservers(GlobalOpenTelemetry.get());
+  }
+
+  public static void registerMemoryAreaObservers(OpenTelemetry openTelemetry) {
     MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
-    Meter meter = GlobalOpenTelemetry.get().getMeterProvider().get(MemoryPools.class.getName());
+    Meter meter = openTelemetry.getMeterProvider().get(MemoryPools.class.getName());
     meter
         .upDownCounterBuilder("runtime.jvm.memory.area")
         .setDescription("Bytes of a given JVM memory area.")
@@ -75,9 +79,12 @@ public final class MemoryPools {
 
   /** Register only the "pool" measurements. */
   public static void registerMemoryPoolObservers() {
-    // TODO(anuraaga): registerObservers should accept an OpenTelemetry instance
+    registerMemoryPoolObservers(GlobalOpenTelemetry.get());
+  }
+
+  public static void registerMemoryPoolObservers(OpenTelemetry openTelemetry) {
     List<MemoryPoolMXBean> poolBeans = ManagementFactory.getMemoryPoolMXBeans();
-    Meter meter = GlobalOpenTelemetry.get().getMeterProvider().get(MemoryPools.class.getName());
+    Meter meter = openTelemetry.getMeterProvider().get(MemoryPools.class.getName());
     List<Attributes> usedLabelSets = new ArrayList<>(poolBeans.size());
     List<Attributes> committedLabelSets = new ArrayList<>(poolBeans.size());
     List<Attributes> maxLabelSets = new ArrayList<>(poolBeans.size());
@@ -110,6 +117,12 @@ public final class MemoryPools {
   public static void registerObservers() {
     registerMemoryAreaObservers();
     registerMemoryPoolObservers();
+  }
+
+  /** Register all measurements provided by this module. */
+  public static void registerObservers(OpenTelemetry openTelemetry) {
+    registerMemoryAreaObservers(openTelemetry);
+    registerMemoryPoolObservers(openTelemetry);
   }
 
   static void recordHeap(ObservableLongMeasurement measurement, MemoryUsage usage) {


### PR DESCRIPTION
Resolves open-telemetry/opentelemetry-java-instrumentation#5715