### PR TITLE
Agent tooling already has access to bootstrap proxy

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -145,7 +145,7 @@ public class AgentInstaller {
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
             .with(AgentTooling.poolStrategy())
             .with(new ClassLoadListener())
-            .with(AgentTooling.locationStrategy(Utils.getBootstrapProxy()));
+            .with(AgentTooling.locationStrategy());
     if (JavaModule.isSupported()) {
       agentBuilder = agentBuilder.with(new ExposeAgentBootstrapListener(inst));
     }

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentTooling.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentTooling.java
@@ -17,17 +17,13 @@ import net.bytebuddy.agent.builder.AgentBuilder;
 public final class AgentTooling {
 
   private static final AgentLocationStrategy LOCATION_STRATEGY =
-      locationStrategy(getBootstrapProxy());
+      new AgentLocationStrategy(getBootstrapProxy());
 
   private static final AgentBuilder.PoolStrategy POOL_STRATEGY =
       new AgentCachingPoolStrategy(LOCATION_STRATEGY);
 
   public static AgentLocationStrategy locationStrategy() {
     return LOCATION_STRATEGY;
-  }
-
-  public static AgentLocationStrategy locationStrategy(ClassLoader bootstrapProxy) {
-    return new AgentLocationStrategy(bootstrapProxy);
   }
 
   public static AgentBuilder.PoolStrategy poolStrategy() {


### PR DESCRIPTION
No need to pass bootstrap proxy as argument as there is a spi for looking it up.