### PR TITLE
Change SpanStatusExtractor to use a builder that can set status description

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultSpanStatusExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultSpanStatusExtractor.java
@@ -21,4 +21,15 @@ final class DefaultSpanStatusExtractor<REQUEST, RESPONSE>
     }
     return StatusCode.UNSET;
   }
+
+  @Override
+  public void extract(
+      SpanStatusBuilder spanStatusBuilder,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
+    if (error != null) {
+      spanStatusBuilder.setStatus(StatusCode.ERROR, error.toString());
+    }
+  }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -9,7 +9,6 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.internal.SupportabilityMetrics;
@@ -215,10 +214,8 @@ public class Instrumenter<REQUEST, RESPONSE> {
       }
     }
 
-    StatusCode statusCode = spanStatusExtractor.extract(request, response, error);
-    if (statusCode != StatusCode.UNSET) {
-      span.setStatus(statusCode);
-    }
+    SpanStatusBuilder spanStatusBuilder = new SpanStatusBuilderImpl(span);
+    spanStatusExtractor.extract(spanStatusBuilder, request, response, error);
 
     if (endTime != null) {
       span.end(endTime);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanStatusBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanStatusBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import io.opentelemetry.api.trace.StatusCode;
+
+/** A builder that exposes methods for setting the status of a span. */
+public interface SpanStatusBuilder {
+
+  /**
+   * Sets the status to the {@code Span}.
+   *
+   * <p>If used, this will override the default {@code Span} status. Default status code is {@link
+   * StatusCode#UNSET}.
+   *
+   * <p>Only the value of the last call will be recorded, and implementations are free to ignore
+   * previous calls.
+   *
+   * @param statusCode the {@link StatusCode} to set.
+   * @return this.
+   * @see Span#setStatus(StatusCode)
+   */
+  default SpanStatusBuilder setStatus(StatusCode statusCode) {
+    return setStatus(statusCode, "");
+  }
+
+  /**
+   * Sets the status to the {@code Span}.
+   *
+   * <p>If used, this will override the default {@code Span} status. Default status code is {@link
+   * StatusCode#UNSET}.
+   *
+   * <p>Only the value of the last call will be recorded, and implementations are free to ignore
+   * previous calls.
+   *
+   * @param statusCode the {@link StatusCode} to set.
+   * @param description the description of the {@code Status}.
+   * @return this.
+   * @see io.opentelemetry.api.trace.Span#setStatus(StatusCode,String)
+   */
+  SpanStatusBuilder setStatus(StatusCode statusCode, String description);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanStatusBuilderImpl.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanStatusBuilderImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+
+final class SpanStatusBuilderImpl implements SpanStatusBuilder {
+  private final Span span;
+
+  SpanStatusBuilderImpl(Span span) {
+    this.span = span;
+  }
+
+  @Override
+  public SpanStatusBuilder setStatus(StatusCode statusCode, String description) {
+    span.setStatus(statusCode, description);
+    return this;
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanStatusExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanStatusExtractor.java
@@ -9,14 +9,25 @@ import io.opentelemetry.api.trace.StatusCode;
 import javax.annotation.Nullable;
 
 /**
- * Extractor of {@link StatusCode}. The {@link #extract(Object, Object, Throwable)} method will be
- * called after a request processing is completed to determine its final status.
+ * Extractor of {@link StatusCode}. The {@link #extract(SpanStatusBuilder, Object, Object,
+ * Throwable)} method will be called after a request processing is completed to determine its final
+ * status.
  */
 @FunctionalInterface
 public interface SpanStatusExtractor<REQUEST, RESPONSE> {
 
   /** Returns the {@link StatusCode}. */
   StatusCode extract(REQUEST request, @Nullable RESPONSE response, @Nullable Throwable error);
+
+  /** Extracts the status from the response and sets it to the {@code spanStatusBuilder}. */
+  default void extract(
+      SpanStatusBuilder spanStatusBuilder,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
+    StatusCode statusCode = extract(request, response, error);
+    spanStatusBuilder.setStatus(statusCode);
+  }
 
   /**
    * Returns the default {@link SpanStatusExtractor}, which returns {@link StatusCode#ERROR} if the

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.TraceState;
@@ -223,7 +224,11 @@ class InstrumenterTest {
         .hasTracesSatisfyingExactly(
             trace ->
                 trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("span").hasStatus(StatusData.error())));
+                    span ->
+                        span.hasName("span")
+                            .hasStatus(
+                                StatusData.create(
+                                    StatusCode.ERROR, "java.lang.IllegalStateException: test"))));
   }
 
   @Test
@@ -332,7 +337,11 @@ class InstrumenterTest {
         .hasTracesSatisfyingExactly(
             trace ->
                 trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("span").hasStatus(StatusData.error())));
+                    span ->
+                        span.hasName("span")
+                            .hasStatus(
+                                StatusData.create(
+                                    StatusCode.ERROR, "java.lang.IllegalStateException: test"))));
   }
 
   @Test


### PR DESCRIPTION
Currently the `SpanStatusExtractor` can only extract a `StatusCode` from the response and any error and never sets an appropriate description for the status of the span.  This change adds a method to the `SpanStatusExtractor` to use a helper interface `SpanStatusBuilder` which delegates the `setStatus` methods to the underlying `Span` so that the extractor may set the status code and description.