### PR TITLE
Fix gRPC latestDepTest failures

### DIFF
--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -1177,8 +1177,8 @@ public abstract class AbstractGrpcTest {
     BindableService greeter =
         new GreeterGrpc.GreeterImplBase() {
           @Override
-          public void sayHello(
-              Helloworld.Request req, StreamObserver<Helloworld.Response> responseObserver) {
+          public void sayMultipleHello(
+              Helloworld.Request request, StreamObserver<Helloworld.Response> responseObserver) {
             // Send a response but don't complete so client can fail itself
             responseObserver.onNext(Helloworld.Response.getDefaultInstance());
           }
@@ -1198,7 +1198,7 @@ public abstract class AbstractGrpcTest {
         .runWithSpan(
             "parent",
             () ->
-                client.sayHello(
+                client.sayMultipleHello(
                     Helloworld.Request.newBuilder().setName("test").build(),
                     new StreamObserver<Helloworld.Response>() {
                       @Override
@@ -1229,14 +1229,14 @@ public abstract class AbstractGrpcTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                     span ->
-                        span.hasName("example.Greeter/SayHello")
+                        span.hasName("example.Greeter/SayMultipleHello")
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasStatus(StatusData.error())
                             .hasAttributesSatisfyingExactly(
                                 equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
                                 equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
+                                equalTo(SemanticAttributes.RPC_METHOD, "SayMultipleHello"),
                                 equalTo(
                                     SemanticAttributes.NET_TRANSPORT,
                                     SemanticAttributes.NetTransportValues.IP_TCP),
@@ -1270,13 +1270,13 @@ public abstract class AbstractGrpcTest {
                                   span.hasException(thrown);
                                 }),
                     span ->
-                        span.hasName("example.Greeter/SayHello")
+                        span.hasName("example.Greeter/SayMultipleHello")
                             .hasKind(SpanKind.SERVER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
                                 equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
+                                equalTo(SemanticAttributes.RPC_METHOD, "SayMultipleHello"),
                                 equalTo(SemanticAttributes.NET_PEER_IP, "127.0.0.1"),
                                 // net.peer.name resolves to "127.0.0.1" on windows which is same as
                                 // net.peer.ip so then not captured

--- a/instrumentation/grpc-1.6/testing/src/main/proto/helloworld.proto
+++ b/instrumentation/grpc-1.6/testing/src/main/proto/helloworld.proto
@@ -6,6 +6,9 @@ service Greeter {
   rpc SayHello (Request) returns (Response) {
   }
 
+  rpc SayMultipleHello (Request) returns (stream Response) {
+  }
+
   rpc Conversation (stream Response) returns (stream Response) {
   }
 }


### PR DESCRIPTION
Fixes #6352 
Fixes #6354 

gRPC does not auto-flush when the server only sends 1 response anymore: https://github.com/grpc/grpc-java/blob/ed58a2c495672a3dec2dd301d707617cc4ea6316/core/src/main/java/io/grpc/internal/ServerCallImpl.java#L172