### PR TITLE
Do not set the http.route attribute in JSF instrumentations by default

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/config/ExperimentalConfig.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/config/ExperimentalConfig.java
@@ -38,11 +38,6 @@ public final class ExperimentalConfig {
         "otel.instrumentation.common.experimental.view-telemetry.enabled", !suppressViewSpans);
   }
 
-  public boolean useViewNameAsHttpRoute() {
-    return config.getBoolean(
-        "otel.instrumentation.common.experimental.view-name-as-http-route.enabled", false);
-  }
-
   public boolean messagingReceiveInstrumentationEnabled() {
     // TODO: remove that `suppress...` flag after 1.13 release
     boolean receiveSpansSuppressed =

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/config/ExperimentalConfig.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/config/ExperimentalConfig.java
@@ -38,6 +38,11 @@ public final class ExperimentalConfig {
         "otel.instrumentation.common.experimental.view-telemetry.enabled", !suppressViewSpans);
   }
 
+  public boolean useViewNameAsHttpRoute() {
+    return config.getBoolean(
+        "otel.instrumentation.common.experimental.view-name-as-http-route.enabled", false);
+  }
+
   public boolean messagingReceiveInstrumentationEnabled() {
     // TODO: remove that `suppress...` flag after 1.13 release
     boolean receiveSpansSuppressed =

--- a/instrumentation/jsf/jsf-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/JsfServerSpanNaming.java
+++ b/instrumentation/jsf/jsf-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/JsfServerSpanNaming.java
@@ -5,52 +5,33 @@
 
 package io.opentelemetry.javaagent.instrumentation.jsf;
 
-import static io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteSource.CONTROLLER;
-
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.ExperimentalConfig;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteGetter;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteHolder;
 import io.opentelemetry.instrumentation.api.server.ServerSpan;
 import io.opentelemetry.javaagent.bootstrap.servlet.ServletContextPath;
 import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
 
-public class JsfServerSpanNaming {
-
-  private static final boolean USE_VIEW_NAME_AS_HTTP_ROUTE =
-      ExperimentalConfig.get().useViewNameAsHttpRoute();
-
-  private static final HttpRouteGetter<FacesContext> SERVER_SPAN_NAME =
-      (context, facesContext) -> {
-        UIViewRoot uiViewRoot = facesContext.getViewRoot();
-        if (uiViewRoot == null) {
-          return null;
-        }
-
-        // JSF spec 7.6.2
-        // view id is a context relative path to the web application resource that produces the
-        // view, such as a JSP page or a Facelets page.
-        String viewId = uiViewRoot.getViewId();
-        return ServletContextPath.prepend(context, viewId);
-      };
+public final class JsfServerSpanNaming {
 
   public static void updateViewName(Context context, FacesContext facesContext) {
-    if (USE_VIEW_NAME_AS_HTTP_ROUTE) {
-      HttpRouteHolder.updateHttpRoute(
-          context, CONTROLLER, JsfServerSpanNaming.SERVER_SPAN_NAME, facesContext);
-    } else {
-      // just update the server span name, without touching the http.route
-      Span serverSpan = ServerSpan.fromContextOrNull(context);
-      if (serverSpan == null) {
-        return;
-      }
-      String name = SERVER_SPAN_NAME.get(context, facesContext);
-      if (name != null) {
-        serverSpan.updateName(name);
-      }
+    // just update the server span name, without touching the http.route
+    Span serverSpan = ServerSpan.fromContextOrNull(context);
+    if (serverSpan == null) {
+      return;
     }
+
+    UIViewRoot uiViewRoot = facesContext.getViewRoot();
+    if (uiViewRoot == null) {
+      return;
+    }
+
+    // JSF spec 7.6.2
+    // view id is a context relative path to the web application resource that produces the
+    // view, such as a JSP page or a Facelets page.
+    String viewId = uiViewRoot.getViewId();
+    String name = ServletContextPath.prepend(context, viewId);
+    serverSpan.updateName(name);
   }
 
   private JsfServerSpanNaming() {}

--- a/instrumentation/jsf/jsf-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/JsfServerSpanNaming.java
+++ b/instrumentation/jsf/jsf-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/JsfServerSpanNaming.java
@@ -5,14 +5,24 @@
 
 package io.opentelemetry.javaagent.instrumentation.jsf;
 
+import static io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteSource.CONTROLLER;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.config.ExperimentalConfig;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteHolder;
+import io.opentelemetry.instrumentation.api.server.ServerSpan;
 import io.opentelemetry.javaagent.bootstrap.servlet.ServletContextPath;
 import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
 
 public class JsfServerSpanNaming {
 
-  public static final HttpRouteGetter<FacesContext> SERVER_SPAN_NAME =
+  private static final boolean USE_VIEW_NAME_AS_HTTP_ROUTE =
+      ExperimentalConfig.get().useViewNameAsHttpRoute();
+
+  private static final HttpRouteGetter<FacesContext> SERVER_SPAN_NAME =
       (context, facesContext) -> {
         UIViewRoot uiViewRoot = facesContext.getViewRoot();
         if (uiViewRoot == null) {
@@ -25,6 +35,23 @@ public class JsfServerSpanNaming {
         String viewId = uiViewRoot.getViewId();
         return ServletContextPath.prepend(context, viewId);
       };
+
+  public static void updateViewName(Context context, FacesContext facesContext) {
+    if (USE_VIEW_NAME_AS_HTTP_ROUTE) {
+      HttpRouteHolder.updateHttpRoute(
+          context, CONTROLLER, JsfServerSpanNaming.SERVER_SPAN_NAME, facesContext);
+    } else {
+      // just update the server span name, without touching the http.route
+      Span serverSpan = ServerSpan.fromContextOrNull(context);
+      if (serverSpan == null) {
+        return;
+      }
+      String name = SERVER_SPAN_NAME.get(context, facesContext);
+      if (name != null) {
+        serverSpan.updateName(name);
+      }
+    }
+  }
 
   private JsfServerSpanNaming() {}
 }

--- a/instrumentation/jsf/jsf-mojarra-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mojarra/RestoreViewPhaseInstrumentation.java
+++ b/instrumentation/jsf/jsf-mojarra-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mojarra/RestoreViewPhaseInstrumentation.java
@@ -5,12 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.mojarra;
 
-import static io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteSource.CONTROLLER;
 import static io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge.currentContext;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteHolder;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.jsf.JsfServerSpanNaming;
@@ -38,8 +36,7 @@ public class RestoreViewPhaseInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void onExit(@Advice.Argument(0) FacesContext facesContext) {
-      HttpRouteHolder.updateHttpRoute(
-          currentContext(), CONTROLLER, JsfServerSpanNaming.SERVER_SPAN_NAME, facesContext);
+      JsfServerSpanNaming.updateViewName(currentContext(), facesContext);
     }
   }
 }

--- a/instrumentation/jsf/jsf-myfaces-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/myfaces/RestoreViewExecutorInstrumentation.java
+++ b/instrumentation/jsf/jsf-myfaces-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/myfaces/RestoreViewExecutorInstrumentation.java
@@ -5,12 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.myfaces;
 
-import static io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteSource.CONTROLLER;
 import static io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge.currentContext;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteHolder;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.jsf.JsfServerSpanNaming;
@@ -38,8 +36,7 @@ public class RestoreViewExecutorInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void onExit(@Advice.Argument(0) FacesContext facesContext) {
-      HttpRouteHolder.updateHttpRoute(
-          currentContext(), CONTROLLER, JsfServerSpanNaming.SERVER_SPAN_NAME, facesContext);
+      JsfServerSpanNaming.updateViewName(currentContext(), facesContext);
     }
   }
 }

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/AttributesAssert.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/asserts/AttributesAssert.groovy
@@ -48,7 +48,7 @@ class AttributesAssert {
 
   def methodMissing(String name, args) {
     if (args.length == 0) {
-      throw new IllegalArgumentException(args.toString())
+      throw new IllegalArgumentException("Attribute $name needs to be provided expected value; zero args were passed: $args")
     }
     attribute(name, args[0])
   }


### PR DESCRIPTION
..., but still override the server span name.

Resolves #5753 
