### PR TITLE
Fix default enabled for runtime and oshi metrics

### DIFF
--- a/instrumentation/oshi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/OshiMetricsInstaller.java
+++ b/instrumentation/oshi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/OshiMetricsInstaller.java
@@ -19,10 +19,14 @@ import java.util.Collections;
  */
 @AutoService(AgentListener.class)
 public class OshiMetricsInstaller implements AgentListener {
+
+  private static final boolean DEFAULT_ENABLED =
+      Config.get().getBoolean("otel.instrumentation.common.default-enabled", true);
+
   @Override
   public void afterAgent(Config config, AutoConfiguredOpenTelemetrySdk unused) {
     if (new AgentConfig(config)
-        .isInstrumentationEnabled(Collections.singleton("oshi"), /* defaultEnabled= */ true)) {
+        .isInstrumentationEnabled(Collections.singleton("oshi"), DEFAULT_ENABLED)) {
       try {
         // Call oshi.SystemInfo.getCurrentPlatformEnum() to activate SystemMetrics.
         // Oshi instrumentation will intercept this call and enable SystemMetrics.

--- a/instrumentation/runtime-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsInstaller.java
+++ b/instrumentation/runtime-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsInstaller.java
@@ -18,11 +18,14 @@ import java.util.Collections;
 /** An {@link AgentListener} that enables runtime metrics during agent startup. */
 @AutoService(AgentListener.class)
 public class RuntimeMetricsInstaller implements AgentListener {
+
+  private static final boolean DEFAULT_ENABLED =
+      Config.get().getBoolean("otel.instrumentation.common.default-enabled", true);
+
   @Override
   public void afterAgent(Config config, AutoConfiguredOpenTelemetrySdk unused) {
     if (new AgentConfig(config)
-        .isInstrumentationEnabled(
-            Collections.singleton("runtime-metrics"), /* defaultEnabled= */ true)) {
+        .isInstrumentationEnabled(Collections.singleton("runtime-metrics"), DEFAULT_ENABLED)) {
       GarbageCollector.registerObservers(GlobalOpenTelemetry.get());
       MemoryPools.registerObservers(GlobalOpenTelemetry.get());
     }


### PR DESCRIPTION
I believe these instrumentation should respect `otel.instrumentation.common.default-enabled` as well