### PR TITLE
Fix missing class errors

### DIFF
--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentTooling.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentTooling.java
@@ -16,11 +16,14 @@ import net.bytebuddy.agent.builder.AgentBuilder;
  */
 public final class AgentTooling {
 
+  private static final AgentLocationStrategy LOCATION_STRATEGY =
+      locationStrategy(getBootstrapProxy());
+
   private static final AgentBuilder.PoolStrategy POOL_STRATEGY =
-      new AgentCachingPoolStrategy(locationStrategy(getBootstrapProxy()));
+      new AgentCachingPoolStrategy(LOCATION_STRATEGY);
 
   public static AgentLocationStrategy locationStrategy() {
-    return locationStrategy(null);
+    return LOCATION_STRATEGY;
   }
 
   public static AgentLocationStrategy locationStrategy(ClassLoader bootstrapProxy) {


### PR DESCRIPTION
I pulled #5724 into our distro to check out the startup perf improvements and ran into some smoke test failures on Wildfly 11, e.g. below stack trace.

I'll open a tracking issue to investigate why the wildfly smoke tests in this repo didn't catch this, maybe we need a bit more instrumentation (e.g. otel-api) in the servlet test app.

```
WARN  muzzleMatcher - Instrumentation skipped, mismatched references were found: opentelemetry-api [class io.opentelemetry.javaagent.instrumentation.opentelemetryapi.OpenTelemetryApiInstrumentationModule] on ModuleClassLoader for Module "deployment.OpenTelemetryApiSupport.war" from Service Module Loader
WARN  muzzleMatcher - -- <no-source> Failed to generate reference check for: ClassRef: io.opentelemetry.javaagent.instrumentation.opentelemetryapi.trace.BridgedTraceFlags extends java.lang.Object implements io.opentelemetry.api.trace.TraceFlags, io.opentelemetry.javaagent.shaded.io.opentelemetry.api.trace.TraceFlags on classloader ModuleClassLoader for Module "deployment.OpenTelemetryApiSupport.war" from Service Module Loader
java.lang.IllegalStateException: Missing class io.opentelemetry.javaagent.shaded.io.opentelemetry.api.trace.TraceFlags
      at io.opentelemetry.javaagent.tooling.muzzle.HelperReferenceWrapper$Factory.create(HelperReferenceWrapper.java:188)
      at io.opentelemetry.javaagent.tooling.muzzle.HelperReferenceWrapper$Factory.access$200(HelperReferenceWrapper.java:152)
      at io.opentelemetry.javaagent.tooling.muzzle.HelperReferenceWrapper$Factory$ReferenceType.lambda$getSuperTypes$0(HelperReferenceWrapper.java:216)
      at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
      at java.util.Iterator.forEachRemaining(Iterator.java:116)
      at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
      at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
      at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
      at java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:313)
      at java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:743)
      at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:647)
      at io.opentelemetry.javaagent.tooling.muzzle.ReferenceMatcher.collectMethodsFromTypeHierarchy(ReferenceMatcher.java:193)
      at io.opentelemetry.javaagent.tooling.muzzle.ReferenceMatcher.checkHelperClassMatch(ReferenceMatcher.java:167)
      at io.opentelemetry.javaagent.tooling.muzzle.ReferenceMatcher.checkMatch(ReferenceMatcher.java:110)
      at io.opentelemetry.javaagent.tooling.muzzle.ReferenceMatcher.getMismatchedReferenceSources(ReferenceMatcher.java:84)
      at io.opentelemetry.javaagent.tooling.instrumentation.InstrumentationModuleInstaller$MuzzleMatcher.doesMatch(InstrumentationModuleInstaller.java:182)
      at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.cache.weaklockfree.AbstractWeakConcurrentMap.lambda$computeIfAbsent$0(AbstractWeakConcurrentMap.java:177)
      at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
      at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.cache.weaklockfree.AbstractWeakConcurrentMap.computeIfAbsent(AbstractWeakConcurrentMap.java:177)
      at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.cache.weaklockfree.WeakConcurrentMap.computeIfAbsent(WeakConcurrentMap.java:48)
      at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.cache.weaklockfree.WeakConcurrentMap$WithInlinedExpunction.computeIfAbsent(WeakConcurrentMap.java:206)
      at io.opentelemetry.javaagent.shaded.instrumentation.api.internal.cache.WeakLockFreeCache.computeIfAbsent(WeakLockFreeCache.java:21)
      at io.opentelemetry.javaagent.tooling.instrumentation.InstrumentationModuleInstaller$MuzzleMatcher.matches(InstrumentationModuleInstaller.java:164)
      at net.bytebuddy.agent.builder.AgentBuilder$RawMatcher$Conjunction.matches(AgentBuilder.java:1668)
      at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:11870)
      at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:11828)
      at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1700(AgentBuilder.java:11545)
      at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:12228)
      at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$LegacyVmDispatcher.run(AgentBuilder.java:12168)
      at java.security.AccessController.doPrivileged(Native Method)
      at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doPrivileged(AgentBuilder.java)
      at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:11737)
      at sun.instrument.TransformerManager.transform(TransformerManager.java:188)
      at sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:428)
      at java.lang.ClassLoader.defineClass1(Native Method)
      at java.lang.ClassLoader.defineClass(ClassLoader.java:757)
      at org.jboss.modules.ModuleClassLoader.doDefineOrLoadClass(ModuleClassLoader.java:358)
      at org.jboss.modules.ModuleClassLoader.defineClass(ModuleClassLoader.java:437)
      at org.jboss.modules.ModuleClassLoader.loadClassLocal(ModuleClassLoader.java:274)
      at org.jboss.modules.ModuleClassLoader$1.loadClassLocal(ModuleClassLoader.java:77)
      at org.jboss.modules.Module.loadModuleClass(Module.java:713)
      at org.jboss.modules.ModuleClassLoader.findClass(ModuleClassLoader.java:190)
      at org.jboss.modules.ConcurrentClassLoader.performLoadClassUnchecked(ConcurrentClassLoader.java:412)
      at org.jboss.modules.ConcurrentClassLoader.performLoadClass(ConcurrentClassLoader.java:400)
      at org.jboss.modules.ConcurrentClassLoader.loadClass(ConcurrentClassLoader.java:116)
      at io.opentelemetry.context.LazyStorage.<clinit>(LazyStorage.java:85)
      at io.opentelemetry.context.ContextStorage.get(ContextStorage.java:72)
      at io.opentelemetry.context.Context.current(Context.java:86)
      at io.opentelemetry.api.trace.Span.current(Span.java:35)
      at com.microsoft.applicationinsights.smoketestapp.TestController.testApi(TestController.java:40)
      at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
      at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
      at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
      at java.lang.reflect.Method.invoke(Method.java:498)
      at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:190)
      at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:138)
      at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:104)
      at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:892)
      at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:797)
      at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
      at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1039)
      at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:942)
      at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1005)
      at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:897)
      at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
```