### PR TITLE
Enable read timeout test for reactor netty

### DIFF
--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/AbstractReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/AbstractReactorNettyHttpClientTest.groovy
@@ -28,13 +28,19 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
   }
 
   @Override
+  boolean testReadTimeout() {
+    true
+  }
+
+  @Override
   String userAgent() {
     return "ReactorNetty"
   }
 
   @Override
   HttpClient.ResponseReceiver buildRequest(String method, URI uri, Map<String, String> headers) {
-    return createHttpClient()
+    def readTimeout = uri.toString().contains("/read-timeout")
+    return createHttpClient(readTimeout)
       .followRedirect(true)
       .headers({ h -> headers.each { k, v -> h.add(k, v) } })
       .baseUrl(resolveAddress("").toString())
@@ -97,7 +103,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
     return super.httpAttributes(uri)
   }
 
-  abstract HttpClient createHttpClient()
+  abstract HttpClient createHttpClient(boolean readTimeout)
 
   def "should expose context to http client callbacks"() {
     given:
@@ -107,7 +113,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
     def afterResponseSpan = new AtomicReference<Span>()
     def latch = new CountDownLatch(1)
 
-    def httpClient = createHttpClient()
+    def httpClient = createHttpClient(false)
       .doOnRequest({ rq, con -> onRequestSpan.set(Span.current()) })
       .doAfterRequest({ rq, con -> afterRequestSpan.set(Span.current()) })
       .doOnResponse({ rs, con -> onResponseSpan.set(Span.current()) })
@@ -155,7 +161,7 @@ abstract class AbstractReactorNettyHttpClientTest extends HttpClientTest<HttpCli
     given:
     def onRequestErrorSpan = new AtomicReference<Span>()
 
-    def httpClient = createHttpClient()
+    def httpClient = createHttpClient(false)
       .doOnRequestError({ rq, err -> onRequestErrorSpan.set(Span.current()) })
 
     when:

--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyHttpClientTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyHttpClientTest.groovy
@@ -6,7 +6,9 @@
 package io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9
 
 import io.netty.channel.ChannelOption
+import io.netty.handler.timeout.ReadTimeoutHandler
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection
+import java.util.concurrent.TimeUnit
 import reactor.netty.http.client.HttpClient
 
 import java.util.concurrent.ExecutionException
@@ -14,8 +16,13 @@ import java.util.concurrent.TimeoutException
 
 class ReactorNettyHttpClientTest extends AbstractReactorNettyHttpClientTest {
 
-  HttpClient createHttpClient() {
+  HttpClient createHttpClient(boolean readTimeout) {
     return HttpClient.create().tcpConfiguration({ tcpClient ->
+      if (readTimeout) {
+        tcpClient = tcpClient.doOnConnected({ connection ->
+          connection.addHandlerLast(new ReadTimeoutHandler(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+        })
+      }
       tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MS)
     })
   }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyHttpClientUsingFromTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyHttpClientUsingFromTest.groovy
@@ -6,13 +6,20 @@
 package io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9
 
 import io.netty.channel.ChannelOption
+import io.netty.handler.timeout.ReadTimeoutHandler
+import java.util.concurrent.TimeUnit
 import reactor.netty.http.client.HttpClient
 import reactor.netty.tcp.TcpClient
 
 class ReactorNettyHttpClientUsingFromTest extends AbstractReactorNettyHttpClientTest {
 
-  HttpClient createHttpClient() {
+  HttpClient createHttpClient(boolean readTimeout) {
     return HttpClient.from(TcpClient.create()).tcpConfiguration({ tcpClient ->
+      if (readTimeout) {
+        tcpClient = tcpClient.doOnConnected({ connection ->
+          connection.addHandlerLast(new ReadTimeoutHandler(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+        })
+      }
       tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MS)
     })
   }


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4421