### PR TITLE
dubbo: fix stack traces in test output on jdk17

### DIFF
--- a/instrumentation/apache-dubbo-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/apache-dubbo-2.7/javaagent/build.gradle.kts
@@ -21,3 +21,9 @@ dependencies {
   latestDepTestLibrary("org.apache.dubbo:dubbo:2.+") // documented limitation
   latestDepTestLibrary("org.apache.dubbo:dubbo-config-api:2.+") // documented limitation
 }
+
+tasks.withType<Test>().configureEach {
+  // to suppress non-fatal errors on jdk17
+  jvmArgs("--add-opens=java.base/java.math=ALL-UNNAMED")
+  jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+}

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/build.gradle.kts
@@ -14,3 +14,9 @@ dependencies {
   latestDepTestLibrary("org.apache.dubbo:dubbo:2.+") // documented limitation
   latestDepTestLibrary("org.apache.dubbo:dubbo-config-api:2.+") // documented limitation
 }
+
+tasks.withType<Test>().configureEach {
+  // to suppress non-fatal errors on jdk17
+  jvmArgs("--add-opens=java.base/java.math=ALL-UNNAMED")
+  jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+}


### PR DESCRIPTION
```
java.lang.reflect.InaccessibleObjectException: Unable to make field final int java.math.BigInteger.signum accessible: module java.base does not "opens java.math" to unnamed module @ba8a1dc
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at com.alibaba.com.caucho.hessian.io.JavaDeserializer.getFieldMap(JavaDeserializer.java:339)
	at com.alibaba.com.caucho.hessian.io.JavaDeserializer.<init>(JavaDeserializer.java:79)
	at com.alibaba.com.caucho.hessian.io.BigIntegerDeserializer.<init>(BigIntegerDeserializer.java:25)
	at com.alibaba.com.caucho.hessian.io.SerializerFactory.<clinit>(SerializerFactory.java:153)
	at org.apache.dubbo.common.serialize.hessian2.Hessian2ObjectOutput.<init>(Hessian2ObjectOutput.java:34)
	at org.apache.dubbo.common.serialize.hessian2.Hessian2Serialization.serialize(Hessian2Serialization.java:51)
	at org.apache.dubbo.remoting.exchange.codec.ExchangeCodec.encodeRequest(ExchangeCodec.java:234)
	at org.apache.dubbo.remoting.exchange.codec.ExchangeCodec.encode(ExchangeCodec.java:69)
	at org.apache.dubbo.rpc.protocol.dubbo.DubboCountCodec.encode(DubboCountCodec.java:40)
```