### PR TITLE
Make gRPC metadata available to AttributeExtractors

### DIFF
--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRequest.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRequest.java
@@ -13,7 +13,8 @@ import javax.annotation.Nullable;
 public final class GrpcRequest {
 
   private final MethodDescriptor<?, ?> method;
-  @Nullable private final Metadata metadata;
+
+  @Nullable private volatile Metadata metadata;
 
   @Nullable private volatile SocketAddress remoteAddress;
 
@@ -33,6 +34,10 @@ public final class GrpcRequest {
   @Nullable
   public Metadata getMetadata() {
     return metadata;
+  }
+
+  void setMetadata(Metadata metadata) {
+    this.metadata = metadata;
   }
 
   @Nullable

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
@@ -93,6 +93,7 @@ final class TracingClientInterceptor implements ClientInterceptor {
     @Override
     public void start(Listener<RESPONSE> responseListener, Metadata headers) {
       propagators.getTextMapPropagator().inject(context, headers, MetadataSetter.INSTANCE);
+      request.setMetadata(headers);
       try (Scope ignored = context.makeCurrent()) {
         super.start(
             new TracingClientCallListener(responseListener, parentContext, context, request),

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
@@ -93,6 +93,7 @@ final class TracingClientInterceptor implements ClientInterceptor {
     @Override
     public void start(Listener<RESPONSE> responseListener, Metadata headers) {
       propagators.getTextMapPropagator().inject(context, headers, MetadataSetter.INSTANCE);
+      // store metadata so that it can be used by custom AttributesExtractors
       request.setMetadata(headers);
       try (Scope ignored = context.makeCurrent()) {
         super.start(

--- a/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
+++ b/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
@@ -42,13 +42,13 @@ class GrpcTest extends AbstractGrpcTest {
   @Override
   protected ServerBuilder<?> configureServer(ServerBuilder<?> server) {
     return server.intercept(
-        GrpcTelemetry.builder(testing.getOpenTelemetry()).build().newServerInterceptor());
+        GrpcTelemetry.create(testing.getOpenTelemetry()).newServerInterceptor());
   }
 
   @Override
   protected ManagedChannelBuilder<?> configureClient(ManagedChannelBuilder<?> client) {
     return client.intercept(
-        GrpcTelemetry.builder(testing.getOpenTelemetry()).build().newClientInterceptor());
+        GrpcTelemetry.create(testing.getOpenTelemetry()).newClientInterceptor());
   }
 
   @Override

--- a/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
+++ b/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
@@ -23,11 +23,11 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 class GrpcTest extends AbstractGrpcTest {
 

--- a/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
+++ b/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
@@ -29,8 +29,6 @@ import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-
 class GrpcTest extends AbstractGrpcTest {
 
   @RegisterExtension

--- a/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
+++ b/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
@@ -5,31 +5,156 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6;
 
+import example.GreeterGrpc;
+import example.Helloworld;
+import io.grpc.BindableService;
+import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.Status;
+import io.grpc.stub.MetadataUtils;
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import javax.annotation.Nullable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
 class GrpcTest extends AbstractGrpcTest {
 
   @RegisterExtension
   static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
+  private static final String customKey = "customKey";
+  private static final Metadata.Key<String> customMetadataKey =
+      Metadata.Key.of(customKey, Metadata.ASCII_STRING_MARSHALLER);
+  private static final AttributesExtractor<GrpcRequest, Status> customMetadataExtractor =
+      new AttributesExtractor<GrpcRequest, Status>() {
+        @Override
+        public void onStart(AttributesBuilder attributes, Context parentContext,
+            GrpcRequest grpcRequest) {}
+
+        @Override
+        public void onEnd(AttributesBuilder attributes, Context context,
+            GrpcRequest grpcRequest, @Nullable Status status,
+            @Nullable Throwable error) {
+          Metadata metadata = grpcRequest.getMetadata();
+          if (metadata != null && metadata.containsKey(customMetadataKey)) {
+            String value = metadata.get(customMetadataKey);
+            if (value != null) {
+              attributes.put(customKey, value);
+            }
+          }
+        }
+      };
+
   @Override
   protected ServerBuilder<?> configureServer(ServerBuilder<?> server) {
-    return server.intercept(
-        GrpcTelemetry.create(testing.getOpenTelemetry()).newServerInterceptor());
+    return configureServer(server, Function.identity());
+  }
+
+  protected ServerBuilder<?> configureServer(ServerBuilder<?> server,
+      Function<? super GrpcTelemetryBuilder, ? extends GrpcTelemetryBuilder> customizer) {
+    GrpcTelemetryBuilder builder =
+        customizer.apply(GrpcTelemetry.builder(testing.getOpenTelemetry()));
+    return server.intercept(builder.build().newServerInterceptor());
   }
 
   @Override
   protected ManagedChannelBuilder<?> configureClient(ManagedChannelBuilder<?> client) {
-    return client.intercept(
-        GrpcTelemetry.create(testing.getOpenTelemetry()).newClientInterceptor());
+    return configureClient(client, Function.identity());
+  }
+
+  protected ManagedChannelBuilder<?> configureClient(ManagedChannelBuilder<?> client,
+      Function<? super GrpcTelemetryBuilder, ? extends GrpcTelemetryBuilder> customizer) {
+    GrpcTelemetryBuilder builder =
+        customizer.apply(GrpcTelemetry.builder(testing.getOpenTelemetry()));
+    return client.intercept(builder.build().newClientInterceptor());
   }
 
   @Override
   protected InstrumentationExtension testing() {
     return testing;
   }
+
+  @Test
+  void metadataProvided() throws Exception {
+    BindableService greeter =
+        new GreeterGrpc.GreeterImplBase() {
+          @Override
+          public void sayHello(
+              Helloworld.Request req, StreamObserver<Helloworld.Response> responseObserver) {
+            Helloworld.Response reply =
+                Helloworld.Response.newBuilder().setMessage("Hello " + req.getName()).build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+          }
+        };
+    Server server = configureServer(
+        ServerBuilder.forPort(0).addService(greeter),
+        customizer -> customizer.addAttributeExtractor(customMetadataExtractor))
+        .build()
+        .start();
+
+    ManagedChannel channel =
+        createChannel(
+            configureClient(
+                ManagedChannelBuilder.forAddress("localhost", server.getPort()),
+                customizer -> customizer.addAttributeExtractor(customMetadataExtractor))
+        );
+
+    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> server.shutdownNow().awaitTermination());
+
+    Metadata extraMetadata = new Metadata();
+    extraMetadata.put(customMetadataKey, "customValue");
+
+    GreeterGrpc.GreeterBlockingStub client = GreeterGrpc
+        .newBlockingStub(channel)
+        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(extraMetadata));
+
+    Helloworld.Response response =
+        testing()
+            .runWithSpan(
+                "parent",
+                () -> client.sayHello(Helloworld.Request.newBuilder().setName("test").build()));
+
+    OpenTelemetryAssertions.assertThat(response.getMessage()).isEqualTo("Hello test");
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        span.hasName("example.Greeter/SayHello")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasParent(trace.getSpan(0))
+                            .hasAttributesSatisfying(
+                                attrs ->
+                                    OpenTelemetryAssertions.assertThat(attrs)
+                                        .containsEntry(customKey, "customValue")),
+                    span ->
+                        span.hasName("example.Greeter/SayHello")
+                            .hasKind(SpanKind.SERVER)
+                            .hasParent(trace.getSpan(1))
+                            .hasAttributesSatisfying(
+                                attrs ->
+                                    OpenTelemetryAssertions.assertThat(attrs)
+                                        .containsEntry(customKey, "customValue"))
+                )
+        );
+  }
+
 }

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -86,7 +86,6 @@ public abstract class AbstractGrpcTest {
     }
   }
 
-
   @ParameterizedTest
   @ValueSource(strings = {"some name", "some other name"})
   void successBlockingStub(String paramName) throws Exception {

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -73,16 +73,12 @@ public abstract class AbstractGrpcTest {
 
   protected abstract InstrumentationExtension testing();
 
-  private final Queue<ThrowingRunnable<?>> closer = new ConcurrentLinkedQueue<>();
-
-  protected Queue<ThrowingRunnable<?>> closer() {
-    return closer;
-  }
+  protected final Queue<ThrowingRunnable<?>> closer = new ConcurrentLinkedQueue<>();
 
   @AfterEach
   void tearDown() throws Throwable {
-    while (!closer().isEmpty()) {
-      closer().poll().run();
+    while (!closer.isEmpty()) {
+      closer.poll().run();
     }
   }
 
@@ -102,8 +98,8 @@ public abstract class AbstractGrpcTest {
         };
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> server.shutdownNow().awaitTermination());
+    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel);
 
@@ -272,8 +268,8 @@ public abstract class AbstractGrpcTest {
 
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> server.shutdownNow().awaitTermination());
+    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterFutureStub client = GreeterGrpc.newFutureStub(channel);
 
@@ -461,8 +457,8 @@ public abstract class AbstractGrpcTest {
 
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> server.shutdownNow().awaitTermination());
+    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterStub client = GreeterGrpc.newStub(channel);
 
@@ -655,8 +651,8 @@ public abstract class AbstractGrpcTest {
         };
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> server.shutdownNow().awaitTermination());
+    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel);
 
@@ -809,8 +805,8 @@ public abstract class AbstractGrpcTest {
         };
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> server.shutdownNow().awaitTermination());
+    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel);
 
@@ -1031,8 +1027,8 @@ public abstract class AbstractGrpcTest {
                         }
                       }
                     }));
