### PR TITLE
Add kafka client metrics

### DIFF
--- a/instrumentation/kafka/kafka-clients/README.md
+++ b/instrumentation/kafka/kafka-clients/README.md
@@ -4,3 +4,230 @@
 |---|---|---|---|
 | `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |
 | `otel.instrumentation.kafka.client-propagation.enabled` | Boolean | `true` | Enables remote context propagation via Kafka message headers. |
+
+# Kafka Metrics
+
+The Kafka client exposes metrics via `org.apache.kafka.common.metrics.MetricsReporter` interface.
+OpenTelemetry provides an implementation that bridges the metrics into OpenTelemetry.
+
+To use, configure `OpenTelemetryKafkaMetrics` with an OpenTelemetry instance
+via `OpenTelemetryKafkaMetrics#setOpenTelemetry(OpenTelemetry)`, and include a reference to this
+class in kafka producer or consumer configuration, i.e.:
+
+```java
+Map<String, Object> config = new HashMap<>();
+config.put(ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG, OpenTelemetryKafkaMetrics.class.getName());
+config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getKafkaConnectString());
+...
+try (KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(config)) { ... }
+```
+
+The following table shows the full set of metrics exposed by the kafka client, and the corresponding
+OpenTelemetry metric each maps to (if available). Empty values in the Instrument Name, Instrument
+Description, etc column indicates there is no registered mapping for the metric and data is NOT
+collected.
+
+| Kafka Group | Kafka Name | Kafka Description | Attribute Keys | Instrument Name | Instrument Description | Instrument Unit | Instrument Type |
+|-------------|------------|-------------------|----------------|-----------------|------------------------|-----------------|-----------------|
+| app-info | commit-id | Metric indicating commit-id | client-id |  |  |  |  |
+| app-info | start-time-ms | Metric indicating start-time-ms | client-id |  |  |  |  |
+| app-info | version | Metric indicating version | client-id |  |  |  |  |
+| consumer-coordinator-metrics | assigned-partitions | The number of partitions currently assigned to this consumer | client-id |  |  |  |  |
+| consumer-coordinator-metrics | commit-latency-avg | The average time taken for a commit request | client-id |  |  |  |  |
+| consumer-coordinator-metrics | commit-latency-max | The max time taken for a commit request | client-id |  |  |  |  |
+| consumer-coordinator-metrics | commit-rate | The number of commit calls per second | client-id |  |  |  |  |
+| consumer-coordinator-metrics | commit-total | The total number of commit calls | client-id |  |  |  |  |
+| consumer-coordinator-metrics | failed-rebalance-rate-per-hour | The number of failed rebalance events per hour | client-id |  |  |  |  |
+| consumer-coordinator-metrics | failed-rebalance-total | The total number of failed rebalance events | client-id |  |  |  |  |
+| consumer-coordinator-metrics | heartbeat-rate | The number of heartbeats per second | client-id |  |  |  |  |
+| consumer-coordinator-metrics | heartbeat-response-time-max | The max time taken to receive a response to a heartbeat request | client-id |  |  |  |  |
+| consumer-coordinator-metrics | heartbeat-total | The total number of heartbeats | client-id |  |  |  |  |
+| consumer-coordinator-metrics | join-rate | The number of group joins per second | client-id |  |  |  |  |
+| consumer-coordinator-metrics | join-time-avg | The average time taken for a group rejoin | client-id |  |  |  |  |
+| consumer-coordinator-metrics | join-time-max | The max time taken for a group rejoin | client-id |  |  |  |  |
+| consumer-coordinator-metrics | join-total | The total number of group joins | client-id |  |  |  |  |
+| consumer-coordinator-metrics | last-heartbeat-seconds-ago | The number of seconds since the last coordinator heartbeat was sent | client-id |  |  |  |  |
+| consumer-coordinator-metrics | last-rebalance-seconds-ago | The number of seconds since the last successful rebalance event | client-id |  |  |  |  |
+| consumer-coordinator-metrics | partition-assigned-latency-avg | The average time taken for a partition-assigned rebalance listener callback | client-id |  |  |  |  |
+| consumer-coordinator-metrics | partition-assigned-latency-max | The max time taken for a partition-assigned rebalance listener callback | client-id |  |  |  |  |
+| consumer-coordinator-metrics | partition-lost-latency-avg | The average time taken for a partition-lost rebalance listener callback | client-id |  |  |  |  |
+| consumer-coordinator-metrics | partition-lost-latency-max | The max time taken for a partition-lost rebalance listener callback | client-id |  |  |  |  |
+| consumer-coordinator-metrics | partition-revoked-latency-avg | The average time taken for a partition-revoked rebalance listener callback | client-id |  |  |  |  |
+| consumer-coordinator-metrics | partition-revoked-latency-max | The max time taken for a partition-revoked rebalance listener callback | client-id |  |  |  |  |
+| consumer-coordinator-metrics | rebalance-latency-avg | The average time taken for a group to complete a successful rebalance, which may be composed of several failed re-trials until it succeeded | client-id |  |  |  |  |
+| consumer-coordinator-metrics | rebalance-latency-max | The max time taken for a group to complete a successful rebalance, which may be composed of several failed re-trials until it succeeded | client-id |  |  |  |  |
+| consumer-coordinator-metrics | rebalance-latency-total | The total number of milliseconds this consumer has spent in successful rebalances since creation | client-id |  |  |  |  |
+| consumer-coordinator-metrics | rebalance-rate-per-hour | The number of successful rebalance events per hour, each event is composed of several failed re-trials until it succeeded | client-id |  |  |  |  |
+| consumer-coordinator-metrics | rebalance-total | The total number of successful rebalance events, each event is composed of several failed re-trials until it succeeded | client-id |  |  |  |  |
+| consumer-coordinator-metrics | sync-rate | The number of group syncs per second | client-id |  |  |  |  |
+| consumer-coordinator-metrics | sync-time-avg | The average time taken for a group sync | client-id |  |  |  |  |
+| consumer-coordinator-metrics | sync-time-max | The max time taken for a group sync | client-id |  |  |  |  |
+| consumer-coordinator-metrics | sync-total | The total number of group syncs | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | bytes-consumed-rate | The average number of bytes consumed per second | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | bytes-consumed-rate | The average number of bytes consumed per second for a topic | client-id,topic |  |  |  |  |
+| consumer-fetch-manager-metrics | bytes-consumed-total | The total number of bytes consumed for a topic | client-id,topic |  |  |  |  |
+| consumer-fetch-manager-metrics | bytes-consumed-total | The total number of bytes consumed | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | fetch-latency-avg | The average time taken for a fetch request. | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | fetch-latency-max | The max time taken for any fetch request. | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | fetch-rate | The number of fetch requests per second. | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | fetch-size-avg | The average number of bytes fetched per request | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | fetch-size-avg | The average number of bytes fetched per request for a topic | client-id,topic |  |  |  |  |
+| consumer-fetch-manager-metrics | fetch-size-max | The maximum number of bytes fetched per request for a topic | client-id,topic |  |  |  |  |
+| consumer-fetch-manager-metrics | fetch-size-max | The maximum number of bytes fetched per request | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | fetch-throttle-time-avg | The average throttle time in ms | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | fetch-throttle-time-max | The maximum throttle time in ms | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | fetch-total | The total number of fetch requests. | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | preferred-read-replica | The current read replica for the partition, or -1 if reading from leader | client-id,topic,partition |  |  |  |  |
+| consumer-fetch-manager-metrics | records-consumed-rate | The average number of records consumed per second | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | records-consumed-rate | The average number of records consumed per second for a topic | client-id,topic |  |  |  |  |
+| consumer-fetch-manager-metrics | records-consumed-total | The total number of records consumed for a topic | client-id,topic |  |  |  |  |
+| consumer-fetch-manager-metrics | records-consumed-total | The total number of records consumed | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | records-lag | The latest lag of the partition | client-id,topic,partition | messaging.kafka.consumer.lag | Current approximate lag of consumer group at partition of topic. | {lag} | DOUBLE_OBSERVABLE_GAUGE |
+| consumer-fetch-manager-metrics | records-lag-avg | The average lag of the partition | client-id,topic,partition |  |  |  |  |
+| consumer-fetch-manager-metrics | records-lag-max | The maximum lag in terms of number of records for any partition in this window | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | records-lag-max | The max lag of the partition | client-id,topic,partition |  |  |  |  |
+| consumer-fetch-manager-metrics | records-lead | The latest lead of the partition | client-id,topic,partition |  |  |  |  |
+| consumer-fetch-manager-metrics | records-lead-avg | The average lead of the partition | client-id,topic,partition |  |  |  |  |
+| consumer-fetch-manager-metrics | records-lead-min | The minimum lead in terms of number of records for any partition in this window | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | records-lead-min | The min lead of the partition | client-id,topic,partition |  |  |  |  |
+| consumer-fetch-manager-metrics | records-per-request-avg | The average number of records in each request | client-id |  |  |  |  |
+| consumer-fetch-manager-metrics | records-per-request-avg | The average number of records in each request for a topic | client-id,topic |  |  |  |  |
+| consumer-metrics | connection-close-rate | The number of connections closed per second | client-id |  |  |  |  |
+| consumer-metrics | connection-close-total | The total number of connections closed | client-id |  |  |  |  |
+| consumer-metrics | connection-count | The current number of active connections. | client-id |  |  |  |  |
+| consumer-metrics | connection-creation-rate | The number of new connections established per second | client-id |  |  |  |  |
+| consumer-metrics | connection-creation-total | The total number of new connections established | client-id |  |  |  |  |
+| consumer-metrics | failed-authentication-rate | The number of connections with failed authentication per second | client-id |  |  |  |  |
+| consumer-metrics | failed-authentication-total | The total number of connections with failed authentication | client-id |  |  |  |  |
+| consumer-metrics | failed-reauthentication-rate | The number of failed re-authentication of connections per second | client-id |  |  |  |  |
+| consumer-metrics | failed-reauthentication-total | The total number of failed re-authentication of connections | client-id |  |  |  |  |
+| consumer-metrics | incoming-byte-rate | The number of bytes read off all sockets per second | client-id |  |  |  |  |
+| consumer-metrics | incoming-byte-total | The total number of bytes read off all sockets | client-id |  |  |  |  |
+| consumer-metrics | io-ratio | The fraction of time the I/O thread spent doing I/O | client-id |  |  |  |  |
+| consumer-metrics | io-time-ns-avg | The average length of time for I/O per select call in nanoseconds. | client-id |  |  |  |  |
+| consumer-metrics | io-wait-ratio | The fraction of time the I/O thread spent waiting | client-id |  |  |  |  |
+| consumer-metrics | io-wait-time-ns-avg | The average length of time the I/O thread spent waiting for a socket ready for reads or writes in nanoseconds. | client-id |  |  |  |  |
+| consumer-metrics | io-waittime-total | The total time the I/O thread spent waiting | client-id |  |  |  |  |
+| consumer-metrics | iotime-total | The total time the I/O thread spent doing I/O | client-id |  |  |  |  |
+| consumer-metrics | last-poll-seconds-ago | The number of seconds since the last poll() invocation. | client-id |  |  |  |  |
+| consumer-metrics | network-io-rate | The number of network operations (reads or writes) on all connections per second | client-id |  |  |  |  |
+| consumer-metrics | network-io-total | The total number of network operations (reads or writes) on all connections | client-id |  |  |  |  |
+| consumer-metrics | outgoing-byte-rate | The number of outgoing bytes sent to all servers per second | client-id |  |  |  |  |
+| consumer-metrics | outgoing-byte-total | The total number of outgoing bytes sent to all servers | client-id |  |  |  |  |
+| consumer-metrics | poll-idle-ratio-avg | The average fraction of time the consumer's poll() is idle as opposed to waiting for the user code to process records. | client-id |  |  |  |  |
+| consumer-metrics | reauthentication-latency-avg | The average latency observed due to re-authentication | client-id |  |  |  |  |
+| consumer-metrics | reauthentication-latency-max | The max latency observed due to re-authentication | client-id |  |  |  |  |
+| consumer-metrics | request-rate | The number of requests sent per second | client-id |  |  |  |  |
+| consumer-metrics | request-size-avg | The average size of requests sent. | client-id |  |  |  |  |
+| consumer-metrics | request-size-max | The maximum size of any request sent. | client-id |  |  |  |  |
+| consumer-metrics | request-total | The total number of requests sent | client-id |  |  |  |  |
+| consumer-metrics | response-rate | The number of responses received per second | client-id |  |  |  |  |
+| consumer-metrics | response-total | The total number of responses received | client-id |  |  |  |  |
+| consumer-metrics | select-rate | The number of times the I/O layer checked for new I/O to perform per second | client-id |  |  |  |  |
+| consumer-metrics | select-total | The total number of times the I/O layer checked for new I/O to perform | client-id |  |  |  |  |
+| consumer-metrics | successful-authentication-no-reauth-total | The total number of connections with successful authentication where the client does not support re-authentication | client-id |  |  |  |  |
+| consumer-metrics | successful-authentication-rate | The number of connections with successful authentication per second | client-id |  |  |  |  |
+| consumer-metrics | successful-authentication-total | The total number of connections with successful authentication | client-id |  |  |  |  |
+| consumer-metrics | successful-reauthentication-rate | The number of successful re-authentication of connections per second | client-id |  |  |  |  |
+| consumer-metrics | successful-reauthentication-total | The total number of successful re-authentication of connections | client-id |  |  |  |  |
+| consumer-metrics | time-between-poll-avg | The average delay between invocations of poll(). | client-id |  |  |  |  |
+| consumer-metrics | time-between-poll-max | The max delay between invocations of poll(). | client-id |  |  |  |  |
+| consumer-node-metrics | incoming-byte-rate | The number of incoming bytes per second | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | incoming-byte-total | The total number of incoming bytes | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | outgoing-byte-rate | The number of outgoing bytes per second | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | outgoing-byte-total | The total number of outgoing bytes | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | request-latency-avg |  | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | request-latency-max |  | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | request-rate | The number of requests sent per second | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | request-size-avg | The average size of requests sent. | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | request-size-max | The maximum size of any request sent. | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | request-total | The total number of requests sent | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | response-rate | The number of responses received per second | client-id,node-id |  |  |  |  |
+| consumer-node-metrics | response-total | The total number of responses received | client-id,node-id |  |  |  |  |
+| kafka-metrics-count | count | total number of registered metrics | client-id |  |  |  |  |
+| producer-metrics | batch-size-avg | The average number of bytes sent per partition per-request. | client-id |  |  |  |  |
+| producer-metrics | batch-size-max | The max number of bytes sent per partition per-request. | client-id |  |  |  |  |
+| producer-metrics | batch-split-rate | The average number of batch splits per second | client-id |  |  |  |  |
+| producer-metrics | batch-split-total | The total number of batch splits | client-id |  |  |  |  |
+| producer-metrics | buffer-available-bytes | The total amount of buffer memory that is not being used (either unallocated or in the free list). | client-id |  |  |  |  |
+| producer-metrics | buffer-exhausted-rate | The average per-second number of record sends that are dropped due to buffer exhaustion | client-id |  |  |  |  |
+| producer-metrics | buffer-exhausted-total | The total number of record sends that are dropped due to buffer exhaustion | client-id |  |  |  |  |
+| producer-metrics | buffer-total-bytes | The maximum amount of buffer memory the client can use (whether or not it is currently used). | client-id |  |  |  |  |
+| producer-metrics | bufferpool-wait-ratio | The fraction of time an appender waits for space allocation. | client-id |  |  |  |  |
+| producer-metrics | bufferpool-wait-time-total | The total time an appender waits for space allocation. | client-id |  |  |  |  |
+| producer-metrics | compression-rate-avg | The average compression rate of record batches, defined as the average ratio of the compressed batch size over the uncompressed size. | client-id |  |  |  |  |
+| producer-metrics | connection-close-rate | The number of connections closed per second | client-id |  |  |  |  |
+| producer-metrics | connection-close-total | The total number of connections closed | client-id |  |  |  |  |
+| producer-metrics | connection-count | The current number of active connections. | client-id |  |  |  |  |
+| producer-metrics | connection-creation-rate | The number of new connections established per second | client-id |  |  |  |  |
+| producer-metrics | connection-creation-total | The total number of new connections established | client-id |  |  |  |  |
+| producer-metrics | failed-authentication-rate | The number of connections with failed authentication per second | client-id |  |  |  |  |
+| producer-metrics | failed-authentication-total | The total number of connections with failed authentication | client-id |  |  |  |  |
+| producer-metrics | failed-reauthentication-rate | The number of failed re-authentication of connections per second | client-id |  |  |  |  |
+| producer-metrics | failed-reauthentication-total | The total number of failed re-authentication of connections | client-id |  |  |  |  |
+| producer-metrics | incoming-byte-rate | The number of bytes read off all sockets per second | client-id |  |  |  |  |
+| producer-metrics | incoming-byte-total | The total number of bytes read off all sockets | client-id |  |  |  |  |
+| producer-metrics | io-ratio | The fraction of time the I/O thread spent doing I/O | client-id |  |  |  |  |
+| producer-metrics | io-time-ns-avg | The average length of time for I/O per select call in nanoseconds. | client-id |  |  |  |  |
+| producer-metrics | io-wait-ratio | The fraction of time the I/O thread spent waiting | client-id |  |  |  |  |
+| producer-metrics | io-wait-time-ns-avg | The average length of time the I/O thread spent waiting for a socket ready for reads or writes in nanoseconds. | client-id |  |  |  |  |
+| producer-metrics | io-waittime-total | The total time the I/O thread spent waiting | client-id |  |  |  |  |
+| producer-metrics | iotime-total | The total time the I/O thread spent doing I/O | client-id |  |  |  |  |
+| producer-metrics | metadata-age | The age in seconds of the current producer metadata being used. | client-id |  |  |  |  |
+| producer-metrics | network-io-rate | The number of network operations (reads or writes) on all connections per second | client-id |  |  |  |  |
+| producer-metrics | network-io-total | The total number of network operations (reads or writes) on all connections | client-id |  |  |  |  |
+| producer-metrics | outgoing-byte-rate | The number of outgoing bytes sent to all servers per second | client-id | messaging.kafka.producer.outgoing-bytes.rate | The average number of outgoing bytes sent per second to all servers. | by/s | DOUBLE_OBSERVABLE_GAUGE |
+| producer-metrics | outgoing-byte-total | The total number of outgoing bytes sent to all servers | client-id |  |  |  |  |
+| producer-metrics | produce-throttle-time-avg | The average time in ms a request was throttled by a broker | client-id |  |  |  |  |
+| producer-metrics | produce-throttle-time-max | The maximum time in ms a request was throttled by a broker | client-id |  |  |  |  |
+| producer-metrics | reauthentication-latency-avg | The average latency observed due to re-authentication | client-id |  |  |  |  |
+| producer-metrics | reauthentication-latency-max | The max latency observed due to re-authentication | client-id |  |  |  |  |
+| producer-metrics | record-error-rate | The average per-second number of record sends that resulted in errors | client-id |  |  |  |  |
+| producer-metrics | record-error-total | The total number of record sends that resulted in errors | client-id |  |  |  |  |
+| producer-metrics | record-queue-time-avg | The average time in ms record batches spent in the send buffer. | client-id |  |  |  |  |
+| producer-metrics | record-queue-time-max | The maximum time in ms record batches spent in the send buffer. | client-id |  |  |  |  |
+| producer-metrics | record-retry-rate | The average per-second number of retried record sends | client-id |  |  |  |  |
+| producer-metrics | record-retry-total | The total number of retried record sends | client-id |  |  |  |  |
+| producer-metrics | record-send-rate | The average number of records sent per second. | client-id |  |  |  |  |
+| producer-metrics | record-send-total | The total number of records sent. | client-id |  |  |  |  |
+| producer-metrics | record-size-avg | The average record size | client-id |  |  |  |  |
+| producer-metrics | record-size-max | The maximum record size | client-id |  |  |  |  |
+| producer-metrics | records-per-request-avg | The average number of records per request. | client-id |  |  |  |  |
+| producer-metrics | request-latency-avg | The average request latency in ms | client-id |  |  |  |  |
+| producer-metrics | request-latency-max | The maximum request latency in ms | client-id |  |  |  |  |
+| producer-metrics | request-rate | The number of requests sent per second | client-id |  |  |  |  |
+| producer-metrics | request-size-avg | The average size of requests sent. | client-id |  |  |  |  |
+| producer-metrics | request-size-max | The maximum size of any request sent. | client-id |  |  |  |  |
+| producer-metrics | request-total | The total number of requests sent | client-id |  |  |  |  |
+| producer-metrics | requests-in-flight | The current number of in-flight requests awaiting a response. | client-id |  |  |  |  |
+| producer-metrics | response-rate | The number of responses received per second | client-id | messaging.kafka.producer.responses.rate | The average number of responses received per second. | {responses}/s | DOUBLE_OBSERVABLE_GAUGE |
+| producer-metrics | response-total | The total number of responses received | client-id |  |  |  |  |
+| producer-metrics | select-rate | The number of times the I/O layer checked for new I/O to perform per second | client-id |  |  |  |  |
+| producer-metrics | select-total | The total number of times the I/O layer checked for new I/O to perform | client-id |  |  |  |  |
+| producer-metrics | successful-authentication-no-reauth-total | The total number of connections with successful authentication where the client does not support re-authentication | client-id |  |  |  |  |
+| producer-metrics | successful-authentication-rate | The number of connections with successful authentication per second | client-id |  |  |  |  |
+| producer-metrics | successful-authentication-total | The total number of connections with successful authentication | client-id |  |  |  |  |
+| producer-metrics | successful-reauthentication-rate | The number of successful re-authentication of connections per second | client-id |  |  |  |  |
+| producer-metrics | successful-reauthentication-total | The total number of successful re-authentication of connections | client-id |  |  |  |  |
+| producer-metrics | waiting-threads | The number of user threads blocked waiting for buffer memory to enqueue their records | client-id |  |  |  |  |
+| producer-node-metrics | incoming-byte-rate | The number of incoming bytes per second | client-id,node-id |  |  |  |  |
+| producer-node-metrics | incoming-byte-total | The total number of incoming bytes | client-id,node-id |  |  |  |  |
+| producer-node-metrics | outgoing-byte-rate | The number of outgoing bytes per second | client-id,node-id |  |  |  |  |
+| producer-node-metrics | outgoing-byte-total | The total number of outgoing bytes | client-id,node-id |  |  |  |  |
+| producer-node-metrics | request-latency-avg |  | client-id,node-id |  |  |  |  |
+| producer-node-metrics | request-latency-max |  | client-id,node-id |  |  |  |  |
+| producer-node-metrics | request-rate | The number of requests sent per second | client-id,node-id |  |  |  |  |
+| producer-node-metrics | request-size-avg | The average size of requests sent. | client-id,node-id |  |  |  |  |
+| producer-node-metrics | request-size-max | The maximum size of any request sent. | client-id,node-id |  |  |  |  |
+| producer-node-metrics | request-total | The total number of requests sent | client-id,node-id |  |  |  |  |
+| producer-node-metrics | response-rate | The number of responses received per second | client-id,node-id |  |  |  |  |
+| producer-node-metrics | response-total | The total number of responses received | client-id,node-id |  |  |  |  |
+| producer-topic-metrics | byte-rate | The average number of bytes sent per second for a topic. | client-id,topic | messaging.kafka.producer.bytes.rate | The average number of bytes sent per second for a specific topic. | by/s | DOUBLE_OBSERVABLE_GAUGE |
+| producer-topic-metrics | byte-total | The total number of bytes sent for a topic. | client-id,topic |  |  |  |  |
+| producer-topic-metrics | compression-rate | The average compression rate of record batches for a topic, defined as the average ratio of the compressed batch size over the uncompressed size. | client-id,topic | messaging.kafka.producer.compression-ratio | The average compression ratio of record batches for a specific topic. | {compression} | DOUBLE_OBSERVABLE_GAUGE |
+| producer-topic-metrics | record-error-rate | The average per-second number of record sends that resulted in errors for a topic | client-id,topic | messaging.kafka.producer.record-error.rate | The average per-second number of record sends that resulted in errors for a specific topic. | {errors}/s | DOUBLE_OBSERVABLE_GAUGE |
+| producer-topic-metrics | record-error-total | The total number of record sends that resulted in errors for a topic | client-id,topic |  |  |  |  |
+| producer-topic-metrics | record-retry-rate | The average per-second number of retried record sends for a topic | client-id,topic | messaging.kafka.producer.record-retry.rate | The average per-second number of retried record sends for a specific topic. | {retries}/s | DOUBLE_OBSERVABLE_GAUGE |
+| producer-topic-metrics | record-retry-total | The total number of retried record sends for a topic | client-id,topic |  |  |  |  |
+| producer-topic-metrics | record-send-rate | The average number of records sent per second for a topic. | client-id,topic | messaging.kafka.producer.record-sent.rate | The average number of records sent per second for a specific topic. | {records_sent}/s | DOUBLE_OBSERVABLE_GAUGE |
+| producer-topic-metrics | record-send-total | The total number of records sent for a topic. | client-id,topic |  |  |  |  |

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/build.gradle.kts
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/build.gradle.kts
@@ -10,4 +10,9 @@ dependencies {
   implementation(project(":instrumentation:kafka:kafka-clients:kafka-clients-common:library"))
 
   implementation("org.testcontainers:kafka")
+
+  runtimeOnly("org.apache.kafka:kafka_2.13:2.8.1")
+  implementation("com.salesforce.kafka.test:kafka-junit5:3.2.3") {
+    exclude(module="zookeeper") // conflicts with zookeeper from kafka_2.x
+  }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/OpenTelemetryKafkaMetricsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/OpenTelemetryKafkaMetricsTest.java
@@ -1,0 +1,98 @@
+package io.opentelemetry.instrumentation.kafkaclients;
+
+import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+abstract class OpenTelemetryKafkaMetricsTest {
+
+  private static final List<String> TOPICS = Arrays.asList("foo", "bar", "baz", "qux");
+  private static final Random RANDOM = new Random();
+
+  @RegisterExtension
+  static final SharedKafkaTestResource kafka = new SharedKafkaTestResource();
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @Test
+  void observeMetrics() {
+    OpenTelemetryKafkaMetrics.setOpenTelemetry(testing.getOpenTelemetry());
+
+    produceRecords();
+    consumeRecords();
+
+    testing.waitAndAssertMetrics("io.opentelemetry.kafka-clients", "messaging.kafka.producer.outgoing-bytes.rate", unused -> {});
+    testing.waitAndAssertMetrics("io.opentelemetry.kafka-clients", "messaging.kafka.producer.responses.rate", unused -> {});
+    testing.waitAndAssertMetrics("io.opentelemetry.kafka-clients", "messaging.kafka.producer.bytes.rate", unused -> {});
+    testing.waitAndAssertMetrics("io.opentelemetry.kafka-clients", "messaging.kafka.producer.compression-ratio", unused -> {});
+    testing.waitAndAssertMetrics("io.opentelemetry.kafka-clients", "messaging.kafka.producer.record-error.rate", unused -> {});
+    testing.waitAndAssertMetrics("io.opentelemetry.kafka-clients", "messaging.kafka.producer.record-retry.rate", unused -> {});
+    testing.waitAndAssertMetrics("io.opentelemetry.kafka-clients", "messaging.kafka.producer.record-sent.rate", unused -> {});
+    testing.waitAndAssertMetrics("io.opentelemetry.kafka-clients", "messaging.kafka.consumer.lag", unused -> {});
+
+    // Print mapping table
+    OpenTelemetryKafkaMetrics.printMappingTable();
+  }
+
+  void produceRecords() {
+    Map<String, Object> config = new HashMap<>();
+    // Register OpenTelemetryKafkaMetrics as reporter
+    config.put(
+        ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG, OpenTelemetryKafkaMetrics.class.getName());
+    config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getKafkaConnectString());
+    config.put(ProducerConfig.CLIENT_ID_CONFIG, "sample-client-id");
+    config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+    config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+    config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "gzip");
+
+    try (KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(config)) {
+      for (int i = 0; i < 100; i++) {
+        producer.send(
+            new ProducerRecord<>(
+                TOPICS.get(RANDOM.nextInt(TOPICS.size())),
+                0,
+                System.currentTimeMillis(),
+                "key".getBytes(StandardCharsets.UTF_8),
+                "value".getBytes(StandardCharsets.UTF_8)));
+      }
+    }
+  }
+
+  void consumeRecords() {
+    Map<String, Object> config = new HashMap<>();
+    // Register OpenTelemetryKafkaMetrics as reporter
+    config.put(
+        ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG, OpenTelemetryKafkaMetrics.class.getName());
+    config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getKafkaConnectString());
+    config.put(ConsumerConfig.GROUP_ID_CONFIG, "sample-group");
+    config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+    config.put(
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+    config.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
+
+    try (KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(config)) {
+      consumer.subscribe(TOPICS);
+      Instant stopTime = Instant.now().plusSeconds(10);
+      while (Instant.now().isBefore(stopTime)) {
+        consumer.poll(1000);
+      }
+    }
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/groovy/io/opentelemetry/instrumentation/kafkaclients/MetricsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/groovy/io/opentelemetry/instrumentation/kafkaclients/MetricsTest.java
@@ -1,0 +1,4 @@
+package io.opentelemetry.instrumentation.kafkaclients;
+
+public class MetricsTest extends OpenTelemetryKafkaMetricsTest {
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/KafkaMetricId.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/KafkaMetricId.java
@@ -1,0 +1,100 @@
+package io.opentelemetry.instrumentation.kafkaclients;
+
+import java.util.Set;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import javax.annotation.Nullable;
+
+/**
+ * A value class collecting the identifying fields of a kafka {@link MetricName}.
+ *
+ * <p>Note: {@link #description} is included in {@link #toString()} but omitted from {@link
+ * #equals(Object)} and {@link #hashCode()}.
+ */
+class KafkaMetricId {
+
+  private final String name;
+  private final String group;
+  private final String description;
+  private final Set<String> tagKeys;
+
+  private KafkaMetricId(String name, String group, String description, Set<String> tagKeys) {
+    this.name = name;
+    this.group = group;
+    this.description = description;
+    this.tagKeys = tagKeys;
+  }
+
+  static KafkaMetricId create(KafkaMetric kafkaMetric) {
+    return new KafkaMetricId(
+        kafkaMetric.metricName().name(),
+        kafkaMetric.metricName().group(),
+        kafkaMetric.metricName().description(),
+        kafkaMetric.metricName().tags().keySet());
+  }
+
+  static KafkaMetricId create(String name, String group, Set<String> tagKeys) {
+    return new KafkaMetricId(name, group, "", tagKeys);
+  }
+
+  String getName() {
+    return name;
+  }
+
+  String getGroup() {
+    return group;
+  }
+
+  String getDescription() {
+    return description;
+  }
+
+  Set<String> getTagKeys() {
+    return tagKeys;
+  }
+
+  @Override
+  public String toString() {
+    return "KafkaMetricId{"
+        + "name="
+        + name
+        + ", "
+        + "group="
+        + group
+        + ", "
+        + "description="
+        + description
+        + ", "
+        + "tagKeys="
+        + tagKeys
+        + "}";
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof KafkaMetricId) {
+      KafkaMetricId that = (KafkaMetricId) o;
+      // Omit description from equality
+      return this.name.equals(that.getName())
+          && this.group.equals(that.getGroup())
+          && this.tagKeys.equals(that.getTagKeys());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    // Omit description from hashcode
+    int hash = 1;
+    hash *= 1000003;
+    hash ^= name.hashCode();
+    hash *= 1000003;
+    hash ^= group.hashCode();
+    hash *= 1000003;
+    hash ^= tagKeys.hashCode();
+    return hash;
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/KafkaMetricRegistry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/KafkaMetricRegistry.java
@@ -1,0 +1,105 @@
+package io.opentelemetry.instrumentation.kafkaclients;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/** A registry mapping kafka metrics to corresponding OpenTelemetry metric definitions. */
+class KafkaMetricRegistry {
+
+  private static final String unitBytesPerSecond = "by/s";
+
+  private static final Map<KafkaMetricId, MetricDescriptor> registry = new HashMap<>();
+
+  static {
+    registerProducerMetrics();
+    registerProducerTopicMetrics();
+    registerConsumerMetrics();
+  }
+
+  private static void registerProducerMetrics() {
+    String group = "producer-metrics";
+    Set<String> tagKeys = Collections.singleton("client-id");
+
+    registry.put(
+        KafkaMetricId.create("outgoing-byte-rate", group, tagKeys),
+        MetricDescriptor.createDoubleGauge(
+            "messaging.kafka.producer.outgoing-bytes.rate",
+            "The average number of outgoing bytes sent per second to all servers.",
+            unitBytesPerSecond));
+    registry.put(
+        KafkaMetricId.create("response-rate", group, tagKeys),
+        MetricDescriptor.createDoubleGauge(
+            "messaging.kafka.producer.responses.rate",
+            "The average number of responses received per second.",
+            "{responses}/s"));
+  }
+
+  private static void registerProducerTopicMetrics() {
+    String group = "producer-topic-metrics";
+    Set<String> tagKeys = new HashSet<>(Arrays.asList("client-id", "topic"));
+
+    registry.put(
+        KafkaMetricId.create("byte-rate", group, tagKeys),
+        MetricDescriptor.createDoubleGauge(
+            "messaging.kafka.producer.bytes.rate",
+            "The average number of bytes sent per second for a specific topic.",
+            unitBytesPerSecond));
+    registry.put(
+        KafkaMetricId.create("compression-rate", group, tagKeys),
+        MetricDescriptor.createDoubleGauge(
+            "messaging.kafka.producer.compression-ratio",
+            "The average compression ratio of record batches for a specific topic.",
+            "{compression}"));
+    registry.put(
+        KafkaMetricId.create("record-error-rate", group, tagKeys),
+        MetricDescriptor.createDoubleGauge(
+            "messaging.kafka.producer.record-error.rate",
+            "The average per-second number of record sends that resulted in errors for a specific topic.",
+            "{errors}/s"));
+    registry.put(
+        KafkaMetricId.create("record-retry-rate", group, tagKeys),
+        MetricDescriptor.createDoubleGauge(
+            "messaging.kafka.producer.record-retry.rate",
+            "The average per-second number of retried record sends for a specific topic.",
+            "{retries}/s"));
+    registry.put(
+        KafkaMetricId.create("record-send-rate", group, tagKeys),
+        MetricDescriptor.createDoubleGauge(
+            "messaging.kafka.producer.record-sent.rate",
+            "The average number of records sent per second for a specific topic.",
+            "{records_sent}/s"));
+  }
+
+  private static void registerConsumerMetrics() {
+    String group = "consumer-fetch-manager-metrics";
+    Set<String> tagKeys = new HashSet<>(Arrays.asList("client-id", "topic", "partition"));
+
+    registry.put(
+        KafkaMetricId.create("records-lag", group, tagKeys),
+        MetricDescriptor.createDoubleGauge(
+            "messaging.kafka.consumer.lag",
+            "Current approximate lag of consumer group at partition of topic.",
+            "{lag}"));
+  }
+
+  /**
+   * Returns the description of the OpenTelemetry metric definition for the kafka metric, or {@code
+   * null} if no mapping exists.
+   */
+  @Nullable
+  static MetricDescriptor getRegisteredInstrument(KafkaMetricId kafkaMetricId) {
+    return registry.get(kafkaMetricId);
+  }
+
+  // Visible for testing
+  static Set<MetricDescriptor> getMetricDescriptors() {
+    return new HashSet<>(registry.values());
+  }
+
+  private KafkaMetricRegistry() {}
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/MetricDescriptor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/MetricDescriptor.java
@@ -1,0 +1,23 @@
+package io.opentelemetry.instrumentation.kafkaclients;
+
+import com.google.auto.value.AutoValue;
+
+/** A description of an OpenTelemetry metric instrument. */
+@AutoValue
+abstract class MetricDescriptor {
+
+  static final String INSTRUMENT_TYPE_DOUBLE_OBSERVABLE_GAUGE = "DOUBLE_OBSERVABLE_GAUGE";
+
+  abstract String getName();
+
+  abstract String getDescription();
+
+  abstract String getUnit();
+
+  abstract String getInstrumentType();
+
+  static MetricDescriptor createDoubleGauge(String name, String description, String unit) {
+    return new AutoValue_MetricDescriptor(
+        name, description, unit, INSTRUMENT_TYPE_DOUBLE_OBSERVABLE_GAUGE);
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/OpenTelemetryKafkaMetrics.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/OpenTelemetryKafkaMetrics.java
@@ -1,0 +1,201 @@
+package io.opentelemetry.instrumentation.kafkaclients;
+
+import static java.lang.System.lineSeparator;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
+
+/**
+ * A {@link MetricsReporter} which bridges Kafka metrics to OpenTelemetry metrics.
+ *
+ * <p>To use, configure OpenTelemetry instance via {@link #setOpenTelemetry(OpenTelemetry)}, and
+ * include a reference to this class in kafka producer or consumer configuration, i.e.:
+ *
+ * <pre>{@code
+ * //    Map<String, Object> config = new HashMap<>();
+ * //    // Register OpenTelemetryKafkaMetrics as reporter
+ * //    config.put(ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG, OpenTelemetryKafkaMetrics.class.getName());
+ * //    config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getKafkaConnectString());
+ * //    ...
+ * //    try (KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(config)) { ... }
+ * }</pre>
+ */
+public class OpenTelemetryKafkaMetrics implements MetricsReporter {
+
+  private static final Logger logger = Logger.getLogger(OpenTelemetryKafkaMetrics.class.getName());
+  private static final Set<KafkaMetricId> seenMetrics = ConcurrentHashMap.newKeySet();
+
+  @Nullable private static volatile Meter meter;
+
+  private static final Map<RegisteredInstrument, AutoCloseable> instrumentMap =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Setup OpenTelemetry. This should be called as early in the application lifecycle as possible.
+   * Kafka metrics that are observed before this is called may not be bridged.
+   */
+  public static void setOpenTelemetry(OpenTelemetry openTelemetry) {
+    meter = openTelemetry.getMeter("io.opentelemetry.kafka-clients");
+  }
+
+  /**
+   * Reset for test by reseting the {@link #meter} to {@code null} and closing all registered
+   * instruments.
+   */
+  static void resetForTest() {
+    meter = null;
+    for(Iterator<Map.Entry<RegisteredInstrument, AutoCloseable>> it = instrumentMap.entrySet().iterator(); it.hasNext(); ) {
+      try {
+        it.next().getValue().close();
+        it.remove();
+      } catch (Exception e) {
+        throw new IllegalStateException("Error occurred closing instrument", e);
+      }
+    }
+  }
+
+  /**
+   * Print a table mapping kafka metrics to equivalent OpenTelemetry metrics, in markdown format.
+   */
+  static void printMappingTable() {
+    StringBuilder sb = new StringBuilder();
+    // Append table headers
+    sb.append(
+            "| Kafka Group | Kafka Name | Kafka Description | Attribute Keys | Instrument Name | Instrument Description | Instrument Unit | Instrument Type |")
+        .append(lineSeparator())
+        .append(
+            "|-------------|------------|-------------------|----------------|-----------------|------------------------|-----------------|-----------------|")
+        .append(lineSeparator());
+    Map<String, List<KafkaMetricId>> kafkaMetricsByGroup =
+        seenMetrics.stream().collect(groupingBy(KafkaMetricId::getGroup));
+    // Iterate through groups in alpha order
+    for (String group : kafkaMetricsByGroup.keySet().stream().sorted().collect(toList())) {
+      List<KafkaMetricId> kafkaMetricIds =
+          kafkaMetricsByGroup.get(group).stream()
+              .sorted(Comparator.comparing(KafkaMetricId::getName))
+              .collect(toList());
+      // Iterate through metrics in alpha order by name
+      for (KafkaMetricId kafkaMetricId : kafkaMetricIds) {
+        Optional<MetricDescriptor> descriptor =
+            Optional.ofNullable(KafkaMetricRegistry.getRegisteredInstrument(kafkaMetricId));
+        // Append table row
+        sb.append(
+            String.format(
+                "| %s | %s | %s | %s | %s | %s | %s | %s |%n",
+                group,
+                kafkaMetricId.getName(),
+                kafkaMetricId.getDescription(),
+                String.join(",", kafkaMetricId.getTagKeys()),
+                descriptor.map(MetricDescriptor::getName).orElse(""),
+                descriptor.map(MetricDescriptor::getDescription).orElse(""),
+                descriptor.map(MetricDescriptor::getUnit).orElse(""),
+                descriptor
+                    .map(MetricDescriptor::getInstrumentType)
+                    .orElse("")));
+      }
+    }
+    logger.log(Level.INFO, "Mapping table" + System.lineSeparator() + sb);
+  }
+
+  @Override
+  public void init(List<KafkaMetric> metrics) {
+    metrics.forEach(this::metricChange);
+  }
+
+  @Override
+  public void metricChange(KafkaMetric metric) {
+    KafkaMetricId kafkaMetricId = KafkaMetricId.create(metric);
+    seenMetrics.add(KafkaMetricId.create(metric));
+    Meter currentMeter = meter;
+    if (currentMeter == null) {
+      logger.log(Level.FINEST, "Metric changed but meter not set: " + kafkaMetricId);
+      return;
+    }
+
+    MetricDescriptor metricDescriptor = KafkaMetricRegistry.getRegisteredInstrument(kafkaMetricId);
+    if (metricDescriptor == null) {
+      logger.log(
+          Level.FINEST,
+          "Metric changed but did not match any metrics from registry: " + kafkaMetricId);
+      return;
+    }
+
+    AttributesBuilder attributesBuilder = Attributes.builder();
+    metric.metricName().tags().forEach(attributesBuilder::put);
+    RegisteredInstrument registeredInstrument =
+        RegisteredInstrument.create(kafkaMetricId, attributesBuilder.build());
+
+    instrumentMap.compute(
+        registeredInstrument,
+        (registeredInstrument1, autoCloseable) -> {
+          if (autoCloseable != null) {
+            logger.log(Level.FINEST, "Replacing instrument " + registeredInstrument1);
+            try {
+              autoCloseable.close();
+            } catch (Exception e) {
+              logger.log(Level.WARNING, "An error occurred closing instrument", e);
+            }
+          } else {
+            logger.log(Level.FINEST, "Adding instrument " + registeredInstrument1);
+          }
+          return createObservable(currentMeter, registeredInstrument1, metricDescriptor, metric);
+        });
+  }
+
+  private static AutoCloseable createObservable(
+      Meter meter,
+      RegisteredInstrument registeredInstrument,
+      MetricDescriptor metricDescriptor,
+      KafkaMetric kafkaMetric) {
+    if (metricDescriptor.getInstrumentType().equals(MetricDescriptor.INSTRUMENT_TYPE_DOUBLE_OBSERVABLE_GAUGE)) {
+      return meter
+          .gaugeBuilder(metricDescriptor.getName())
+          .setDescription(metricDescriptor.getDescription())
+          .setUnit(metricDescriptor.getUnit())
+          .buildWithCallback(
+              observableMeasurement ->
+                  observableMeasurement.record(
+                      kafkaMetric.value(), registeredInstrument.getAttributes()));
+    }
+    // TODO: add support for other instrument types and value types as needed for new instruments
+    // registered in KafkaMetricRegistry.
+    // This should not happen.
+    throw new IllegalStateException("Unsupported metric descriptor: " + metricDescriptor);
+  }
+
+  private static Attributes toAttributes(KafkaMetric kafkaMetric) {
+    AttributesBuilder attributesBuilder = Attributes.builder();
+    kafkaMetric.metricName().tags().forEach(attributesBuilder::put);
+    return attributesBuilder.build();
+  }
+
+  @Override
+  public void metricRemoval(KafkaMetric metric) {
+    KafkaMetricId kafkaMetricId = KafkaMetricId.create(metric);
+    seenMetrics.add(kafkaMetricId);
+    logger.log(Level.FINEST, "Metric removed: " + kafkaMetricId);
+    instrumentMap.remove(RegisteredInstrument.create(kafkaMetricId, toAttributes(metric)));
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void configure(Map<String, ?> configs) {}
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/RegisteredInstrument.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/RegisteredInstrument.java
@@ -1,0 +1,16 @@
+package io.opentelemetry.instrumentation.kafkaclients;
+
+import com.google.auto.value.AutoValue;
+import io.opentelemetry.api.common.Attributes;
+
+@AutoValue
+abstract class RegisteredInstrument {
+
+  abstract KafkaMetricId getKafkaMetricId();
+
+  abstract Attributes getAttributes();
+
+  static RegisteredInstrument create(KafkaMetricId kafkaMetricId, Attributes attributes) {
+    return new AutoValue_RegisteredInstrument(kafkaMetricId, attributes);
+  }
+}


### PR DESCRIPTION
Proposal to bridge metrics from the kafka client library into OpenTelemetry.

As this PR currently stands, only metrics which align with those already declared in the [kafka metric semantic convention](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/instrumentation/kafka.md) are bridged. However, the semantic conventions are focused around the use case of monitoring kafka brokers, rather than clients. There's a lot more useful data available, which I'd like the semantic conventions to be extended with.

I've added a utility that makes it easier to explore which metrics are available, and if / how they're mapped into OpenTelemetry metrics. The utility prints out all this info in a markdown table, which I've included in the [README](https://github.com/jack-berg/opentelemetry-java-instrumentation/tree/kafka-metrics/instrumentation/kafka/kafka-clients#kafka-metrics).

I could use some feedback about:
- The best place to include this code from an artifact standpoint.
- Which of the available but unmapped metrics are most important to collect. 
