### PR TITLE
GC JVM runtime metrics proposal

### DIFF
--- a/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/Gc.java
+++ b/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/Gc.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.runtimemetrics;
+
+import com.sun.management.GarbageCollectionNotificationInfo;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import javax.management.Notification;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+
+public final class Gc {
+
+  // Visible for testing
+  static final Gc INSTANCE = new Gc();
+
+  private static final AttributeKey<String> GC_KEY = AttributeKey.stringKey("gc");
+  private static final AttributeKey<String> CAUSE_KEY = AttributeKey.stringKey("cause");
+  private static final AttributeKey<String> ACTION_KEY = AttributeKey.stringKey("action");
+
+  private static final NotificationFilter GC_FILTER =
+      notification ->
+          notification
+              .getType()
+              .equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION);
+
+  public static void registerObservers(OpenTelemetry openTelemetry) {
+    INSTANCE.registerObservers(openTelemetry, ManagementFactory.getGarbageCollectorMXBeans());
+  }
+
+  // Visible for testing
+  void registerObservers(OpenTelemetry openTelemetry, List<GarbageCollectorMXBean> gcBeans) {
+    Meter meter = openTelemetry.getMeter("io.opentelemetry.runtime-metrics");
+
+    LongHistogram gcTime =
+        meter
+            .histogramBuilder("process.runtime.jvm.gc.time")
+            .setDescription("Time spent performing JVM garbage collection actions")
+            .setUnit("ms")
+            .ofLongs()
+            .build();
+
+    for (GarbageCollectorMXBean gcBean : ManagementFactory.getGarbageCollectorMXBeans()) {
+      if (!(gcBean instanceof NotificationEmitter)) {
+        continue;
+      }
+      NotificationEmitter notificationEmitter = (NotificationEmitter) gcBean;
+      notificationEmitter.addNotificationListener(
+          new GcNotificationListener(gcTime), GC_FILTER, null);
+    }
+  }
+
+  private static final class GcNotificationListener implements NotificationListener {
+
+    private final LongHistogram gcTime;
+
+    private GcNotificationListener(LongHistogram gcTime) {
+      this.gcTime = gcTime;
+    }
+
+    @Override
+    public void handleNotification(Notification notification, Object handback) {
+      GarbageCollectionNotificationInfo notificationInfo =
+          GarbageCollectionNotificationInfo.from((CompositeData) notification.getUserData());
+      gcTime.record(
+          notificationInfo.getGcInfo().getDuration(),
+          Attributes.of(
+              GC_KEY,
+              notificationInfo.getGcName(),
+              CAUSE_KEY,
+              notificationInfo.getGcCause(),
+              ACTION_KEY,
+              notificationInfo.getGcAction()));
+    }
+  }
+
+  private Gc() {}
+}


### PR DESCRIPTION
Garbage collection is one of the important remaining items for the JVM runtime working group. Hoping we can make some progress async, and using this draft PR to collect feedback on a proposal.

The current GC prototype metrics follow the schema:

| Name | Unit | Unit UCUM | Instrument Type | Value Type | Attribute Key | Attribute Values  |
|--|---|---|---|---|---|---|
| runtime.jvm.gc.time | Milliseconds | `ms` | Counter | Int64 | gc | Name of garbage collector |
| runtime.jvm.gc.count | Collections | `{collections}` | Counter | Int64 | gc | Name of garbage collector |

