### PR TITLE
Remove old status check

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -91,25 +91,3 @@ jobs:
           needs.gradle-plugins.result != 'success' ||
           needs.examples.result != 'success'
         run: exit 1
-
-  # TODO (trask) this is just to avoid disruption for existing PRs
-  # remove this and change required check to above once existing PRs are merged
-  accept-pr:
-    needs:
-      - assemble
-      - test
-      - smoke-test
-      - muzzle
-      - gradle-plugins
-      - examples
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - if: |
-          needs.assemble.result != 'success' ||
-          needs.test.result != 'success' ||
-          needs.smoke-test.result != 'success' ||
-          needs.muzzle.result != 'success' ||
-          needs.gradle-plugins.result != 'success' ||
-          needs.examples.result != 'success'
-        run: exit 1

--- a/docs/contributing/repository-settings.md
+++ b/docs/contributing/repository-settings.md
@@ -20,11 +20,20 @@
 
 (In addition to https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md)
 
-### `main` and `v*`
+### `main` and `release/*`
 
 * Require branches to be up to date before merging: UNCHECKED
 
   PR jobs take too long, and leaving this unchecked has not been a significant problem.
+
+* Status checks that are required:
+
+  * EasyCLA
+  * required-status-check
+
+### `v*` (old release branches)
+
+Same settings as above for new release branches (`release/**`), except:
 
 * Status checks that are required:
 


### PR DESCRIPTION
I updated the status check in branch protections for `main` and `release/*`, but I did not change the branch protection for `v*` (old release branches).