### PR TITLE
Remove markdown-link-check version pin

### DIFF
--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install markdown-link-check
-        run: npm install -g markdown-link-check@3.10.0
+        run: npm install -g markdown-link-check
 
       - name: Run markdown-link-check
         run: |


### PR DESCRIPTION
Looks like this got fixed in 3.10.2