### PR TITLE
Enable logging in the benchmark overhead

### DIFF
--- a/benchmark-overhead/build.gradle.kts
+++ b/benchmark-overhead/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
   testImplementation("org.jooq:joox:1.6.2")
   testImplementation("com.jayway.jsonpath:json-path:2.6.0")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")
+  testImplementation("org.slf4j:slf4j-simple:1.7.36")
 }
 
 tasks {


### PR DESCRIPTION
Enable logging in the benchmark overhead: remove "SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder"

cc @breedx-splk 