### PR TITLE
Rename netty `always-create-connect-span` property to `connection-tel…

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/config/ExperimentalConfig.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/config/ExperimentalConfig.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.config;
 
+import io.opentelemetry.instrumentation.api.internal.DeprecatedConfigPropertyWarning;
+
 public final class ExperimentalConfig {
 
   private static final ExperimentalConfig instance = new ExperimentalConfig(Config.get());
@@ -22,6 +24,10 @@ public final class ExperimentalConfig {
 
   public boolean controllerTelemetryEnabled() {
     // TODO: remove that `suppress...` flag after 1.13 release
+    DeprecatedConfigPropertyWarning.warnIfUsed(
+        config,
+        "otel.instrumentation.common.experimental.suppress-controller-spans",
+        "otel.instrumentation.common.experimental.controller-telemetry.enabled");
     boolean suppressControllerSpans =
         config.getBoolean(
             "otel.instrumentation.common.experimental.suppress-controller-spans", false);
@@ -32,6 +38,10 @@ public final class ExperimentalConfig {
 
   public boolean viewTelemetryEnabled() {
     // TODO: remove that `suppress...` flag after 1.13 release
+    DeprecatedConfigPropertyWarning.warnIfUsed(
+        config,
+        "otel.instrumentation.common.experimental.suppress-view-spans",
+        "otel.instrumentation.common.experimental.view-telemetry.enabled");
     boolean suppressViewSpans =
         config.getBoolean("otel.instrumentation.common.experimental.suppress-view-spans", false);
     return config.getBoolean(
@@ -40,6 +50,10 @@ public final class ExperimentalConfig {
 
   public boolean messagingReceiveInstrumentationEnabled() {
     // TODO: remove that `suppress...` flag after 1.13 release
+    DeprecatedConfigPropertyWarning.warnIfUsed(
+        config,
+        "otel.instrumentation.common.experimental.suppress-messaging-receive-spans",
+        "otel.instrumentation.messaging.experimental.receive-telemetry.enabled");
     boolean receiveSpansSuppressed =
         config.getBoolean(
             "otel.instrumentation.common.experimental.suppress-messaging-receive-spans", true);

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/internal/DeprecatedConfigPropertyWarning.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/internal/DeprecatedConfigPropertyWarning.java
@@ -10,6 +10,10 @@ import static java.util.logging.Level.WARNING;
 import io.opentelemetry.instrumentation.api.config.Config;
 import java.util.logging.Logger;
 
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
 public final class DeprecatedConfigPropertyWarning {
 
   private static final Logger logger =

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/internal/DeprecatedConfigPropertyWarning.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/internal/DeprecatedConfigPropertyWarning.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+import static java.util.logging.Level.WARNING;
+
+import io.opentelemetry.instrumentation.api.config.Config;
+import java.util.logging.Logger;
+
+public final class DeprecatedConfigPropertyWarning {
+
+  private static final Logger logger =
+      Logger.getLogger(DeprecatedConfigPropertyWarning.class.getName());
+
+  public static void warnIfUsed(
+      Config config, String deprecatedPropertyName, String newPropertyName) {
+    if (config.getString(deprecatedPropertyName) != null) {
+      logger.log(
+          WARNING,
+          "Deprecated property '{0}' was used; use the '{1}' property instead",
+          new Object[] {deprecatedPropertyName, newPropertyName});
+    }
+  }
+
+  private DeprecatedConfigPropertyWarning() {}
+}

--- a/instrumentation/netty/README.md
+++ b/instrumentation/netty/README.md
@@ -1,6 +1,6 @@
 # Settings for the Netty instrumentation
 
-| System property                                           | Type    | Default  | Description                                                                                       |
-|-----------------------------------------------------------|---------|----------|---------------------------------------------------------------------------------------------------|
-| `otel.instrumentation.netty.connection-telemetry.enabled` | Boolean | `false`  | Enable the creation of Connect and DNS spans by default for Netty 4.0 and higher instrumentation. |
-| `otel.instrumentation.netty.ssl-telemetry.enabled`        | Boolean | `false ` | Enable SSL telemetry for Netty 4.0 and higher instrumentation.                                    |
+| System property                                           | Type    | Default | Description                                                                                       |
+|-----------------------------------------------------------|---------|---------|---------------------------------------------------------------------------------------------------|
+| `otel.instrumentation.netty.connection-telemetry.enabled` | Boolean | `false` | Enable the creation of Connect and DNS spans by default for Netty 4.0 and higher instrumentation. |
+| `otel.instrumentation.netty.ssl-telemetry.enabled`        | Boolean | `false` | Enable SSL telemetry for Netty 4.0 and higher instrumentation.                                    |

--- a/instrumentation/netty/README.md
+++ b/instrumentation/netty/README.md
@@ -1,6 +1,6 @@
 # Settings for the Netty instrumentation
 
-| System property | Type | Default | Description |
-|---|---|---|---|
-| `otel.instrumentation.netty.always-create-connect-span` | Boolean | `false` | Enable the creation of Connect and DNS spans by default for Netty 4.0 and higher instrumentation. |
-| `otel.instrumentation.netty.ssl-telemetry.enabled` | Boolean | `false ` | Enable SSL telemetry for Netty 4.0 and higher instrumentation. |
+| System property                                           | Type    | Default  | Description                                                                                       |
+|-----------------------------------------------------------|---------|----------|---------------------------------------------------------------------------------------------------|
+| `otel.instrumentation.netty.connection-telemetry.enabled` | Boolean | `false`  | Enable the creation of Connect and DNS spans by default for Netty 4.0 and higher instrumentation. |
+| `otel.instrumentation.netty.ssl-telemetry.enabled`        | Boolean | `false ` | Enable SSL telemetry for Netty 4.0 and higher instrumentation.                                    |

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/common/client/NettyClientInstrumenterFactory.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/common/client/NettyClientInstrumenterFactory.java
@@ -22,13 +22,13 @@ import io.opentelemetry.javaagent.instrumentation.netty.common.NettyConnectionRe
 public final class NettyClientInstrumenterFactory {
 
   private final String instrumentationName;
-  private final boolean alwaysCreateConnectSpan;
+  private final boolean connectionTelemetryEnabled;
   private final boolean sslTelemetryEnabled;
 
   public NettyClientInstrumenterFactory(
-      String instrumentationName, boolean alwaysCreateConnectSpan, boolean sslTelemetryEnabled) {
+      String instrumentationName, boolean connectionTelemetryEnabled, boolean sslTelemetryEnabled) {
     this.instrumentationName = instrumentationName;
-    this.alwaysCreateConnectSpan = alwaysCreateConnectSpan;
+    this.connectionTelemetryEnabled = connectionTelemetryEnabled;
     this.sslTelemetryEnabled = sslTelemetryEnabled;
   }
 
@@ -58,11 +58,11 @@ public final class NettyClientInstrumenterFactory {
             .addAttributesExtractor(PeerServiceAttributesExtractor.create(netAttributesGetter))
             .setTimeExtractor(new NettyConnectionTimeExtractor())
             .newInstrumenter(
-                alwaysCreateConnectSpan
+                connectionTelemetryEnabled
                     ? SpanKindExtractor.alwaysInternal()
                     : SpanKindExtractor.alwaysClient());
 
-    return alwaysCreateConnectSpan
+    return connectionTelemetryEnabled
         ? new NettyConnectionInstrumenterImpl(instrumenter)
         : new NettyErrorOnlyConnectionInstrumenter(instrumenter);
   }

--- a/instrumentation/netty/netty-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/netty/netty-4.0/javaagent/build.gradle.kts
@@ -40,7 +40,7 @@ tasks {
       includeTestsMatching("Netty40ClientSslTest")
     }
     include("**/Netty40ConnectionSpanTest.*", "**/Netty40ClientSslTest.*")
-    jvmArgs("-Dotel.instrumentation.netty.always-create-connect-span=true")
+    jvmArgs("-Dotel.instrumentation.netty.connection-telemetry.enabled=true")
     jvmArgs("-Dotel.instrumentation.netty.ssl-telemetry.enabled=true")
   }
 

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/NettyClientSingletons.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/NettyClientSingletons.java
@@ -15,10 +15,19 @@ import io.opentelemetry.javaagent.instrumentation.netty.common.client.NettySslIn
 
 public final class NettyClientSingletons {
 
-  private static final boolean alwaysCreateConnectSpan =
-      Config.get().getBoolean("otel.instrumentation.netty.always-create-connect-span", false);
-  private static final boolean sslTelemetryEnabled =
-      Config.get().getBoolean("otel.instrumentation.netty.ssl-telemetry.enabled", false);
+  private static final boolean connectionTelemetryEnabled;
+  private static final boolean sslTelemetryEnabled;
+
+  static {
+    Config config = Config.get();
+    boolean alwaysCreateConnectSpan =
+        config.getBoolean("otel.instrumentation.netty.always-create-connect-span", false);
+    connectionTelemetryEnabled =
+        config.getBoolean(
+            "otel.instrumentation.netty.connection-telemetry.enabled", alwaysCreateConnectSpan);
+    sslTelemetryEnabled =
+        config.getBoolean("otel.instrumentation.netty.ssl-telemetry.enabled", false);
+  }
 
   private static final Instrumenter<HttpRequestAndChannel, HttpResponse> INSTRUMENTER;
   private static final NettyConnectionInstrumenter CONNECTION_INSTRUMENTER;
@@ -27,7 +36,7 @@ public final class NettyClientSingletons {
   static {
     NettyClientInstrumenterFactory factory =
         new NettyClientInstrumenterFactory(
-            "io.opentelemetry.netty-4.0", alwaysCreateConnectSpan, sslTelemetryEnabled);
+            "io.opentelemetry.netty-4.0", connectionTelemetryEnabled, sslTelemetryEnabled);
     INSTRUMENTER = factory.createHttpInstrumenter();
     CONNECTION_INSTRUMENTER = factory.createConnectionInstrumenter();
     SSL_INSTRUMENTER = factory.createSslInstrumenter();

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/NettyClientSingletons.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/NettyClientSingletons.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_0.client;
 import io.netty.handler.codec.http.HttpResponse;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.DeprecatedConfigPropertyWarning;
 import io.opentelemetry.javaagent.instrumentation.netty.common.HttpRequestAndChannel;
 import io.opentelemetry.javaagent.instrumentation.netty.common.client.NettyClientInstrumenterFactory;
 import io.opentelemetry.javaagent.instrumentation.netty.common.client.NettyConnectionInstrumenter;
@@ -20,6 +21,10 @@ public final class NettyClientSingletons {
 
   static {
     Config config = Config.get();
+    DeprecatedConfigPropertyWarning.warnIfUsed(
+        config,
+        "otel.instrumentation.netty.always-create-connect-span",
+        "otel.instrumentation.netty.connection-telemetry.enabled");
     boolean alwaysCreateConnectSpan =
         config.getBoolean("otel.instrumentation.netty.always-create-connect-span", false);
     connectionTelemetryEnabled =

--- a/instrumentation/netty/netty-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/netty/netty-4.1/javaagent/build.gradle.kts
@@ -45,7 +45,7 @@ tasks {
       includeTestsMatching("Netty41ClientSslTest")
     }
     include("**/Netty41ConnectionSpanTest.*", "**/Netty41ClientSslTest.*")
-    jvmArgs("-Dotel.instrumentation.netty.always-create-connect-span=true")
+    jvmArgs("-Dotel.instrumentation.netty.connection-telemetry.enabled=true")
     jvmArgs("-Dotel.instrumentation.netty.ssl-telemetry.enabled=true")
   }
 

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/NettyClientSingletons.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/client/NettyClientSingletons.java
@@ -9,6 +9,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.util.AttributeKey;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.DeprecatedConfigPropertyWarning;
 import io.opentelemetry.javaagent.instrumentation.netty.common.HttpRequestAndChannel;
 import io.opentelemetry.javaagent.instrumentation.netty.common.client.NettyClientInstrumenterFactory;
 import io.opentelemetry.javaagent.instrumentation.netty.common.client.NettyConnectionInstrumenter;
@@ -26,6 +27,10 @@ public final class NettyClientSingletons {
 
   static {
     Config config = Config.get();
+    DeprecatedConfigPropertyWarning.warnIfUsed(
+        config,
+        "otel.instrumentation.netty.always-create-connect-span",
+        "otel.instrumentation.netty.connection-telemetry.enabled");
     boolean alwaysCreateConnectSpan =
         config.getBoolean("otel.instrumentation.netty.always-create-connect-span", false);
     connectionTelemetryEnabled =

--- a/instrumentation/reactor/reactor-netty/README.md
+++ b/instrumentation/reactor/reactor-netty/README.md
@@ -1,5 +1,5 @@
 # Settings for the Reactor Netty instrumentation
 
-| System property | Type | Default | Description |
-|---|---|---|---|
-| `otel.instrumentation.reactor-netty.always-create-connect-span` | Boolean | `false` | Enable the creation of Connect and DNS spans by default. |
+| System property                                                   | Type    | Default | Description                                              |
+|-------------------------------------------------------------------|---------|---------|----------------------------------------------------------|
+| `otel.instrumentation.reactor-netty.connection-telemetry.enabled` | Boolean | `false` | Enable the creation of Connect and DNS spans by default. |

--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ tasks {
       includeTestsMatching("ReactorNettyConnectionSpanTest")
     }
     include("**/ReactorNettyConnectionSpanTest.*")
-    jvmArgs("-Dotel.instrumentation.netty.always-create-connect-span=true")
+    jvmArgs("-Dotel.instrumentation.netty.connection-telemetry.enabled=true")
   }
 
   test {

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/build.gradle.kts
@@ -42,7 +42,7 @@ tasks {
     }
     include("**/ReactorNettyConnectionSpanTest.*", "**/ReactorNettyClientSslTest.*")
     jvmArgs("-Dotel.instrumentation.netty.ssl-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.reactor-netty.always-create-connect-span=true")
+    jvmArgs("-Dotel.instrumentation.reactor-netty.connection-telemetry.enabled=true")
   }
 
   test {

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettySingletons.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettySingletons.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.DeprecatedConfigPropertyWarning;
 import io.opentelemetry.javaagent.instrumentation.netty.common.client.NettyClientInstrumenterFactory;
 import io.opentelemetry.javaagent.instrumentation.netty.common.client.NettyConnectionInstrumenter;
 import reactor.netty.http.client.HttpClientConfig;
@@ -28,6 +29,10 @@ public final class ReactorNettySingletons {
 
   static {
     Config config = Config.get();
+    DeprecatedConfigPropertyWarning.warnIfUsed(
+        config,
+        "otel.instrumentation.reactor-netty.always-create-connect-span",
+        "otel.instrumentation.reactor-netty.connection-telemetry.enabled");
     boolean alwaysCreateConnectSpan =
         config.getBoolean("otel.instrumentation.reactor-netty.always-create-connect-span", false);
     connectionTelemetryEnabled =

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettySingletons.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettySingletons.java
@@ -24,9 +24,17 @@ public final class ReactorNettySingletons {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.reactor-netty-1.0";
 
-  private static final boolean alwaysCreateConnectSpan =
-      Config.get()
-          .getBoolean("otel.instrumentation.reactor-netty.always-create-connect-span", false);
+  private static final boolean connectionTelemetryEnabled;
+
+  static {
+    Config config = Config.get();
+    boolean alwaysCreateConnectSpan =
+        config.getBoolean("otel.instrumentation.reactor-netty.always-create-connect-span", false);
+    connectionTelemetryEnabled =
+        config.getBoolean(
+            "otel.instrumentation.reactor-netty.connection-telemetry.enabled",
+            alwaysCreateConnectSpan);
+  }
 
   private static final Instrumenter<HttpClientConfig, HttpClientResponse> INSTRUMENTER;
   private static final NettyConnectionInstrumenter CONNECTION_INSTRUMENTER;
@@ -51,7 +59,7 @@ public final class ReactorNettySingletons {
             .newInstrumenter(SpanKindExtractor.alwaysClient());
 
     NettyClientInstrumenterFactory instrumenterFactory =
-        new NettyClientInstrumenterFactory(INSTRUMENTATION_NAME, alwaysCreateConnectSpan, false);
+        new NettyClientInstrumenterFactory(INSTRUMENTATION_NAME, connectionTelemetryEnabled, false);
     CONNECTION_INSTRUMENTER = instrumenterFactory.createConnectionInstrumenter();
   }
 


### PR DESCRIPTION
…emetry`

This should make it more uniform and similar to `ssl-telemetry`, `controller-telemetry` etc.