### PR TITLE
Hide the GC runtime metrics behind an experimental config flag

### DIFF
--- a/instrumentation/runtime-metrics/javaagent/build.gradle.kts
+++ b/instrumentation/runtime-metrics/javaagent/build.gradle.kts
@@ -8,3 +8,9 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   compileOnly(project(":javaagent-tooling"))
 }
+
+tasks {
+  withType<Test>().configureEach {
+    jvmArgs("-Dotel.instrumentation.runtime-metrics.experimental-metrics.enabled=true")
+  }
+}

--- a/instrumentation/runtime-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsInstaller.java
+++ b/instrumentation/runtime-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsInstaller.java
@@ -26,8 +26,13 @@ public class RuntimeMetricsInstaller implements AgentListener {
   public void afterAgent(Config config, AutoConfiguredOpenTelemetrySdk unused) {
     if (new AgentConfig(config)
         .isInstrumentationEnabled(Collections.singleton("runtime-metrics"), DEFAULT_ENABLED)) {
-      GarbageCollector.registerObservers(GlobalOpenTelemetry.get());
+
       MemoryPools.registerObservers(GlobalOpenTelemetry.get());
+
+      if (config.getBoolean(
+          "otel.instrumentation.runtime-metrics.experimental-metrics.enabled", false)) {
+        GarbageCollector.registerObservers(GlobalOpenTelemetry.get());
+      }
     }
   }
 }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -77,8 +77,6 @@ class SpringBootSmokeTest extends SmokeTest {
 
     then: "JVM metrics are exported"
     def metrics = new MetricsInspector(waitForMetrics())
-    metrics.hasMetricsNamed("runtime.jvm.gc.time")
-    metrics.hasMetricsNamed("runtime.jvm.gc.count")
     metrics.hasMetricsNamed("process.runtime.jvm.memory.init")
     metrics.hasMetricsNamed("process.runtime.jvm.memory.usage")
     metrics.hasMetricsNamed("process.runtime.jvm.memory.committed")


### PR DESCRIPTION
The GC metrics are still not specified (unlike the memory metrics), let's hide them behind an experimental flag (similar to what we're already doing in the Oshi instrumentation).