### PR TITLE
Don't fail fast on matrix build

### DIFF
--- a/.github/workflows/reusable-muzzle.yml
+++ b/.github/workflows/reusable-muzzle.yml
@@ -17,6 +17,7 @@ jobs:
           - ":instrumentation:muzzle2"
           - ":instrumentation:muzzle3"
           - ":instrumentation:muzzle4"
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
It confused me that some of the muzzle builds got "cancelled", I checked and all other matrix builds do not fail fast.