### PR TITLE
Resolve end strategy after WithSpan method instead of before.

### DIFF
--- a/instrumentation/reactor/reactor-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-3.1/javaagent/build.gradle.kts
@@ -34,3 +34,20 @@ dependencies {
   // Looks like later versions on reactor need this dependency for some reason even though it is marked as optional.
   latestDepTestLibrary("io.micrometer:micrometer-core:1.+")
 }
+
+testing {
+  suites {
+    val testInitialization by registering(JvmTestSuite::class) {
+      dependencies {
+        implementation(project(":instrumentation:reactor:reactor-3.1:library"))
+        implementation("io.projectreactor:reactor-test:3.1.0.RELEASE")
+      }
+    }
+  }
+}
+
+tasks {
+  check {
+    dependsOn(testing.suites)
+  }
+}

--- a/instrumentation/reactor/reactor-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-3.1/javaagent/build.gradle.kts
@@ -40,6 +40,7 @@ testing {
     val testInitialization by registering(JvmTestSuite::class) {
       dependencies {
         implementation(project(":instrumentation:reactor:reactor-3.1:library"))
+        implementation("io.opentelemetry:opentelemetry-extension-annotations")
         implementation("io.projectreactor:reactor-test:3.1.0.RELEASE")
       }
     }

--- a/instrumentation/reactor/reactor-3.1/javaagent/src/testInitialization/java/io/opentelemetry/javaagent/instrumentation/reactor/InitializationTest.java
+++ b/instrumentation/reactor/reactor-3.1/javaagent/src/testInitialization/java/io/opentelemetry/javaagent/instrumentation/reactor/InitializationTest.java
@@ -1,0 +1,37 @@
+package io.opentelemetry.javaagent.instrumentation.reactor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.context.ContextKey;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import reactor.core.Scannable;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.UnicastProcessor;
+
+//
+class InitializationTest {
+
+  private static final ContextKey<String> ANIMAL = ContextKey.named("animal");
+
+  @Test
+  void contextPropagated() {
+    AtomicReference<String> capturedAnimal = new AtomicReference<>();
+
+    UnicastProcessor<String> source1 = UnicastProcessor.create();
+    Mono<String> mono1 = source1.singleOrEmpty();
+    source1.onNext("foo");
+    source1.onComplete();
+    mono1.block();
+
+    List<Scannable> parents1 = ((Scannable) mono1).parents().collect(Collectors.toList());
+
+    UnicastProcessor<String> source2 = UnicastProcessor.create();
+    Mono<String> mono2 = source2.singleOrEmpty();
+
+    List<Scannable> parents2 = ((Scannable) mono1).parents().collect(Collectors.toList());
+    assertThat(parents1).isNotEmpty();
+  }
+}


### PR DESCRIPTION
End strategies may be registered as a result of classload, e.g. reactor strategy will only be registered after reactor is classloaded since we instrument static initializer. Luckily we can just move the resolution of end strategy to after the method when any classes would have been loaded, since the end strategy isn't needed until then.