### PR TITLE
Fix flaky SpringRestTemplateTest

### DIFF
--- a/instrumentation/spring/spring-web-3.1/testing/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/instrumentation/spring/spring-web-3.1/testing/src/test/groovy/SpringRestTemplateTest.groovy
@@ -50,6 +50,12 @@ class SpringRestTemplateTest extends HttpClientTest<HttpEntity<String>> implemen
       restTemplate.execute(uri, HttpMethod.valueOf(method), { req ->
         req.getHeaders().putAll(request.getHeaders())
       }, { response ->
+        // read request body to avoid broken pipe errors on the server side
+        byte[] buffer = new byte[1024]
+        try (InputStream inputStream = response.body) {
+          while (inputStream.read(buffer) >= 0) {
+          }
+        }
         requestResult.complete(response.statusCode.value())
       })
     } catch (ResourceAccessException exception) {


### PR DESCRIPTION
https://ge.opentelemetry.io/s/grzgthkltkify/tests/:instrumentation:spring:spring-web-3.1:testing:test/SpringRestTemplateTest/high%20concurrency%20test%20with%20callback?top-execution=1
Same as https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5672