### PR TITLE
Increase timeout for kafka topic creation

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/groovy/io/opentelemetry/instrumentation/kafkaclients/KafkaClientBaseTest.groovy
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/groovy/io/opentelemetry/instrumentation/kafkaclients/KafkaClientBaseTest.groovy
@@ -54,7 +54,7 @@ abstract class KafkaClientBaseTest extends InstrumentationSpecification {
 
     // create test topic
     AdminClient.create(["bootstrap.servers": kafka.bootstrapServers]).withCloseable { admin ->
-      admin.createTopics([new NewTopic(SHARED_TOPIC, 1, (short) 1)]).all().get(10, TimeUnit.SECONDS)
+      admin.createTopics([new NewTopic(SHARED_TOPIC, 1, (short) 1)]).all().get(30, TimeUnit.SECONDS)
     }
 
     producer = new KafkaProducer<>(producerProps())


### PR DESCRIPTION
https://ge.opentelemetry.io/s/3woctim4xthv4/tests/:instrumentation:kafka:kafka-clients:kafka-clients-2.6:library:test/io.opentelemetry.instrumentation.kafkaclients.WrappersTest/initializationError?expanded-stacktrace=WyIwIl0&top-execution=1
Hopefully larger timeout reduces flakiness