### PR TITLE
Remove commons-codec (not needed?)

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -18,15 +18,14 @@ rootProject.extra["otelVersion"] = otelVersion
 val groovyVersion = "4.0.2"
 
 // We don't force libraries we instrument to new versions since we compile and test against specific
-// old baseline versions
-// but we do try to force those libraries' transitive dependencies to new versions where possible
-// so that we don't end up with explosion of dependency versions in Intellij, which causes
-// Intellij to spend lots of time indexing all of those different dependency versions,
-// and makes debugging painful because Intellij has no idea which dependency version's source
-// to use when stepping through code.
+// old baseline versions but we do try to force those libraries' transitive dependencies to new
+// versions where possible so that we don't end up with explosion of dependency versions in
+// Intellij, which causes Intellij to spend lots of time indexing all of those different dependency
+// versions, and makes debugging painful because Intellij has no idea which dependency version's
+// source to use when stepping through code.
 //
-// Sometimes libraries we instrument do require a specific version of a transitive dependency
-// and that can be applied in the specific instrumentation gradle file, e.g.
+// Sometimes libraries we instrument do require a specific version of a transitive dependency and
+// that can be applied in the specific instrumentation gradle file, e.g.
 // configurations.testRuntimeClasspath.resolutionStrategy.force "com.google.guava:guava:19.0"
 
 val DEPENDENCY_BOMS = listOf(
@@ -78,6 +77,9 @@ val DEPENDENCY_SETS = listOf(
   ),
 )
 
+// See the comment above about why we keep this rather large list.
+// There are dependencies included here that appear to have no usages, but are maintained at
+// this top level to help consistently satisfy large numbers of transitive dependencies.
 val DEPENDENCIES = listOf(
   "ch.qos.logback:logback-classic:1.2.11",
   "com.github.stefanbirkner:system-lambda:1.2.1",
@@ -86,6 +88,7 @@ val DEPENDENCIES = listOf(
   "com.uber.nullaway:nullaway:0.9.7",
   "commons-beanutils:commons-beanutils:1.9.4",
   "commons-cli:commons-cli:1.5.0",
+  "commons-codec:commons-codec:1.15",
   "commons-collections:commons-collections:3.2.2",
   "commons-digester:commons-digester:2.1",
   "commons-fileupload:commons-fileupload:1.4",

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -86,7 +86,6 @@ val DEPENDENCIES = listOf(
   "com.uber.nullaway:nullaway:0.9.7",
   "commons-beanutils:commons-beanutils:1.9.4",
   "commons-cli:commons-cli:1.5.0",
-  "commons-codec:commons-codec:1.15",
   "commons-collections:commons-collections:3.2.2",
   "commons-digester:commons-digester:2.1",
   "commons-fileupload:commons-fileupload:1.4",


### PR DESCRIPTION
I couldn't find any real usages, so I figured I would see what breaks.