### PR TITLE
Update azure-sdk instrumentation

### DIFF
--- a/instrumentation/azure-core/azure-core-1.19/library-instrumentation-shaded/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.19/library-instrumentation-shaded/build.gradle.kts
@@ -7,10 +7,14 @@ plugins {
 group = "io.opentelemetry.javaagent.instrumentation"
 
 dependencies {
+  // this is the latest version that works with azure-core 1.14
+  // because newer versions use the new fluent ClientLogger.atWarning() from azure-core 1.24
+  //
+  // note:
   // to look at (potentially incompatible) differences in new versions of the injected artifact, run:
-  // git diff azure-core-tracing-opentelemetry_1.0.0-beta.25 azure-core-tracing-opentelemetry_1.0.0-beta.26
+  // git diff azure-core-tracing-opentelemetry_1.0.0-beta.23 azure-core-tracing-opentelemetry_1.0.0-beta.25
   //          -- sdk/core/azure-core-tracing-opentelemetry/src/main
-  implementation("com.azure:azure-core-tracing-opentelemetry:1.0.0-beta.25")
+  implementation("com.azure:azure-core-tracing-opentelemetry:1.0.0-beta.23")
 }
 
 tasks {

--- a/instrumentation/azure-core/azure-core-1.19/library-instrumentation-shaded/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.19/library-instrumentation-shaded/build.gradle.kts
@@ -8,9 +8,9 @@ group = "io.opentelemetry.javaagent.instrumentation"
 
 dependencies {
   // to look at (potentially incompatible) differences in new versions of the injected artifact, run:
-  // git diff azure-core-tracing-opentelemetry_1.0.0-beta.19 azure-core-tracing-opentelemetry_1.0.0-beta.20
-  //          -- sdk/core/azure-core-tracing-opentelemetry
-  implementation("com.azure:azure-core-tracing-opentelemetry:1.0.0-beta.20")
+  // git diff azure-core-tracing-opentelemetry_1.0.0-beta.25 azure-core-tracing-opentelemetry_1.0.0-beta.26
+  //          -- sdk/core/azure-core-tracing-opentelemetry/src/main
+  implementation("com.azure:azure-core-tracing-opentelemetry:1.0.0-beta.25")
 }
 
 tasks {


### PR DESCRIPTION
@lmolkova I didn't find any binary incompatibilities that would prevent injecting beta.25 instead of beta.20, ~and beta.25 removes the need for special span suppression(?)~ EDIT: forgot again, beta.25 brings span suppression within Azure SDK spans, but not across Azure SDK and OTel auto-instrumentation spans

```
git diff azure-core-tracing-opentelemetry_1.0.0-beta.20 azure-core-tracing-opentelemetry_1.0.0-beta.25 \
         -- sdk/core/azure-core-tracing-opentelemetry/src/main
```