### PR TITLE
Tweak Guava WithSpan test pattern.

### DIFF
--- a/instrumentation/guava-10.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/guava/TracedWithSpan.java
+++ b/instrumentation/guava-10.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/guava/TracedWithSpan.java
@@ -5,12 +5,26 @@
 
 package io.opentelemetry.javaagent.instrumentation.guava;
 
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import io.opentelemetry.extension.annotations.WithSpan;
 
 final class TracedWithSpan {
+  static final IllegalArgumentException FAILURE = new IllegalArgumentException("Boom");
+
   @WithSpan
-  ListenableFuture<String> listenableFuture(ListenableFuture<String> future) {
-    return future;
+  SettableFuture<String> completable() {
+    return SettableFuture.create();
+  }
+
+  @WithSpan
+  ListenableFuture<String> alreadySucceeded() {
+    return Futures.immediateFuture("Value");
+  }
+
+  @WithSpan
+  ListenableFuture<String> alreadyFailed() {
+    return Futures.immediateFailedFuture(FAILURE);
   }
 }


### PR DESCRIPTION
I was looking through the TracedWithSpan tests to potentially share logic and realized the pattern looks a bit weird to me. We pass in a future to the traced method, which is not a real-world pattern - indeed if the same future gets passed through multiple WithSpan methods the behavior is undefined. We don't expect that problem to happen in the real world (though maybe we do want to add some sort of detection / logging of this) but either way it would be good for the tests to match real world patterns better.

Will in another PR extract these tests into a shared location