### PR TITLE
Extract reusable create-operator-pull-request workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - gradle-plugins
       - examples
     outputs:
-      release-version: ${{ steps.output-step.outputs.release-version }}
+      version: ${{ steps.output-step.outputs.version }}
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -252,12 +252,12 @@ jobs:
                        --base main
 
       - id: output-step
-        run: echo "::set-output name=release-version::$VERSION"
+        run: echo "::set-output name=version::$VERSION"
 
   create-operator-pull-request:
     needs: release
     uses: ./.github/workflows/reusable-create-operator-pull-request.yml
     with:
-      release-version: ${{ needs.release.outputs.release-version }}
+      javaagent-version: ${{ needs.release.outputs.version }}
     secrets:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
       - smoke-test
       - gradle-plugins
       - examples
+    outputs:
+      release-version: ${{ steps.output-step.outputs.release-version }}
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -249,40 +251,13 @@ jobs:
                        --head $branch \
                        --base main
 
-      - uses: actions/checkout@v3
-        with:
-          repository: opentelemetry-java-bot/opentelemetry-operator
-          # this is the personal access token used for "git push" below
-          token: ${{ secrets.BOT_TOKEN }}
+      - id: output-step
+        run: echo "::set-output name=release-version::$VERSION"
 
-      - name: Initialize pull request branch
-        run: |
-          git remote add upstream https://github.com/open-telemetry/opentelemetry-operator.git
-          git fetch upstream
-          git checkout -b update-opentelemetry-javaagent-to-${VERSION} upstream/main
-
-      - name: Update version
-        run: |
-          echo $VERSION > autoinstrumentation/java/version.txt
-
-      - name: Set git user
-        run: .github/scripts/set-git-user.sh
-
-      - name: Create pull request against opentelemetry-operator
-        env:
-          # this is the personal access token used for "gh pr create" below
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-        run: |
-          message="Update the javaagent version to $VERSION"
-          body="Update the javaagent version to \`$VERSION\`."
-
-          # gh pr create doesn't have a way to explicitly specify different head and base
-          # repositories currently, but it will implicitly pick up the head from a different
-          # repository if you set up a tracking branch
-
-          git commit -a -m "$message"
-          git push --set-upstream origin update-opentelemetry-javaagent-to-${VERSION}
-          gh pr create --title "$message" \
-                       --body "$body" \
-                       --repo open-telemetry/opentelemetry-operator \
-                       --base main
+  create-operator-pull-request:
+    needs: release
+    uses: ./.github/workflows/reusable-create-operator-pull-request.yml
+    with:
+      release-version: ${{ needs.release.outputs.release-version }}
+    secrets:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - gradle-plugins
       - examples
     outputs:
-      version: ${{ steps.output-step.outputs.version }}
+      version: ${{ steps.create-github-release.outputs.version }}
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -162,7 +162,8 @@ jobs:
           .github/scripts/generate-release-contributors.sh v$PRIOR_VERSION >> /tmp/release-notes.txt
           fi
 
-      - name: Create GitHub release
+      - id: create-github-release
+        name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -173,6 +174,8 @@ jobs:
                             --discussion-category announcements \
                             v$VERSION \
                             opentelemetry-javaagent.jar
+
+          echo "::set-output name=version::$VERSION"
 
       - uses: actions/checkout@v3
         with:
@@ -250,9 +253,6 @@ jobs:
                        --body "$body" \
                        --head $branch \
                        --base main
-
-      - id: output-step
-        run: echo "::set-output name=version::$VERSION"
 
   create-operator-pull-request:
     needs: release

--- a/.github/workflows/reusable-create-operator-pull-request.yml
+++ b/.github/workflows/reusable-create-operator-pull-request.yml
@@ -3,7 +3,7 @@ name: Reusable - Create operator pull request
 on:
   workflow_call:
     inputs:
-      release-version:
+      javaagent-version:
         type: string
         required: true
     secrets:
@@ -12,8 +12,8 @@ on:
   # to help with partial release build failures
   workflow_dispatch:
     inputs:
-      release-version:
-        description: "Javaagent release version"
+      javaagent-version:
+        description: "Javaagent version"
         required: true
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
 
       - name: Initialize pull request branch
         env:
-          VERSION: ${{ inputs.release-version }}
+          VERSION: ${{ inputs.javaagent-version }}
         run: |
           git remote add upstream https://github.com/open-telemetry/opentelemetry-operator.git
           git fetch upstream
@@ -36,9 +36,9 @@ jobs:
 
       - name: Update version
         env:
-          VERSION: ${{ inputs.release-version }}
+          VERSION: ${{ inputs.javaagent-version }}
         run: |
-          # TODO
+          echo $VERSION > autoinstrumentation/java/version.txt
 
       - name: Set git user
         run: |
@@ -49,7 +49,7 @@ jobs:
         env:
           # this is the personal access token used for "gh pr create" below
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-          VERSION: ${{ inputs.release-version }}
+          VERSION: ${{ inputs.javaagent-version }}
         run: |
           message="Update the javaagent version to $VERSION"
           body="Update the javaagent version to \`$VERSION\`."

--- a/.github/workflows/reusable-create-operator-pull-request.yml
+++ b/.github/workflows/reusable-create-operator-pull-request.yml
@@ -1,0 +1,66 @@
+name: Reusable - Create operator pull request
+
+on:
+  workflow_call:
+    inputs:
+      release-version:
+        type: string
+        required: true
+    secrets:
+      BOT_TOKEN:
+        required: true
+  # to help with partial release build failures
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: "Javaagent release version"
+        required: true
+
+jobs:
+  create-operator-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: opentelemetry-java-bot/opentelemetry-operator
+          # this is the personal access token used for "git push" below
+          token: ${{ secrets.BOT_TOKEN }}
+
+      - name: Initialize pull request branch
+        env:
+          VERSION: ${{ inputs.release-version }}
+        run: |
+          git remote add upstream https://github.com/open-telemetry/opentelemetry-operator.git
+          git fetch upstream
+          git checkout -b update-opentelemetry-javaagent-to-${VERSION} upstream/main
+
+      - name: Update version
+        env:
+          VERSION: ${{ inputs.release-version }}
+        run: |
+          # TODO
+
+      - name: Set git user
+        run: |
+          git config user.name opentelemetry-java-bot
+          git config user.email 97938252+opentelemetry-java-bot@users.noreply.github.com
+
+      - name: Create pull request against opentelemetry-operator
+        env:
+          # this is the personal access token used for "gh pr create" below
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          VERSION: ${{ inputs.release-version }}
+        run: |
+          message="Update the javaagent version to $VERSION"
+          body="Update the javaagent version to \`$VERSION\`."
+
+          # gh pr create doesn't have a way to explicitly specify different head and base
+          # repositories currently, but it will implicitly pick up the head from a different
+          # repository if you set up a tracking branch
+
+          git commit -a -m "$message"
+          git push --set-upstream origin HEAD:update-opentelemetry-javaagent-to-${VERSION}
+          gh pr create --title "$message" \
+                       --body "$body" \
+                       --repo open-telemetry/opentelemetry-operator \
+                       --base main


### PR DESCRIPTION
Primarily so that it can be run independently when there's a partial release failure (sent the PR for 1.15.0 when testing the workflow from my fork just now)