### PR TITLE
Instrumenting additional Akka server methods

### DIFF
--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerInstrumentationModule.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerInstrumentationModule.java
@@ -8,10 +8,18 @@ package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.akkahttp.server.AkkaHttpServerSingletons.errorResponse;
 import static io.opentelemetry.javaagent.instrumentation.akkahttp.server.AkkaHttpServerSingletons.instrumenter;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
+import akka.stream.Attributes;
+import akka.stream.BidiShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -31,7 +39,11 @@ public class AkkaHttpServerInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new HttpExtServerInstrumentation());
+    return asList(
+        new HttpExtServerInstrumentation(),
+        new AkkaHttpServerSourceInstrumentation(),
+        new DispatchersInstrumentation()
+    );
   }
 
   public static class SyncWrapper extends AbstractFunction1<HttpRequest, HttpResponse> {
@@ -99,6 +111,114 @@ public class AkkaHttpServerInstrumentationModule extends InstrumentationModule {
       } catch (Throwable t) {
         instrumenter().end(context, request, null, t);
         throw t;
+      }
+    }
+  }
+
+  public static class FlowWrapper extends GraphStage<BidiShape<HttpResponse, HttpResponse, HttpRequest, HttpRequest>> {
+    private final Inlet<HttpResponse> in1 = Inlet.create("out.in");
+    private final Outlet<HttpResponse> out1 = Outlet.create("out.out");
+    private final Inlet<HttpRequest> in2 = Inlet.create("in.in");
+    private final Outlet<HttpRequest> out2 = Outlet.create("in.out");
+
+    @Override
+    public BidiShape<HttpResponse, HttpResponse, HttpRequest, HttpRequest> shape() {
+      return BidiShape.of(in1, out1, in2, out2);
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes inheritedAttributes) {
+      return new FlowSpanLogic(shape());
+    }
+
+    //An instance of this class will be created per connection. Only one request will be processed at a time.
+    private static class FlowSpanLogic extends GraphStageLogic {
+      private Context ctx = null;
+      private Scope scope = null;
+      private HttpRequest currentRequest = null;
+
+      public FlowSpanLogic(BidiShape<HttpResponse, HttpResponse, HttpRequest, HttpRequest> shape) {
+        super(shape);
+
+        setHandler(
+            shape.out1(),
+            new AbstractOutHandler() {
+              @Override
+              public void onPull() {
+                pull(shape.in1());
+              }
+            }
+        );
+
+        setHandler(
+            shape.out2(),
+            new AbstractOutHandler() {
+              @Override
+              public void onPull() {
+                pull(shape.in2());
+              }
+            }
+        );
+
+        setHandler(
+            shape.in2(),
+            new AbstractInHandler() {
+              @Override
+              public void onPush() {
+                HttpRequest request = grab(shape.in2());
+                createSpan(request);
+                push(shape.out2(), request);
+              }
+
+              @Override
+              public void onUpstreamFailure(Throwable ex) throws Exception {
+                finishSpan(null, ex);
+                super.onUpstreamFailure(ex);
+              }
+            }
+        );
+
+        setHandler(
+            shape.in1(),
+            new AbstractInHandler() {
+              @Override
+              public void onPush() {
+                HttpResponse response = grab(shape.in1());
+                finishSpan(response, null);
+                push(shape.out1(), response);
+              }
+
+              @Override
+              public void onUpstreamFailure(Throwable ex) throws Exception {
+                finishSpan(null, ex);
+                super.onUpstreamFailure(ex);
+              }
+            }
+        );
+      }
+
+      private void createSpan(HttpRequest request) {
+        Context parentContext = currentContext();
+
+        if (instrumenter().shouldStart(parentContext, request)) {
+          scope = parentContext != null ? parentContext.makeCurrent() : null;
+          ctx = instrumenter().start(parentContext, request);
+
+          currentRequest = request;
+          scope = ctx.makeCurrent();
+        }
+      }
+
+      private void finishSpan(HttpResponse response, Throwable t) {
+        if(null != scope) {
+          scope.close();
+
+          instrumenter().end(ctx, currentRequest, response, t);
+
+          currentRequest = null;
+          scope = null;
+          ctx = null;
+        }
       }
     }
   }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSingletons.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSingletons.java
