### PR TITLE
Log a warning when GlobalOpenTelemetry#resetForTest() is called

### DIFF
--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/OpenTelemetryInstrumentation.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/OpenTelemetryInstrumentation.java
@@ -45,6 +45,9 @@ public class OpenTelemetryInstrumentation implements TypeInstrumentation {
             .and(takesArguments(1))
             .and(takesArgument(0, named("application.io.opentelemetry.api.OpenTelemetry"))),
         OpenTelemetryInstrumentation.class.getName() + "$SetAdvice");
+    transformer.applyAdviceToMethod(
+        isMethod().and(isStatic()).and(named("resetForTest")).and(takesArguments(0)),
+        OpenTelemetryInstrumentation.class.getName() + "$ResetForTestAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -73,6 +76,21 @@ public class OpenTelemetryInstrumentation implements TypeInstrumentation {
               WARNING,
               "You are currently using the OpenTelemetry Instrumentation Java Agent;"
                   + " all GlobalOpenTelemetry.set calls are ignored - the agent provides"
+                  + " the global OpenTelemetry object used by your application.",
+              new Throwable());
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class ResetForTestAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter() {
+      Logger.getLogger(application.io.opentelemetry.api.GlobalOpenTelemetry.class.getName())
+          .log(
+              WARNING,
+              "You are currently using the OpenTelemetry Instrumentation Java Agent;"
+                  + " all GlobalOpenTelemetry.resetForTest calls are ignored - the agent provides"
                   + " the global OpenTelemetry object used by your application.",
               new Throwable());
     }


### PR DESCRIPTION
I thought it might be useful to log a warning whenever this method is called in an instrumented app; like `set()`, it will not actually change the state anyway, so we might as well inform the user about it.