### PR TITLE
record exception in dubbo high version

### DIFF
--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/TracingFilter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/TracingFilter.java
@@ -63,7 +63,7 @@ final class TracingFilter implements Filter {
       throw e;
     }
     if (isSynchronous) {
-      instrumenter.end(context, request, result, null);
+      instrumenter.end(context, request, result, result.getException());
     }
     return result;
   }


### PR DESCRIPTION
in dubbo server side, it will not throw exception. instead it will put the exception in` Result`, so we miss the exception in server side now