### PR TITLE
Correct spelling of opentelemetry-exporter-logging

### DIFF
--- a/instrumentation/spring/README.md
+++ b/instrumentation/spring/README.md
@@ -54,7 +54,7 @@ Replace `OPENTELEMETRY_VERSION` with the latest stable [release](https://search.
 ```xml
 <dependency>
    <groupId>io.opentelemetry</groupId>
-   <artifactId>opentelemetry-exporters-logging</artifactId>
+   <artifactId>opentelemetry-exporter-logging</artifactId>
    <version>OPENTELEMETRY_VERSION</version>
 </dependency>
 ```
@@ -83,7 +83,7 @@ implementation("io.opentelemetry:opentelemetry-sdk:OPENTELEMETRY_VERSION")
 
 #### LoggingExporter
 ```gradle
-implementation("io.opentelemetry:opentelemetry-exporters-logging:OPENTELEMETRY_VERSION")
+implementation("io.opentelemetry:opentelemetry-exporter-logging:OPENTELEMETRY_VERSION")
 ```
 
 #### Jaeger Exporter

--- a/instrumentation/spring/spring-boot-autoconfigure/README.md
+++ b/instrumentation/spring/spring-boot-autoconfigure/README.md
@@ -32,7 +32,7 @@ For Maven add to your `pom.xml`:
    <!-- provides opentelemetry-sdk artifact -->
    <dependency>
     <groupId>io.opentelemetry</groupId>
-    <artifactId>opentelemetry-exporters-logging</artifactId>
+    <artifactId>opentelemetry-exporter-logging</artifactId>
     <version>OPENTELEMETRY_VERSION</version>
   </dependency>
 

--- a/instrumentation/spring/spring-web-3.1/library/README.md
+++ b/instrumentation/spring/spring-web-3.1/library/README.md
@@ -28,7 +28,7 @@ For Maven add to your `pom.xml`:
   <!-- provides opentelemetry-sdk -->
   <dependency>
     <groupId>io.opentelemetry</groupId>
-    <artifactId>opentelemetry-exporters-logging</artifactId>
+    <artifactId>opentelemetry-exporter-logging</artifactId>
     <version>OPENTELEMETRY_VERSION</version>
   </dependency>
 
@@ -47,7 +47,7 @@ For Gradle add to your dependencies:
 
 ```groovy
 implementation("io.opentelemetry.instrumentation:opentelemetry-spring-web-3.1:OPENTELEMETRY_VERSION")
-implementation("io.opentelemetry:opentelemetry-exporters-logging:OPENTELEMETRY_VERSION")
+implementation("io.opentelemetry:opentelemetry-exporter-logging:OPENTELEMETRY_VERSION")
 
 //this artifact should already be present in your application
 implementation("org.springframework:spring-web:SPRING_VERSION")

--- a/instrumentation/spring/spring-webflux-5.0/library/README.md
+++ b/instrumentation/spring/spring-webflux-5.0/library/README.md
@@ -27,7 +27,7 @@ For Maven add to your `pom.xml`:
    <!-- replace this default exporter with your opentelemetry exporter (ex. otlp/zipkin/jaeger/..) -->
    <dependency>
     <groupId>io.opentelemetry</groupId>
-    <artifactId>opentelemetry-exporters-logging</artifactId>
+    <artifactId>opentelemetry-exporter-logging</artifactId>
     <version>OPENTELEMETRY_VERSION</version>
   </dependency>
 
@@ -50,7 +50,7 @@ implementation("io.opentelemetry.instrumentation:opentelemetry-spring-webflux-5.
 
 // opentelemetry exporter
 // replace this default exporter with your opentelemetry exporter (ex. otlp/zipkin/jaeger/..)
-implementation("io.opentelemetry:opentelemetry-exporters-logging:OPENTELEMETRY_VERSION")
+implementation("io.opentelemetry:opentelemetry-exporter-logging:OPENTELEMETRY_VERSION")
 
 // required to instrument spring-webmvc
 // this artifact should already be present in your application

--- a/instrumentation/spring/spring-webmvc-3.1/library/README.md
+++ b/instrumentation/spring/spring-webmvc-3.1/library/README.md
@@ -27,7 +27,7 @@ For Maven add to your `pom.xml`:
    <!-- replace this default exporter with your opentelemetry exporter (ex. otlp/zipkin/jaeger/..) -->
    <dependency>
     <groupId>io.opentelemetry</groupId>
-    <artifactId>opentelemetry-exporters-logging</artifactId>
+    <artifactId>opentelemetry-exporter-logging</artifactId>
     <version>OPENTELEMETRY_VERSION</version>
   </dependency>
 
@@ -51,7 +51,7 @@ implementation("io.opentelemetry.instrumentation:opentelemetry-spring-webmvc-3.1
 
 // opentelemetry exporter
 // replace this default exporter with your opentelemetry exporter (ex. otlp/zipkin/jaeger/..)
-implementation("io.opentelemetry:opentelemetry-exporters-logging:OPENTELEMETRY_VERSION")
+implementation("io.opentelemetry:opentelemetry-exporter-logging:OPENTELEMETRY_VERSION")
 
 // required to instrument spring-webmvc
 // this artifact should already be present in your application


### PR DESCRIPTION
It looks like some docs still had the old name.