### PR TITLE
Smaller github action cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: assemble publishToSonatype
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: caches/build-cache-1
 
       - name: Build and publish gradle plugin snapshots
         env:
@@ -107,5 +109,7 @@ jobs:
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build publishToSonatype
           build-root-directory: gradle-plugins
+          arguments: build publishToSonatype
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: caches/build-cache-1

--- a/.github/workflows/pr-smoke-test-fake-backend-images.yml
+++ b/.github/workflows/pr-smoke-test-fake-backend-images.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           arguments: :smoke-tests:images:fake-backend:jibDockerBuild -Djib.httpTimeout=120000 -Djib.console=plain
           cache-read-only: true
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: caches/build-cache-1
 
   buildWindows:
     runs-on: windows-2019

--- a/.github/workflows/reusable-assemble.yml
+++ b/.github/workflows/reusable-assemble.yml
@@ -42,6 +42,8 @@ jobs:
           # javadoc task fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
           arguments: assemble -x javadoc ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
           cache-read-only: ${{ inputs.cache-read-only }}
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: caches/build-cache-1
 
       - name: Upload deadlock detector artifacts if any
         if: always()

--- a/.github/workflows/reusable-smoke-test.yml
+++ b/.github/workflows/reusable-smoke-test.yml
@@ -65,6 +65,8 @@ jobs:
           arguments: ":smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}${{ inputs.no-build-cache && ' --no-build-cache' || '' }}"
           # only push cache for one matrix option per OS since github action cache space is limited
           cache-read-only: ${{ inputs.cache-read-only || matrix.smoke-test-suite != 'tomcat' }}
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: caches/build-cache-1
 
       - name: Upload jvm crash dump files if any
         if: always()

--- a/.github/workflows/reusable-test-latest-deps.yml
+++ b/.github/workflows/reusable-test-latest-deps.yml
@@ -56,7 +56,6 @@ jobs:
           GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
         with:
           arguments: test -PtestLatestDeps=true ${{ inputs.no-build-cache && ' --no-build-cache' || '' }}
-          # testLatestDeps dependencies bundle is over 2gb, which causes restoring it to fail with:
-          #     RangeError [ERR_OUT_OF_RANGE]: The value of "length" is out of range.
-          #     It must be >= 0 && <= 2147483647. Received 2299528741
-          cache-read-only: true
+          cache-read-only: ${{ inputs.cache-read-only }}
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: caches/build-cache-1

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -67,8 +67,7 @@ jobs:
           # only push cache for one matrix option since github action cache space is limited
           cache-read-only: ${{ inputs.cache-read-only || matrix.test-java-version != 11 || matrix.vm != 'hotspot' }}
           # gradle enterprise is used for the build cache
-          gradle-home-cache-excludes: |
-            caches/build-cache-1
+          gradle-home-cache-excludes: caches/build-cache-1
 
       - name: Upload deadlock detector artifacts if any
         if: always()


### PR DESCRIPTION
Note: I don't think this helps with #5839, because I think it's the dependency bundle that is >2gb, not the gradle home cache