### PR TITLE
Spring starter - Add api opentelemetry-sdk-extension-autoconfigure-spi

### DIFF
--- a/instrumentation/spring/starters/spring-starter/build.gradle.kts
+++ b/instrumentation/spring/starters/spring-starter/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   api("org.springframework.boot:spring-boot-starter-aop:${versions["org.springframework.boot"]}")
   api(project(":instrumentation:spring:spring-boot-autoconfigure"))
   api("io.opentelemetry:opentelemetry-extension-annotations")
+  api("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   api("io.opentelemetry:opentelemetry-api")
   api("io.opentelemetry:opentelemetry-exporter-logging")
   api("io.opentelemetry:opentelemetry-sdk")


### PR DESCRIPTION
A colleague was encountering [this error](https://gist.github.com/breedx-splk/e83a0ed816130ef37ea92dc3ff302e62) when attempting to use `opentelemetry-spring-starter`.

I'm not 100% confident in this, but it looks like the starter includes the `spring:spring-boot-autoconfigure` instrumentation, which includes the `OtelResourceAutoConfiguration` class from the stack trace. That class directly references `ResourceProvider`, which is brought in from `opentelemetry-sdk-extension-autoconfigure-spi` but [via `compileOnly`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts#L25), so the user doesn't have it at runtime.

The colleague was able to work around the error by including `opentelemetry-sdk-extension-autoconfigure-spi` in their dependency list, but we don't include that in the docs and it seemed like it made sense to include it in the starter bundle. 

If adding the dep here isn't the right approach, I'm happy to pivot, just let me know.
 