### PR TITLE
Fix debugging assertion in redisson async test

### DIFF
--- a/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonAsyncClientTest.groovy
+++ b/instrumentation/redisson-3.0/javaagent/src/test/groovy/RedissonAsyncClientTest.groovy
@@ -89,7 +89,9 @@ class RedissonAsyncClientTest extends AgentInstrumentationSpecification {
     RFuture<Boolean> result = runWithSpan("parent") {
       RFuture<Boolean> result = rSet.addAsync("s1")
       result.whenComplete({ res, throwable ->
-        assert Span.current().getSpanContext().isValid(): "Callback should have a parent span."
+        if (!Span.current().getSpanContext().isValid()) {
+          new Exception("Callback should have a parent span.").printStackTrace()
+        }
         runWithSpan("callback") {
         }
       })


### PR DESCRIPTION
Fixes assertion added in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5768
exception thrown inside `whenComplete` gets swallowed so it isn't really useful, print the stack trace instead so we could see where this future was completed from 