### PR TITLE
Remove config property name normalization

### DIFF
--- a/instrumentation/oshi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/OshiMetricsInstaller.java
+++ b/instrumentation/oshi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/oshi/OshiMetricsInstaller.java
@@ -10,7 +10,6 @@ import io.opentelemetry.javaagent.extension.AgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.lang.reflect.Method;
-import java.util.Locale;
 
 /**
  * An {@link AgentListener} that enables oshi metrics during agent startup if oshi is present on the
@@ -23,9 +22,8 @@ public class OshiMetricsInstaller implements AgentListener {
   public void afterAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredSdk) {
     ConfigProperties config = autoConfiguredSdk.getConfig();
 
-    boolean defaultEnabled =
-        config.getBoolean(normalize("otel.instrumentation.common.default-enabled"), true);
-    if (!config.getBoolean(normalize("otel.instrumentation.oshi.enabled"), defaultEnabled)) {
+    boolean defaultEnabled = config.getBoolean("otel.instrumentation.common.default-enabled", true);
+    if (!config.getBoolean("otel.instrumentation.oshi.enabled", defaultEnabled)) {
       return;
     }
 
@@ -49,10 +47,5 @@ public class OshiMetricsInstaller implements AgentListener {
       // renamed in oshi 6.0.0
       return oshiSystemInfoClass.getMethod("getCurrentPlatform");
     }
-  }
-
-  // TODO: remove after https://github.com/open-telemetry/opentelemetry-java/issues/4562 is fixed
-  private static String normalize(String key) {
-    return key.toLowerCase(Locale.ROOT).replace('-', '.');
   }
 }

--- a/instrumentation/runtime-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsInstaller.java
+++ b/instrumentation/runtime-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/runtimemetrics/RuntimeMetricsInstaller.java
@@ -16,7 +16,6 @@ import io.opentelemetry.instrumentation.runtimemetrics.Threads;
 import io.opentelemetry.javaagent.extension.AgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import java.util.Locale;
 
 /** An {@link AgentListener} that enables runtime metrics during agent startup. */
 @AutoService(AgentListener.class)
