### PR TITLE
Rename view and controller suppression config properties

### DIFF
--- a/docs/contributing/using-instrumenter-api.md
+++ b/docs/contributing/using-instrumenter-api.md
@@ -420,8 +420,9 @@ method.
 ### Disable the instrumentation
 
 In some rare cases it may be useful to completely disable the constructed `Instrumenter`, for
-example, based on a configuration property. The `InstrumenterBuilder` exposes a `setDisabled()`
-method for that: passing `true` will turn the newly created `Instrumenter` into a no-op instance.
+example, based on a configuration property. The `InstrumenterBuilder` exposes a `disable()`
+method for that: calling it will turn the newly created `Instrumenter` into a no-op instance.
+Alternatively, you can use the `setEnabled()` method and pass `false` as the argument.
 
 ### Finally, set the span kind with the `SpanKindExtractor` and get a new `Instrumenter`!
 

--- a/docs/contributing/using-instrumenter-api.md
+++ b/docs/contributing/using-instrumenter-api.md
@@ -420,9 +420,8 @@ method.
 ### Disable the instrumentation
 
 In some rare cases it may be useful to completely disable the constructed `Instrumenter`, for
-example, based on a configuration property. The `InstrumenterBuilder` exposes a `disable()`
-method for that: calling it will turn the newly created `Instrumenter` into a no-op instance.
-Alternatively, you can use the `setEnabled()` method and pass `false` as the argument.
+example, based on a configuration property. The `InstrumenterBuilder` exposes a `setEnabled()`
+method for that: passing `false` will turn the newly created `Instrumenter` into a no-op instance.
 
 ### Finally, set the span kind with the `SpanKindExtractor` and get a new `Instrumenter`!
 

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/config/ExperimentalConfig.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/config/ExperimentalConfig.java
@@ -23,13 +23,22 @@ public final class ExperimentalConfig {
     this.config = config;
   }
 
-  public boolean suppressControllerSpans() {
+  public boolean controllerTelemetryEnabled() {
+    // TODO: remove that `suppress...` flag after 1.13 release
+    boolean suppressControllerSpans =
+        config.getBoolean(
+            "otel.instrumentation.common.experimental.suppress-controller-spans", false);
     return config.getBoolean(
-        "otel.instrumentation.common.experimental.suppress-controller-spans", false);
+        "otel.instrumentation.common.experimental.controller-telemetry.enabled",
+        !suppressControllerSpans);
   }
 
