### PR TITLE
Suppress logging from PeriodicMetricReader during tests

### DIFF
--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingCustomizer.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingCustomizer.java
@@ -28,6 +28,13 @@ public class AgentTestingCustomizer implements AutoConfigurationCustomizerProvid
     autoConfigurationCustomizer.addTracerProviderCustomizer(
         (tracerProvider, config) -> tracerProvider.addSpanProcessor(spanProcessor));
 
+    // as we configure PeriodicMetricReader with a short interval it repeatedly logs
+    // No metric data to export - skipping export.
+    // to get rid of these log lines we change PeriodicMetricReader log level from DEBUG to INFO
+    System.setProperty(
+        "io.opentelemetry.javaagent.slf4j.simpleLogger.log.io.opentelemetry.sdk.metrics.export.PeriodicMetricReader",
+        "INFO");
+
     autoConfigurationCustomizer.addMeterProviderCustomizer(
         (meterProvider, config) ->
             meterProvider.registerMetricReader(


### PR DESCRIPTION
For testing agent configures `PeriodicMetricReader` to run with a short interval. Due to this it may log `No metric data to export - skipping export.` multiple times for each test. 