### PR TITLE
Ignore span oder in flaky test

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -22,6 +22,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -554,14 +555,25 @@ public abstract class AbstractHttpClientTest<REQUEST> {
 
     testing.waitAndAssertTraces(
         trace -> {
-          trace.hasSpansSatisfyingExactly(
-              span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-              span ->
-                  assertClientSpan(span, uri, method, null)
-                      .hasParent(trace.getSpan(0))
-                      .hasException(clientError),
-              span ->
-                  span.hasName("callback").hasKind(SpanKind.INTERNAL).hasParent(trace.getSpan(0)));
+          List<Consumer<SpanDataAssert>> spanAsserts =
+              Arrays.asList(
+                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                  span ->
+                      assertClientSpan(span, uri, method, null)
+                          .hasParent(trace.getSpan(0))
+                          .hasException(clientError),
+                  span ->
+                      span.hasName("callback")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(0)));
+          boolean jdk8 = "1.8".equals(System.getProperty("java.specification.version"));
+          if (jdk8) {
+            // on some netty based http clients odering of `CONNECT` and `callback` span isn't
+            // guranteed when running on jdk8
+            trace.hasSpansSatisfyingExactlyInAnyOrder(spanAsserts);
+          } else {
+            trace.hasSpansSatisfyingExactly(spanAsserts);
+          }
         });
   }
 


### PR DESCRIPTION
Order of spans isn't guaranteed for http client `connectionErrorUnopenedPortWithCallback` test on jdk8 for some netty based clients because netty `CONNECT` span start time comes from `Instant.now()` not the anchored clock used for other spans.
https://ge.opentelemetry.io/s/tp3leevka7lj6/tests/:instrumentation:reactor:reactor-netty:reactor-netty-0.9:javaagent:test/io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9.ReactorNettyHttpClientUsingFromTest/connection%20error%20(unopened%20port)%20with%20callback?expanded-stacktrace=WyIwLTEiXQ&top-execution=1