### PR TITLE
Small consistency

### DIFF
--- a/instrumentation/azure-core/azure-core-1.14/javaagent/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.14/javaagent/build.gradle.kts
@@ -19,7 +19,7 @@ sourceSets {
 }
 
 dependencies {
-  compileOnly(project(path = ":instrumentation:azure-core:azure-core-1.14:library-instrumentation-shaded", configuration = "shadow"))
+  compileOnly(project(":instrumentation:azure-core:azure-core-1.14:library-instrumentation-shaded", configuration = "shadow"))
 
   library("com.azure:azure-core:1.14.0")
 

--- a/instrumentation/azure-core/azure-core-1.19/javaagent/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.19/javaagent/build.gradle.kts
@@ -19,7 +19,7 @@ sourceSets {
 }
 
 dependencies {
-  compileOnly(project(path = ":instrumentation:azure-core:azure-core-1.19:library-instrumentation-shaded", configuration = "shadow"))
+  compileOnly(project(":instrumentation:azure-core:azure-core-1.19:library-instrumentation-shaded", configuration = "shadow"))
 
   library("com.azure:azure-core:1.19.0")
 

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -24,8 +24,8 @@ subprojects {
     // this only exists to make Intellij happy since it doesn't (currently at least) understand our
     // inclusion of this artifact inside :testing-common
     dependencies {
-      compileOnly(project(path = ":testing:armeria-shaded-for-testing", configuration = "shadow"))
-      testCompileOnly(project(path = ":testing:armeria-shaded-for-testing", configuration = "shadow"))
+      compileOnly(project(":testing:armeria-shaded-for-testing", configuration = "shadow"))
+      testCompileOnly(project(":testing:armeria-shaded-for-testing", configuration = "shadow"))
     }
   }
 

--- a/instrumentation/opentelemetry-annotations-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-annotations-1.0/javaagent/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   // the @WithSpan annotation references the OpenTelemetry API's SpanKind class
   //
   // see the comment in opentelemetry-api-1.0.gradle for more details
-  compileOnly(project(path = ":opentelemetry-ext-annotations-shaded-for-instrumenting", configuration = "shadow"))
+  compileOnly(project(":opentelemetry-ext-annotations-shaded-for-instrumenting", configuration = "shadow"))
 
   testImplementation("io.opentelemetry:opentelemetry-extension-annotations")
   testImplementation(project(":instrumentation-api-annotation-support"))

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   //
   // and in the code "io.opentelemetry.*" refers to the (shaded) OpenTelemetry API that is used by
   // the agent (as those references will later be shaded)
-  compileOnly(project(path = ":opentelemetry-api-shaded-for-instrumenting", configuration = "shadow"))
+  compileOnly(project(":opentelemetry-api-shaded-for-instrumenting", configuration = "shadow"))
 
   // using OpenTelemetry SDK to make sure that instrumentation doesn't cause
   // OpenTelemetrySdk.getTracerProvider() to throw ClassCastException

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.10/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.10/javaagent/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  compileOnly(project(path = ":opentelemetry-api-shaded-for-instrumenting", configuration = "shadow"))
+  compileOnly(project(":opentelemetry-api-shaded-for-instrumenting", configuration = "shadow"))
   implementation(project(":instrumentation:opentelemetry-api:opentelemetry-api-1.0:javaagent"))
   implementation(project(":instrumentation:opentelemetry-api:opentelemetry-api-1.4:javaagent"))
 }

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.4/javaagent/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-  compileOnly(project(path = ":opentelemetry-api-shaded-for-instrumenting", configuration = "shadow"))
+  compileOnly(project(":opentelemetry-api-shaded-for-instrumenting", configuration = "shadow"))
   implementation(project(":instrumentation:opentelemetry-api:opentelemetry-api-1.0:javaagent"))
 }

--- a/instrumentation/reactor/reactor-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-3.1/javaagent/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 
   compileOnly(project(":javaagent-tooling"))
   compileOnly(project(":instrumentation-api-annotation-support"))
-  compileOnly(project(path = ":opentelemetry-api-shaded-for-instrumenting", configuration = "shadow"))
+  compileOnly(project(":opentelemetry-api-shaded-for-instrumenting", configuration = "shadow"))
 
   testLibrary("io.projectreactor:reactor-test:3.1.0.RELEASE")
   testImplementation(project(":instrumentation:opentelemetry-annotations-1.0:testing"))

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
   testImplementation("com.github.docker-java:docker-java-transport-httpclient5:$dockerJavaVersion")
 
   // make IntelliJ see shaded Armeria
-  testCompileOnly(project(path = ":testing:armeria-shaded-for-testing", configuration = "shadow"))
+  testCompileOnly(project(":testing:armeria-shaded-for-testing", configuration = "shadow"))
 }
 
 tasks {

--- a/testing-common/build.gradle.kts
+++ b/testing-common/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 
   api("com.google.guava:guava")
 
-  compileOnly(project(path = ":testing:armeria-shaded-for-testing", configuration = "shadow"))
+  compileOnly(project(":testing:armeria-shaded-for-testing", configuration = "shadow"))
 
   implementation("io.opentelemetry.proto:opentelemetry-proto")
 


### PR DESCRIPTION
I think this format is more natural, since matches other `project("...")` calls that do not have additional arg