### PR TITLE
Rename p.r.j.memory.max to p.r.j.memory.limit

### DIFF
--- a/instrumentation/runtime-metrics/javaagent/src/test/groovy/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsTest.groovy
+++ b/instrumentation/runtime-metrics/javaagent/src/test/groovy/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsTest.groovy
@@ -27,7 +27,7 @@ class RuntimeMetricsTest extends AgentInstrumentationSpecification {
       assert getMetrics().any { it.name == "process.runtime.jvm.memory.init" }
       assert getMetrics().any { it.name == "process.runtime.jvm.memory.usage" }
       assert getMetrics().any { it.name == "process.runtime.jvm.memory.committed" }
-      assert getMetrics().any { it.name == "process.runtime.jvm.memory.max" }
+      assert getMetrics().any { it.name == "process.runtime.jvm.memory.limit" }
       assert getMetrics().any { it.name == "process.runtime.jvm.threads.count" }
     }
   }

--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/MemoryPools.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/MemoryPools.java
@@ -83,7 +83,7 @@ public final class MemoryPools {
         .buildWithCallback(callback(poolBeans, MemoryUsage::getCommitted));
 
     meter
-        .upDownCounterBuilder("process.runtime.jvm.memory.max")
+        .upDownCounterBuilder("process.runtime.jvm.memory.limit")
         .setDescription("Measure of max obtainable memory")
         .setUnit("By")
         .buildWithCallback(callback(poolBeans, MemoryUsage::getMax));

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -80,7 +80,7 @@ class SpringBootSmokeTest extends SmokeTest {
     metrics.hasMetricsNamed("process.runtime.jvm.memory.init")
     metrics.hasMetricsNamed("process.runtime.jvm.memory.usage")
     metrics.hasMetricsNamed("process.runtime.jvm.memory.committed")
-    metrics.hasMetricsNamed("process.runtime.jvm.memory.max")
+    metrics.hasMetricsNamed("process.runtime.jvm.memory.limit")
 
     cleanup:
     stopTarget()


### PR DESCRIPTION
Reflects change to [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/pull/2605). 