### PR TITLE
Fix build failure on M1 mac

### DIFF
--- a/conventions/src/main/kotlin/otel.protobuf-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.protobuf-conventions.gradle.kts
@@ -10,6 +10,10 @@ protobuf {
   protoc {
     // The artifact spec for the Protobuf Compiler
     artifact = "com.google.protobuf:protoc:3.3.0"
+    if (osdetector.os == "osx") {
+      // Always use x86_64 version as ARM binary is not available
+      artifact += ":osx-x86_64"
+    }
   }
   plugins {
     id("grpc") {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6242
Use x86_64 binaries on arm mac too as suggested in https://github.com/grpc/grpc-java/issues/7690#issuecomment-760332746