### PR TITLE
Update Protobuf versions for M1 support

### DIFF
--- a/conventions/src/main/kotlin/otel.protobuf-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.protobuf-conventions.gradle.kts
@@ -9,11 +9,11 @@ plugins {
 protobuf {
   protoc {
     // The artifact spec for the Protobuf Compiler
-    artifact = "com.google.protobuf:protoc:3.3.0"
+    artifact = "com.google.protobuf:protoc:3.17.3"
   }
   plugins {
     id("grpc") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.6.0"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.42.1"
     }
   }
   generateProtoTasks {

--- a/instrumentation/grpc-1.6/testing/build.gradle.kts
+++ b/instrumentation/grpc-1.6/testing/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
   id("otel.protobuf-conventions")
 }
 
-val grpcVersion = "1.6.0"
+val grpcVersion = "1.42.1"
 
 dependencies {
   api(project(":testing-common"))


### PR DESCRIPTION
See issue #6242. Creating a PR to show what versions I had to edit to successfully compile on an M1 Mac.