This is ok, but we can do better by hooking into [garbage collection notifications](https://docs.oracle.com/javase/8/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html), which grants access to details of each garbage collection event. I propose collecting a single histogram with measurements representing the durations of individual gc events: 

| Name | Unit | Unit UCUM | Instrument Type | Value Type | Attribute Key | Attribute Values  |
|---|---|---|---|---|---|---|
| process.runtime.jvm.gc.time | Milliseconds | `ms`                                      | Histogram | Int64 | gc | Name of garbage collector |
| | | | | | cause | The cause of the collection |
| | | | | | action | The collection action performed |

Some of the types of analysis that are possible with the histogram include:
- Total time spent on garbage collection
- Count of garbage collection events
- Min, max, average, percentiles of garbage collection time events
- The attributes allow you to characterize gc time by the types of events and their cause. With a little prior knowledge you can analyze all gc spent concurrently vs stop the world. 

I've done some testing locally to try to better understand the series that are produced using the attributes described above when different garbage collectors are used. The list isn't exhaustive as my test setup surely didn't exercise all the things that can trigger different types of gc.

* G1 Garbage Collector (default for many jvms)
  * name: `G1 Young Generation`, action: `end of minor GC`, cause: `G1 Evacuation Pause`
  * name: `G1 Young Generation`, action: `end of minor GC`, cause: `G1 Prevention Collection`
  * name: `G1 Young Generation`, action: `end of minor GC`, cause: `Metadata GC Threshold`
  * name: `G1 Old Generation`, action: `end of major GC`, cause: `System.gc()`
* Serial Garbage Collector `-Xlog:gc -XX:+UseSerialGC`
  * name: `Copy`, action: `end of minor GC`, cause: `Allocation Failure`
  * name: `MarkSweepCompact`, action: `end of major GC`, cause: `Metadata GC Threshold`
  * name: `MarkSweepCompact`, action: `end of major GC`, cause: `System.gc()`
* Parallel Garbage Collector `-Xlog:gc -XX:+UseParallelGC`
  * name: `PS Scavenge`, action: `end of minor GC`, cause: `Allocation Failure`
  * name: `PS Scavenge`, action: `end of minor GC`, cause: `Metadata GC Threshold`
  * name: `PS Scavenge`, action: `end of minor GC`, cause: `System.gc()`
  * name: `PS MarkSweep`, action: `end of major GC`, cause: `Metadata GC Threshold`
  * name: `PS MarkSweep`, action: `end of major GC`, cause: `System.gc()`
* Z Garbage Collector `-Xlog:gc -XX:+UseZGC`
  * name: `ZGC Cycles`, action: `end of GC cycle`, cause: `Proactive`
  * name: `ZGC Cycles`, action: `end of GC cycle`, cause: `Warmup`
  * name: `ZGC Cycles`, action: `end of GC cycle`, cause: `System.gc()`
  * name: `ZGC Cycles`, action: `end of GC cycle`, cause: `Metadata GC Threshold`
  * name: `ZGC Pauses`, action: `end of GC pause`, cause: `Metadata GC Threshold`
  * name: `ZGC Pauses`, action: `end of GC pause`, cause: `Proactive`
  * name: `ZGC Pauses`, action: `end of GC pause`, cause: `System.gc()`
  * name: `ZGC Pauses`, action: `end of GC pause`, cause: `Warmup`
* Shenandoah `-Xlog:gc -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC`
  * name: `Shenandoah Cycles`, action: `end of GC cycle`, cause: `Concurrent GC`
  * name: `Shenandoah Cycles`, action: `end of GC cycle`, cause: `System.gc()`
  * name: `Shenandoah Pauses`, action: `end of GC pause`, cause: `Concurrent GC`
  * name: `Shenandoah Pauses`, action: `end of GC pause`, cause: `System.gc()`
* CMS Garbage Collector `-XX:+PrintGCDetails -XX:+UseParNewGC`
  * name: `ParNew`, action: `end of minor GC`, cause: `Allocation Failure`
  * name: `MarkSweepCompact`, action: `end of major GC`, cause: `System.gc`
  * name: `MarkSweepCompact`, action: `end of major GC`, cause: `Metadata GC Threshold`

I've punted on a couple of things that could provide additional value, but IMO aren't needed initially:

- Include an additional attribute indicating whether the collection was concurrent, stop the world, or unknown. Would make it simpler to build dashboards that show the time spent in stop the world collections.
- Include an additional metric capturing the size of memory before and after. The gc notification actions give access to [GcInfo](https://docs.oracle.com/javase/10/docs/api/com/sun/management/GcInfo.html#getMemoryUsageAfterGc()), which includes information about memory usage before and after collection. Could process this information and record measurements to an instrument (e.g. histogram) representing how much memory was reclaimed by the collection.  

Will hold off on a full PR until we reach some sort of consensus. Let me know what you think!