### PR TITLE
fix bug: get return type in a wrong way for method instrumentation

### DIFF
--- a/instrumentation/methods/javaagent/build.gradle.kts
+++ b/instrumentation/methods/javaagent/build.gradle.kts
@@ -14,5 +14,5 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
-  jvmArgs("-Dotel.instrumentation.methods.include=io.opentelemetry.javaagent.instrumentation.methods.MethodTest\$ConfigTracedCallable[call]")
+  jvmArgs("-Dotel.instrumentation.methods.include=io.opentelemetry.javaagent.instrumentation.methods.MethodTest\$ConfigTracedCallable[call];io.opentelemetry.javaagent.instrumentation.methods.MethodTest\$ConfigTracedCompletableFuture[getResult]")
 }

--- a/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodInstrumentation.java
+++ b/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodInstrumentation.java
@@ -18,6 +18,7 @@ import io.opentelemetry.instrumentation.api.annotation.support.async.AsyncOperat
 import io.opentelemetry.instrumentation.api.util.ClassAndMethod;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.lang.reflect.Method;
 import java.util.Set;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -72,7 +73,7 @@ public class MethodInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
-        @Advice.Origin("#r") Class<?> returnType,
+        @Advice.Origin Method method,
         @Advice.Local("otelMethod") ClassAndMethod classAndMethod,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope,
@@ -81,7 +82,7 @@ public class MethodInstrumentation implements TypeInstrumentation {
       scope.close();
 
       returnValue =
-          AsyncOperationEndSupport.create(instrumenter(), Void.class, returnType)
+          AsyncOperationEndSupport.create(instrumenter(), Void.class, method.getReturnType())
               .asyncEnd(context, classAndMethod, returnValue, throwable);
     }
   }

--- a/instrumentation/methods/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/methods/MethodTest.java
+++ b/instrumentation/methods/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/methods/MethodTest.java
@@ -48,6 +48,7 @@ class MethodTest {
 
 
   static class ConfigTracedCompletableFuture {
+
     CompletableFuture<String> getResult() {
       CompletableFuture<String> completableFuture = new CompletableFuture<>();
       //can not use CompletableFuture#completeOnTimeout on language level 8
@@ -64,6 +65,7 @@ class MethodTest {
   }
 
   static class ConfigTracedCallable implements Callable<String> {
+
     @Override
     public String call() {
       return "Hello!";

--- a/instrumentation/methods/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/methods/MethodTest.java
+++ b/instrumentation/methods/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/methods/MethodTest.java
@@ -11,7 +11,10 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -23,7 +26,6 @@ class MethodTest {
   @Test
   void methodTraced() {
     assertThat(new ConfigTracedCallable().call()).isEqualTo("Hello!");
-
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -31,6 +33,34 @@ class MethodTest {
                     span.hasName("ConfigTracedCallable.call")
                         .hasKind(SpanKind.INTERNAL)
                         .hasAttributes(Attributes.empty())));
+    testing.clearData();
+    new ConfigTracedCompletableFuture().getResult()
+        .thenAccept(t -> assertThat(t).isEqualTo("Hello!"));
+    testing.waitAndAssertTraces(
+        trace -> {
+          SpanData spanData = trace.getSpan(0);
+          assertThat(spanData).isNotNull();
+          assertThat(spanData.getName()).isEqualTo("ConfigTracedCompletableFuture.getResult");
+          assertThat(spanData.getEndEpochNanos() - spanData.getStartEpochNanos())
+              .isGreaterThan(TimeUnit.MILLISECONDS.toNanos(100));
+        });
+  }
+
+
+  static class ConfigTracedCompletableFuture {
+    CompletableFuture<String> getResult() {
+      CompletableFuture<String> completableFuture = new CompletableFuture<>();
+      //can not use CompletableFuture#completeOnTimeout on language level 8
+      new Thread(() -> {
+        try {
+          TimeUnit.MILLISECONDS.sleep(100);
+        } catch (InterruptedException e) {
+          //ignore
+        }
+        completableFuture.complete("Hello!");
+      }).start();
+      return completableFuture;
+    }
   }
 
   static class ConfigTracedCallable implements Callable<String> {

--- a/instrumentation/methods/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/methods/MethodTest.java
+++ b/instrumentation/methods/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/methods/MethodTest.java
@@ -34,7 +34,8 @@ class MethodTest {
                         .hasKind(SpanKind.INTERNAL)
                         .hasAttributes(Attributes.empty())));
     testing.clearData();
-    new ConfigTracedCompletableFuture().getResult()
+    new ConfigTracedCompletableFuture()
+        .getResult()
         .thenAccept(t -> assertThat(t).isEqualTo("Hello!"));
     testing.waitAndAssertTraces(
         trace -> {
@@ -46,20 +47,21 @@ class MethodTest {
         });
   }
 
-
   static class ConfigTracedCompletableFuture {
 
     CompletableFuture<String> getResult() {
       CompletableFuture<String> completableFuture = new CompletableFuture<>();
-      //can not use CompletableFuture#completeOnTimeout on language level 8
-      new Thread(() -> {
-        try {
-          TimeUnit.MILLISECONDS.sleep(100);
-        } catch (InterruptedException e) {
-          //ignore
-        }
-        completableFuture.complete("Hello!");
-      }).start();
+      // can not use CompletableFuture#completeOnTimeout on language level 8
+      new Thread(
+              () -> {
+                try {
+                  TimeUnit.MILLISECONDS.sleep(100);
+                } catch (InterruptedException e) {
+                  // ignore
+                }
+                completableFuture.complete("Hello!");
+              })
+          .start();
       return completableFuture;
     }
   }


### PR DESCRIPTION
After testing, @Advice.Origin("#r") can only insert a string type parameter from the constant pool.
@Advice.Origin("#r") Class<?> returnType: returnType is current class for method