### PR TITLE
Show correct runnable name in spring scheduling actuator

### DIFF
--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingInstrumentationModule.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingInstrumentationModule.java
@@ -21,6 +21,6 @@ public class SpringSchedulingInstrumentationModule extends InstrumentationModule
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new TaskInstrumentation());
+    return singletonList(new TaskSchedulerInstrumentation());
   }
 }

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/TaskSchedulerInstrumentation.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/TaskSchedulerInstrumentation.java
@@ -33,8 +33,7 @@ public class TaskSchedulerInstrumentation implements TypeInstrumentation {
   public static class ScheduleMethodAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onSchedule(
-        @Advice.Argument(value = 0, readOnly = false) Runnable runnable) {
+    public static void onSchedule(@Advice.Argument(value = 0, readOnly = false) Runnable runnable) {
       runnable = SpringSchedulingRunnableWrapper.wrapIfNeeded(runnable);
     }
   }

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/TaskSchedulerInstrumentation.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/TaskSchedulerInstrumentation.java
@@ -5,7 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.scheduling;
 
-import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -15,24 +16,24 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-public class TaskInstrumentation implements TypeInstrumentation {
+public class TaskSchedulerInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return named("org.springframework.scheduling.config.Task");
+    return implementsInterface(named("org.springframework.scheduling.TaskScheduler"));
   }
 
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        isConstructor().and(takesArgument(0, Runnable.class)),
-        this.getClass().getName() + "$ConstructorAdvice");
+        nameStartsWith("schedule").and(takesArgument(0, Runnable.class)),
+        this.getClass().getName() + "$ScheduleMethodAdvice");
   }
 
   @SuppressWarnings("unused")
-  public static class ConstructorAdvice {
+  public static class ScheduleMethodAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onConstruction(
+    public static void onSchedule(
         @Advice.Argument(value = 0, readOnly = false) Runnable runnable) {
       runnable = SpringSchedulingRunnableWrapper.wrapIfNeeded(runnable);
     }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6103
Wrap `Runnable` used in spring scheduling a bit later so that `/actuator/scheduledtasks` wouldn show the actual scheduled class or method instead of `io.opentelemetry.javaagent.instrumentation.spring.scheduling.SpringSchedulingRunnablewrapper`