### PR TITLE
InstrumentationConfig part 5: library logging appenders

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v2_17/Log4jHelper.java
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v2_17/Log4jHelper.java
@@ -5,10 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.log4j.appender.v2_17;
 
+import static java.util.Collections.emptyList;
+
 import io.opentelemetry.instrumentation.api.appender.internal.LogBuilder;
 import io.opentelemetry.instrumentation.log4j.appender.v2_17.internal.ContextDataAccessor;
 import io.opentelemetry.instrumentation.log4j.appender.v2_17.internal.LogEventMapper;
 import io.opentelemetry.javaagent.bootstrap.AgentLogEmitterProvider;
+import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
@@ -19,8 +23,32 @@ import org.apache.logging.log4j.message.Message;
 
 public final class Log4jHelper {
 
-  private static final LogEventMapper<Map<String, String>> mapper =
-      new LogEventMapper<>(ContextDataAccessorImpl.INSTANCE);
+  private static final LogEventMapper<Map<String, String>> mapper;
+
+  static {
+    InstrumentationConfig config = InstrumentationConfig.get();
+
+    boolean captureExperimentalAttributes =
+        config.getBoolean("otel.instrumentation.log4j-appender.experimental-log-attributes", false);
+    boolean captureMapMessageAttributes =
+        config.getBoolean(
+            "otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes",
+            false);
+    List<String> captureContextDataAttributes =
+        config.getList(
+            "otel.instrumentation.log4j-appender.experimental.capture-context-data-attributes",
+            emptyList());
+    boolean captureAllContextDataAttributes =
+        captureContextDataAttributes.size() == 1 && captureContextDataAttributes.get(0).equals("*");
+
+    mapper =
+        new LogEventMapper<>(
+            ContextDataAccessorImpl.INSTANCE,
+            captureExperimentalAttributes,
+            captureMapMessageAttributes,
+            captureContextDataAttributes,
+            captureAllContextDataAttributes);
+  }
 
   public static void capture(Logger logger, Level level, Message message, Throwable throwable) {
     String instrumentationName = logger.getName();

--- a/instrumentation/log4j/log4j-appender-2.17/library/build.gradle.kts
+++ b/instrumentation/log4j/log4j-appender-2.17/library/build.gradle.kts
@@ -12,9 +12,3 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-sdk-logs")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 }
-
-tasks.withType<Test>().configureEach {
-  // TODO run tests both with and without experimental log attributes
-  jvmArgs("-Dotel.instrumentation.log4j-appender.experimental.capture-map-message-attributes=true")
-  jvmArgs("-Dotel.instrumentation.log4j-appender.experimental.capture-context-data-attributes=*")
-}

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapper.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapper.java
@@ -5,15 +5,12 @@
 
 package io.opentelemetry.instrumentation.log4j.appender.v2_17.internal;
 
-import static java.util.Collections.emptyList;
-
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.appender.internal.LogBuilder;
 import io.opentelemetry.instrumentation.api.appender.internal.Severity;
-import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.io.PrintWriter;
@@ -33,48 +30,30 @@ public final class LogEventMapper<T> {
 
   private static final String SPECIAL_MAP_MESSAGE_ATTRIBUTE = "message";
 
-  private static final boolean captureExperimentalAttributes =
-      Config.get()
-          .getBoolean("otel.instrumentation.log4j-appender.experimental-log-attributes", false);
-
   private static final Cache<String, AttributeKey<String>> contextDataAttributeKeyCache =
       Cache.bounded(100);
   private static final Cache<String, AttributeKey<String>> mapMessageAttributeKeyCache =
       Cache.bounded(100);
 
-  private final boolean captureMapMessageAttributes;
-
-  private final List<String> captureContextDataAttributes;
-
-  // cached as an optimization
-  private final boolean captureAllContextDataAttributes;
-
   private final ContextDataAccessor<T> contextDataAccessor;
 
-  public LogEventMapper(ContextDataAccessor<T> contextDataAccessor) {
-    this(
-        contextDataAccessor,
-        Config.get()
-            .getBoolean(
-                "otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes",
-                false),
-        Config.get()
-            .getList(
-                "otel.instrumentation.log4j-appender.experimental.capture-context-data-attributes",
-                emptyList()));
-  }
+  private final boolean captureExperimentalAttributes;
+  private final boolean captureMapMessageAttributes;
+  private final List<String> captureContextDataAttributes;
+  private final boolean captureAllContextDataAttributes;
 
-  // visible for testing
-  LogEventMapper(
+  public LogEventMapper(
       ContextDataAccessor<T> contextDataAccessor,
+      boolean captureExperimentalAttributes,
       boolean captureMapMessageAttributes,
-      List<String> captureContextDataAttributes) {
+      List<String> captureContextDataAttributes,
+      boolean captureAllContextDataAttributes) {
 
     this.contextDataAccessor = contextDataAccessor;
+    this.captureExperimentalAttributes = captureExperimentalAttributes;
     this.captureMapMessageAttributes = captureMapMessageAttributes;
     this.captureContextDataAttributes = captureContextDataAttributes;
-    this.captureAllContextDataAttributes =
-        captureContextDataAttributes.size() == 1 && captureContextDataAttributes.get(0).equals("*");
+    this.captureAllContextDataAttributes = captureAllContextDataAttributes;
   }
 
   /**

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderConfigTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderConfigTest.java
@@ -53,8 +53,11 @@ class OpenTelemetryAppenderConfigTest {
             .addLogProcessor(SimpleLogProcessor.create(logExporter))
             .build();
 
-    OpenTelemetryAppender.resetSdkLogEmitterProviderForTest();
+    OpenTelemetryAppender.resetForTest();
     OpenTelemetryAppender.setSdkLogEmitterProvider(logEmitterProvider);
+    // TODO run tests both with and without experimental log attributes
+    OpenTelemetryAppender.setCaptureMapMessageAttributes(true);
+    OpenTelemetryAppender.setCaptureAllContextDataAttributes(true);
   }
 
   @BeforeEach

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapperTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapperTest.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 import org.apache.logging.log4j.message.StringMapMessage;
 import org.apache.logging.log4j.message.StructuredDataMessage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 class LogEventMapperTest {
 
@@ -32,7 +32,7 @@ class LogEventMapperTest {
   void testDefault() {
     // given
     LogEventMapper<Map<String, String>> mapper =
-        new LogEventMapper<>(ContextDataAccessorImpl.INSTANCE, false, emptyList());
+        new LogEventMapper<>(ContextDataAccessorImpl.INSTANCE, false, false, emptyList(), false);
     Map<String, String> contextData = new HashMap<>();
     contextData.put("key1", "value1");
     contextData.put("key2", "value2");
@@ -49,7 +49,8 @@ class LogEventMapperTest {
   void testSome() {
     // given
     LogEventMapper<Map<String, String>> mapper =
-        new LogEventMapper<>(ContextDataAccessorImpl.INSTANCE, false, singletonList("key2"));
+        new LogEventMapper<>(
+            ContextDataAccessorImpl.INSTANCE, false, false, singletonList("key2"), false);
     Map<String, String> contextData = new HashMap<>();
     contextData.put("key1", "value1");
     contextData.put("key2", "value2");
@@ -67,7 +68,8 @@ class LogEventMapperTest {
   void testAll() {
     // given
     LogEventMapper<Map<String, String>> mapper =
-        new LogEventMapper<>(ContextDataAccessorImpl.INSTANCE, false, singletonList("*"));
+        new LogEventMapper<>(
+            ContextDataAccessorImpl.INSTANCE, false, false, singletonList("key1"), true);
     Map<String, String> contextData = new HashMap<>();
     contextData.put("key1", "value1");
     contextData.put("key2", "value2");
@@ -87,7 +89,8 @@ class LogEventMapperTest {
   void testCaptureMapMessageDisabled() {
     // given
     LogEventMapper<Map<String, String>> mapper =
-        new LogEventMapper<>(ContextDataAccessorImpl.INSTANCE, false, singletonList("*"));
+        new LogEventMapper<>(
+            ContextDataAccessorImpl.INSTANCE, false, false, singletonList("key1"), true);
 
     StringMapMessage message = new StringMapMessage();
     message.put("key1", "value1");
@@ -108,7 +111,8 @@ class LogEventMapperTest {
   void testCaptureMapMessageWithSpecialAttribute() {
     // given
     LogEventMapper<Map<String, String>> mapper =
-        new LogEventMapper<>(ContextDataAccessorImpl.INSTANCE, true, singletonList("*"));
+        new LogEventMapper<>(
+            ContextDataAccessorImpl.INSTANCE, false, true, singletonList("key1"), true);
 
     StringMapMessage message = new StringMapMessage();
     message.put("key1", "value1");
@@ -129,7 +133,8 @@ class LogEventMapperTest {
   void testCaptureMapMessageWithoutSpecialAttribute() {
     // given
     LogEventMapper<Map<String, String>> mapper =
-        new LogEventMapper<>(ContextDataAccessorImpl.INSTANCE, true, singletonList("*"));
+        new LogEventMapper<>(
+            ContextDataAccessorImpl.INSTANCE, false, true, singletonList("key1"), true);
 
     StringMapMessage message = new StringMapMessage();
     message.put("key1", "value1");
@@ -153,7 +158,8 @@ class LogEventMapperTest {
   void testCaptureStructuredDataMessage() {
     // given
     LogEventMapper<Map<String, String>> mapper =
-        new LogEventMapper<>(ContextDataAccessorImpl.INSTANCE, true, singletonList("*"));
+        new LogEventMapper<>(
+            ContextDataAccessorImpl.INSTANCE, false, true, singletonList("key1"), true);
 
     StructuredDataMessage message = new StructuredDataMessage("an id", "a message", "a type");
     message.put("key1", "value1");

--- a/instrumentation/logback/logback-appender-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/appender/v1_0/LogbackInstrumentation.java
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/appender/v1_0/LogbackInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.logback.appender.v1_0;
 
+import static io.opentelemetry.javaagent.instrumentation.logback.appender.v1_0.LogbackSingletons.mapper;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -13,7 +14,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import io.opentelemetry.instrumentation.api.appender.internal.LogEmitterProvider;
-import io.opentelemetry.instrumentation.logback.appender.v1_0.internal.LoggingEventMapper;
 import io.opentelemetry.javaagent.bootstrap.AgentLogEmitterProvider;
 import io.opentelemetry.javaagent.bootstrap.CallDepth;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
@@ -51,7 +51,7 @@ class LogbackInstrumentation implements TypeInstrumentation {
       // logging framework delegates to another
       callDepth = CallDepth.forClass(LogEmitterProvider.class);
       if (callDepth.getAndIncrement() == 0) {
-        LoggingEventMapper.INSTANCE.emit(AgentLogEmitterProvider.get(), event);
+        mapper().emit(AgentLogEmitterProvider.get(), event);
       }
     }
 

--- a/instrumentation/logback/logback-appender-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/appender/v1_0/LogbackSingletons.java
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/appender/v1_0/LogbackSingletons.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.logback.appender.v1_0;
+
+import static java.util.Collections.emptyList;
+
+import io.opentelemetry.instrumentation.logback.appender.v1_0.internal.LoggingEventMapper;
+import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
+import java.util.List;
+
+public class LogbackSingletons {
+
+  private static final LoggingEventMapper mapper;
+
+  static {
+    InstrumentationConfig config = InstrumentationConfig.get();
+
+    boolean captureExperimentalAttributes =
+        config.getBoolean(
+            "otel.instrumentation.logback-appender.experimental-log-attributes", false);
+    List<String> captureMdcAttributes =
+        config.getList(
+            "otel.instrumentation.logback-appender.experimental.capture-mdc-attributes",
+            emptyList());
+    boolean captureAllMdcAttributes =
+        captureMdcAttributes.size() == 1 && captureMdcAttributes.get(0).equals("*");
+
+    mapper =
+        new LoggingEventMapper(
+            captureExperimentalAttributes, captureMdcAttributes, captureAllMdcAttributes);
+  }
+
+  public static LoggingEventMapper mapper() {
+    return mapper;
+  }
+}

--- a/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/library/build.gradle.kts
@@ -11,8 +11,3 @@ dependencies {
   testImplementation("io.opentelemetry:opentelemetry-sdk-logs")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 }
-
-tasks.withType<Test>().configureEach {
-  // TODO run tests both with and without experimental log attributes
-  jvmArgs("-Dotel.instrumentation.logback-appender.experimental.capture-mdc-attributes=*")
-}

--- a/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/OpenTelemetryAppender.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/OpenTelemetryAppender.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.logback.appender.v1_0;
 
+import static java.util.Collections.emptyList;
+
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import io.opentelemetry.instrumentation.api.appender.internal.LogEmitterProvider;
@@ -12,17 +14,45 @@ import io.opentelemetry.instrumentation.api.appender.internal.LogEmitterProvider
 import io.opentelemetry.instrumentation.logback.appender.v1_0.internal.LoggingEventMapper;
 import io.opentelemetry.instrumentation.sdk.appender.internal.DelegatingLogEmitterProvider;
 import io.opentelemetry.sdk.logs.SdkLogEmitterProvider;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.slf4j.MDC;
 
 public class OpenTelemetryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   private static final LogEmitterProviderHolder logEmitterProviderHolder =
       new LogEmitterProviderHolder();
 
+  private static volatile boolean captureExperimentalAttributes = false;
+  private static volatile List<String> captureMdcAttributes = emptyList();
+  private static volatile boolean captureAllMdcAttributes = false;
+
+  private final Object mapperLock = new Object();
+  // lazy initialized
+  private volatile LoggingEventMapper mapper;
+
   public OpenTelemetryAppender() {}
 
   @Override
   protected void append(ILoggingEvent event) {
-    LoggingEventMapper.INSTANCE.emit(logEmitterProviderHolder.get(), event);
+    mapper().emit(logEmitterProviderHolder.get(), event);
+  }
+
+  private LoggingEventMapper mapper() {
+    LoggingEventMapper m = mapper;
+    if (m == null) {
+      synchronized (mapperLock) {
+        m = mapper;
+        if (m == null) {
+          mapper =
+              m =
+                  new LoggingEventMapper(
+                      captureExperimentalAttributes, captureMdcAttributes, captureAllMdcAttributes);
+        }
+      }
+    }
+    return m;
   }
 
   /**
@@ -37,9 +67,46 @@ public class OpenTelemetryAppender extends UnsynchronizedAppenderBase<ILoggingEv
   }
 
   /**
+   * Sets whether experimental attributes should be set to logs. These attributes may be changed or
+   * removed in the future, so only enable this if you know you do not require attributes filled by
+   * this instrumentation to be stable across versions.
+   */
+  public static void setCaptureExperimentalAttributes(boolean captureExperimentalAttributes) {
+    OpenTelemetryAppender.captureExperimentalAttributes = captureExperimentalAttributes;
+  }
+
+  /** Configures the {@link MDC} attributes that will be copied to logs. */
+  public static void setCapturedMdcAttributes(Collection<String> captureMdcAttributes) {
+    OpenTelemetryAppender.captureMdcAttributes = new ArrayList<>(captureMdcAttributes);
+  }
+
+  /**
+   * Sets whether all log4j {@link MDC} attributes should be copied to logs. This setting overrides
+   * the attributes list set in {@link #setCapturedMdcAttributes(Collection)}.
+   */
+  public static void setCaptureAllMdcAttributes(boolean captureAllMdcAttributes) {
+    OpenTelemetryAppender.captureAllMdcAttributes = captureAllMdcAttributes;
+  }
+
+  /**
+   * Unsets the global {@link LogEmitterProvider} and the appender configuration. This is only meant
+   * to be used from tests which need to reconfigure the appender.
+   */
+  public static void resetForTest() {
+    logEmitterProviderHolder.resetForTest();
+
+    captureExperimentalAttributes = false;
+    captureMdcAttributes = emptyList();
+    captureAllMdcAttributes = false;
+  }
+
+  /**
    * Unsets the global {@link LogEmitterProvider}. This is only meant to be used from tests which
    * need to reconfigure {@link LogEmitterProvider}.
+   *
+   * @deprecated Use {@link #resetForTest()} instead.
    */
+  @Deprecated
   public static void resetSdkLogEmitterProviderForTest() {
     logEmitterProviderHolder.resetForTest();
   }

--- a/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/internal/LoggingEventMapper.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/appender/v1_0/internal/LoggingEventMapper.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.logback.appender.v1_0.internal;
 
-import static java.util.Collections.emptyList;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
@@ -17,7 +15,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.appender.internal.LogBuilder;
 import io.opentelemetry.instrumentation.api.appender.internal.LogEmitterProvider;
 import io.opentelemetry.instrumentation.api.appender.internal.Severity;
-import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.io.PrintWriter;
@@ -32,32 +29,19 @@ import java.util.concurrent.TimeUnit;
  */
 public final class LoggingEventMapper {
 
-  public static final LoggingEventMapper INSTANCE = new LoggingEventMapper();
-
-  private static final boolean captureExperimentalAttributes =
-      Config.get()
-          .getBoolean("otel.instrumentation.logback-appender.experimental-log-attributes", false);
-
   private static final Cache<String, AttributeKey<String>> mdcAttributeKeys = Cache.bounded(100);
 
+  private final boolean captureExperimentalAttributes;
   private final List<String> captureMdcAttributes;
-
-  // cached as an optimization
   private final boolean captureAllMdcAttributes;
 
-  private LoggingEventMapper() {
-    this(
-        Config.get()
-            .getList(
-                "otel.instrumentation.logback-appender.experimental.capture-mdc-attributes",
-                emptyList()));
-  }
-
-  // visible for testing
-  LoggingEventMapper(List<String> captureMdcAttributes) {
+  public LoggingEventMapper(
+      boolean captureExperimentalAttributes,
+      List<String> captureMdcAttributes,
+      boolean captureAllMdcAttributes) {
+    this.captureExperimentalAttributes = captureExperimentalAttributes;
     this.captureMdcAttributes = captureMdcAttributes;
-    this.captureAllMdcAttributes =
-        captureMdcAttributes.size() == 1 && captureMdcAttributes.get(0).equals("*");
+    this.captureAllMdcAttributes = captureAllMdcAttributes;
   }
 
   public void emit(LogEmitterProvider logEmitterProvider, ILoggingEvent event) {

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/OpenTelemetryAppenderConfigTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/OpenTelemetryAppenderConfigTest.java
@@ -52,8 +52,10 @@ class OpenTelemetryAppenderConfigTest {
             .addLogProcessor(SimpleLogProcessor.create(logExporter))
             .build();
 
-    OpenTelemetryAppender.resetSdkLogEmitterProviderForTest();
+    OpenTelemetryAppender.resetForTest();
     OpenTelemetryAppender.setSdkLogEmitterProvider(logEmitterProvider);
+    // TODO run tests both with and without experimental log attributes
+    OpenTelemetryAppender.setCaptureAllMdcAttributes(true);
   }
 
   @BeforeEach

--- a/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/internal/LoggingEventMapperTest.java
+++ b/instrumentation/logback/logback-appender-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/appender/v1_0/internal/LoggingEventMapperTest.java
@@ -22,7 +22,7 @@ class LoggingEventMapperTest {
   @Test
   void testDefault() {
     // given
-    LoggingEventMapper mapper = new LoggingEventMapper(emptyList());
+    LoggingEventMapper mapper = new LoggingEventMapper(false, emptyList(), false);
     Map<String, String> contextData = new HashMap<>();
     contextData.put("key1", "value1");
     contextData.put("key2", "value2");
@@ -38,7 +38,7 @@ class LoggingEventMapperTest {
   @Test
   void testSome() {
     // given
-    LoggingEventMapper mapper = new LoggingEventMapper(singletonList("key2"));
+    LoggingEventMapper mapper = new LoggingEventMapper(false, singletonList("key2"), false);
     Map<String, String> contextData = new HashMap<>();
     contextData.put("key1", "value1");
     contextData.put("key2", "value2");
@@ -55,7 +55,7 @@ class LoggingEventMapperTest {
   @Test
   void testAll() {
     // given
-    LoggingEventMapper mapper = new LoggingEventMapper(singletonList("*"));
+    LoggingEventMapper mapper = new LoggingEventMapper(false, singletonList("key1"), true);
     Map<String, String> contextData = new HashMap<>();
     contextData.put("key1", "value1");
     contextData.put("key2", "value2");


### PR DESCRIPTION
This one's a bit controversial, I removed config usages from library log appenders and introduced a programmatic configuration (setters) instead - which unfortunately resulted in some minor hackery around the mapper initialization. @trask  please take a look at this one.