### PR TITLE
Fix petclinic docker image

### DIFF
--- a/.github/workflows/publish-petclinic-benchmark-image.yml
+++ b/.github/workflows/publish-petclinic-benchmark-image.yml
@@ -25,9 +25,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Create timestamp for docker image tag
+        run: echo "TS=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+
       - name: Push to GitHub packages
         uses: docker/build-push-action@v3
         with:
           push: true
           file: benchmark-overhead/Dockerfile-petclinic-base
-          tags: ghcr.io/open-telemetry/opentelemetry-java-instrumentation/petclinic-rest-base:latest
+          tags: ghcr.io/open-telemetry/opentelemetry-java-instrumentation/petclinic-rest-base:${{ env.TS }}

--- a/benchmark-overhead/Dockerfile-petclinic-base
+++ b/benchmark-overhead/Dockerfile-petclinic-base
@@ -7,6 +7,8 @@ FROM eclipse-temurin:11 as app-build
 RUN apt update && apt install -y git
 WORKDIR /app
 RUN git clone http://github.com/spring-petclinic/spring-petclinic-rest.git
+# We have to pin the version because upstream petclinic has breaking api changes after this commit
+RUN git checkout 8aa4d49
 WORKDIR /app/spring-petclinic-rest
 RUN ./mvnw package -Dmaven.test.skip=true
 RUN cp target/spring-petclinic-rest*.jar /app/spring-petclinic-rest.jar


### PR DESCRIPTION
`spring-petclinic-rest` has had a large number of breaking API changes mostly around the adoption of an OpenAPI spec and some generated DTOs. Because of that, the tests have not been running correctly.

We need to pin the repo version until the api is fixed.

It also came up that we shouldn't be tagging the docker container with `latest` so that we refer to prior builds.