### PR TITLE
Remove tag protection rule

### DIFF
--- a/docs/contributing/repository-settings.md
+++ b/docs/contributing/repository-settings.md
@@ -57,10 +57,3 @@ Same settings as above for new release branches (`release/**`), except:
 * Allow deletions: CHECKED
 
   So that bot PR branches can be deleted
-
-## Tag protections
-
-* `v*`
-
-  To prevent accidents. Though sometimes useful for release snafu, so may reconsider if
-  maintainers lose admin rights.


### PR DESCRIPTION
Bot couldn't create the tag 😞

From https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules

> Only users with admin or maintain permissions in the repository will be able to create protected tags, and only users with admin permissions in the repository will be able to delete protected tags.