### PR TITLE
Wait a bit before retrying

### DIFF
--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaTest.java
@@ -90,6 +90,7 @@ public abstract class AbstractSpringKafkaTest {
         break;
       } else if (i < maxAttempts) {
         testing.waitForTraces(2);
+        Thread.sleep(1_000); // sleep a bit to give time for all the spans to arrive
         testing.clearData();
         logger.info("Messages weren't received as batch, retrying");
       }


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.javaagent.instrumentation.spring.kafka.SpringKafkaNoReceiveTelemetryTest&tests.sortField=FLAKY&tests.test=shouldCreateSpansForBatchReceiveAndProcess()&tests.unstableOnly=true
We have a spring kafka test that assumes that messages are sent as a batch. If we detect that messages weren't sent as a batch we clear traces and retry the test. After this test was converted to java a week ago it has been flaky a couple of times. I guess that we should wait a bit before clearing traces in case there are some spans that have not arrived yet to ensure that when the test is rerun it won't get any extra traces.