### PR TITLE
Fix flaky exception handler test

### DIFF
--- a/javaagent-tooling/src/testExceptionHandler/java/io/opentelemetry/javaagent/tooling/bytebuddy/ExceptionHandlerTest.java
+++ b/javaagent-tooling/src/testExceptionHandler/java/io/opentelemetry/javaagent/tooling/bytebuddy/ExceptionHandlerTest.java
@@ -30,6 +30,7 @@ class ExceptionHandlerTest {
 
   private static final TestHandler testHandler = new TestHandler();
   private static ResettableClassFileTransformer transformer;
+  private static Logger exceptionLogger;
 
   @BeforeAll
   static void setUp() {
@@ -58,9 +59,11 @@ class ExceptionHandlerTest {
     ByteBuddyAgent.install();
     transformer = builder.installOn(ByteBuddyAgent.getInstrumentation());
 
-    Logger logger = Logger.getLogger(ExceptionLogger.class.getName());
-    logger.setLevel(Level.FINE);
-    logger.addHandler(testHandler);
+    // keep logger in static field to ensure that it won't get gcd before ExceptionLogger
+    // class is initialized which would reset logger back to default configuration
+    exceptionLogger = Logger.getLogger(ExceptionLogger.class.getName());
+    exceptionLogger.setLevel(Level.FINE);
+    exceptionLogger.addHandler(testHandler);
   }
 
   @AfterAll


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.javaagent.tooling.bytebuddy.ExceptionHandlerTest&tests.sortField=FLAKY&tests.test=exceptionHandlerInvoked()&tests.unstableOnly=true
I believe the issue is that the logger configured in test gets gcd before `ExceptionLogger` class that also uses it is initialized. This causes the configuration changes to get lost. Instead of keeping the logger in a field could also force initialization of `ExceptionLogger` before changing logger configuration. 