-    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> server.shutdownNow().awaitTermination());
+    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterStub client = GreeterGrpc.newStub(channel);
 
@@ -1187,8 +1183,8 @@ public abstract class AbstractGrpcTest {
 
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> server.shutdownNow().awaitTermination());
+    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterStub client = GreeterGrpc.newStub(channel);
 
@@ -1327,8 +1323,8 @@ public abstract class AbstractGrpcTest {
             .build()
             .start();
     ManagedChannel channel = createChannel(server);
-    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> server.shutdownNow().awaitTermination());
+    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> server.shutdownNow().awaitTermination());
 
     ServerReflectionGrpc.ServerReflectionStub client = ServerReflectionGrpc.newStub(channel);
 
@@ -1492,8 +1488,8 @@ public abstract class AbstractGrpcTest {
     // Multiple calls to build on the same builder
     channelBuilder.build();
     ManagedChannel channel = channelBuilder.build();
-    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> server.shutdownNow().awaitTermination());
+    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel);
 
@@ -1624,13 +1620,13 @@ public abstract class AbstractGrpcTest {
             .build()
             .start();
     ManagedChannel backendChannel = createChannel(backend);
-    closer().add(() -> backendChannel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> backend.shutdownNow().awaitTermination());
+    closer.add(() -> backendChannel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> backend.shutdownNow().awaitTermination());
     GreeterGrpc.GreeterBlockingStub backendStub = GreeterGrpc.newBlockingStub(backendChannel);
 
     // This executor does not propagate context without the javaagent available.
     ExecutorService executor = Executors.newFixedThreadPool(1);
-    closer().add(executor::shutdownNow);
+    closer.add(executor::shutdownNow);
 
     CountDownLatch clientCallDone = new CountDownLatch(1);
     AtomicReference<Throwable> error = new AtomicReference<>();
@@ -1664,8 +1660,8 @@ public abstract class AbstractGrpcTest {
             .build()
             .start();
     ManagedChannel frontendChannel = createChannel(frontend);
-    closer().add(() -> frontendChannel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer().add(() -> frontend.shutdownNow().awaitTermination());
+    closer.add(() -> frontendChannel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer.add(() -> frontend.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterBlockingStub frontendStub = GreeterGrpc.newBlockingStub(frontendChannel);
     frontendStub.sayHello(Helloworld.Request.newBuilder().setName("test").build());

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -75,12 +75,17 @@ public abstract class AbstractGrpcTest {
 
   private final Queue<ThrowingRunnable<?>> closer = new ConcurrentLinkedQueue<>();
 
+  protected Queue<ThrowingRunnable<?>> closer() {
+    return closer;
+  }
+
   @AfterEach
   void tearDown() throws Throwable {
-    while (!closer.isEmpty()) {
-      closer.poll().run();
+    while (!closer().isEmpty()) {
+      closer().poll().run();
     }
   }
+
 
   @ParameterizedTest
   @ValueSource(strings = {"some name", "some other name"})
@@ -98,8 +103,8 @@ public abstract class AbstractGrpcTest {
         };
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> server.shutdownNow().awaitTermination());
+    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel);
 
@@ -268,8 +273,8 @@ public abstract class AbstractGrpcTest {
 
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> server.shutdownNow().awaitTermination());
+    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterFutureStub client = GreeterGrpc.newFutureStub(channel);
 
@@ -457,8 +462,8 @@ public abstract class AbstractGrpcTest {
 
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> server.shutdownNow().awaitTermination());
+    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterStub client = GreeterGrpc.newStub(channel);
 
@@ -651,8 +656,8 @@ public abstract class AbstractGrpcTest {
         };
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> server.shutdownNow().awaitTermination());
+    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel);
 
@@ -805,8 +810,8 @@ public abstract class AbstractGrpcTest {
         };
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> server.shutdownNow().awaitTermination());
+    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel);
 
@@ -1027,8 +1032,8 @@ public abstract class AbstractGrpcTest {
                         }
                       }
                     }));
