### PR TITLE
Fix flaky spring batch test

### DIFF
--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ApplicationConfigTrait.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ApplicationConfigTrait.groovy
@@ -33,6 +33,10 @@ trait ApplicationConfigTrait {
 
   def runJob(String jobName, Map<String, JobParameter> params) {
     def job = applicationContext.getBean(jobName, Job)
+    postProcessJob(jobName, job)
     jobLauncher.run(job, new JobParameters(params))
+  }
+
+  def postProcessJob(String jobName, Job job) {
   }
 }

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ItemLevelSpanTest.groovy
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/test/groovy/ItemLevelSpanTest.groovy
@@ -11,7 +11,7 @@ import org.springframework.batch.core.Step
 import org.springframework.batch.core.job.AbstractJob
 import org.springframework.batch.core.step.tasklet.TaskletStep
 import org.springframework.batch.repeat.policy.SimpleCompletionPolicy
-import org.springframework.batch.repeat.support.RepeatTemplate
+import org.springframework.batch.repeat.support.TaskExecutorRepeatTemplate
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.support.ClassPathXmlApplicationContext
@@ -269,11 +269,9 @@ abstract class ItemLevelSpanTest extends AgentInstrumentationSpecification {
     if ("parallelItemsJob" == jobName) {
       Step step = ((AbstractJob) job).getStep("parallelItemsStep")
       TaskletStep taskletStep = (TaskletStep) step
-      RepeatTemplate stepOperations = new RepeatTemplate()
       // explicitly set the number of chunks we expect from this test to ensure we always get
       // the same number of spans
-      stepOperations.setCompletionPolicy(new SimpleCompletionPolicy(3))
-      taskletStep.setStepOperations(stepOperations)
+      ((TaskExecutorRepeatTemplate) taskletStep.stepOperations).completionPolicy = new SimpleCompletionPolicy(3)
     }
   }
 }


### PR DESCRIPTION
Hopefully fixes flaky spring batch test
https://ge.opentelemetry.io/s/valgzon6rud2i/tests/:instrumentation:spring:spring-batch-3.0:javaagent:testItemLevelSpan/JavaConfigItemLevelSpanTest/should%20trace%20all%20item%20operations%20on%20a%20parallel%20items%20job?expanded-stacktrace=WyIwIl0
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=XmlConfigItemLevelSpanTest&tests.sortField=FLAKY&tests.test=should%20trace%20all%20item%20operations%20on%20a%20parallel%20items%20job&tests.unstableOnly=true