### PR TITLE
Disable periodic metric reading in tests

### DIFF
--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingCustomizer.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingCustomizer.java
@@ -23,7 +23,9 @@ public class AgentTestingCustomizer implements AutoConfigurationCustomizerProvid
 
   static final MetricReader metricReader =
       PeriodicMetricReader.builder(AgentTestingExporterFactory.metricExporter)
-          .setInterval(Duration.ofMillis(100))
+          // Set really long interval. We'll call forceFlush when we need the metrics
+          // instead of collecting them periodically.
+          .setInterval(Duration.ofNanos(Long.MAX_VALUE))
           .build();
 
   static void reset() {

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingExporterFactory.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/AgentTestingExporterFactory.java
@@ -19,6 +19,7 @@ public class AgentTestingExporterFactory {
   }
 
   public static List<byte[]> getMetricExportRequests() {
+    AgentTestingCustomizer.metricReader.forceFlush().join(10, TimeUnit.SECONDS);
     return metricExporter.getCollectedExportRequests();
   }
 


### PR DESCRIPTION
Instead of collecting metrics periodically collect them when they are needed e.g. for asserting metrics in a test. Hopefully this fixes the metrics test flakiness caused from CUMULATIVE to DELTA change that was discussed 2 weeks ago at the SIG meeting.
An alternative proposed at the sig was to somehow clear the metrics between the tests and use CUMULATIVE.