### PR TITLE
Flaky easticsearch5 test

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/ElasticsearchRest5Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/ElasticsearchRest5Test.groovy
@@ -66,7 +66,8 @@ class ElasticsearchRest5Test extends AgentInstrumentationSpecification {
     Map result = new JsonSlurper().parseText(EntityUtils.toString(response.entity))
 
     expect:
-    result.status == "green"
+    // usually this test reports green status, but sometimes it is yellow
+    result.status == "green" || result.status == "yellow"
 
     assertTraces(1) {
       trace(0, 2) {


### PR DESCRIPTION
https://ge.opentelemetry.io/s/2tx3kzwmmlns4/tests/:instrumentation:elasticsearch:elasticsearch-rest-5.0:javaagent:test/ElasticsearchRest5Test/test%20elasticsearch%20status?top-execution=1
Occasionally test fails because status is `yellow` instead of the expected `green`. For us it isn't really important what it is.
Same fix as in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4814 which fixed another test in the same file.