@@ -20,6 +20,8 @@ public class AkkaHttpServerSingletons {
 
   private static final Instrumenter<HttpRequest, HttpResponse> INSTRUMENTER;
 
+  public static final String OTEL_DISPATCHER_NAME = "otel-pinned-dispatcher";
+
   static {
     AkkaHttpServerAttributesGetter httpAttributesGetter = new AkkaHttpServerAttributesGetter();
     INSTRUMENTER =

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSourceInstrumentation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import akka.http.scaladsl.model.HttpRequest;
+import akka.http.scaladsl.model.HttpResponse;
+import akka.stream.ActorAttributes;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class AkkaHttpServerSourceInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("akka.http.scaladsl.Http$IncomingConnection");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("handleWith").and(takesArgument(0, named("akka.stream.scaladsl.Flow"))),
+        this.getClass().getName() + "$ConnectionAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConnectionAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void wrapHandler(
+        @Advice.Argument(value = 0, readOnly = false)
+        akka.stream.scaladsl.Flow<HttpRequest, HttpResponse, ?> handler) {
+        handler = handler.join(new AkkaHttpServerInstrumentationModule.FlowWrapper()).withAttributes(ActorAttributes.dispatcher(AkkaHttpServerSingletons.OTEL_DISPATCHER_NAME));
+    }
+  }
+}

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/DispatchersInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/DispatchersInstrumentation.java
@@ -1,0 +1,51 @@
+package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import akka.dispatch.DispatcherPrerequisites;
+import akka.dispatch.Dispatchers;
+import akka.dispatch.PinnedDispatcherConfigurator;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.util.HashMap;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class DispatchersInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("akka.dispatch.Dispatchers");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    // Instrument the Dispatchers to add a custom OTEL PinnedDispatcher
+    // This is used to enforce a single thread per actor
+    // This should allow ThreadLocals to function properly and stop scope leakage
+    transformer.applyAdviceToMethod(isConstructor().and(takesArgument(1, named("akka.dispatch.DispatcherPrerequisites"))), this.getClass().getName() + "$DispatchersAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class DispatchersAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void wrapHandler(@Advice.Argument(value = 1) DispatcherPrerequisites dispatcherPrerequisites,
+                                   @Advice.This Dispatchers dispatchers) {
+      HashMap<String, Object> threadPoolExecutorMap = new HashMap<>();
+      threadPoolExecutorMap.put("allow-core-timeout", "off");
+
+      HashMap<String, Object> dispatcherConfigMap = new HashMap<>();
+      dispatcherConfigMap.put("id", AkkaHttpServerSingletons.OTEL_DISPATCHER_NAME);
+      dispatcherConfigMap.put("type", "PinnedDispatcher");
+      dispatcherConfigMap.put("executor", "thread-pool-executor");
+      dispatcherConfigMap.put("thread-pool-executor", threadPoolExecutorMap);
+
+      Config config = ConfigFactory.parseMap(dispatcherConfigMap).withFallback(dispatchers.defaultDispatcherConfig());
+      dispatchers.registerConfigurator(AkkaHttpServerSingletons.OTEL_DISPATCHER_NAME, new PinnedDispatcherConfigurator(config, dispatcherPrerequisites));
+    }
+  }
+}

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpServerInstrumentationTest.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpServerInstrumentationTest.scala
@@ -1,0 +1,29 @@
+package io.opentelemetry.javaagent.instrumentation.akkahttp
+
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension
+import io.opentelemetry.instrumentation.testing.junit.http.{HttpServerInstrumentationExtension, HttpServerTestOptions}
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class AkkaHttpServerInstrumentationTest extends AbstractHttpServerInstrumentationTest {
+  @RegisterExtension val extension: InstrumentationExtension =
+    HttpServerInstrumentationExtension.forAgent()
+
+  override protected def setupServer(): AnyRef = {
+    AkkaHttpTestWebServer.start(port)
+    null
+  }
+
+  override protected def stopServer(server: Object): Unit =
+    AkkaHttpTestWebServer.stop()
+
+  override protected def configure(
+                                    options: HttpServerTestOptions
+                                  ): Unit = {
+    super.configure(options)
+    //Akka HTTP actively prevents exceptions from reaching the controller through implicit handleException methods,
+    // as unhandled exceptions reaching the HTTP controller would kill the entire HTTP server.
+    options.setTestException(false)
+  }
+}
+
+

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpServerInstrumentationTestSource.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpServerInstrumentationTestSource.scala
@@ -1,0 +1,32 @@
+package io.opentelemetry.javaagent.instrumentation.akkahttp
+
+import io.opentelemetry.instrumentation.testing.junit.http.{
+  HttpServerInstrumentationExtension,
+  HttpServerTestOptions
+}
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class AkkaHttpServerInstrumentationTestSource extends AbstractHttpServerInstrumentationTest {
+  @RegisterExtension val extension: InstrumentationExtension =
+    HttpServerInstrumentationExtension.forAgent()
+
+  override protected def setupServer(): AnyRef = {
+    AkkaHttpTestSourceWebServer.start(port)
+    null
+  }
+
+  override protected def stopServer(server: Object): Unit =
+    AkkaHttpTestSourceWebServer.stop()
+
+  override protected def configure(
+                                    options: HttpServerTestOptions
+                                  ): Unit = {
+    super.configure(options)
+    //Akka HTTP actively prevents exceptions from reaching the controller through implicit handleException methods,
+    // as unhandled exceptions reaching the HTTP controller would kill the entire HTTP server.
+    options.setTestException(false)
+  }
+}
+
+

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpTestSourceWebServer.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpTestSourceWebServer.scala
@@ -1,8 +1,3 @@
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package io.opentelemetry.javaagent.instrumentation.akkahttp
 
 import akka.actor.ActorSystem
