### PR TITLE
Fix duplicate class error on Android build

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/package-info.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/package-info.java
@@ -1,4 +1,0 @@
-@ParametersAreNonnullByDefault
-package io.opentelemetry.instrumentation.api;
-
-import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
I tried to bump the OTel instrumentation versions to 1.13 in our Splunk Android instrumentation repo (https://github.com/signalfx/splunk-otel-android/pull/276), got this error:

```
Duplicate class io.opentelemetry.instrumentation.api.package-info found in modules opentelemetry-instrumentation-api-1.13.0-alpha (io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:1.13.0-alpha) and opentelemetry-instrumentation-api-semconv-1.13.0-alpha (io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:1.13.0-alpha)
```

Looks like that file only appears once in the javaagent, and it's probably only a problem for the Android gradle plugin.
@open-telemetry/java-instrumentation-maintainers do you think this warrants a patch release?