### PR TITLE
Don't wait for netty to shut down

### DIFF
--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ClientSslTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ClientSslTest.groovy
@@ -50,7 +50,7 @@ class Netty40ClientSslTest extends AgentInstrumentationSpecification {
 
   def cleanupSpec() {
     server.stop().get(10, TimeUnit.SECONDS)
-    eventLoopGroup.shutdownGracefully().sync()
+    eventLoopGroup.shutdownGracefully()
   }
 
   def "should fail SSL handshake"() {

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientSslTest.groovy
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/groovy/Netty41ClientSslTest.groovy
@@ -52,7 +52,7 @@ class Netty41ClientSslTest extends AgentInstrumentationSpecification {
 
   def cleanupSpec() {
     server.stop().get(10, TimeUnit.SECONDS)
-    eventLoopGroup.shutdownGracefully().sync()
+    eventLoopGroup.shutdownGracefully()
   }
 
   def "should fail SSL handshake"() {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6269
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5136
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6091

None of the other netty tests call `sync` after `shutdownGracefully`. Apparently in netty40 tests this can hang with the following stack trace:
```
"Test worker" #1 prio=5 os_prio=0 cpu=3704.50ms elapsed=814.87s tid=0x00007f3c4002d800 nid=0x1e887 in Object.wait()  [0x00007f3c45259000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.15/Native Method)
	- waiting on <0x00000000e17bc590> (a io.netty.util.concurrent.DefaultPromise)
	at java.lang.Object.wait(java.base@11.0.15/Object.java:328)
	at io.netty.util.concurrent.DefaultPromise.await(DefaultPromise.java:240)
	- waiting to re-lock in wait() <0x00000000e17bc590> (a io.netty.util.concurrent.DefaultPromise)
	at io.netty.util.concurrent.DefaultPromise.sync(DefaultPromise.java:204)
	at io.netty.util.concurrent.Promise$sync.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:130)
	at Netty40ClientSslTest.cleanupSpec(Netty40ClientSslTest.groovy:53)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@11.0.15/Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@11.0.15/NativeMethodAccessorImpl.java:62)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@11.0.15/DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(java.base@11.0.15/Method.java:566)
	at org.spockframework.util.ReflectionUtil.invokeMethod(ReflectionUtil.java:198)
	at org.spockframework.runtime.model.MethodInfo.lambda$new$0(MethodInfo.java:47)
	at org.spockframework.runtime.model.MethodInfo$$Lambda$253/0x0000000100388c40.invoke(Unknown Source)
	at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:148)
	at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:102)
	at org.spockframework.junit4.ExceptionAdapterInterceptor.intercept(ExceptionAdapterInterceptor.java:13)
	at org.spockframework.runtime.extension.MethodInvocation.proceed(MethodInvocation.java:101)
	at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:398)
	at org.spockframework.runtime.PlatformSpecRunner.doRunCleanupSpec(PlatformSpecRunner.java:175)
	at org.spockframework.runtime.PlatformSpecRunner.lambda$createMethodForDoRunCleanupSpec$3(PlatformSpecRunner.java:162)
	at org.spockframework.runtime.PlatformSpecRunner$$Lambda$865/0x00000001007d3c40.invoke(Unknown Source)
	at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:148)
	at org.spockframework.runtime.PlatformSpecRunner.invokeRaw(PlatformSpecRunner.java:407)
	at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:390)
	at org.spockframework.runtime.PlatformSpecRunner.runCleanupSpec(PlatformSpecRunner.java:157)
	at org.spockframework.runtime.PlatformSpecRunner.runCleanupSpec(PlatformSpecRunner.java:152)
	at org.spockframework.runtime.SpecNode.after(SpecNode.java:55)
	at org.spockframework.runtime.SpecNode.after(SpecNode.java:11)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:161)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda$797/0x0000000100725440.execute(Unknown Source)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:161)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda$375/0x00000001003da440.invoke(Unknown Source)
	at org.spockframework.runtime.SpockNode.sneakyInvoke(SpockNode.java:40)
	at org.spockframework.runtime.SpecNode.lambda$around$0(SpecNode.java:63)
	at org.spockframework.runtime.SpecNode$$Lambda$440/0x000000010043a040.run(Unknown Source)
	at org.spockframework.runtime.PlatformSpecRunner.lambda$createMethodInfoForDoRunSpec$0(PlatformSpecRunner.java:61)
	at org.spockframework.runtime.PlatformSpecRunner$$Lambda$441/0x000000010043a440.invoke(Unknown Source)
	at org.spockframework.runtime.model.MethodInfo.invoke(MethodInfo.java:148)
	at org.spockframework.runtime.PlatformSpecRunner.invokeRaw(PlatformSpecRunner.java:407)
	at org.spockframework.runtime.PlatformSpecRunner.invoke(PlatformSpecRunner.java:390)
	at org.spockframework.runtime.PlatformSpecRunner.runSpec(PlatformSpecRunner.java:55)
	at org.spockframework.runtime.SpecNode.around(SpecNode.java:63)
	at org.spockframework.runtime.SpecNode.around(SpecNode.java:11)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda$374/0x00000001003da040.execute(Unknown Source)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService$$Lambda$380/0x00000001003db840.accept(Unknown Source)
	at java.util.ArrayList.forEach(java.base@11.0.15/ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda$376/0x00000001003da840.execute(Unknown Source)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda$375/0x00000001003da440.invoke(Unknown Source)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda$374/0x00000001003da040.execute(Unknown Source)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:108)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator$$Lambda$348/0x00000001003d2840.accept(Unknown Source)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:96)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:75)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(java.base@11.0.15/Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(java.base@11.0.15/NativeMethodAccessorImpl.java:62)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@11.0.15/DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(java.base@11.0.15/Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy24.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```