### PR TITLE
Use separate steps to build and test smoke tests

### DIFF
--- a/.github/workflows/reusable-smoke-test.yml
+++ b/.github/workflows/reusable-smoke-test.yml
@@ -55,6 +55,20 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Build
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
+          GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          # running suite "none" compiles everything needed by smoke tests without executing any tests
+          arguments: ":smoke-tests:test -PsmokeTestSuite=none --no-daemon ${{ inputs.no-build-cache && ' --no-build-cache' || '' }}"
+          # only push cache for one matrix option per OS since github action cache space is limited
+          cache-read-only: ${{ inputs.cache-read-only || matrix.smoke-test-suite != 'tomcat' }}
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: caches/build-cache-1
+
       - name: Test
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -63,10 +77,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: ":smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}${{ inputs.no-build-cache && ' --no-build-cache' || '' }}"
-          # only push cache for one matrix option per OS since github action cache space is limited
-          cache-read-only: ${{ inputs.cache-read-only || matrix.smoke-test-suite != 'tomcat' }}
-          # gradle enterprise is used for the build cache
-          gradle-home-cache-excludes: caches/build-cache-1
+          # Build step takes care of caching
+          cache-disabled: true
 
       - name: Upload jvm crash dump files if any
         if: always()

--- a/.github/workflows/reusable-smoke-test.yml
+++ b/.github/workflows/reusable-smoke-test.yml
@@ -55,30 +55,27 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Set up Gradle cache
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ inputs.cache-read-only }}
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: caches/build-cache-1
+
       - name: Build
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
           GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-        uses: gradle/gradle-build-action@v2
-        with:
-          # running suite "none" compiles everything needed by smoke tests without executing any tests
-          arguments: ":smoke-tests:test -PsmokeTestSuite=none --no-daemon ${{ inputs.no-build-cache && ' --no-build-cache' || '' }}"
-          # only push cache for one matrix option per OS since github action cache space is limited
-          cache-read-only: ${{ inputs.cache-read-only || matrix.smoke-test-suite != 'tomcat' }}
-          # gradle enterprise is used for the build cache
-          gradle-home-cache-excludes: caches/build-cache-1
+        # running suite "none" compiles everything needed by smoke tests without executing any tests
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=none --no-daemon ${{ inputs.no-build-cache && ' --no-build-cache' || '' }}
 
       - name: Test
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
           GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: ":smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}${{ inputs.no-build-cache && ' --no-build-cache' || '' }}"
-          # Build step takes care of caching
-          cache-disabled: true
+        run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}${{ inputs.no-build-cache && ' --no-build-cache' || '' }}
 
       - name: Upload jvm crash dump files if any
         if: always()

--- a/.github/workflows/reusable-smoke-test.yml
+++ b/.github/workflows/reusable-smoke-test.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Set up Gradle cache
         uses: gradle/gradle-build-action@v2
         with:
-          cache-read-only: ${{ inputs.cache-read-only }}
+          # only push cache for one matrix option per OS since github action cache space is limited
+          cache-read-only: ${{ inputs.cache-read-only || matrix.smoke-test-suite != 'tomcat' }}
           # gradle enterprise is used for the build cache
           gradle-home-cache-excludes: caches/build-cache-1
 

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -72,6 +72,10 @@ tasks {
         suites.values.forEach {
           exclude(it)
         }
+      } else if (smokeTestSuite == "none") {
+        // Exclude all tests. Running this suite will compile everything needed by smoke tests
+        // without executing any tests.
+        exclude("**/*")
       } else {
         throw GradleException("Unknown smoke test suite: $smokeTestSuite")
       }


### PR DESCRIPTION
Hopefully this way we'll have more free memory when tests are executed