### PR TITLE
Fix sorting spans in reactor netty connection span tests

### DIFF
--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.groovy
@@ -51,8 +51,8 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
     responseCode == 200
     assertTraces(1) {
       trace(0, 5) {
-        def list = Arrays.asList("RESOLVE", "CONNECT")
-        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
+        def list = Arrays.asList("CONNECT", "RESOLVE")
+        spans.subList(2, 4).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL
@@ -113,8 +113,8 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
     and:
     assertTraces(1) {
       trace(0, 3) {
-        def list = Arrays.asList("RESOLVE", "CONNECT")
-        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
+        def list = Arrays.asList("CONNECT", "RESOLVE")
+        spans.subList(2, 4).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL

--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyConnectionSpanTest.groovy
@@ -51,8 +51,8 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
     responseCode == 200
     assertTraces(1) {
       trace(0, 5) {
-        def list = Arrays.asList("CONNECT", "RESOLVE")
-        spans.subList(2, 4).sort(Comparator.comparing { item -> list.indexOf(item.name) })
+        def list = Arrays.asList("RESOLVE", "CONNECT")
+        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL
@@ -113,8 +113,8 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
     and:
     assertTraces(1) {
       trace(0, 3) {
-        def list = Arrays.asList("CONNECT", "RESOLVE")
-        spans.subList(2, 4).sort(Comparator.comparing { item -> list.indexOf(item.name) })
+        def list = Arrays.asList("RESOLVE", "CONNECT")
+        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.groovy
@@ -56,7 +56,7 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
     assertTraces(1) {
       trace(0, 5) {
         def list = Arrays.asList("RESOLVE", "CONNECT")
-        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
+        spans.subList(2, 4).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL
@@ -130,7 +130,7 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
     assertTraces(1) {
       trace(0, 4) {
         def list = Arrays.asList("RESOLVE", "CONNECT")
-        spans.subList(1, 3).sort(Comparator.comparing { item -> list.indexOf(item.name) })
+        spans.subList(2, 4).sort(Comparator.comparing { item -> list.indexOf(item.name) })
         span(0) {
           name "parent"
           kind INTERNAL


### PR DESCRIPTION
This sorting is intended to reduce test flakiness like https://ge.opentelemetry.io/s/znkvvxo25jfm6/tests/:instrumentation:reactor:reactor-netty:reactor-netty-1.0:javaagent:testConnectionSpan/io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0.ReactorNettyConnectionSpanTest/test%20failing%20request?top-execution=1