### PR TITLE
Instrumenting classes with missing method return or parameter types

### DIFF
--- a/javaagent-tooling/build.gradle.kts
+++ b/javaagent-tooling/build.gradle.kts
@@ -68,6 +68,18 @@ testing {
         compileOnly("com.google.code.findbugs:annotations")
       }
     }
+
+    val testMissingType by registering(JvmTestSuite::class) {
+      dependencies {
+        implementation(project(":javaagent-bootstrap"))
+        implementation(project(":javaagent-tooling"))
+        implementation("net.bytebuddy:byte-buddy-dep")
+        compileOnly("com.google.guava:guava")
+
+        // Used by byte-buddy but not brought in as a transitive dependency.
+        compileOnly("com.google.code.findbugs:annotations")
+      }
+    }
   }
 }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bytebuddy/SafeTypeStrategy.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bytebuddy/SafeTypeStrategy.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.bytebuddy;
+
+import static net.bytebuddy.matcher.ElementMatchers.failSafe;
+import static net.bytebuddy.matcher.ElementMatchers.hasParameters;
+import static net.bytebuddy.matcher.ElementMatchers.hasType;
+import static net.bytebuddy.matcher.ElementMatchers.isVisibleTo;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.whereNone;
+
+import java.security.ProtectionDomain;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.scaffold.inline.MethodNameTransformer;
+import net.bytebuddy.utility.JavaModule;
+
+/**
+ * Wrapper for {@link AgentBuilder.TypeStrategy} that excludes methods with missing return or
+ * parameter types. By default, byte-buddy fails transforming such classes.
+ */
+public final class SafeTypeStrategy implements AgentBuilder.TypeStrategy {
+  private final AgentBuilder.TypeStrategy delegate;
+
+  public SafeTypeStrategy(AgentBuilder.TypeStrategy delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public DynamicType.Builder<?> builder(
+      TypeDescription typeDescription,
+      ByteBuddy byteBuddy,
+      ClassFileLocator classFileLocator,
+      MethodNameTransformer methodNameTransformer,
+      ClassLoader classLoader,
+      JavaModule module,
+      ProtectionDomain protectionDomain) {
+    // type description wrapper that removes methods with missing return or parameter types
+    TypeDescription newTypeDescription =
+        new TypeDescription.AbstractBase.OfSimpleType.WithDelegation() {
+
+          @Override
+          public String getName() {
+            return delegate().getName();
+          }
+
+          @Override
+          protected TypeDescription delegate() {
+            return typeDescription;
+          }
+
+          @Override
+          public MethodList<MethodDescription.InDefinedShape> getDeclaredMethods() {
+            MethodList<MethodDescription.InDefinedShape> methodList = super.getDeclaredMethods();
+            return filterMethods(methodList, typeDescription);
+          }
+        };
+
+    return delegate.builder(
+        newTypeDescription,
+        byteBuddy,
+        classFileLocator,
+        methodNameTransformer,
+        classLoader,
+        module,
+        protectionDomain);
+  }
+
+  private static <T extends MethodDescription> MethodList<T> filterMethods(
+      MethodList<T> methodList, TypeDescription viewPoint) {
+    // filter out methods missing return or parameter types
+    return methodList.filter(
+        failSafe(
+            returns(isVisibleTo(viewPoint))
+                .and(hasParameters(whereNone(hasType(not(isVisibleTo(viewPoint))))))));
+  }
+}

--- a/javaagent-tooling/src/testMissingType/java/io/opentelemetry/javaagent/tooling/bytebuddy/MissingTypeTest.java
+++ b/javaagent-tooling/src/testMissingType/java/io/opentelemetry/javaagent/tooling/bytebuddy/MissingTypeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.bytebuddy;
+
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.google.common.base.Joiner;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.scaffold.MethodGraph;
+import net.bytebuddy.utility.JavaModule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class MissingTypeTest {
+  private static final Logger logger = LoggerFactory.getLogger(MissingTypeTest.class);
+
+  private static ResettableClassFileTransformer transformer;
+  private static final AtomicBoolean hasErrors = new AtomicBoolean(false);
+
+  @BeforeAll
+  static void setUp() {
+    AgentBuilder builder =
+        new AgentBuilder.Default(
+                new ByteBuddy().with(MethodGraph.Compiler.ForDeclaredMethods.INSTANCE))
+            .disableClassFormatChanges()
+            .with(new SafeTypeStrategy(AgentBuilder.TypeStrategy.Default.REDEFINE_FROZEN))
+            .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+            .with(
+                new AgentBuilder.Listener.Adapter() {
+                  @Override
+                  public void onError(
+                      String typeName,
+                      ClassLoader classLoader,
+                      JavaModule module,
+                      boolean loaded,
+                      Throwable throwable) {
+                    logger.error("Transformation error", throwable);
+                    hasErrors.set(true);
+                  }
+                })
+            .type(named(MissingTypeTest.class.getName() + "$SomeClass"))
+            .transform(
+                new AgentBuilder.Transformer.ForAdvice()
+                    .with(
+                        new AgentBuilder.LocationStrategy.Simple(
+                            ClassFileLocator.ForClassLoader.of(TestAdvice.class.getClassLoader())))
+                    .advice(isMethod().and(named("isInstrumented")), TestAdvice.class.getName()));
+
+    ByteBuddyAgent.install();
+    transformer = builder.installOn(ByteBuddyAgent.getInstrumentation());
+  }
+
+  @AfterAll
+  static void tearDown() {
+    transformer.reset(
+        ByteBuddyAgent.getInstrumentation(), AgentBuilder.RedefinitionStrategy.RETRANSFORMATION);
+  }
+
+  @Test
+  void guavaNotAvailable() {
+    // these tests expect com.google.common.base.Joiner to be missing from runtime class path
+    try {
+      Class.forName("com.google.common.base.Joiner");
+      fail("guava should not be available during runtime");
+    } catch (ClassNotFoundException exception) {
+      // ignore
+    }
+  }
+
+  @Test
+  void instrumented() {
+    assertThat(SomeClass.isInstrumented()).isTrue();
+  }
+
+  @Test
+  void hasNoErrors() {
+    assertThat(hasErrors.get()).isFalse();
+  }
+
+  // com.google.common.base.Joiner is missing from runtime class path
+  @SuppressWarnings({"UnusedMethod", "MethodCanBeStatic"})
+  private static class SomeClass {
+    public static boolean isInstrumented() {
+      return false;
+    }
+
+    public void methodWithMissingParameterType(Joiner joiner) {}
+
+    public Joiner methodWithMissingReturnType() {
+      return null;
+    }
+
+    public static void staticMethodWithMissingParameterType(Joiner joiner) {}
+
+    public static Joiner staticMethodWithMissingReturnType() {
+      return null;
+    }
+  }
+}

--- a/javaagent-tooling/src/testMissingType/java/io/opentelemetry/javaagent/tooling/bytebuddy/TestAdvice.java
+++ b/javaagent-tooling/src/testMissingType/java/io/opentelemetry/javaagent/tooling/bytebuddy/TestAdvice.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.bytebuddy;
+
+import net.bytebuddy.asm.Advice;
+
+@SuppressWarnings("unused")
+public class TestAdvice {
+
+  @Advice.OnMethodExit
+  public static void returnTrue(@Advice.Return(readOnly = false) boolean returnVal) {
+    returnVal = true;
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5761
Byte-buddy fails class transformation when it can't find method return or parameter types. To avoid this we can hide the problematic methods. For the same purpose elastic is using a custom method graph compiler https://github.com/elastic/apm-agent-java/blob/main/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/FailSafeDeclaredMethodsCompiler.java 