### PR TITLE
Fix jaxws metro tests on jdk8

### DIFF
--- a/instrumentation/jaxws/jaxws-2.0-metro-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/jaxws/jaxws-2.0-metro-2.2/javaagent/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
   bootstrap(project(":instrumentation:servlet:servlet-common:bootstrap"))
 
   library("com.sun.xml.ws:jaxws-rt:2.2.0.1")
+  // early versions of streambuffer depend on latest release of org.jvnet.staxex:stax-ex
+  // which doesn't work with java 8
+  library("com.sun.xml.stream.buffer:streambuffer:1.4")
 
   compileOnly("javax.servlet:javax.servlet-api:3.0.1")
 
@@ -30,6 +33,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:jetty:jetty-8.0:javaagent"))
 
   latestDepTestLibrary("com.sun.xml.ws:jaxws-rt:2.+")
+  latestDepTestLibrary("com.sun.xml.stream.buffer:streambuffer:1.+")
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
Metro tests fail on jdk8 with
```
SEVERE: WSSERVLET11: failed to parse runtime descriptor: java.lang.UnsupportedClassVersionError: org/jvnet/staxex/XMLStreamReaderEx has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
java.lang.UnsupportedClassVersionError: org/jvnet/staxex/XMLStreamReaderEx has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:355)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at com.sun.xml.stream.buffer.stax.StreamReaderBufferCreator.storeElementAndChildren(StreamReaderBufferCreator.java:174)
	at com.sun.xml.stream.buffer.stax.StreamReaderBufferCreator.storeDocumentAndChildren(StreamReaderBufferCreator.java:158)
	at com.sun.xml.stream.buffer.stax.StreamReaderBufferCreator.store(StreamReaderBufferCreator.java:139)
	at com.sun.xml.stream.buffer.stax.StreamReaderBufferCreator.create(StreamReaderBufferCreator.java:82)
	at com.sun.xml.stream.buffer.MutableXMLStreamBuffer.createFromXMLStreamReader(MutableXMLStreamBuffer.java:113)
	at com.sun.xml.stream.buffer.XMLStreamBuffer.createNewBufferFromXMLStreamReader(XMLStreamBuffer.java:398)
```
Surprisingly this doesn't seem to always happen, first noticed it a couple of days ago. Example of a failing build https://github.com/open-telemetry/opentelemetry-java-instrumentation/runs/5986069789?check_suite_focus=true