### PR TITLE
Flaky spring kafka batch test

### DIFF
--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/groovy/SpringKafkaInstrumentationTest.groovy
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/groovy/SpringKafkaInstrumentationTest.groovy
@@ -76,7 +76,6 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
       Listener.reset()
 
       runWithSpan("producer") {
-        // wrapping in a transaction is needed to remove the possibility of messages being picked up separately by the consumer
         kafkaTemplate.executeInTransaction({ ops ->
           ops.send("testTopic", "10", "testSpan1")
           ops.send("testTopic", "20", "testSpan2")

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/groovy/SpringKafkaInstrumentationTest.groovy
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/groovy/SpringKafkaInstrumentationTest.groovy
@@ -8,6 +8,9 @@ import io.opentelemetry.instrumentation.testing.GlobalTraceUtil
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.springframework.boot.SpringApplication
@@ -64,12 +67,29 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
     def kafkaTemplate = applicationContext.getBean("kafkaTemplate", KafkaTemplate)
 
     when:
-    runWithSpan("producer") {
-      // wrapping in a transaction is needed to remove the possibility of messages being picked up separately by the consumer
-      kafkaTemplate.executeInTransaction({ ops ->
-        ops.send("testTopic", "10", "testSpan1")
-        ops.send("testTopic", "20", "testSpan2")
-      })
+    // This test assumes that messages are sent and received as a batch. Occasionally it happens
+    // that the messages are not received as a batch, but one by one. This doesn't match what the
+    // assertion expects. To reduce flakiness we retry the test when messages weren't received as
+    // a batch.
+    def maxAttempts = 5
+    for (i in 1..maxAttempts) {
+      Listener.reset()
+
+      runWithSpan("producer") {
+        // wrapping in a transaction is needed to remove the possibility of messages being picked up separately by the consumer
+        kafkaTemplate.executeInTransaction({ ops ->
+          ops.send("testTopic", "10", "testSpan1")
+          ops.send("testTopic", "20", "testSpan2")
+        })
+      }
+
+      Listener.waitForMessages()
+      if (Listener.getLastBatchSize() == 2) {
+        break
+      } else if (i < maxAttempts) {
+        ignoreTracesAndClear(2)
+        System.err.println("Messages weren't received as batch, retrying")
+      }
     }
 
     then:
@@ -242,15 +262,35 @@ class SpringKafkaInstrumentationTest extends AgentInstrumentationSpecification {
   }
 
   static class Listener {
+    static AtomicInteger lastBatchSize = new AtomicInteger()
+    static CountDownLatch messageReceived = new CountDownLatch(2)
 
     @KafkaListener(id = "testListener", topics = "testTopic", containerFactory = "batchFactory")
     void listener(List<ConsumerRecord<String, String>> records) {
+      lastBatchSize.set(records.size())
+      records.size().times {
+        messageReceived.countDown()
+      }
+
       GlobalTraceUtil.runWithSpan("consumer") {}
       records.forEach({ record ->
         if (record.value() == "error") {
           throw new IllegalArgumentException("boom")
         }
       })
+    }
+
+    static void reset() {
+      messageReceived = new CountDownLatch(2)
+      lastBatchSize.set(0)
+    }
+
+    static void waitForMessages() {
+      messageReceived.await(30, TimeUnit.SECONDS)
+    }
+
+    static int getLastBatchSize() {
+      return lastBatchSize.get()
     }
   }
 }


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.relativeStartTime=P7D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=SpringKafkaInstrumentationTest&tests.sortField=FLAKY&tests.test=should%20create%20spans%20for%20batch%20receive%2Bprocess&tests.unstableOnly=true
`kafkaTemplate.executeInTransaction` doesn't seem to guarantee that messages will be sent as one batch. To reproduce the failure insert a `Thread.sleep` between sending the messages. I couldn't come up with anything else besides retrying like in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4922