@@ -10,15 +5,15 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.ExceptionHandler
 import akka.stream.ActorMaterializer
-import io.opentelemetry.instrumentation.testing.junit.http.{AbstractHttpServerTest, ServerEndpoint}
+import akka.stream.scaladsl.Sink
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint._
+import io.opentelemetry.instrumentation.testing.junit.http.{AbstractHttpServerTest, ServerEndpoint}
 
 import java.util.function.Supplier
 import scala.concurrent.Await
 
-object AkkaHttpTestWebServer {
+object AkkaHttpTestSourceWebServer {
   implicit val system = ActorSystem("my-system")
   implicit val materializer = ActorMaterializer()
   // needed for the future flatMap/onComplete in the end
@@ -59,8 +54,9 @@ object AkkaHttpTestWebServer {
   def start(port: Int): Unit = synchronized {
     if (null == binding) {
       import scala.concurrent.duration._
+
       binding =
-        Await.result(Http().bindAndHandle(route, "localhost", port), 10.seconds)
+        Await.result(Http().bind( "localhost", port).map(_.handleWith(route)).to(Sink.ignore).run(), 10.seconds)
     }
   }
 
@@ -71,4 +67,5 @@ object AkkaHttpTestWebServer {
       binding = null
     }
   }
+
 }


### PR DESCRIPTION
Add support for auto-instrumentation of Akka's IncomingConnection.handleWith and HttpExt.bindAndHandle methods. Both methods utilize a custom BidiGraphStage to wrap a request in instrumentation. A PinnedDispatcher is utilized to make sure the graph stage runs on the same thread for both request and response handling, preventing scope leakage.

Fixes #6081 and #5137
