### PR TITLE
Hikaricp: Avoid registering duplicate metrics

### DIFF
--- a/instrumentation/hikaricp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hikaricp/HikariPoolInstrumentation.java
+++ b/instrumentation/hikaricp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hikaricp/HikariPoolInstrumentation.java
@@ -44,8 +44,9 @@ public class HikariPoolInstrumentation implements TypeInstrumentation {
         throws Exception {
 
       if (existingMetricsTracker != null) {
-        // we call close on the existing metrics tracker so that our wrapper could unregister
-        // itself to avoid warnings about duplicate metrics
+        // we call close on the existing metrics tracker in case it's our wrapper, so that our wrapper
+        // will unregister itself and won't keep recording metrics which leads to warnings about
+        // duplicate metrics
         existingMetricsTracker.close();
       }
       userMetricsTracker = HikariSingletons.createMetricsTrackerFactory(userMetricsTracker);

--- a/instrumentation/hikaricp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hikaricp/HikariPoolInstrumentation.java
+++ b/instrumentation/hikaricp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hikaricp/HikariPoolInstrumentation.java
@@ -39,8 +39,15 @@ public class HikariPoolInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
-        @Advice.Argument(value = 0, readOnly = false) MetricsTrackerFactory userMetricsTracker) {
+        @Advice.Argument(value = 0, readOnly = false) MetricsTrackerFactory userMetricsTracker,
+        @Advice.FieldValue(value = "metricsTracker") AutoCloseable existingMetricsTracker)
+        throws Exception {
 
+      if (existingMetricsTracker != null) {
+        // we call close on the existing metrics tracker so that our wrapper could unregister
+        // itself to avoid warnings about duplicate metrics
+        existingMetricsTracker.close();
+      }
       userMetricsTracker = HikariSingletons.createMetricsTrackerFactory(userMetricsTracker);
     }
   }

--- a/instrumentation/hikaricp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hikaricp/HikariPoolInstrumentation.java
+++ b/instrumentation/hikaricp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hikaricp/HikariPoolInstrumentation.java
@@ -44,9 +44,9 @@ public class HikariPoolInstrumentation implements TypeInstrumentation {
         throws Exception {
 
       if (existingMetricsTracker != null) {
-        // we call close on the existing metrics tracker in case it's our wrapper, so that our wrapper
-        // will unregister itself and won't keep recording metrics which leads to warnings about
-        // duplicate metrics
+        // we call close on the existing metrics tracker in case it's our wrapper, so that our
+        // wrapper will unregister itself and won't keep recording metrics which leads to warnings
+        // about duplicate metrics
         existingMetricsTracker.close();
       }
       userMetricsTracker = HikariSingletons.createMetricsTrackerFactory(userMetricsTracker);


### PR DESCRIPTION
`setMetricsTrackerFactory` may be called multiple times which will cause us to report the same metrics multiple times which causes warnings
```
[otel.javaagent 2022-07-14 21:03:38:958 +0300] [Thread-0] WARN io.opentelemetry.sdk.metrics.internal.state.AsynchronousMetricStorage - Instrument db.client.connections.usage has recorded multiple values for the same attributes.
```
Such warnings can be seen for example when running spring petclinic.
Calling `close` as done in this pr is not completely safe as besides calling `close` on our wrapper it will call `close` on the underlying object for which it would not be called when running without the agent.