### PR TITLE
Exclude spring temporary type matching class loader

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -117,6 +117,8 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
         .ignoreClassLoader("jdk.internal.reflect.DelegatingClassLoader")
         .ignoreClassLoader("clojure.lang.DynamicClassLoader")
         .ignoreClassLoader("org.apache.cxf.common.util.ASMHelper$TypeHelperClassLoader")
+        .ignoreClassLoader(
+            "org.springframework.context.support.ContextTypeMatchClassLoader$ContextOverridingClassLoader")
         .ignoreClassLoader("sun.misc.Launcher$ExtClassLoader")
         .ignoreClassLoader(AgentClassLoader.class.getName())
         .ignoreClassLoader(ExtensionClassLoader.class.getName());


### PR DESCRIPTION
When load time weaving is enabled spring loads classes into a temporary class loader to do type matching (is this a factory bean? etc.). As this type matching class loader is recreated for each type matching attempt there can be a lot of them. For each class loader we run a bunch of matchers that call `getResource`. With these temp class loaders this can consume excessive amount of time. As we don't really need to instrument the classes in temp class loaders we can just exclude it.