### PR TITLE
Limit cassandra memory usage

### DIFF
--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/groovy/CassandraClientTest.groovy
@@ -37,6 +37,8 @@ class CassandraClientTest extends AgentInstrumentationSpecification {
 
   def setupSpec() {
     cassandra = new GenericContainer("cassandra:3")
+      // limit memory usage
+      .withEnv("JVM_OPTS", "-Xmx128m -Xms128m")
       .withExposedPorts(9042)
       .withLogConsumer(new Slf4jLogConsumer(logger))
       .withStartupTimeout(Duration.ofSeconds(120))

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/test/groovy/CassandraClientTest.groovy
@@ -32,6 +32,8 @@ class CassandraClientTest extends AgentInstrumentationSpecification {
 
   def setupSpec() {
     cassandra = new GenericContainer("cassandra:4.0")
+      // limit memory usage
+      .withEnv("JVM_OPTS", "-Xmx128m -Xms128m")
       .withExposedPorts(9042)
       .withLogConsumer(new Slf4jLogConsumer(logger))
       .withStartupTimeout(Duration.ofSeconds(120))


### PR DESCRIPTION
I suspect that cassandra is what pushes the tests over memory limit and gets gradle daemon killed which results in
```
The message received from the daemon indicates that the daemon has disappeared.
Build request sent: Build{id=2fdf4cb4-badd-4a03-8e85-b6c83732b793, currentDir=/home/runner/work/opentelemetry-java-instrumentation/opentelemetry-java-instrumentation}
Attempting to read last messages from the daemon log...
```