### PR TITLE
Fix the build

### DIFF
--- a/instrumentation/redisson-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/redisson-3.0/javaagent/build.gradle.kts
@@ -6,12 +6,15 @@ muzzle {
   pass {
     group.set("org.redisson")
     module.set("redisson")
-    versions.set("[3.0.0,)")
+    versions.set("[3.0.0,3.17.2)")
   }
 }
 
 dependencies {
   library("org.redisson:redisson:3.0.0")
+
+  // TODO (trask) split out instrumentation into two modules and support 3.17.2+
+  latestDepTestLibrary("org.redisson:redisson:3.17.1")
 
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")


### PR DESCRIPTION
`RPromise` was removed in redisson 3.17.2 which is causing muzzle to fail, but it looks like that class was already unused since 3.16.8, and we have a different instrumentation path since then already.

I'm guessing we just need to split redisson instrumentation into two modules (+ one probably for common code)?