### PR TITLE
Bump Spring Boot version for autoconfigure and starters

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -110,7 +110,7 @@ val DEPENDENCIES = listOf(
   "org.spockframework:spock-junit4:2.2-M1-groovy-4.0",
   "org.scala-lang:scala-library:2.11.12",
   // Note that this is only referenced as "org.springframework.boot" in build files, not the artifact name.
-  "org.springframework.boot:spring-boot-dependencies:2.3.1.RELEASE"
+  "org.springframework.boot:spring-boot-dependencies:2.7.2"
 )
 
 javaPlatform {

--- a/instrumentation/spring/spring-jms-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms-2.0/javaagent/build.gradle.kts
@@ -42,8 +42,8 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:jms-1.1:javaagent"))
 
-  testImplementation("org.springframework.boot:spring-boot-starter-activemq:${versions["org.springframework.boot"]}")
-  testImplementation("org.springframework.boot:spring-boot-starter-test:${versions["org.springframework.boot"]}") {
+  testImplementation("org.springframework.boot:spring-boot-starter-activemq:2.5.3")
+  testImplementation("org.springframework.boot:spring-boot-starter-test:2.5.3") {
     exclude("org.junit.vintage", "junit-vintage-engine")
   }
 


### PR DESCRIPTION
I thought about this for a while, and I came to a conclusion that the spring-boot-autoconfigure module is not really a library instrumentation -- it's a tool that contains a collection of library instrumentations and applies them automagically to the instrumented application, not unlike the javaagent. "Usual" library instrumentations do not include the instrumented library, they only have a compile time reference; while the autoconfigure (and the starters) _includes_ Spring Boot and builds on top of it -- again, somewhat similar to how the javaagent includes ByteBuddy.
Since the starters are ready-made auto-instrumentation packages, I think it makes more sense to use the newest Spring Boot version for them. 