-    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> server.shutdownNow().awaitTermination());
+    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterStub client = GreeterGrpc.newStub(channel);
 
@@ -1183,8 +1188,8 @@ public abstract class AbstractGrpcTest {
 
     Server server = configureServer(ServerBuilder.forPort(0).addService(greeter)).build().start();
     ManagedChannel channel = createChannel(server);
-    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> server.shutdownNow().awaitTermination());
+    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterStub client = GreeterGrpc.newStub(channel);
 
@@ -1323,8 +1328,8 @@ public abstract class AbstractGrpcTest {
             .build()
             .start();
     ManagedChannel channel = createChannel(server);
-    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> server.shutdownNow().awaitTermination());
+    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> server.shutdownNow().awaitTermination());
 
     ServerReflectionGrpc.ServerReflectionStub client = ServerReflectionGrpc.newStub(channel);
 
@@ -1488,8 +1493,8 @@ public abstract class AbstractGrpcTest {
     // Multiple calls to build on the same builder
     channelBuilder.build();
     ManagedChannel channel = channelBuilder.build();
-    closer.add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> server.shutdownNow().awaitTermination());
+    closer().add(() -> channel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> server.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel);
 
@@ -1620,13 +1625,13 @@ public abstract class AbstractGrpcTest {
             .build()
             .start();
     ManagedChannel backendChannel = createChannel(backend);
-    closer.add(() -> backendChannel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> backend.shutdownNow().awaitTermination());
+    closer().add(() -> backendChannel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> backend.shutdownNow().awaitTermination());
     GreeterGrpc.GreeterBlockingStub backendStub = GreeterGrpc.newBlockingStub(backendChannel);
 
     // This executor does not propagate context without the javaagent available.
     ExecutorService executor = Executors.newFixedThreadPool(1);
-    closer.add(executor::shutdownNow);
+    closer().add(executor::shutdownNow);
 
     CountDownLatch clientCallDone = new CountDownLatch(1);
     AtomicReference<Throwable> error = new AtomicReference<>();
@@ -1660,8 +1665,8 @@ public abstract class AbstractGrpcTest {
             .build()
             .start();
     ManagedChannel frontendChannel = createChannel(frontend);
-    closer.add(() -> frontendChannel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
-    closer.add(() -> frontend.shutdownNow().awaitTermination());
+    closer().add(() -> frontendChannel.shutdownNow().awaitTermination(10, TimeUnit.SECONDS));
+    closer().add(() -> frontend.shutdownNow().awaitTermination());
 
     GreeterGrpc.GreeterBlockingStub frontendStub = GreeterGrpc.newBlockingStub(frontendChannel);
     frontendStub.sayHello(Helloworld.Request.newBuilder().setName("test").build());


### PR DESCRIPTION
Addresses #6123

I wasn't really sure where to add a test for this, and I don't particularly like the way I've done so.  It also doesn't seem to be easy to create a javaagent version of this (I think it would involve creating an Instrumentation extension), so I've restricted the test to just the "library" version of the instrumentation.

Feel free to completely change the test structure.