### PR TITLE
Rename newInstrumenter() into buildInstrumenter()

### DIFF
--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpRouteHolderTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpRouteHolderTest.java
@@ -23,7 +23,7 @@ class HttpRouteHolderTest {
     Instrumenter<String, Void> instrumenter =
         Instrumenter.<String, Void>builder(testing.getOpenTelemetry(), "test", s -> s)
             .addContextCustomizer(HttpRouteHolder.get())
-            .newInstrumenter();
+            .buildInstrumenter();
 
     Context context = instrumenter.start(Context.root(), "test");
 

--- a/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
+++ b/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
@@ -45,7 +45,7 @@ public class InstrumenterBenchmark {
               HttpClientAttributesExtractor.create(ConstantHttpAttributesGetter.INSTANCE))
           .addAttributesExtractor(
               NetServerAttributesExtractor.create(new ConstantNetAttributesGetter()))
-          .newInstrumenter();
+          .buildInstrumenter();
 
   @Benchmark
   public Context start() {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
@@ -183,9 +183,83 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
   /**
    * Returns a new {@link Instrumenter} which will create {@linkplain SpanKind#CLIENT client} spans
    * and inject context into requests.
+   *
+   * @deprecated Use {@link #buildClientInstrumenter(TextMapSetter)} instead.
    */
+  @Deprecated
   public Instrumenter<REQUEST, RESPONSE> newClientInstrumenter(TextMapSetter<REQUEST> setter) {
-    return newInstrumenter(
+    return buildInstrumenter(
+        InstrumenterConstructor.propagatingToDownstream(setter), SpanKindExtractor.alwaysClient());
+  }
+
+  /**
+   * Returns a new {@link Instrumenter} which will create {@linkplain SpanKind#SERVER server} spans
+   * and extract context from requests.
+   *
+   * @deprecated Use {@link #buildServerInstrumenter(TextMapGetter)} instead.
+   */
+  @Deprecated
+  public Instrumenter<REQUEST, RESPONSE> newServerInstrumenter(TextMapGetter<REQUEST> getter) {
+    return buildInstrumenter(
+        InstrumenterConstructor.propagatingFromUpstream(getter), SpanKindExtractor.alwaysServer());
+  }
+
+  /**
+   * Returns a new {@link Instrumenter} which will create {@linkplain SpanKind#PRODUCER producer}
+   * spans and inject context into requests.
+   *
+   * @deprecated Use {@link #buildProducerInstrumenter(TextMapSetter)} instead.
+   */
+  @Deprecated
+  public Instrumenter<REQUEST, RESPONSE> newProducerInstrumenter(TextMapSetter<REQUEST> setter) {
+    return buildInstrumenter(
+        InstrumenterConstructor.propagatingToDownstream(setter),
+        SpanKindExtractor.alwaysProducer());
+  }
+
+  /**
+   * Returns a new {@link Instrumenter} which will create {@linkplain SpanKind#CONSUMER consumer}
+   * spans and extract context from requests.
+   *
+   * @deprecated Use {@link #buildConsumerInstrumenter(TextMapGetter)} instead.
+   */
+  @Deprecated
+  public Instrumenter<REQUEST, RESPONSE> newConsumerInstrumenter(TextMapGetter<REQUEST> getter) {
+    return buildInstrumenter(
+        InstrumenterConstructor.propagatingFromUpstream(getter),
+        SpanKindExtractor.alwaysConsumer());
+  }
+
+  /**
+   * Returns a new {@link Instrumenter} which will create {@linkplain SpanKind#INTERNAL internal}
+   * spans and do no context propagation.
+   *
+   * @deprecated Use {@link #buildInstrumenter()} instead.
+   */
+  @Deprecated
+  public Instrumenter<REQUEST, RESPONSE> newInstrumenter() {
+    return buildInstrumenter(InstrumenterConstructor.internal(),
+        SpanKindExtractor.alwaysInternal());
+  }
+
+  /**
+   * Returns a new {@link Instrumenter} which will create spans with kind determined by the passed
+   * {@link SpanKindExtractor} and do no context propagation.
+   *
+   * @deprecated Use {@link #buildInstrumenter(SpanKindExtractor)} instead.
+   */
+  @Deprecated
+  public Instrumenter<REQUEST, RESPONSE> newInstrumenter(
+      SpanKindExtractor<? super REQUEST> spanKindExtractor) {
+    return buildInstrumenter(InstrumenterConstructor.internal(), spanKindExtractor);
+  }
+
+  /**
+   * Returns a new {@link Instrumenter} which will create {@linkplain SpanKind#CLIENT client} spans
+   * and inject context into requests.
+   */
+  public Instrumenter<REQUEST, RESPONSE> buildClientInstrumenter(TextMapSetter<REQUEST> setter) {
+    return buildInstrumenter(
         InstrumenterConstructor.propagatingToDownstream(setter), SpanKindExtractor.alwaysClient());
   }
 
@@ -193,8 +267,8 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
    * Returns a new {@link Instrumenter} which will create {@linkplain SpanKind#SERVER server} spans
    * and extract context from requests.
    */
-  public Instrumenter<REQUEST, RESPONSE> newServerInstrumenter(TextMapGetter<REQUEST> getter) {
-    return newInstrumenter(
+  public Instrumenter<REQUEST, RESPONSE> buildServerInstrumenter(TextMapGetter<REQUEST> getter) {
+    return buildInstrumenter(
         InstrumenterConstructor.propagatingFromUpstream(getter), SpanKindExtractor.alwaysServer());
   }
 
@@ -202,8 +276,8 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
    * Returns a new {@link Instrumenter} which will create {@linkplain SpanKind#PRODUCER producer}
    * spans and inject context into requests.
    */
-  public Instrumenter<REQUEST, RESPONSE> newProducerInstrumenter(TextMapSetter<REQUEST> setter) {
-    return newInstrumenter(
+  public Instrumenter<REQUEST, RESPONSE> buildProducerInstrumenter(TextMapSetter<REQUEST> setter) {
+    return buildInstrumenter(
         InstrumenterConstructor.propagatingToDownstream(setter),
         SpanKindExtractor.alwaysProducer());
   }
@@ -212,8 +286,8 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
    * Returns a new {@link Instrumenter} which will create {@linkplain SpanKind#CONSUMER consumer}
    * spans and extract context from requests.
    */
-  public Instrumenter<REQUEST, RESPONSE> newConsumerInstrumenter(TextMapGetter<REQUEST> getter) {
-    return newInstrumenter(
+  public Instrumenter<REQUEST, RESPONSE> buildConsumerInstrumenter(TextMapGetter<REQUEST> getter) {
+    return buildInstrumenter(
         InstrumenterConstructor.propagatingFromUpstream(getter),
         SpanKindExtractor.alwaysConsumer());
   }
@@ -222,20 +296,21 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
    * Returns a new {@link Instrumenter} which will create {@linkplain SpanKind#INTERNAL internal}
    * spans and do no context propagation.
    */
-  public Instrumenter<REQUEST, RESPONSE> newInstrumenter() {
-    return newInstrumenter(InstrumenterConstructor.internal(), SpanKindExtractor.alwaysInternal());
+  public Instrumenter<REQUEST, RESPONSE> buildInstrumenter() {
+    return buildInstrumenter(InstrumenterConstructor.internal(),
+        SpanKindExtractor.alwaysInternal());
   }
 
   /**
    * Returns a new {@link Instrumenter} which will create spans with kind determined by the passed
    * {@link SpanKindExtractor} and do no context propagation.
    */
-  public Instrumenter<REQUEST, RESPONSE> newInstrumenter(
+  public Instrumenter<REQUEST, RESPONSE> buildInstrumenter(
       SpanKindExtractor<? super REQUEST> spanKindExtractor) {
-    return newInstrumenter(InstrumenterConstructor.internal(), spanKindExtractor);
+    return buildInstrumenter(InstrumenterConstructor.internal(), spanKindExtractor);
   }
 
-  private Instrumenter<REQUEST, RESPONSE> newInstrumenter(
+  private Instrumenter<REQUEST, RESPONSE> buildInstrumenter(
       InstrumenterConstructor<REQUEST, RESPONSE> constructor,
       SpanKindExtractor<? super REQUEST> spanKindExtractor) {
     this.spanKindExtractor = spanKindExtractor;

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -156,7 +156,7 @@ class InstrumenterTest {
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
             .addSpanLinksExtractor(new LinksExtractor())
-            .newServerInstrumenter(new MapGetter());
+            .buildServerInstrumenter(new MapGetter());
 
     Context context = instrumenter.start(Context.root(), REQUEST);
     SpanContext spanContext = Span.fromContext(context).getSpanContext();
@@ -196,7 +196,7 @@ class InstrumenterTest {
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
-            .newServerInstrumenter(new MapGetter());
+            .buildServerInstrumenter(new MapGetter());
 
     Context context = instrumenter.start(Context.root(), REQUEST);
     assertThat(Span.fromContext(context).getSpanContext().isValid()).isTrue();
@@ -217,7 +217,7 @@ class InstrumenterTest {
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
-            .newServerInstrumenter(new MapGetter());
+            .buildServerInstrumenter(new MapGetter());
 
     Map<String, String> request = new HashMap<>(REQUEST);
     W3CTraceContextPropagator.getInstance()
@@ -258,7 +258,7 @@ class InstrumenterTest {
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
             .addSpanLinksExtractor(new LinksExtractor())
-            .newClientInstrumenter(Map::put);
+            .buildClientInstrumenter(Map::put);
 
     Map<String, String> request = new HashMap<>(REQUEST);
     Context context = instrumenter.start(Context.root(), request);
@@ -301,7 +301,7 @@ class InstrumenterTest {
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
-            .newClientInstrumenter(Map::put);
+            .buildClientInstrumenter(Map::put);
 
     Map<String, String> request = new HashMap<>(REQUEST);
     Context context = instrumenter.start(Context.root(), request);
@@ -326,7 +326,7 @@ class InstrumenterTest {
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
-            .newClientInstrumenter(Map::put);
+            .buildClientInstrumenter(Map::put);
 
     Context parent =
         Context.root()
@@ -383,7 +383,7 @@ class InstrumenterTest {
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addOperationListener(operationListener)
-            .newServerInstrumenter(new MapGetter());
+            .buildServerInstrumenter(new MapGetter());
 
     Context context = instrumenter.start(Context.root(), REQUEST);
     instrumenter.end(context, REQUEST, RESPONSE, null);
@@ -415,7 +415,7 @@ class InstrumenterTest {
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
             .addOperationMetrics(meter -> operationListener)
-            .newServerInstrumenter(new MapGetter());
+            .buildServerInstrumenter(new MapGetter());
 
     Context context = instrumenter.start(Context.root(), REQUEST);
     instrumenter.end(context, REQUEST, RESPONSE, null);
@@ -432,7 +432,7 @@ class InstrumenterTest {
                 otelTesting.getOpenTelemetry(), "test", request -> "test span")
             .addSpanLinksExtractor(
                 (spanLinks, parentContext, request) -> spanLinks.addLink(SpanContext.getInvalid()))
-            .newInstrumenter();
+            .buildInstrumenter();
 
     // when
     Context context = instrumenter.start(Context.root(), "request");
@@ -456,7 +456,7 @@ class InstrumenterTest {
                 otelTesting.getOpenTelemetry(), "test", request -> "test span")
             .addContextCustomizer(
                 (context, request, attributes) -> context.with(testKey, "testVal"))
-            .newInstrumenter();
+            .buildInstrumenter();
 
     // when
     Context context = instrumenter.start(Context.root(), "request");
@@ -471,7 +471,7 @@ class InstrumenterTest {
         Instrumenter.<String, String>builder(
                 otelTesting.getOpenTelemetry(), "test", request -> "test span")
             .setEnabled(false)
-            .newInstrumenter();
+            .buildInstrumenter();
 
     assertThat(instrumenter.shouldStart(Context.root(), "request")).isFalse();
   }
@@ -482,7 +482,7 @@ class InstrumenterTest {
         Instrumenter.builder(
             otelTesting.getOpenTelemetry(), "test-instrumentation", name -> "span");
 
-    Instrumenter<Map<String, String>, Map<String, String>> instrumenter = builder.newInstrumenter();
+    Instrumenter<Map<String, String>, Map<String, String>> instrumenter = builder.buildInstrumenter();
 
     Context context = instrumenter.start(Context.root(), Collections.emptyMap());
     assertThat(Span.fromContext(context)).isNotNull();
@@ -507,7 +507,7 @@ class InstrumenterTest {
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", name -> "span")
             .setInstrumentationVersion("1.0")
-            .newInstrumenter();
+            .buildInstrumenter();
 
     Context context = instrumenter.start(Context.root(), Collections.emptyMap());
     assertThat(Span.fromContext(context)).isNotNull();
@@ -532,7 +532,7 @@ class InstrumenterTest {
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", name -> "span")
             .setSchemaUrl("https://opentelemetry.io/schemas/1.0.0")
-            .newInstrumenter();
+            .buildInstrumenter();
 
     Context context = instrumenter.start(Context.root(), Collections.emptyMap());
     assertThat(Span.fromContext(context)).isNotNull();
@@ -564,7 +564,7 @@ class InstrumenterTest {
                 mockHttpClientAttributes,
                 mockNetClientAttributes,
                 mockDbClientAttributes)
-            .newInstrumenter();
+            .buildInstrumenter();
 
     Context context = instrumenter.start(Context.root(), REQUEST);
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientSingletons.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientSingletons.java
@@ -44,7 +44,7 @@ public class AkkaHttpClientSingletons {
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<HttpRequest, HttpResponse> instrumenter() {

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSingletons.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerSingletons.java
@@ -36,7 +36,7 @@ public class AkkaHttpServerSingletons {
                     .build())
             .addOperationMetrics(HttpServerMetrics.get())
             .addContextCustomizer(HttpRouteHolder.get())
-            .newServerInstrumenter(AkkaHttpServerHeaders.INSTANCE);
+            .buildServerInstrumenter(AkkaHttpServerHeaders.INSTANCE);
   }
 
   public static Instrumenter<HttpRequest, HttpResponse> instrumenter() {

--- a/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelSingletons.java
+++ b/instrumentation/apache-camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/CamelSingletons.java
@@ -74,7 +74,7 @@ public final class CamelSingletons {
     builder.addAttributesExtractor(attributesExtractor);
     builder.setSpanStatusExtractor(spanStatusExtractor);
 
-    INSTRUMENTER = builder.newInstrumenter(request -> request.getSpanKind());
+    INSTRUMENTER = builder.buildInstrumenter(request -> request.getSpanKind());
   }
 
   public static Instrumenter<CamelRequest, Void> instrumenter() {

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
@@ -82,7 +82,7 @@ public final class DubboTelemetryBuilder {
     }
 
     return new DubboTelemetry(
-        serverInstrumenterBuilder.newServerInstrumenter(DubboHeadersGetter.INSTANCE),
-        clientInstrumenterBuilder.newClientInstrumenter(DubboHeadersSetter.INSTANCE));
+        serverInstrumenterBuilder.buildServerInstrumenter(DubboHeadersGetter.INSTANCE),
+        clientInstrumenterBuilder.buildClientInstrumenter(DubboHeadersSetter.INSTANCE));
   }
 }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientSingletons.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientSingletons.java
@@ -43,7 +43,7 @@ public final class ApacheHttpAsyncClientSingletons {
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(HttpHeaderSetter.INSTANCE);
+            .buildClientInstrumenter(HttpHeaderSetter.INSTANCE);
   }
 
   public static Instrumenter<ApacheHttpClientRequest, HttpResponse> instrumenter() {

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientSingletons.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientSingletons.java
@@ -43,7 +43,7 @@ public final class ApacheHttpClientSingletons {
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(HttpHeaderSetter.INSTANCE);
+            .buildClientInstrumenter(HttpHeaderSetter.INSTANCE);
   }
 
   public static Instrumenter<HttpMethod, HttpMethod> instrumenter() {

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientSingletons.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientSingletons.java
@@ -43,7 +43,7 @@ public final class ApacheHttpClientSingletons {
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(HttpHeaderSetter.INSTANCE);
+            .buildClientInstrumenter(HttpHeaderSetter.INSTANCE);
   }
 
   public static Instrumenter<ApacheHttpClientRequest, HttpResponse> instrumenter() {

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTelemetryBuilder.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTelemetryBuilder.java
@@ -86,7 +86,7 @@ public final class ApacheHttpClientTelemetryBuilder {
             .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractors(additionalExtractors)
             // We manually inject because we need to inject internal requests for redirects.
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     return new ApacheHttpClientTelemetry(instrumenter, openTelemetry.getPropagators());
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientSingletons.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientSingletons.java
@@ -44,7 +44,7 @@ public final class ApacheHttpClientSingletons {
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(HttpHeaderSetter.INSTANCE);
+            .buildClientInstrumenter(HttpHeaderSetter.INSTANCE);
   }
 
   public static Instrumenter<HttpRequest, HttpResponse> instrumenter() {

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTelemetryBuilder.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaTelemetryBuilder.java
@@ -186,7 +186,7 @@ public final class ArmeriaTelemetryBuilder {
     }
 
     return new ArmeriaTelemetry(
-        clientInstrumenterBuilder.newClientInstrumenter(ClientRequestContextSetter.INSTANCE),
-        serverInstrumenterBuilder.newServerInstrumenter(RequestContextGetter.INSTANCE));
+        clientInstrumenterBuilder.buildClientInstrumenter(ClientRequestContextSetter.INSTANCE),
+        serverInstrumenterBuilder.buildServerInstrumenter(RequestContextGetter.INSTANCE));
   }
 }

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientSingletons.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientSingletons.java
@@ -44,7 +44,7 @@ public final class AsyncHttpClientSingletons {
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(HttpHeaderSetter.INSTANCE);
+            .buildClientInstrumenter(HttpHeaderSetter.INSTANCE);
   }
 
   public static Instrumenter<Request, Response> instrumenter() {

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientSingletons.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientSingletons.java
@@ -44,7 +44,7 @@ public final class AsyncHttpClientSingletons {
                     netAttributeGetter, CommonConfig.get().getPeerServiceMapping()))
             .addAttributesExtractor(new AsyncHttpClientAdditionalAttributesExtractor())
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(HttpHeaderSetter.INSTANCE);
+            .buildClientInstrumenter(HttpHeaderSetter.INSTANCE);
   }
 
   public static Instrumenter<RequestContext, Response> instrumenter() {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionInstrumenterFactory.java
@@ -24,7 +24,7 @@ public class AwsLambdaFunctionInstrumenterFactory {
                 "io.opentelemetry.aws-lambda-core-1.0",
                 AwsLambdaFunctionInstrumenterFactory::spanName)
             .addAttributesExtractors(new AwsLambdaFunctionAttributesExtractor())
-            .newInstrumenter(SpanKindExtractor.alwaysServer()));
+            .buildInstrumenter(SpanKindExtractor.alwaysServer()));
   }
 
   private static String spanName(AwsLambdaRequest input) {

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/AwsLambdaEventsInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/AwsLambdaEventsInstrumenterFactory.java
@@ -29,7 +29,7 @@ public class AwsLambdaEventsInstrumenterFactory {
             .addAttributesExtractors(
                 new AwsLambdaFunctionAttributesExtractor(),
                 new ApiGatewayProxyAttributesExtractor())
-            .newInstrumenter(SpanKindExtractor.alwaysServer()));
+            .buildInstrumenter(SpanKindExtractor.alwaysServer()));
   }
 
   private static String spanName(AwsLambdaRequest input) {

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/AwsLambdaSqsInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/AwsLambdaSqsInstrumenterFactory.java
@@ -24,7 +24,7 @@ public class AwsLambdaSqsInstrumenterFactory {
             AwsLambdaSqsInstrumenterFactory::spanName)
         .addAttributesExtractors(new SqsEventAttributesExtractor())
         .addSpanLinksExtractor(new SqsEventSpanLinksExtractor())
-        .newInstrumenter(SpanKindExtractor.alwaysConsumer());
+        .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 
   public static Instrumenter<SQSMessage, Void> forMessage(OpenTelemetry openTelemetry) {
@@ -34,7 +34,7 @@ public class AwsLambdaSqsInstrumenterFactory {
             message -> message.getEventSource() + " process")
         .addAttributesExtractors(new SqsMessageAttributesExtractor())
         .addSpanLinksExtractor(new SqsMessageSpanLinksExtractor())
-        .newInstrumenter(SpanKindExtractor.alwaysConsumer());
+        .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 
   private static String spanName(SQSEvent event) {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkInstrumenterFactory.java
@@ -68,7 +68,7 @@ final class AwsSdkInstrumenterFactory {
             captureExperimentalSpanAttributes
                 ? extendedAttributesExtractors
                 : defaultAttributesExtractors)
-        .newInstrumenter(kindExtractor);
+        .buildInstrumenter(kindExtractor);
   }
 
   private AwsSdkInstrumenterFactory() {}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkInstrumenterFactory.java
@@ -73,7 +73,7 @@ final class AwsSdkInstrumenterFactory {
             captureExperimentalSpanAttributes
                 ? extendedAttributesExtractors
                 : defaultAttributesExtractors)
-        .newInstrumenter(spanKindExtractor);
+        .buildInstrumenter(spanKindExtractor);
   }
 
   private static String spanName(ExecutionAttributes attributes) {

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
@@ -38,7 +38,7 @@ public final class CassandraSingletons {
                     .build())
             .addAttributesExtractor(
                 NetClientAttributesExtractor.create(new CassandraNetAttributesGetter()))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<CassandraRequest, ExecutionInfo> instrumenter() {

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSingletons.java
@@ -38,7 +38,7 @@ public final class CassandraSingletons {
             .addAttributesExtractor(
                 NetClientAttributesExtractor.create(new CassandraNetAttributesGetter()))
             .addAttributesExtractor(new CassandraAttributesExtractor())
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<CassandraRequest, ExecutionInfo> instrumenter() {

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSingletons.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSingletons.java
@@ -46,7 +46,7 @@ public final class CouchbaseSingletons {
       builder.addAttributesExtractor(new ExperimentalAttributesExtractor());
     }
 
-    INSTRUMENTER = builder.newInstrumenter(SpanKindExtractor.alwaysClient());
+    INSTRUMENTER = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<CouchbaseRequestInfo, Void> instrumenter() {

--- a/instrumentation/dropwizard/dropwizard-views-0.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/DropwizardSingletons.java
+++ b/instrumentation/dropwizard/dropwizard-views-0.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/dropwizardviews/DropwizardSingletons.java
@@ -18,7 +18,7 @@ public final class DropwizardSingletons {
       Instrumenter.<View, Void>builder(
               GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, DropwizardSingletons::spanName)
           .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-          .newInstrumenter();
+          .buildInstrumenter();
 
   private static String spanName(View view) {
     return "Render " + view.getTemplateName();

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestInstrumenterFactory.java
@@ -33,7 +33,7 @@ public final class ElasticsearchRestInstrumenterFactory {
         .addAttributesExtractor(
             PeerServiceAttributesExtractor.create(
                 netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
-        .newInstrumenter(SpanKindExtractor.alwaysClient());
+        .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private ElasticsearchRestInstrumenterFactory() {}

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportInstrumenterFactory.java
@@ -40,7 +40,7 @@ public final class ElasticsearchTransportInstrumenterFactory {
       instrumenterBuilder.addAttributesExtractor(experimentalAttributesExtractor);
     }
 
-    return instrumenterBuilder.newInstrumenter(SpanKindExtractor.alwaysClient());
+    return instrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private ElasticsearchTransportInstrumenterFactory() {}

--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/ExternalAnnotationSingletons.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extannotations/ExternalAnnotationSingletons.java
@@ -26,7 +26,7 @@ public final class ExternalAnnotationSingletons {
                 "io.opentelemetry.external-annotations",
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<ClassAndMethod, Void> instrumenter() {

--- a/instrumentation/finatra-2.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/finatra/FinatraSingletons.java
+++ b/instrumentation/finatra-2.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/finatra/FinatraSingletons.java
@@ -18,7 +18,7 @@ public final class FinatraSingletons {
   private static final Instrumenter<Class<?>, Void> INSTRUMENTER =
       Instrumenter.<Class<?>, Void>builder(
               GlobalOpenTelemetry.get(), "io.opentelemetry.finatra-2.9", ClassNames::simpleName)
-          .newInstrumenter();
+          .buildInstrumenter();
 
   public static Instrumenter<Class<?>, Void> instrumenter() {
     return INSTRUMENTER;

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeSingletons.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeSingletons.java
@@ -25,7 +25,7 @@ public final class GeodeSingletons {
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbClientAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<GeodeRequest, Void> instrumenter() {

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientSingletons.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientSingletons.java
@@ -44,7 +44,7 @@ public class GoogleHttpClientSingletons {
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(HttpHeaderSetter.INSTANCE);
+            .buildClientInstrumenter(HttpHeaderSetter.INSTANCE);
   }
 
   public static Instrumenter<HttpRequest, HttpResponse> instrumenter() {

--- a/instrumentation/grails-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grails/GrailsSingletons.java
+++ b/instrumentation/grails-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grails/GrailsSingletons.java
@@ -19,7 +19,7 @@ public final class GrailsSingletons {
         Instrumenter.<HandlerData, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, HandlerData::spanName)
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<HandlerData, Void> instrumenter() {

--- a/instrumentation/graphql-java-12.0/library/src/main/java/io/opentelemetry/instrumentation/graphql/GraphQLTelemetry.java
+++ b/instrumentation/graphql-java-12.0/library/src/main/java/io/opentelemetry/instrumentation/graphql/GraphQLTelemetry.java
@@ -52,7 +52,7 @@ public final class GraphQLTelemetry {
                 });
     builder.addAttributesExtractor(new GraphqlAttributesExtractor());
 
-    this.instrumenter = builder.newInstrumenter();
+    this.instrumenter = builder.buildInstrumenter();
     this.sanitizeQuery = sanitizeQuery;
   }
 

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlySingletons.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlySingletons.java
@@ -48,7 +48,7 @@ public final class GrizzlySingletons {
             .addContextCustomizer(
                 (context, httpRequestPacket, startAttributes) -> GrizzlyErrorHolder.init(context))
             .addContextCustomizer(HttpRouteHolder.get())
-            .newServerInstrumenter(HttpRequestHeadersGetter.INSTANCE);
+            .buildServerInstrumenter(HttpRequestHeadersGetter.INSTANCE);
   }
 
   public static Instrumenter<HttpRequestPacket, HttpResponsePacket> instrumenter() {

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -155,10 +155,10 @@ public final class GrpcTelemetryBuilder {
     }
 
     return new GrpcTelemetry(
-        serverInstrumenterBuilder.newServerInstrumenter(GrpcRequestGetter.INSTANCE),
+        serverInstrumenterBuilder.buildServerInstrumenter(GrpcRequestGetter.INSTANCE),
         // gRPC client interceptors require two phases, one to set up request and one to execute.
         // So we go ahead and inject manually in this instrumentation.
-        clientInstrumenterBuilder.newInstrumenter(SpanKindExtractor.alwaysClient()),
+        clientInstrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient()),
         openTelemetry.getPropagators(),
         captureExperimentalSpanAttributes);
   }

--- a/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/GwtSingletons.java
+++ b/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/GwtSingletons.java
@@ -31,7 +31,7 @@ public final class GwtSingletons {
             .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
             // TODO(anuraaga): This should be a server span, but we currently have no way to merge
             // with the HTTP instrumentation's server span.
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<Method, Void> instrumenter() {

--- a/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/HibernateInstrumenterFactory.java
+++ b/instrumentation/hibernate/hibernate-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/HibernateInstrumenterFactory.java
@@ -25,7 +25,7 @@ public final class HibernateInstrumenterFactory {
       instrumenterBuilder.addAttributesExtractor(new HibernateExperimentalAttributesExtractor());
     }
 
-    return instrumenterBuilder.newInstrumenter();
+    return instrumenterBuilder.buildInstrumenter();
   }
 
   private HibernateInstrumenterFactory() {}

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionSingletons.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionSingletons.java
@@ -44,7 +44,7 @@ public final class HttpUrlConnectionSingletons {
                 (context, httpRequestPacket, startAttributes) ->
                     GetOutputStreamContext.init(context))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(RequestPropertySetter.INSTANCE);
+            .buildClientInstrumenter(RequestPropertySetter.INSTANCE);
   }
 
   public static Instrumenter<HttpURLConnection, Integer> instrumenter() {

--- a/instrumentation/hystrix-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixSingletons.java
+++ b/instrumentation/hystrix-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixSingletons.java
@@ -26,7 +26,7 @@ public final class HystrixSingletons {
       builder.addAttributesExtractor(new ExperimentalAttributesExtractor());
     }
 
-    INSTRUMENTER = builder.newInstrumenter();
+    INSTRUMENTER = builder.buildInstrumenter();
   }
 
   public static Instrumenter<HystrixRequest, Void> instrumenter() {

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpClientSingletons.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpClientSingletons.java
@@ -44,7 +44,7 @@ public class JdkHttpClientSingletons {
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(SETTER);
+            .buildClientInstrumenter(SETTER);
   }
 
   public static Instrumenter<HttpRequest, HttpResponse<?>> instrumenter() {

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientSingletons.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientSingletons.java
@@ -42,7 +42,7 @@ public class JaxRsClientSingletons {
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(ClientRequestHeaderSetter.INSTANCE);
+            .buildClientInstrumenter(ClientRequestHeaderSetter.INSTANCE);
   }
 
   public static Instrumenter<ClientRequest, ClientResponse> instrumenter() {

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxrsSingletons.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxrsSingletons.java
@@ -32,7 +32,7 @@ public final class JaxrsSingletons {
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<HandlerData, Void> instrumenter() {

--- a/instrumentation/jaxrs/jaxrs-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/JaxrsInstrumenterFactory.java
+++ b/instrumentation/jaxrs/jaxrs-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/JaxrsInstrumenterFactory.java
@@ -22,7 +22,7 @@ public final class JaxrsInstrumenterFactory {
             CodeSpanNameExtractor.create(codeAttributesGetter))
         .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
         .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-        .newInstrumenter();
+        .buildInstrumenter();
   }
 
   private JaxrsInstrumenterFactory() {}

--- a/instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/axis2/Axis2Singletons.java
+++ b/instrumentation/jaxws/jaxws-2.0-axis2-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/axis2/Axis2Singletons.java
@@ -19,7 +19,7 @@ public class Axis2Singletons {
         Instrumenter.<Axis2Request, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, Axis2Request::spanName)
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<Axis2Request, Void> instrumenter() {

--- a/instrumentation/jaxws/jaxws-2.0-cxf-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cxf/CxfSingletons.java
+++ b/instrumentation/jaxws/jaxws-2.0-cxf-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cxf/CxfSingletons.java
@@ -19,7 +19,7 @@ public class CxfSingletons {
         Instrumenter.<CxfRequest, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, CxfRequest::spanName)
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<CxfRequest, Void> instrumenter() {

--- a/instrumentation/jaxws/jaxws-2.0-metro-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/metro/MetroSingletons.java
+++ b/instrumentation/jaxws/jaxws-2.0-metro-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/metro/MetroSingletons.java
@@ -19,7 +19,7 @@ public class MetroSingletons {
         Instrumenter.<MetroRequest, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, MetroRequest::spanName)
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<MetroRequest, Void> instrumenter() {

--- a/instrumentation/jaxws/jaxws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/common/JaxWsInstrumenterFactory.java
+++ b/instrumentation/jaxws/jaxws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/common/JaxWsInstrumenterFactory.java
@@ -22,7 +22,7 @@ public final class JaxWsInstrumenterFactory {
             CodeSpanNameExtractor.create(codeAttributesGetter))
         .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
         .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-        .newInstrumenter();
+        .buildInstrumenter();
   }
 
   private JaxWsInstrumenterFactory() {}

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcSingletons.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcSingletons.java
@@ -40,7 +40,7 @@ public final class JdbcSingletons {
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<DbRequest, Void> instrumenter() {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/DataSourceSingletons.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/DataSourceSingletons.java
@@ -29,7 +29,7 @@ public final class DataSourceSingletons {
                 INSTRUMENTATION_NAME,
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<DataSource, Void> instrumenter() {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcSingletons.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcSingletons.java
@@ -38,7 +38,7 @@ public final class JdbcSingletons {
                             "otel.instrumentation.common.db-statement-sanitizer.enabled", true))
                     .build())
             .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<DbRequest, Void> instrumenter() {

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisSingletons.java
@@ -33,7 +33,7 @@ public final class JedisSingletons {
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<JedisRequest, Void> instrumenter() {

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisSingletons.java
@@ -33,7 +33,7 @@ public final class JedisSingletons {
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<JedisRequest, Void> instrumenter() {

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
@@ -33,7 +33,7 @@ public final class JedisSingletons {
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<JedisRequest, Void> instrumenter() {

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientInstrumenterBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientInstrumenterBuilder.java
@@ -69,6 +69,6 @@ public final class JettyClientInstrumenterBuilder {
         .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
         .addAttributesExtractors(additionalExtractors)
         .addOperationMetrics(HttpClientMetrics.get())
-        .newClientInstrumenter(HttpHeaderSetter.INSTANCE);
+        .buildClientInstrumenter(HttpHeaderSetter.INSTANCE);
   }
 }

--- a/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
+++ b/instrumentation/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsSingletons.java
@@ -32,7 +32,7 @@ public final class JmsSingletons {
             INSTRUMENTATION_NAME,
             MessagingSpanNameExtractor.create(getter, operation))
         .addAttributesExtractor(MessagingAttributesExtractor.create(getter, operation))
-        .newProducerInstrumenter(MessagePropertySetter.INSTANCE);
+        .buildProducerInstrumenter(MessagePropertySetter.INSTANCE);
   }
 
   private static Instrumenter<MessageWithDestination, Void> buildConsumerInstrumenter() {
@@ -46,7 +46,7 @@ public final class JmsSingletons {
             MessagingSpanNameExtractor.create(getter, operation))
         .addAttributesExtractor(MessagingAttributesExtractor.create(getter, operation))
         .setEnabled(ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
-        .newInstrumenter(SpanKindExtractor.alwaysConsumer());
+        .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 
   private static Instrumenter<MessageWithDestination, Void> buildListenerInstrumenter() {
@@ -58,7 +58,7 @@ public final class JmsSingletons {
             INSTRUMENTATION_NAME,
             MessagingSpanNameExtractor.create(getter, operation))
         .addAttributesExtractor(MessagingAttributesExtractor.create(getter, operation))
-        .newConsumerInstrumenter(MessagePropertyGetter.INSTANCE);
+        .buildConsumerInstrumenter(MessagePropertyGetter.INSTANCE);
   }
 
   public static Instrumenter<MessageWithDestination, Void> producerInstrumenter() {

--- a/instrumentation/jsf/jsf-mojarra-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mojarra/MojarraSingletons.java
+++ b/instrumentation/jsf/jsf-mojarra-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mojarra/MojarraSingletons.java
@@ -22,7 +22,7 @@ public class MojarraSingletons {
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, JsfRequest::spanName)
             .setErrorCauseExtractor(new JsfErrorCauseExtractor())
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<JsfRequest, Void> instrumenter() {

--- a/instrumentation/jsf/jsf-myfaces-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/myfaces/MyFacesSingletons.java
+++ b/instrumentation/jsf/jsf-myfaces-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/myfaces/MyFacesSingletons.java
@@ -21,7 +21,7 @@ public class MyFacesSingletons {
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, JsfRequest::spanName)
             .setErrorCauseExtractor(new MyFacesErrorCauseExtractor())
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<JsfRequest, Void> instrumenter() {

--- a/instrumentation/jsp-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/HttpJspPageInstrumentationSingletons.java
+++ b/instrumentation/jsp-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/HttpJspPageInstrumentationSingletons.java
@@ -36,7 +36,7 @@ public class HttpJspPageInstrumentationSingletons {
                 "io.opentelemetry.jsp-2.3",
                 HttpJspPageInstrumentationSingletons::spanNameOnRender)
             .addAttributesExtractor(new RenderAttributesExtractor())
-            .newInstrumenter(SpanKindExtractor.alwaysInternal());
+            .buildInstrumenter(SpanKindExtractor.alwaysInternal());
   }
 
   private static String spanNameOnRender(HttpServletRequest req) {

--- a/instrumentation/jsp-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/JspCompilationContextInstrumentationSingletons.java
+++ b/instrumentation/jsp-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsp/JspCompilationContextInstrumentationSingletons.java
@@ -30,7 +30,7 @@ public class JspCompilationContextInstrumentationSingletons {
                 "io.opentelemetry.jsp-2.3",
                 JspCompilationContextInstrumentationSingletons::spanNameOnCompile)
             .addAttributesExtractor(new CompilationAttributesExtractor())
-            .newInstrumenter(SpanKindExtractor.alwaysInternal());
+            .buildInstrumenter(SpanKindExtractor.alwaysInternal());
   }
 
   public static String spanNameOnCompile(JspCompilationContext jspCompilationContext) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
@@ -78,7 +78,7 @@ public final class KafkaInstrumenterFactory {
         .addAttributesExtractors(extractors)
         .addAttributesExtractor(new KafkaProducerAdditionalAttributesExtractor())
         .setErrorCauseExtractor(errorCauseExtractor)
-        .newInstrumenter(SpanKindExtractor.alwaysProducer());
+        .buildInstrumenter(SpanKindExtractor.alwaysProducer());
   }
 
   public Instrumenter<ConsumerRecords<?, ?>, Void> createConsumerReceiveInstrumenter() {
@@ -92,7 +92,7 @@ public final class KafkaInstrumenterFactory {
         .addAttributesExtractor(MessagingAttributesExtractor.create(getter, operation))
         .setErrorCauseExtractor(errorCauseExtractor)
         .setEnabled(messagingReceiveInstrumentationEnabled)
-        .newInstrumenter(SpanKindExtractor.alwaysConsumer());
+        .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 
   public Instrumenter<ConsumerRecord<?, ?>, Void> createConsumerProcessInstrumenter() {
@@ -119,15 +119,15 @@ public final class KafkaInstrumenterFactory {
     }
 
     if (!propagationEnabled) {
-      return builder.newInstrumenter(SpanKindExtractor.alwaysConsumer());
+      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
     } else if (messagingReceiveInstrumentationEnabled) {
       builder.addSpanLinksExtractor(
           SpanLinksExtractor.extractFromRequest(
               openTelemetry.getPropagators().getTextMapPropagator(),
               KafkaConsumerRecordGetter.INSTANCE));
-      return builder.newInstrumenter(SpanKindExtractor.alwaysConsumer());
+      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
     } else {
-      return builder.newConsumerInstrumenter(KafkaConsumerRecordGetter.INSTANCE);
+      return builder.buildConsumerInstrumenter(KafkaConsumerRecordGetter.INSTANCE);
     }
   }
 
@@ -144,6 +144,6 @@ public final class KafkaInstrumenterFactory {
             new KafkaBatchProcessSpanLinksExtractor(
                 openTelemetry.getPropagators().getTextMapPropagator()))
         .setErrorCauseExtractor(errorCauseExtractor)
-        .newInstrumenter(SpanKindExtractor.alwaysConsumer());
+        .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 }

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorServerTracing.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorServerTracing.kt
@@ -109,7 +109,7 @@ class KtorServerTracing private constructor(
         addContextCustomizer(HttpRouteHolder.get())
       }
 
-      val instrumenter = instrumenterBuilder.newServerInstrumenter(ApplicationRequestGetter)
+      val instrumenter = instrumenterBuilder.buildServerInstrumenter(ApplicationRequestGetter)
 
       val feature = KtorServerTracing(instrumenter)
 

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorServerTracing.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorServerTracing.kt
@@ -109,7 +109,7 @@ class KtorServerTracing private constructor(
         addContextCustomizer(HttpRouteHolder.get())
       }
 
-      val instrumenter = instrumenterBuilder.newServerInstrumenter(ApplicationRequestGetter)
+      val instrumenter = instrumenterBuilder.buildServerInstrumenter(ApplicationRequestGetter)
 
       val feature = KtorServerTracing(instrumenter)
 

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientSingletons.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesClientSingletons.java
@@ -54,7 +54,7 @@ public class KubernetesClientSingletons {
 
     // Initialize with .newInstrumenter(alwaysClient()) instead of .newClientInstrumenter(..)
     // because Request is immutable so context must be injected manually
-    INSTRUMENTER = instrumenterBuilder.newInstrumenter(alwaysClient());
+    INSTRUMENTER = instrumenterBuilder.buildInstrumenter(alwaysClient());
 
     CONTEXT_PROPAGATORS = GlobalOpenTelemetry.getPropagators();
   }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -36,7 +36,7 @@ public final class LettuceSingletons {
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     LettuceConnectNetAttributesGetter netAttributesGetter = new LettuceConnectNetAttributesGetter();
 
@@ -48,7 +48,7 @@ public final class LettuceSingletons {
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addAttributesExtractor(new LettuceConnectAttributesExtractor())
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<RedisCommand<?, ?, ?>, Void> instrumenter() {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
@@ -36,7 +36,7 @@ public final class LettuceSingletons {
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     LettuceConnectNetAttributesGetter connectNetAttributesGetter =
         new LettuceConnectNetAttributesGetter();
@@ -49,7 +49,7 @@ public final class LettuceSingletons {
                 PeerServiceAttributesExtractor.create(
                     connectNetAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addAttributesExtractor(new LettuceConnectAttributesExtractor())
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<RedisCommand<?, ?, ?>, Void> instrumenter() {

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherSingletons.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherSingletons.java
@@ -40,7 +40,7 @@ public final class LibertyDispatcherSingletons {
             .addAttributesExtractor(NetServerAttributesExtractor.create(netAttributesGetter))
             .addContextCustomizer(HttpRouteHolder.get())
             .addOperationMetrics(HttpServerMetrics.get())
-            .newServerInstrumenter(LibertyDispatcherRequestGetter.INSTANCE);
+            .buildServerInstrumenter(LibertyDispatcherRequestGetter.INSTANCE);
   }
 
   public static Instrumenter<LibertyRequest, LibertyResponse> instrumenter() {

--- a/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodSingletons.java
+++ b/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodSingletons.java
@@ -23,7 +23,7 @@ public final class MethodSingletons {
     INSTRUMENTER =
         Instrumenter.<ClassAndMethod, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, spanName)
-            .newInstrumenter(SpanKindExtractor.alwaysInternal());
+            .buildInstrumenter(SpanKindExtractor.alwaysInternal());
   }
 
   public static Instrumenter<ClassAndMethod, Void> instrumenter() {

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoInstrumenterFactory.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoInstrumenterFactory.java
@@ -33,6 +33,6 @@ class MongoInstrumenterFactory {
         .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
         .addAttributesExtractor(netAttributesExtractor)
         .addAttributesExtractor(attributesExtractor)
-        .newInstrumenter(SpanKindExtractor.alwaysClient());
+        .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyClientSingletons.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyClientSingletons.java
@@ -52,7 +52,7 @@ public final class NettyClientSingletons {
             .addOperationMetrics(HttpClientMetrics.get())
             .addContextCustomizer(
                 (context, requestAndChannel, startAttributes) -> NettyErrorHolder.init(context))
-            .newClientInstrumenter(HttpRequestHeadersSetter.INSTANCE);
+            .buildClientInstrumenter(HttpRequestHeadersSetter.INSTANCE);
 
     NettyConnectNetAttributesGetter nettyConnectAttributesGetter =
         new NettyConnectNetAttributesGetter();
@@ -66,7 +66,7 @@ public final class NettyClientSingletons {
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     nettyConnectAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<HttpRequestAndChannel, HttpResponse> instrumenter() {

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyServerSingletons.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyServerSingletons.java
@@ -43,7 +43,7 @@ final class NettyServerSingletons {
             .addContextCustomizer(
                 (context, requestAndChannel, startAttributes) -> NettyErrorHolder.init(context))
             .addContextCustomizer(HttpRouteHolder.get())
-            .newServerInstrumenter(NettyHeadersGetter.INSTANCE);
+            .buildServerInstrumenter(NettyHeadersGetter.INSTANCE);
   }
 
   public static Instrumenter<HttpRequestAndChannel, HttpResponse> instrumenter() {

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/client/NettyClientInstrumenterFactory.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/client/NettyClientInstrumenterFactory.java
@@ -55,7 +55,7 @@ public final class NettyClientInstrumenterFactory {
             PeerServiceAttributesExtractor.create(
                 netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
         .addOperationMetrics(HttpClientMetrics.get())
-        .newClientInstrumenter(HttpRequestHeadersSetter.INSTANCE);
+        .buildClientInstrumenter(HttpRequestHeadersSetter.INSTANCE);
   }
 
   public NettyConnectionInstrumenter createConnectionInstrumenter() {
@@ -80,7 +80,7 @@ public final class NettyClientInstrumenterFactory {
     }
 
     Instrumenter<NettyConnectionRequest, Channel> instrumenter =
-        instrumenterBuilder.newInstrumenter(
+        instrumenterBuilder.buildInstrumenter(
             connectionTelemetryEnabled
                 ? SpanKindExtractor.alwaysInternal()
                 : SpanKindExtractor.alwaysClient());
@@ -99,7 +99,7 @@ public final class NettyClientInstrumenterFactory {
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
-            .newInstrumenter(
+            .buildInstrumenter(
                 sslTelemetryEnabled
                     ? SpanKindExtractor.alwaysInternal()
                     : SpanKindExtractor.alwaysClient());

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/server/NettyServerInstrumenterFactory.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/server/NettyServerInstrumenterFactory.java
@@ -40,7 +40,7 @@ public final class NettyServerInstrumenterFactory {
         .addOperationMetrics(HttpServerMetrics.get())
         .addContextCustomizer((context, request, attributes) -> NettyErrorHolder.init(context))
         .addContextCustomizer(HttpRouteHolder.get())
-        .newServerInstrumenter(HttpRequestHeadersGetter.INSTANCE);
+        .buildServerInstrumenter(HttpRequestHeadersGetter.INSTANCE);
   }
 
   private NettyServerInstrumenterFactory() {}

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2Singletons.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2Singletons.java
@@ -49,7 +49,7 @@ public final class OkHttp2Singletons {
                 PeerServiceAttributesExtractor.create(
                     netClientAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
-            .newInstrumenter(alwaysClient());
+            .buildInstrumenter(alwaysClient());
 
     TRACING_INTERCEPTOR = new TracingInterceptor(INSTRUMENTER, openTelemetry.getPropagators());
   }

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetryBuilder.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetryBuilder.java
@@ -84,7 +84,7 @@ public final class OkHttpTelemetryBuilder {
             .addAttributesExtractor(NetClientAttributesExtractor.create(attributesGetter))
             .addAttributesExtractors(additionalExtractors)
             .addOperationMetrics(HttpClientMetrics.get())
-            .newInstrumenter(alwaysClient());
+            .buildInstrumenter(alwaysClient());
     return new OkHttpTelemetry(instrumenter, openTelemetry.getPropagators());
   }
 }

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/WithSpanSingletons.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/WithSpanSingletons.java
@@ -36,7 +36,7 @@ public final class WithSpanSingletons {
   private static Instrumenter<Method, Object> createInstrumenter() {
     return Instrumenter.builder(
             GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, WithSpanSingletons::spanNameFromMethod)
-        .newInstrumenter(WithSpanSingletons::spanKindFromMethod);
+        .buildInstrumenter(WithSpanSingletons::spanKindFromMethod);
   }
 
   private static Instrumenter<MethodRequest, Object> createInstrumenterWithAttributes() {
@@ -49,7 +49,7 @@ public final class WithSpanSingletons {
                 MethodRequest::method,
                 WithSpanParameterAttributeNamesExtractor.INSTANCE,
                 MethodRequest::args))
-        .newInstrumenter(WithSpanSingletons::spanKindFromMethodRequest);
+        .buildInstrumenter(WithSpanSingletons::spanKindFromMethodRequest);
   }
 
   private static SpanKind spanKindFromMethodRequest(MethodRequest request) {

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/WithSpanSingletons.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/WithSpanSingletons.java
@@ -36,7 +36,7 @@ public final class WithSpanSingletons {
   private static Instrumenter<Method, Object> createInstrumenter() {
     return Instrumenter.builder(
             GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, WithSpanSingletons::spanNameFromMethod)
-        .newInstrumenter(WithSpanSingletons::spanKindFromMethod);
+        .buildInstrumenter(WithSpanSingletons::spanKindFromMethod);
   }
 
   private static Instrumenter<MethodRequest, Object> createInstrumenterWithAttributes() {
@@ -49,7 +49,7 @@ public final class WithSpanSingletons {
                 MethodRequest::method,
                 WithSpanParameterAttributeNamesExtractor.INSTANCE,
                 MethodRequest::args))
-        .newInstrumenter(WithSpanSingletons::spanKindFromMethodRequest);
+        .buildInstrumenter(WithSpanSingletons::spanKindFromMethodRequest);
   }
 
   private static SpanKind spanKindFromMethodRequest(MethodRequest request) {

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
@@ -25,7 +25,7 @@ public final class AgentSpanTestingInstrumenter {
       Instrumenter.<String, Void>builder(GlobalOpenTelemetry.get(), "test", request -> request)
           .addContextCustomizer(
               (context, request, startAttributes) -> context.with(REQUEST_CONTEXT_KEY, request))
-          .newInstrumenter(SpanKindExtractor.alwaysInternal());
+          .buildInstrumenter(SpanKindExtractor.alwaysInternal());
 
   private static final Instrumenter<String, Void> HTTP_SERVER_INSTRUMENTER =
       Instrumenter.<String, Void>builder(GlobalOpenTelemetry.get(), "test", request -> request)
@@ -34,7 +34,7 @@ public final class AgentSpanTestingInstrumenter {
           .addContextCustomizer(HttpRouteHolder.get())
           .addContextCustomizer(
               (context, request, startAttributes) -> context.with(REQUEST_CONTEXT_KEY, request))
-          .newInstrumenter(SpanKindExtractor.alwaysServer());
+          .buildInstrumenter(SpanKindExtractor.alwaysServer());
 
   public static Context startHttpServerSpan(String name) {
     Context context = HTTP_SERVER_INSTRUMENTER.start(Context.current(), name);

--- a/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/Play24Singletons.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_4/Play24Singletons.java
@@ -19,7 +19,7 @@ public final class Play24Singletons {
   private static final Instrumenter<Void, Void> INSTRUMENTER =
       Instrumenter.<Void, Void>builder(
               GlobalOpenTelemetry.get(), "io.opentelemetry.play-mvc-2.4", s -> SPAN_NAME)
-          .newInstrumenter();
+          .buildInstrumenter();
 
   public static Instrumenter<Void, Void> instrumenter() {
     return INSTRUMENTER;

--- a/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/Play26Singletons.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/play/v2_6/Play26Singletons.java
@@ -25,7 +25,7 @@ public final class Play26Singletons {
   private static final Instrumenter<Void, Void> INSTRUMENTER =
       Instrumenter.<Void, Void>builder(
               GlobalOpenTelemetry.get(), "io.opentelemetry.play-mvc-2.6", s -> SPAN_NAME)
-          .newInstrumenter();
+          .buildInstrumenter();
 
   @Nullable private static final Method typedKeyGetUnderlying;
 

--- a/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientInstrumenterFactory.java
+++ b/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientInstrumenterFactory.java
@@ -38,7 +38,7 @@ public final class PlayWsClientInstrumenterFactory {
             PeerServiceAttributesExtractor.create(
                 netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
         .addOperationMetrics(HttpClientMetrics.get())
-        .newClientInstrumenter(HttpHeaderSetter.INSTANCE);
+        .buildClientInstrumenter(HttpHeaderSetter.INSTANCE);
   }
 
   private PlayWsClientInstrumenterFactory() {}

--- a/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzTelemetryBuilder.java
+++ b/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzTelemetryBuilder.java
@@ -50,6 +50,6 @@ public final class QuartzTelemetryBuilder {
         CodeAttributesExtractor.create(new QuartzCodeAttributesGetter()));
     instrumenter.addAttributesExtractors(additionalExtractors);
 
-    return new QuartzTelemetry(new TracingJobListener(instrumenter.newInstrumenter()));
+    return new QuartzTelemetry(new TracingJobListener(instrumenter.buildInstrumenter()));
   }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitSingletons.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitSingletons.java
@@ -55,7 +55,7 @@ public class RabbitSingletons {
                 RabbitChannelAttributesGetter.INSTANCE, MessageOperation.SEND))
         .addAttributesExtractor(
             NetClientAttributesExtractor.create(new RabbitChannelNetAttributesGetter()))
-        .newInstrumenter(
+        .buildInstrumenter(
             channelAndMethod ->
                 channelAndMethod.getMethod().equals("Channel.basicPublish") ? PRODUCER : CLIENT);
   }
@@ -73,7 +73,7 @@ public class RabbitSingletons {
     return Instrumenter.<ReceiveRequest, GetResponse>builder(
             GlobalOpenTelemetry.get(), instrumentationName, ReceiveRequest::spanName)
         .addAttributesExtractors(extractors)
-        .newInstrumenter(SpanKindExtractor.alwaysClient());
+        .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private static Instrumenter<DeliveryRequest, Void> createDeliverInstrumenter() {
@@ -89,6 +89,6 @@ public class RabbitSingletons {
     return Instrumenter.<DeliveryRequest, Void>builder(
             GlobalOpenTelemetry.get(), instrumentationName, DeliveryRequest::spanName)
         .addAttributesExtractors(extractors)
-        .newConsumerInstrumenter(DeliveryRequestGetter.INSTANCE);
+        .buildConsumerInstrumenter(DeliveryRequestGetter.INSTANCE);
   }
 }

--- a/instrumentation/ratpack/ratpack-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/RatpackSingletons.java
+++ b/instrumentation/ratpack/ratpack-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/RatpackSingletons.java
@@ -19,7 +19,7 @@ public final class RatpackSingletons {
   private static final Instrumenter<String, Void> INSTRUMENTER =
       Instrumenter.<String, Void>builder(
               GlobalOpenTelemetry.get(), "io.opentelemetry.ratpack-1.4", s -> s)
-          .newInstrumenter();
+          .buildInstrumenter();
 
   public static Instrumenter<String, Void> instrumenter() {
     return INSTRUMENTER;

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTelemetryBuilder.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackTelemetryBuilder.java
@@ -118,7 +118,7 @@ public final class RatpackTelemetryBuilder {
             .addAttributesExtractor(httpServerAttributesExtractorBuilder.build())
             .addAttributesExtractors(additionalExtractors)
             .addOperationMetrics(HttpServerMetrics.get())
-            .newServerInstrumenter(RatpackGetter.INSTANCE);
+            .buildServerInstrumenter(RatpackGetter.INSTANCE);
 
     return new RatpackTelemetry(instrumenter, httpClientInstrumenter());
   }
@@ -134,6 +134,6 @@ public final class RatpackTelemetryBuilder {
         .addAttributesExtractor(httpClientAttributesExtractorBuilder.build())
         .addAttributesExtractors(additionalHttpClientExtractors)
         .addOperationMetrics(HttpServerMetrics.get())
-        .newClientInstrumenter(RequestHeaderSetter.INSTANCE);
+        .buildClientInstrumenter(RequestHeaderSetter.INSTANCE);
   }
 }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettySingletons.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettySingletons.java
@@ -68,7 +68,7 @@ public final class ReactorNettySingletons {
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addOperationMetrics(HttpClientMetrics.get())
             // headers are injected in ResponseReceiverInstrumenter
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     NettyClientInstrumenterFactory instrumenterFactory =
         new NettyClientInstrumenterFactory(INSTRUMENTATION_NAME, connectionTelemetryEnabled, false);

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaSingletons.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaSingletons.java
@@ -27,7 +27,7 @@ public final class RediscalaSingletons {
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<RedisCommand<?, ?>, Void> instrumenter() {

--- a/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonInstrumenterFactory.java
+++ b/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonInstrumenterFactory.java
@@ -24,7 +24,7 @@ public final class RedissonInstrumenterFactory {
             DbClientSpanNameExtractor.create(dbAttributesGetter))
         .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
         .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
-        .newInstrumenter(SpanKindExtractor.alwaysClient());
+        .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private RedissonInstrumenterFactory() {}

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletTelemetryBuilder.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletTelemetryBuilder.java
@@ -83,7 +83,7 @@ public final class RestletTelemetryBuilder {
             .addAttributesExtractor(NetServerAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractors(additionalExtractors)
             .addOperationMetrics(HttpServerMetrics.get())
-            .newServerInstrumenter(RestletHeadersGetter.INSTANCE);
+            .buildServerInstrumenter(RestletHeadersGetter.INSTANCE);
 
     return new RestletTelemetry(instrumenter);
   }

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletInstrumenterFactory.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletInstrumenterFactory.java
@@ -40,6 +40,6 @@ public class RestletInstrumenterFactory {
         .addAttributesExtractor(NetServerAttributesExtractor.create(netAttributesGetter))
         .addAttributesExtractors(additionalExtractors)
         .addOperationMetrics(HttpServerMetrics.get())
-        .newServerInstrumenter(new RestletHeadersGetter());
+        .buildServerInstrumenter(new RestletHeadersGetter());
   }
 }

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientSingletons.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientSingletons.java
@@ -25,7 +25,7 @@ public final class RmiClientSingletons {
                 "io.opentelemetry.rmi",
                 RpcSpanNameExtractor.create(rpcAttributesGetter))
             .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<Method, Void> instrumenter() {

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerSingletons.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerSingletons.java
@@ -25,7 +25,7 @@ public final class RmiServerSingletons {
                 "io.opentelemetry.rmi",
                 RpcSpanNameExtractor.create(rpcAttributesGetter))
             .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
-            .newInstrumenter(SpanKindExtractor.alwaysServer());
+            .buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 
   public static Instrumenter<ClassAndMethod, Void> instrumenter() {

--- a/instrumentation/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmq/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmq/RocketMqInstrumenterFactory.java
@@ -44,9 +44,9 @@ class RocketMqInstrumenterFactory {
     }
 
     if (propagationEnabled) {
-      return instrumenterBuilder.newProducerInstrumenter(MapSetter.INSTANCE);
+      return instrumenterBuilder.buildProducerInstrumenter(MapSetter.INSTANCE);
     } else {
-      return instrumenterBuilder.newInstrumenter(SpanKindExtractor.alwaysProducer());
+      return instrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysProducer());
     }
   }
 
@@ -66,7 +66,7 @@ class RocketMqInstrumenterFactory {
             openTelemetry, captureExperimentalSpanAttributes, propagationEnabled, false),
         createProcessInstrumenter(
             openTelemetry, captureExperimentalSpanAttributes, propagationEnabled, true),
-        batchReceiveInstrumenterBuilder.newInstrumenter(SpanKindExtractor.alwaysConsumer()));
+        batchReceiveInstrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysConsumer()));
   }
 
   private static Instrumenter<MessageExt, Void> createProcessInstrumenter(
@@ -90,7 +90,7 @@ class RocketMqInstrumenterFactory {
     }
 
     if (!propagationEnabled) {
-      return builder.newInstrumenter(SpanKindExtractor.alwaysConsumer());
+      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
     }
 
     if (batch) {
@@ -101,9 +101,9 @@ class RocketMqInstrumenterFactory {
 
       return builder
           .addSpanLinksExtractor(spanLinksExtractor)
-          .newInstrumenter(SpanKindExtractor.alwaysConsumer());
+          .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
     } else {
-      return builder.newConsumerInstrumenter(TextMapExtractAdapter.INSTANCE);
+      return builder.buildConsumerInstrumenter(TextMapExtractAdapter.INSTANCE);
     }
   }
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletInstrumenterBuilder.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletInstrumenterBuilder.java
@@ -76,7 +76,7 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
         contextCustomizers) {
       builder.addContextCustomizer(contextCustomizer);
     }
-    return builder.newServerInstrumenter(new ServletRequestGetter<>(accessor));
+    return builder.buildServerInstrumenter(new ServletRequestGetter<>(accessor));
   }
 
   public Instrumenter<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>> build(

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/response/ResponseInstrumenterFactory.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/response/ResponseInstrumenterFactory.java
@@ -15,7 +15,7 @@ public final class ResponseInstrumenterFactory {
   public static Instrumenter<ClassAndMethod, Void> createInstrumenter(String instrumentationName) {
     return Instrumenter.<ClassAndMethod, Void>builder(
             GlobalOpenTelemetry.get(), instrumentationName, SpanNames::fromMethod)
-        .newInstrumenter();
+        .buildInstrumenter();
   }
 
   private ResponseInstrumenterFactory() {}

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/chunk/ChunkSingletons.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/chunk/ChunkSingletons.java
@@ -32,7 +32,7 @@ public class ChunkSingletons {
       instrumenterBuilder.addSpanLinksExtractor(ChunkSingletons::extractSpanLinks);
     }
 
-    INSTRUMENTER = instrumenterBuilder.newInstrumenter();
+    INSTRUMENTER = instrumenterBuilder.buildInstrumenter();
   }
 
   public static Instrumenter<ChunkContextAndBuilder, Void> chunkInstrumenter() {

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/item/ItemSingletons.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/item/ItemSingletons.java
@@ -22,7 +22,7 @@ public class ItemSingletons {
   private static final Instrumenter<String, Void> INSTRUMENTER =
       Instrumenter.<String, Void>builder(
               GlobalOpenTelemetry.get(), instrumentationName(), str -> str)
-          .newInstrumenter();
+          .buildInstrumenter();
 
   public static Instrumenter<String, Void> itemInstrumenter() {
     return INSTRUMENTER;

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/job/JobSingletons.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/job/JobSingletons.java
@@ -16,7 +16,7 @@ public class JobSingletons {
   private static final Instrumenter<JobExecution, Void> INSTRUMENTER =
       Instrumenter.<JobExecution, Void>builder(
               GlobalOpenTelemetry.get(), instrumentationName(), JobSingletons::extractSpanName)
-          .newInstrumenter();
+          .buildInstrumenter();
 
   private static String extractSpanName(JobExecution jobExecution) {
     return "BatchJob " + jobExecution.getJobInstance().getJobName();

--- a/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/step/StepSingletons.java
+++ b/instrumentation/spring/spring-batch-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/batch/step/StepSingletons.java
@@ -16,7 +16,7 @@ public class StepSingletons {
   private static final Instrumenter<StepExecution, Void> INSTRUMENTER =
       Instrumenter.<StepExecution, Void>builder(
               GlobalOpenTelemetry.get(), instrumentationName(), StepSingletons::spanName)
-          .newInstrumenter();
+          .buildInstrumenter();
 
   public static Instrumenter<StepExecution, Void> stepInstrumenter() {
     return INSTRUMENTER;

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/WithSpanAspect.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/WithSpanAspect.java
@@ -49,7 +49,7 @@ public class WithSpanAspect {
                     JoinPointRequest::method,
                     parameterAttributeNamesExtractor,
                     JoinPointRequest::args))
-            .newInstrumenter(WithSpanAspect::spanKind);
+            .buildInstrumenter(WithSpanAspect::spanKind);
   }
 
   private static String spanName(JoinPointRequest request) {

--- a/instrumentation/spring/spring-data-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataSingletons.java
+++ b/instrumentation/spring/spring-data-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/data/SpringDataSingletons.java
@@ -15,7 +15,7 @@ public final class SpringDataSingletons {
   private static final Instrumenter<ClassAndMethod, Void> INSTRUMENTER =
       Instrumenter.<ClassAndMethod, Void>builder(
               GlobalOpenTelemetry.get(), "io.opentelemetry.spring-data-1.8", SpanNames::fromMethod)
-          .newInstrumenter();
+          .buildInstrumenter();
 
   public static Instrumenter<ClassAndMethod, Void> instrumenter() {
     return INSTRUMENTER;

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/SpringIntegrationTelemetryBuilder.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/SpringIntegrationTelemetryBuilder.java
@@ -70,7 +70,7 @@ public final class SpringIntegrationTelemetryBuilder {
             .addAttributesExtractor(
                 MessagingAttributesExtractor.create(
                     SpringMessagingAttributesGetter.INSTANCE, MessageOperation.PROCESS))
-            .newConsumerInstrumenter(MessageHeadersGetter.INSTANCE);
+            .buildConsumerInstrumenter(MessageHeadersGetter.INSTANCE);
 
     Instrumenter<MessageWithChannel, Void> producerInstrumenter =
         Instrumenter.<MessageWithChannel, Void>builder(
@@ -81,7 +81,7 @@ public final class SpringIntegrationTelemetryBuilder {
             .addAttributesExtractor(
                 MessagingAttributesExtractor.create(
                     SpringMessagingAttributesGetter.INSTANCE, MessageOperation.SEND))
-            .newInstrumenter(SpanKindExtractor.alwaysProducer());
+            .buildInstrumenter(SpanKindExtractor.alwaysProducer());
     return new SpringIntegrationTelemetry(
         openTelemetry.getPropagators(),
         consumerInstrumenter,

--- a/instrumentation/spring/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/SpringJmsSingletons.java
+++ b/instrumentation/spring/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/SpringJmsSingletons.java
@@ -29,7 +29,7 @@ public final class SpringJmsSingletons {
             INSTRUMENTATION_NAME,
             MessagingSpanNameExtractor.create(getter, operation))
         .addAttributesExtractor(MessagingAttributesExtractor.create(getter, operation))
-        .newConsumerInstrumenter(MessagePropertyGetter.INSTANCE);
+        .buildConsumerInstrumenter(MessagePropertyGetter.INSTANCE);
   }
 
   public static Instrumenter<MessageWithDestination, Void> listenerInstrumenter() {

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/SpringRabbitSingletons.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/SpringRabbitSingletons.java
@@ -28,7 +28,7 @@ public final class SpringRabbitSingletons {
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(getter, operation))
             .addAttributesExtractor(MessagingAttributesExtractor.create(getter, operation))
-            .newConsumerInstrumenter(MessageHeaderGetter.INSTANCE);
+            .buildConsumerInstrumenter(MessageHeaderGetter.INSTANCE);
   }
 
   public static Instrumenter<Message, Void> instrumenter() {

--- a/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springrmi/SpringRmiSingletons.java
+++ b/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springrmi/SpringRmiSingletons.java
@@ -31,7 +31,7 @@ public final class SpringRmiSingletons {
             INSTRUMENTATION_NAME,
             RpcSpanNameExtractor.create(rpcAttributesGetter))
         .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter))
-        .newInstrumenter(SpanKindExtractor.alwaysClient());
+        .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private static Instrumenter<ClassAndMethod, Void> buildServerInstrumenter() {
@@ -42,7 +42,7 @@ public final class SpringRmiSingletons {
             INSTRUMENTATION_NAME,
             RpcSpanNameExtractor.create(rpcAttributesGetter))
         .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
-        .newInstrumenter(SpanKindExtractor.alwaysServer());
+        .buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 
   public static Instrumenter<Method, Void> clientInstrumenter() {

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingSingletons.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/SpringSchedulingSingletons.java
@@ -23,7 +23,7 @@ public final class SpringSchedulingSingletons {
                 "io.opentelemetry.spring-scheduling-3.1",
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<Runnable, Void> instrumenter() {

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebTelemetryBuilder.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebTelemetryBuilder.java
@@ -82,7 +82,7 @@ public final class SpringWebTelemetryBuilder {
             .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractors(additionalExtractors)
             .addOperationMetrics(HttpClientMetrics.get())
-            .newClientInstrumenter(HttpRequestSetter.INSTANCE);
+            .buildClientInstrumenter(HttpRequestSetter.INSTANCE);
 
     return new SpringWebTelemetry(instrumenter);
   }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/WebfluxSingletons.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/WebfluxSingletons.java
@@ -30,7 +30,7 @@ public final class WebfluxSingletons {
     }
 
     INSTRUMENTER =
-        builder.setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled()).newInstrumenter();
+        builder.setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled()).buildInstrumenter();
   }
 
   public static Instrumenter<Object, Void> instrumenter() {

--- a/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxTelemetryBuilder.java
@@ -106,7 +106,7 @@ public final class SpringWebfluxTelemetryBuilder {
 
     // headers are injected elsewhere; ClientRequest is immutable
     Instrumenter<ClientRequest, ClientResponse> instrumenter =
-        builder.newInstrumenter(alwaysClient());
+        builder.buildInstrumenter(alwaysClient());
 
     return new SpringWebfluxTelemetry(instrumenter, openTelemetry.getPropagators());
   }

--- a/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcSingletons.java
+++ b/instrumentation/spring/spring-webmvc-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springwebmvc/SpringWebMvcSingletons.java
@@ -22,7 +22,7 @@ public final class SpringWebMvcSingletons {
         Instrumenter.<Object, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, new HandlerSpanNameExtractor())
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
 
     MODEL_AND_VIEW_INSTRUMENTER =
         Instrumenter.<ModelAndView, Void>builder(
@@ -31,7 +31,7 @@ public final class SpringWebMvcSingletons {
                 new ModelAndViewSpanNameExtractor())
             .addAttributesExtractor(new ModelAndViewAttributesExtractor())
             .setEnabled(ExperimentalConfig.get().viewTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<Object, Void> handlerInstrumenter() {

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcTelemetryBuilder.java
@@ -87,7 +87,7 @@ public final class SpringWebMvcTelemetryBuilder {
             .addAttributesExtractors(additionalExtractors)
             .addOperationMetrics(HttpServerMetrics.get())
             .addContextCustomizer(HttpRouteHolder.get())
-            .newServerInstrumenter(JavaxHttpServletRequestGetter.INSTANCE);
+            .buildServerInstrumenter(JavaxHttpServletRequestGetter.INSTANCE);
 
     return new SpringWebMvcTelemetry(instrumenter);
   }

--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/SpringWsSingletons.java
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/SpringWsSingletons.java
@@ -26,7 +26,7 @@ public class SpringWsSingletons {
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<SpringWsRequest, Void> instrumenter() {

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SpymemcachedSingletons.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SpymemcachedSingletons.java
@@ -25,7 +25,7 @@ public final class SpymemcachedSingletons {
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   public static Instrumenter<SpymemcachedRequest, Object> instrumenter() {

--- a/instrumentation/struts-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/struts2/StrutsSingletons.java
+++ b/instrumentation/struts-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/struts2/StrutsSingletons.java
@@ -27,7 +27,7 @@ public class StrutsSingletons {
                 CodeSpanNameExtractor.create(codeAttributesGetter))
             .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<ActionInvocation, Void> instrumenter() {

--- a/instrumentation/tapestry-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tapestry/TapestrySingletons.java
+++ b/instrumentation/tapestry-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tapestry/TapestrySingletons.java
@@ -28,7 +28,7 @@ public class TapestrySingletons {
                   return ErrorCauseExtractor.jdk().extract(error);
                 })
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
   }
 
   public static Instrumenter<TapestryRequest, Void> instrumenter() {

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatInstrumenterFactory.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatInstrumenterFactory.java
@@ -49,6 +49,6 @@ public final class TomcatInstrumenterFactory {
                     .recordException()
                     .init(context))
         .addOperationMetrics(HttpServerMetrics.get())
-        .newServerInstrumenter(TomcatRequestGetter.INSTANCE);
+        .buildServerInstrumenter(TomcatRequestGetter.INSTANCE);
   }
 }

--- a/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioSingletons.java
+++ b/instrumentation/twilio-6.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/twilio/TwilioSingletons.java
@@ -30,7 +30,7 @@ public class TwilioSingletons {
       instrumenterBuilder.addAttributesExtractor(new TwilioExperimentalAttributesExtractor());
     }
 
-    INSTRUMENTER = instrumenterBuilder.newInstrumenter(alwaysClient());
+    INSTRUMENTER = instrumenterBuilder.buildInstrumenter(alwaysClient());
   }
 
   public static Instrumenter<String, Object> instrumenter() {

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowSingletons.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowSingletons.java
@@ -52,7 +52,7 @@ public final class UndertowSingletons {
                       .init(context);
                 })
             .addOperationMetrics(HttpServerMetrics.get())
-            .newServerInstrumenter(UndertowExchangeGetter.INSTANCE);
+            .buildServerInstrumenter(UndertowExchangeGetter.INSTANCE);
   }
 
   private static final UndertowHelper HELPER = new UndertowHelper(INSTRUMENTER);

--- a/instrumentation/vaadin-14.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vaadin/VaadinSingletons.java
+++ b/instrumentation/vaadin-14.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vaadin/VaadinSingletons.java
@@ -38,7 +38,7 @@ public class VaadinSingletons {
                 CodeSpanNameExtractor.create(clientCallableAttributesGetter))
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
             .addAttributesExtractor(CodeAttributesExtractor.create(clientCallableAttributesGetter))
-            .newInstrumenter();
+            .buildInstrumenter();
 
     REQUEST_HANDLER_INSTRUMENTER =
         Instrumenter.<VaadinHandlerRequest, Void>builder(
@@ -48,13 +48,13 @@ public class VaadinSingletons {
             .addContextCustomizer(
                 (context, vaadinHandlerRequest, startAttributes) ->
                     context.with(REQUEST_HANDLER_CONTEXT_KEY, Boolean.TRUE))
-            .newInstrumenter();
+            .buildInstrumenter();
 
     RPC_INSTRUMENTER =
         Instrumenter.<VaadinRpcRequest, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, VaadinSingletons::rpcSpanName)
             .setEnabled(ExperimentalConfig.get().controllerTelemetryEnabled())
-            .newInstrumenter();
+            .buildInstrumenter();
 
     SERVICE_INSTRUMENTER =
         Instrumenter.<VaadinServiceRequest, Void>builder(
@@ -64,7 +64,7 @@ public class VaadinSingletons {
             .addContextCustomizer(
                 (context, vaadinServiceRequest, startAttributes) ->
                     context.with(SERVICE_CONTEXT_KEY, new VaadinServiceContext()))
-            .newInstrumenter();
+            .buildInstrumenter();
 
     HELPER = new VaadinHelper(REQUEST_HANDLER_INSTRUMENTER, SERVICE_INSTRUMENTER);
   }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/client/VertxClientInstrumenterFactory.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/client/VertxClientInstrumenterFactory.java
@@ -49,7 +49,7 @@ public final class VertxClientInstrumenterFactory {
                   netAttributesGetter, CommonConfig.get().getPeerServiceMapping()));
     }
 
-    return builder.newClientInstrumenter(new HttpRequestHeaderSetter());
+    return builder.buildClientInstrumenter(new HttpRequestHeaderSetter());
   }
 
   private VertxClientInstrumenterFactory() {}

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
@@ -31,19 +31,19 @@ final class TestInstrumenters {
   TestInstrumenters(OpenTelemetry openTelemetry) {
     instrumenter =
         Instrumenter.<String, Void>builder(openTelemetry, "test", name -> name)
-            .newInstrumenter(SpanKindExtractor.alwaysInternal());
+            .buildInstrumenter(SpanKindExtractor.alwaysInternal());
     httpClientInstrumenter =
         Instrumenter.<String, Void>builder(openTelemetry, "test", name -> name)
             // cover both semconv and span-kind strategies
             .addAttributesExtractor(new SpanKeyAttributesExtractor(SpanKey.HTTP_CLIENT))
             .addAttributesExtractor(new SpanKeyAttributesExtractor(SpanKey.KIND_CLIENT))
-            .newInstrumenter(SpanKindExtractor.alwaysClient());
+            .buildInstrumenter(SpanKindExtractor.alwaysClient());
     httpServerInstrumenter =
         Instrumenter.<String, Void>builder(openTelemetry, "test", name -> name)
             // cover both semconv and span-kind strategies
             .addAttributesExtractor(new SpanKeyAttributesExtractor(SpanKey.HTTP_SERVER))
             .addAttributesExtractor(new SpanKeyAttributesExtractor(SpanKey.KIND_SERVER))
-            .newInstrumenter(SpanKindExtractor.alwaysServer());
+            .buildInstrumenter(SpanKindExtractor.alwaysServer());
   }
 
   /**


### PR DESCRIPTION
All OTel API/SDK builders use `build*()` for the terminal operation name, I figured that we should follow that convention too.