-  public boolean suppressViewSpans() {
-    return config.getBoolean("otel.instrumentation.common.experimental.suppress-view-spans", false);
+  public boolean viewTelemetryEnabled() {
+    // TODO: remove that `suppress...` flag after 1.13 release
+    boolean suppressViewSpans =
+        config.getBoolean("otel.instrumentation.common.experimental.suppress-view-spans", false);
+    return config.getBoolean(
+        "otel.instrumentation.common.experimental.view-telemetry.enabled", !suppressViewSpans);
   }
 
   public boolean messagingReceiveInstrumentationEnabled() {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -103,7 +103,7 @@ public class Instrumenter<REQUEST, RESPONSE> {
   private final List<? extends RequestListener> requestListeners;
   private final ErrorCauseExtractor errorCauseExtractor;
   @Nullable private final TimeExtractor<REQUEST, RESPONSE> timeExtractor;
-  private final boolean disabled;
+  private final boolean enabled;
   private final SpanSuppressionStrategy spanSuppressionStrategy;
 
   Instrumenter(InstrumenterBuilder<REQUEST, RESPONSE> builder) {
@@ -119,7 +119,7 @@ public class Instrumenter<REQUEST, RESPONSE> {
     this.requestListeners = new ArrayList<>(builder.requestListeners);
     this.errorCauseExtractor = builder.errorCauseExtractor;
     this.timeExtractor = builder.timeExtractor;
-    this.disabled = builder.disabled;
+    this.enabled = builder.enabled;
     this.spanSuppressionStrategy = builder.getSpanSuppressionStrategy();
   }
 
@@ -130,7 +130,7 @@ public class Instrumenter<REQUEST, RESPONSE> {
    * without calling those methods.
    */
   public boolean shouldStart(Context parentContext, REQUEST request) {
-    if (disabled) {
+    if (!enabled) {
       return false;
     }
     SpanKind spanKind = spanKindExtractor.extract(request);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
@@ -160,15 +160,6 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
   }
 
   /**
-   * Disables the {@link Instrumenter} - it will not generate any telemetry.
-   *
-   * <p>Equivalent to calling {@code .setEnabled(false)}.
-   */
-  public InstrumenterBuilder<REQUEST, RESPONSE> disable() {
-    return setEnabled(false);
-  }
-
-  /**
    * Allows enabling/disabling the {@link Instrumenter} based on the {@code enabled} value passed as
    * parameter. All instrumenters are enabled by default.
    */

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
@@ -55,7 +55,7 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
       SpanStatusExtractor.getDefault();
   ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.jdk();
   @Nullable TimeExtractor<REQUEST, RESPONSE> timeExtractor = null;
-  boolean disabled = false;
+  boolean enabled = true;
 
   private boolean enableSpanSuppressionByType = ENABLE_SPAN_SUPPRESSION_BY_TYPE;
 
@@ -159,9 +159,32 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
     return this;
   }
 
-  public InstrumenterBuilder<REQUEST, RESPONSE> setDisabled(boolean disabled) {
-    this.disabled = disabled;
+  /**
+   * Disables the {@link Instrumenter} - it will not generate any telemetry.
+   *
+   * <p>Equivalent to calling {@code .setEnabled(false)}.
+   */
+  public InstrumenterBuilder<REQUEST, RESPONSE> disable() {
+    return setEnabled(false);
+  }
+
+  /**
+   * Allows enabling/disabling the {@link Instrumenter} based on the {@code enabled} value passed as
+   * parameter. All instrumenters are enabled by default.
+   */
+  public InstrumenterBuilder<REQUEST, RESPONSE> setEnabled(boolean enabled) {
+    this.enabled = enabled;
     return this;
+  }
+
+  /**
+   * Allows to disable the {@link Instrumenter}.
+   *
+   * @deprecated Use {@link #setEnabled(boolean)} instead.
+   */
+  @Deprecated
+  public InstrumenterBuilder<REQUEST, RESPONSE> setDisabled(boolean disabled) {
+    return setEnabled(!disabled);
   }
 
   // visible for tests

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -520,6 +520,17 @@ class InstrumenterTest {
   }
 
   @Test
+  void shouldDisableInstrumenter() {
+    Instrumenter<String, String> instrumenter =
+        Instrumenter.<String, String>builder(
+                otelTesting.getOpenTelemetry(), "test", request -> "test span")
+            .disable()
+            .newInstrumenter();
+
+    assertThat(instrumenter.shouldStart(Context.root(), "request")).isFalse();
+  }
+
+  @Test
   void clientNestedSpansSuppressed_whenInstrumentationTypeDisabled() {
     // this test depends on default config option for InstrumentationType
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -524,7 +524,7 @@ class InstrumenterTest {
     Instrumenter<String, String> instrumenter =
         Instrumenter.<String, String>builder(
                 otelTesting.getOpenTelemetry(), "test", request -> "test span")
-            .disable()
+            .setEnabled(false)
             .newInstrumenter();
 
     assertThat(instrumenter.shouldStart(Context.root(), "request")).isFalse();

--- a/instrumentation/dropwizard/dropwizard-views-0.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/DropwizardSingletons.java
+++ b/instrumentation/dropwizard/dropwizard-views-0.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/DropwizardSingletons.java
@@ -17,7 +17,7 @@ public final class DropwizardSingletons {
   private static final Instrumenter<View, Void> INSTRUMENTER =
       Instrumenter.<View, Void>builder(
               GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, DropwizardSingletons::spanName)
-          .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+          .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
           .newInstrumenter();
 
   private static String spanName(View view) {

--- a/instrumentation/grails-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grails/GrailsSingletons.java
+++ b/instrumentation/grails-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grails/GrailsSingletons.java
@@ -18,7 +18,7 @@ public final class GrailsSingletons {
     INSTRUMENTER =
         Instrumenter.<HandlerData, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, HandlerData::spanName)
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxrsSingletons.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxrsSingletons.java
@@ -31,7 +31,7 @@ public final class JaxrsSingletons {
                 INSTRUMENTATION_NAME,
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsSingletons.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsSingletons.java
@@ -31,7 +31,7 @@ public final class JaxrsSingletons {
                 INSTRUMENTATION_NAME,
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/axis2/Axis2Singletons.java
+++ b/instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/axis2/Axis2Singletons.java
@@ -18,7 +18,7 @@ public class Axis2Singletons {
     INSTRUMENTER =
         Instrumenter.<Axis2Request, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, Axis2Request::spanName)
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/jaxws/jaxws-2.0-cxf-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cxf/CxfSingletons.java
+++ b/instrumentation/jaxws/jaxws-2.0-cxf-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cxf/CxfSingletons.java
@@ -18,7 +18,7 @@ public class CxfSingletons {
     INSTRUMENTER =
         Instrumenter.<CxfRequest, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, CxfRequest::spanName)
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/jaxws/jaxws-2.0-metro-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/metro/MetroSingletons.java
+++ b/instrumentation/jaxws/jaxws-2.0-metro-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/metro/MetroSingletons.java
@@ -18,7 +18,7 @@ public class MetroSingletons {
     INSTRUMENTER =
         Instrumenter.<MetroRequest, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, MetroRequest::spanName)
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/jaxws/jaxws-common/library/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/common/JaxWsSingletons.java
+++ b/instrumentation/jaxws/jaxws-common/library/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/common/JaxWsSingletons.java
@@ -25,7 +25,7 @@ public class JaxWsSingletons {
                 INSTRUMENTATION_NAME,
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
@@ -46,7 +46,7 @@ public final class JmsSingletons {
             MessagingSpanNameExtractor.create(getter, operation))
         .addAttributesExtractor(MessagingAttributesExtractor.create(getter, operation))
         .setTimeExtractor(new JmsMessageTimeExtractor())
-        .setDisabled(!ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
+        .setEnabled(ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
         .newInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 

--- a/instrumentation/jsf/jsf-mojarra-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mojarra/MojarraSingletons.java
+++ b/instrumentation/jsf/jsf-mojarra-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mojarra/MojarraSingletons.java
@@ -21,7 +21,7 @@ public class MojarraSingletons {
         Instrumenter.<JsfRequest, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, JsfRequest::spanName)
             .setErrorCauseExtractor(new JsfErrorCauseExtractor())
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/jsf/jsf-myfaces-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/myfaces/MyFacesSingletons.java
+++ b/instrumentation/jsf/jsf-myfaces-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/myfaces/MyFacesSingletons.java
@@ -20,7 +20,7 @@ public class MyFacesSingletons {
         Instrumenter.<JsfRequest, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, JsfRequest::spanName)
             .setErrorCauseExtractor(new MyFacesErrorCauseExtractor())
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
@@ -71,7 +71,7 @@ public final class KafkaInstrumenterFactory {
         .addAttributesExtractor(MessagingAttributesExtractor.create(getter, operation))
         .addAttributesExtractors(extractors)
         .setTimeExtractor(new KafkaConsumerTimeExtractor())
-        .setDisabled(!ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
+        .setEnabled(ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
         .newInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/WebfluxSingletons.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/WebfluxSingletons.java
@@ -30,7 +30,7 @@ public final class WebfluxSingletons {
     }
 
     INSTRUMENTER =
-        builder.setDisabled(ExperimentalConfig.get().suppressControllerSpans()).newInstrumenter();
+        builder.setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled()).newInstrumenter();
   }
 
   public static Instrumenter<Object, Void> instrumenter() {

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcSingletons.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcSingletons.java
@@ -21,7 +21,7 @@ public final class SpringWebMvcSingletons {
     HANDLER_INSTRUMENTER =
         Instrumenter.<Object, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, new HandlerSpanNameExtractor())
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
 
     MODEL_AND_VIEW_INSTRUMENTER =
@@ -30,7 +30,7 @@ public final class SpringWebMvcSingletons {
                 INSTRUMENTATION_NAME,
                 new ModelAndViewSpanNameExtractor())
             .addAttributesExtractor(new ModelAndViewAttributesExtractor())
-            .setDisabled(ExperimentalConfig.get().suppressViewSpans())
+            .setEnabled(ExperimentalConfig.get().viewTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/SpringWsSingletons.java
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/SpringWsSingletons.java
@@ -25,7 +25,7 @@ public class SpringWsSingletons {
                 INSTRUMENTATION_NAME,
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/struts-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/struts2/StrutsSingletons.java
+++ b/instrumentation/struts-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/struts2/StrutsSingletons.java
@@ -26,7 +26,7 @@ public class StrutsSingletons {
                 INSTRUMENTATION_NAME,
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/tapestry-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tapestry/TapestrySingletons.java
+++ b/instrumentation/tapestry-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tapestry/TapestrySingletons.java
@@ -27,7 +27,7 @@ public class TapestrySingletons {
                   }
                   return ErrorCauseExtractor.jdk().extractCause(error);
                 })
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
   }
 

--- a/instrumentation/vaadin-14.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vaadin/VaadinSingletons.java
+++ b/instrumentation/vaadin-14.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vaadin/VaadinSingletons.java
@@ -36,14 +36,14 @@ public class VaadinSingletons {
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
                 CodeSpanNameExtractor.create(clientCallableAttributesGetter))
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .addAttributesExtractor(CodeAttributesExtractor.create(clientCallableAttributesGetter))
             .newInstrumenter();
 
     REQUEST_HANDLER_INSTRUMENTER =
         Instrumenter.<VaadinHandlerRequest, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, VaadinHandlerRequest::getSpanName)
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             // add context for tracking nested request handler calls
             .addContextCustomizer(
                 (context, vaadinHandlerRequest, startAttributes) ->
@@ -53,13 +53,13 @@ public class VaadinSingletons {
     RPC_INSTRUMENTER =
         Instrumenter.<VaadinRpcRequest, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, VaadinSingletons::rpcSpanName)
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .newInstrumenter();
 
     SERVICE_INSTRUMENTER =
         Instrumenter.<VaadinServiceRequest, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, VaadinServiceRequest::getSpanName)
-            .setDisabled(ExperimentalConfig.get().suppressControllerSpans())
+            .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             // add context for tracking whether any request handler handled the request
             .addContextCustomizer(
                 (context, vaadinServiceRequest, startAttributes) ->


### PR DESCRIPTION
... so that they use the `...something-telemetry.enabled` naming scheme.

Also, I changed the Instrumenter API and added the `setEnabled()` method so that you don't have to negate the boolean value before passing it to the builder.