### PR TITLE
Don't run misspell on licenses

### DIFF
--- a/.github/workflows/reusable-misspell-check.yml
+++ b/.github/workflows/reusable-misspell-check.yml
@@ -15,4 +15,8 @@ jobs:
           sh ./install-misspell.sh
 
       - name: Run misspell
-        run: bin/misspell -error .
+        run: |
+          find . -type f \
+                 -not -path './licenses/*' \
+                 -not -path '*/build/*' \
+                 | xargs bin/misspell -error


### PR DESCRIPTION
```
licenses/jackson-jr-objects-2.13.2.jar/META-INF/LICENSE:4:26: "derivate" is a misspelling of "derivative"
```