### PR TITLE
Add diff-suppression-keys-with-docs script back

### DIFF
--- a/.github/scripts/diff-suppression-keys-with-docs.sh
+++ b/.github/scripts/diff-suppression-keys-with-docs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# this script reports some false positives, but is helpful in comparing the keys listed
+# in suppressing-instrumentation.md with the keys listed in the source files
+
+set -e -u -o pipefail
+
+comm -3 \
+  <(
+    sed -n '/----------------------/,${p;/^$/q}' \
+        ../opentelemetry.io/content/en/docs/instrumentation/java/automatic/agent-config.md \
+      | sed '1d;$d' \
+      | cut -d '|' -f 3 \
+      | tr -d ' ' \
+      | sort -u
+  ) \
+  <(
+    git ls-files '*Module.java' \
+      | xargs grep super \
+      | grep -oP '(?<=super\(")[^"]+' \
+      | sort -u
+  )

--- a/.github/scripts/diff-suppression-keys-with-docs.sh
+++ b/.github/scripts/diff-suppression-keys-with-docs.sh
@@ -5,10 +5,11 @@
 
 set -e -u -o pipefail
 
+curl https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/content/en/docs/instrumentation/java/automatic/agent-config.md > agent-config.md
+
 comm -3 \
   <(
-    sed -n '/----------------------/,${p;/^$/q}' \
-        ../opentelemetry.io/content/en/docs/instrumentation/java/automatic/agent-config.md \
+    sed -n '/----------------------/,${p;/^$/q}' agent-config.md \
       | sed '1d;$d' \
       | cut -d '|' -f 3 \
       | tr -d ' ' \


### PR DESCRIPTION
We removed from this, but it's still useful for now, e.g. https://github.com/open-telemetry/opentelemetry.io/pull/1353, until future state of https://github.com/open-telemetry/opentelemetry.io/issues/1236.