### PR TITLE
Avoid looking up annotation types during type matching

### DIFF
--- a/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategyTest.java
+++ b/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.muzzle;
+
+import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.opentelemetry.test.AnnotatedTestClass;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.pool.TypePool;
+import org.junit.jupiter.api.Test;
+
+class AgentCachingPoolStrategyTest {
+
+  @Test
+  void testSkipResourceLookupForAnnotations() {
+    ClassLoader classLoader =
+        new ClassLoader(AgentCachingPoolStrategyTest.class.getClassLoader()) {
+
+          private void checkResource(String name) {
+            if (name.contains("TestAnnotation")) {
+              throw new IllegalStateException("Unexpected resource lookup for " + name);
+            }
+          }
+
+          @Override
+          public URL getResource(String name) {
+            checkResource(name);
+            return super.getResource(name);
+          }
+
+          @Override
+          public InputStream getResourceAsStream(String name) {
+            checkResource(name);
+            return super.getResourceAsStream(name);
+          }
+
+          @Override
+          public Enumeration<URL> getResources(String name) throws IOException {
+            checkResource(name);
+            return super.getResources(name);
+          }
+        };
+
+    ClassFileLocator locator = ClassFileLocator.ForClassLoader.of(classLoader);
+    TypePool pool = AgentTooling.poolStrategy().typePool(locator, classLoader);
+    TypePool.Resolution resolution = pool.describe(AnnotatedTestClass.class.getName());
+    TypeDescription typeDescription = resolution.resolve();
+
+    assertTrue(isAnnotatedWith(AnnotatedTestClass.TestAnnotation.class).matches(typeDescription));
+    assertTrue(
+        declaresMethod(isAnnotatedWith(AnnotatedTestClass.TestAnnotation.class))
+            .matches(typeDescription));
+  }
+}

--- a/muzzle/src/test/java/io/opentelemetry/test/AnnotatedTestClass.java
+++ b/muzzle/src/test/java/io/opentelemetry/test/AnnotatedTestClass.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.test;
+
+@AnnotatedTestClass.TestAnnotation
+public class AnnotatedTestClass {
+
+  @AnnotatedTestClass.TestAnnotation
+  void testMethod() {}
+
+  public @interface TestAnnotation {}
+}


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5791
Like jdk, byte-buddy getDeclaredAnnotations does not report annotations whose class is missing. To do this it needs to locate the bytes for annotation types used in class. Which means that if we have a matcher that matches methods annotated with `@Foo` byte-buddy will end up location bytes for all annotations used on any method in the classes that this matcher is applied to. From our perspective this is unreasonable, we just want to match based on annotation name with as little overhead as possible. As we match only based on annotation name we never need to locate the bytes for the annotation type.
Implementation is a bit of a hack, so we'll have to consider whether we want to do this at all.