### PR TITLE
Add JavaagentFileHolder

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent;
 
 import io.opentelemetry.javaagent.bootstrap.AgentInitializer;
 import io.opentelemetry.javaagent.bootstrap.InstrumentationHolder;
+import io.opentelemetry.javaagent.bootstrap.JavaagentFileHolder;
 import java.io.File;
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
@@ -52,6 +53,7 @@ public final class OpenTelemetryAgent {
     try {
       File javaagentFile = installBootstrapJar(inst);
       InstrumentationHolder.setInstrumentation(inst);
+      JavaagentFileHolder.setJavaagentFile(javaagentFile);
       AgentInitializer.initialize(inst, javaagentFile, fromPremain);
     } catch (Throwable ex) {
       // Don't rethrow.  We don't have a log manager here, so just print.

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/InstrumentationHolder.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/InstrumentationHolder.java
@@ -6,11 +6,14 @@
 package io.opentelemetry.javaagent.bootstrap;
 
 import java.lang.instrument.Instrumentation;
+import javax.annotation.Nullable;
 
-/** This class serves as a "everywhere accessible" source of {@link Instrumentation} instance. */
+/** This class serves as an "everywhere accessible" source of {@link Instrumentation} instance. */
 public class InstrumentationHolder {
-  private static volatile Instrumentation instrumentation;
 
+  @Nullable private static volatile Instrumentation instrumentation;
+
+  @Nullable
   public static Instrumentation getInstrumentation() {
     return instrumentation;
   }

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/JavaagentFileHolder.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/JavaagentFileHolder.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.bootstrap;
+
+import java.io.File;
+import javax.annotation.Nullable;
+
+// this is currently unused in this repository, but is available for use in distros
+/** This class serves as an "everywhere accessible" source of the agent jar file. */
+public class JavaagentFileHolder {
+
+  @Nullable private static volatile File javaagentFile;
+
+  @Nullable
+  public static File getJavaagentFile() {
+    return javaagentFile;
+  }
+
+  public static void setJavaagentFile(File javaagentFile) {
+    JavaagentFileHolder.javaagentFile = javaagentFile;
+  }
+}


### PR DESCRIPTION
I would like a standard way to get the javaagent file location in our distro (we load configuration file relative to this, and write log file relative to this by default).

I could also add `File` as callback to the AgentListener methods, but didn't really want to pollute those with this rare(?) case.