@@ -26,10 +25,8 @@ public class RuntimeMetricsInstaller implements AgentListener {
   public void afterAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredSdk) {
     ConfigProperties config = autoConfiguredSdk.getConfig();
 
-    boolean defaultEnabled =
-        config.getBoolean(normalize("otel.instrumentation.common.default-enabled"), true);
-    if (!config.getBoolean(
-        normalize("otel.instrumentation.runtime-metrics.enabled"), defaultEnabled)) {
+    boolean defaultEnabled = config.getBoolean("otel.instrumentation.common.default-enabled", true);
+    if (!config.getBoolean("otel.instrumentation.runtime-metrics.enabled", defaultEnabled)) {
       return;
     }
 
@@ -39,14 +36,9 @@ public class RuntimeMetricsInstaller implements AgentListener {
     Threads.registerObservers(GlobalOpenTelemetry.get());
 
     if (config.getBoolean(
-        normalize("otel.instrumentation.runtime-metrics.experimental-metrics.enabled"), false)) {
+        "otel.instrumentation.runtime-metrics.experimental-metrics.enabled", false)) {
       GarbageCollector.registerObservers(GlobalOpenTelemetry.get());
       BufferPools.registerObservers(GlobalOpenTelemetry.get());
     }
-  }
-
-  // TODO: remove after https://github.com/open-telemetry/opentelemetry-java/issues/4562 is fixed
-  private static String normalize(String key) {
-    return key.toLowerCase(Locale.ROOT).replace('-', '.');
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigPropertiesBridge.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigPropertiesBridge.java
@@ -10,7 +10,6 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import java.time.Duration;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -26,7 +25,7 @@ public final class ConfigPropertiesBridge extends InstrumentationConfig {
   @Override
   public String getString(String name) {
     try {
-      return configProperties.getString(normalize(name));
+      return configProperties.getString(name);
     } catch (ConfigurationException ignored) {
       return null;
     }
@@ -35,7 +34,7 @@ public final class ConfigPropertiesBridge extends InstrumentationConfig {
   @Override
   public String getString(String name, String defaultValue) {
     try {
-      return configProperties.getString(normalize(name), defaultValue);
+      return configProperties.getString(name, defaultValue);
     } catch (ConfigurationException ignored) {
       return defaultValue;
     }
@@ -44,7 +43,7 @@ public final class ConfigPropertiesBridge extends InstrumentationConfig {
   @Override
   public boolean getBoolean(String name, boolean defaultValue) {
     try {
-      return configProperties.getBoolean(normalize(name), defaultValue);
+      return configProperties.getBoolean(name, defaultValue);
     } catch (ConfigurationException ignored) {
       return defaultValue;
     }
@@ -53,7 +52,7 @@ public final class ConfigPropertiesBridge extends InstrumentationConfig {
   @Override
   public int getInt(String name, int defaultValue) {
     try {
-      return configProperties.getInt(normalize(name), defaultValue);
+      return configProperties.getInt(name, defaultValue);
     } catch (ConfigurationException ignored) {
       return defaultValue;
     }
@@ -62,7 +61,7 @@ public final class ConfigPropertiesBridge extends InstrumentationConfig {
   @Override
   public long getLong(String name, long defaultValue) {
     try {
-      return configProperties.getLong(normalize(name), defaultValue);
+      return configProperties.getLong(name, defaultValue);
     } catch (ConfigurationException ignored) {
       return defaultValue;
     }
@@ -71,7 +70,7 @@ public final class ConfigPropertiesBridge extends InstrumentationConfig {
   @Override
   public double getDouble(String name, double defaultValue) {
     try {
-      return configProperties.getDouble(normalize(name), defaultValue);
+      return configProperties.getDouble(name, defaultValue);
     } catch (ConfigurationException ignored) {
       return defaultValue;
     }
@@ -80,7 +79,7 @@ public final class ConfigPropertiesBridge extends InstrumentationConfig {
   @Override
   public Duration getDuration(String name, Duration defaultValue) {
     try {
-      return configProperties.getDuration(normalize(name), defaultValue);
+      return configProperties.getDuration(name, defaultValue);
     } catch (ConfigurationException ignored) {
       return defaultValue;
     }
@@ -89,7 +88,7 @@ public final class ConfigPropertiesBridge extends InstrumentationConfig {
   @Override
   public List<String> getList(String name, List<String> defaultValue) {
     try {
-      return configProperties.getList(normalize(name), defaultValue);
+      return configProperties.getList(name, defaultValue);
     } catch (ConfigurationException ignored) {
       return defaultValue;
     }
@@ -98,14 +97,9 @@ public final class ConfigPropertiesBridge extends InstrumentationConfig {
   @Override
   public Map<String, String> getMap(String name, Map<String, String> defaultValue) {
     try {
-      return configProperties.getMap(normalize(name), defaultValue);
+      return configProperties.getMap(name, defaultValue);
     } catch (ConfigurationException ignored) {
       return defaultValue;
     }
-  }
-
-  // TODO: remove after https://github.com/open-telemetry/opentelemetry-java/issues/4562 is fixed
-  private static String normalize(String key) {
-    return key.toLowerCase(Locale.ROOT).replace('-', '.');
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/AdditionalLibraryIgnoredTypesConfigurer.java
@@ -9,7 +9,6 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesBuilder;
 import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import java.util.Locale;
 
 /**
  * Additional global ignore settings that are used to reduce number of classes we try to apply
@@ -30,7 +29,7 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
 
   @Override
   public void configure(ConfigProperties config, IgnoredTypesBuilder builder) {
-    if (config.getBoolean(normalize(ADDITIONAL_LIBRARY_IGNORES_ENABLED), true)) {
+    if (config.getBoolean(ADDITIONAL_LIBRARY_IGNORES_ENABLED, true)) {
       configure(builder);
     }
   }
@@ -275,10 +274,5 @@ public class AdditionalLibraryIgnoredTypesConfigurer implements IgnoredTypesConf
 
     // kotlin, note we do not ignore kotlinx because we instrument coroutines code
     builder.ignoreClass("kotlin.").allowClass("kotlin.coroutines.jvm.internal.DebugProbesKt");
-  }
-
-  // TODO: remove after https://github.com/open-telemetry/opentelemetry-java/issues/4562 is fixed
-  private static String normalize(String key) {
-    return key.toLowerCase(Locale.ROOT).replace('-', '.');
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/UserExcludedClassesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/UserExcludedClassesConfigurer.java
@@ -12,7 +12,6 @@ import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesBuilder;
 import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.List;
-import java.util.Locale;
 
 @AutoService(IgnoredTypesConfigurer.class)
 public class UserExcludedClassesConfigurer implements IgnoredTypesConfigurer {
@@ -22,7 +21,7 @@ public class UserExcludedClassesConfigurer implements IgnoredTypesConfigurer {
 
   @Override
   public void configure(ConfigProperties config, IgnoredTypesBuilder builder) {
-    List<String> excludedClasses = config.getList(normalize(EXCLUDED_CLASSES_CONFIG), emptyList());
+    List<String> excludedClasses = config.getList(EXCLUDED_CLASSES_CONFIG, emptyList());
     for (String excludedClass : excludedClasses) {
       excludedClass = excludedClass.trim();
       // remove the trailing *
@@ -31,10 +30,5 @@ public class UserExcludedClassesConfigurer implements IgnoredTypesConfigurer {
       }
       builder.ignoreClass(excludedClass);
     }
-  }
-
-  // TODO: remove after https://github.com/open-telemetry/opentelemetry-java/issues/4562 is fixed
-  private static String normalize(String key) {
-    return key.toLowerCase(Locale.ROOT).replace('-', '.');
   }
 }

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/ignore/UserExcludedClassesConfigurerTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/ignore/UserExcludedClassesConfigurerTest.java
@@ -40,9 +40,7 @@ class UserExcludedClassesConfigurerTest {
   @Test
   void shouldIgnoreClassesAndPackages() {
     // given
-    // TODO: remove normalization after
-    // https://github.com/open-telemetry/opentelemetry-java/issues/4562 is fixed
-    when(config.getList(EXCLUDED_CLASSES_CONFIG.replace('-', '.'), emptyList()))
+    when(config.getList(EXCLUDED_CLASSES_CONFIG, emptyList()))
         .thenReturn(
             asList("com.example.IgnoredClass", "com.example.ignored.*", "com.another_ignore"));
 


### PR DESCRIPTION
We don't need to normalize property names anymore after the last SDK update