### PR TITLE
Add quotes to fix dependabot

### DIFF
--- a/.github/workflows/pr-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/pr-smoke-test-fake-backend-images.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build Docker image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :smoke-tests:images:fake-backend:jibDockerBuild -Djib.httpTimeout=120000 -Djib.console=plain
+          arguments: ":smoke-tests:images:fake-backend:jibDockerBuild -Djib.httpTimeout=120000 -Djib.console=plain"
           cache-read-only: true
 
   buildWindows:
@@ -44,5 +44,5 @@ jobs:
       - name: Build Docker image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :smoke-tests:images:fake-backend:windowsBackendImageBuild
+          arguments: ":smoke-tests:images:fake-backend:windowsBackendImageBuild"
           cache-read-only: true

--- a/.github/workflows/pr-smoke-test-grpc-images.yml
+++ b/.github/workflows/pr-smoke-test-grpc-images.yml
@@ -10,5 +10,5 @@ jobs:
   build:
     uses: ./.github/workflows/reusable-smoke-test-images.yml
     with:
-      project: :smoke-tests:images:grpc
+      project: ":smoke-tests:images:grpc"
       cache-read-only: true

--- a/.github/workflows/pr-smoke-test-play-images.yml
+++ b/.github/workflows/pr-smoke-test-play-images.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     uses: ./.github/workflows/reusable-smoke-test-images.yml
     with:
-      project: :smoke-tests:images:play
+      project: ":smoke-tests:images:play"
       cache-read-only: true
       # Play doesn't support Java 16+ yet
       # https://github.com/playframework/playframework/pull/10819

--- a/.github/workflows/pr-smoke-test-quarkus-images.yml
+++ b/.github/workflows/pr-smoke-test-quarkus-images.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     uses: ./.github/workflows/reusable-smoke-test-images.yml
     with:
-      project: :smoke-tests:images:quarkus
+      project: ":smoke-tests:images:quarkus"
       cache-read-only: true
       # Quarkus 2.0+ does not support Java 8
       skip-java-8: true

--- a/.github/workflows/pr-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/pr-smoke-test-spring-boot-images.yml
@@ -10,5 +10,5 @@ jobs:
   build:
     uses: ./.github/workflows/reusable-smoke-test-images.yml
     with:
-      project: :smoke-tests:images:spring-boot
+      project: ":smoke-tests:images:spring-boot"
       cache-read-only: true

--- a/.github/workflows/publish-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/publish-smoke-test-fake-backend-images.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build Docker image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :smoke-tests:images:fake-backend:jib -Djib.httpTimeout=120000 -Djib.console=plain -PextraTag=${{ env.TAG }}
+          arguments: ":smoke-tests:images:fake-backend:jib -Djib.httpTimeout=120000 -Djib.console=plain -PextraTag=${{ env.TAG }}"
 
   publishWindows:
     runs-on: windows-2019
@@ -66,7 +66,7 @@ jobs:
       - name: Build Docker image
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :smoke-tests:images:fake-backend:dockerPush -PextraTag=${{ env.TAG }}
+          arguments: ":smoke-tests:images:fake-backend:dockerPush -PextraTag=${{ env.TAG }}"
 
   open-issue-on-failure:
     needs:

--- a/.github/workflows/publish-smoke-test-grpc-images.yml
+++ b/.github/workflows/publish-smoke-test-grpc-images.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     uses: ./.github/workflows/reusable-smoke-test-images.yml
     with:
-      project: :smoke-tests:images:grpc
+      project: ":smoke-tests:images:grpc"
       publish: true
 
   open-issue-on-failure:

--- a/.github/workflows/publish-smoke-test-play-images.yml
+++ b/.github/workflows/publish-smoke-test-play-images.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     uses: ./.github/workflows/reusable-smoke-test-images.yml
     with:
-      project: :smoke-tests:images:play
+      project: ":smoke-tests:images:play"
       publish: true
       # Play doesn't support Java 16+ yet
       # https://github.com/playframework/playframework/pull/10819

--- a/.github/workflows/publish-smoke-test-quarkus-images.yml
+++ b/.github/workflows/publish-smoke-test-quarkus-images.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     uses: ./.github/workflows/reusable-smoke-test-images.yml
     with:
-      project: :smoke-tests:images:quarkus
+      project: ":smoke-tests:images:quarkus"
       publish: true
       # Quarkus 2.0+ does not support Java 8
       skip-java-8: true

--- a/.github/workflows/publish-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/publish-smoke-test-spring-boot-images.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     uses: ./.github/workflows/reusable-smoke-test-images.yml
     with:
-      project: :smoke-tests:images:spring-boot
+      project: ":smoke-tests:images:spring-boot"
       publish: true
 
   open-issue-on-failure:

--- a/.github/workflows/reusable-muzzle.yml
+++ b/.github/workflows/reusable-muzzle.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       matrix:
         task:
-          - :instrumentation:muzzle1
-          - :instrumentation:muzzle2
-          - :instrumentation:muzzle3
-          - :instrumentation:muzzle4
+          - ":instrumentation:muzzle1"
+          - ":instrumentation:muzzle2"
+          - ":instrumentation:muzzle3"
+          - ":instrumentation:muzzle4"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
I saw some dependabot updates in the other two java repos and wondered why we weren't getting them here, and found this:

https://github.com/open-telemetry/opentelemetry-java-instrumentation/network/updates/346718840

```
Dependabot can't parse your pr-smoke-test-fake-backend-images.yml
Dependabot failed to update your dependencies because there was an error parsing the pr-smoke-test-fake-backend-images.yml found at /.github/workflows/pr-smoke-test-fake-backend-images.yml.

Dependabot encountered the following error:

Dependabot::DependencyFileNotParseable
```