### PR TITLE
Fix workflow links

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ as the last step, which publishes a snapshot build to
   `## Version 1.9.0 (unreleased)`.
   * Use `.github/scripts/draft-change-log-entries.sh` as a starting point for writing the change
     log.
-* Run the [Prepare release branch workflow](.github/workflows/prepare-release-branch.yml).
+* Run the [Prepare release branch workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflow/prepare-release-branch.yml).
 * Review and merge the two pull requests that it creates
   (one is targeted to the release branch and one is targeted to the `main` branch).
 
@@ -30,7 +30,7 @@ In general, patch releases are only made for regressions, security vulnerabiliti
 and deadlocks.
 
 * Backport pull request(s) to the release branch.
-  * Run the [Backport workflow](.github/workflows/backport.yml).
+  * Run the [Backport workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflow/backport.yml).
   * Press the "Run workflow" button, then select the release branch from the dropdown list,
     e.g. `release/v1.9.x`, then enter the pull request number that you want to backport,
     then click the "Run workflow" button below that.
@@ -38,14 +38,14 @@ and deadlocks.
 * Merge a pull request to the release branch updating the `CHANGELOG.md`.
   * The heading for the release should include the release version but not the release date, e.g.
   `## Version 1.9.0 (unreleased)`.
-* Run the [Prepare patch release workflow](.github/workflows/prepare-patch-release.yml).
+* Run the [Prepare patch release workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflow/prepare-patch-release.yml).
   * Press the "Run workflow" button, then select the release branch from the dropdown list,
     e.g. `release/v1.9.x`, and click the "Run workflow" button below that.
 * Review and merge the pull request that it creates.
 
 ## Making the release
 
-Run the [Release workflow](.github/workflows/release.yml).
+Run the [Release workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflow/release.yml).
 
 * Press the "Run workflow" button, then select the release branch from the dropdown list,
   e.g. `release/v1.9.x`, and click the "Run workflow" button below that.
@@ -56,7 +56,7 @@ Run the [Release workflow](.github/workflows/release.yml).
 
 ## After the release
 
-Run the [Merge change log to main workflow](.github/workflows/merge-change-log-to-main.yml).
+Run the [Merge change log to main workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflow/merge-change-log-to-main.yml).
 
 * Press the "Run workflow" button, then select the release branch from the dropdown list,
   e.g. `release/v1.9.x`, and click the "Run workflow" button below that.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ as the last step, which publishes a snapshot build to
 * Close the release milestone if there is one.
 * Merge a pull request to `main` updating the `CHANGELOG.md`.
   * The heading for the release should include the release version but not the release date, e.g.
-  `## Version 1.9.0 (unreleased)`.
+    `## Version 1.9.0 (unreleased)`.
   * Use `.github/scripts/draft-change-log-entries.sh` as a starting point for writing the change
     log.
 * Run the [Prepare release branch workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/prepare-release-branch.yml).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ as the last step, which publishes a snapshot build to
   `## Version 1.9.0 (unreleased)`.
   * Use `.github/scripts/draft-change-log-entries.sh` as a starting point for writing the change
     log.
-* Run the [Prepare release branch workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflow/prepare-release-branch.yml).
+* Run the [Prepare release branch workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/prepare-release-branch.yml).
 * Review and merge the two pull requests that it creates
   (one is targeted to the release branch and one is targeted to the `main` branch).
 
@@ -30,7 +30,7 @@ In general, patch releases are only made for regressions, security vulnerabiliti
 and deadlocks.
 
 * Backport pull request(s) to the release branch.
-  * Run the [Backport workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflow/backport.yml).
+  * Run the [Backport workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/backport.yml).
   * Press the "Run workflow" button, then select the release branch from the dropdown list,
     e.g. `release/v1.9.x`, then enter the pull request number that you want to backport,
     then click the "Run workflow" button below that.
@@ -38,14 +38,14 @@ and deadlocks.
 * Merge a pull request to the release branch updating the `CHANGELOG.md`.
   * The heading for the release should include the release version but not the release date, e.g.
   `## Version 1.9.0 (unreleased)`.
-* Run the [Prepare patch release workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflow/prepare-patch-release.yml).
+* Run the [Prepare patch release workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/prepare-patch-release.yml).
   * Press the "Run workflow" button, then select the release branch from the dropdown list,
     e.g. `release/v1.9.x`, and click the "Run workflow" button below that.
 * Review and merge the pull request that it creates.
 
 ## Making the release
 
-Run the [Release workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflow/release.yml).
+Run the [Release workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/release.yml).
 
 * Press the "Run workflow" button, then select the release branch from the dropdown list,
   e.g. `release/v1.9.x`, and click the "Run workflow" button below that.
@@ -56,7 +56,7 @@ Run the [Release workflow](https://github.com/open-telemetry/opentelemetry-java-
 
 ## After the release
 
-Run the [Merge change log to main workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflow/merge-change-log-to-main.yml).
+Run the [Merge change log to main workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/merge-change-log-to-main.yml).
 
 * Press the "Run workflow" button, then select the release branch from the dropdown list,
   e.g. `release/v1.9.x`, and click the "Run workflow" button below that.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ and deadlocks.
   * Review and merge the backport pull request that it generates.
 * Merge a pull request to the release branch updating the `CHANGELOG.md`.
   * The heading for the release should include the release version but not the release date, e.g.
-  `## Version 1.9.0 (unreleased)`.
+    `## Version 1.9.0 (unreleased)`.
 * Run the [Prepare patch release workflow](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/prepare-patch-release.yml).
   * Press the "Run workflow" button, then select the release branch from the dropdown list,
     e.g. `release/v1.9.x`, and click the "Run workflow" button below that.


### PR DESCRIPTION
link to the place where you run the workflows, not to the underlying yml files themselves

unfortunately this means they cannot be relative links (well, they can by using `../../actions/workflow/*`, but the link checker understandably doesn't know how to resolve relative parent links)