### PR TITLE
Add a label for running windows smoke tests

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -41,7 +41,7 @@ jobs:
     uses: ./.github/workflows/reusable-smoke-test.yml
     with:
       # windows smoke tests are slower, and it's rare for only the windows smoke tests to break
-      skip-windows: true
+      skip-windows: ${{ !contains(github.event.pull_request.labels.*.name, 'test windows') }}
       cache-read-only: true
 
   muzzle:


### PR DESCRIPTION
Run windows smoke tests when pr has label `windows tests` similarly how latest dep tests can be run `test latest deps`