### PR TITLE
Freeze markdown-link-check-version

### DIFF
--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install markdown-link-check
-        run: npm install -g markdown-link-check
+        run: npm install -g markdown-link-check@3.10.0
 
       - name: Run markdown-link-check
         run: |


### PR DESCRIPTION
Looks like a new release (3.10.1) was published just a couple of hours ago, and it consistently fails with 

```
Error: Cannot find module 'cheerio'
Require stack:
- /usr/local/lib/node_modules/markdown-link-check/node_modules/html-link-extractor/index.js
- /usr/local/lib/node_modules/markdown-link-check/node_modules/markdown-link-extractor/index.js
- /usr/local/lib/node_modules/markdown-link-check/index.js
- /usr/local/lib/node_modules/markdown-link-check/markdown-link-check
```