### PR TITLE
Allow instrumenting built-in class loaders

### DIFF
--- a/instrumentation/internal/internal-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/ClassLoaderIgnoredTypesConfigurer.java
+++ b/instrumentation/internal/internal-class-loader/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/classloader/ClassLoaderIgnoredTypesConfigurer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.internal.classloader;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesBuilder;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
+
+@AutoService(IgnoredTypesConfigurer.class)
+public class ClassLoaderIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
+
+  @Override
+  public void configure(Config config, IgnoredTypesBuilder builder) {
+    builder.allowClass("jdk.internal.loader.BuiltinClassLoader");
+    builder.allowClass("sun.misc.Launcher$AppClassLoader");
+  }
+}


### PR DESCRIPTION
While experimenting with some stuff it took me a while to realize that our `internal-class-loader` instrumentation doesn't apply on `AppClassLoader`.