### PR TITLE
Deprecate uncompressed content length HTTP attributes

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
@@ -62,10 +62,6 @@ abstract class HttpCommonAttributesExtractor<
         attributes,
         SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH,
         getter.requestContentLength(request, response));
-    internalSet(
-        attributes,
-        SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
-        getter.requestContentLengthUncompressed(request, response));
 
     if (response != null) {
       Integer statusCode = getter.statusCode(request, response);
@@ -76,10 +72,6 @@ abstract class HttpCommonAttributesExtractor<
           attributes,
           SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,
           getter.responseContentLength(request, response));
-      internalSet(
-          attributes,
-          SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
-          getter.responseContentLengthUncompressed(request, response));
 
       for (String name : capturedResponseHeaders) {
         List<String> values = getter.responseHeader(request, response, name);

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesGetter.java
@@ -43,9 +43,14 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
    *
    * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, whether
    * {@code response} is {@code null} or not.
+   *
+   * @deprecated This method is deprecated and will be removed in the next release.
    */
+  @Deprecated
   @Nullable
-  Long requestContentLengthUncompressed(REQUEST request, @Nullable RESPONSE response);
+  default Long requestContentLengthUncompressed(REQUEST request, @Nullable RESPONSE response) {
+    throw new UnsupportedOperationException("This method is deprecated and will be removed");
+  }
 
   /**
    * Extracts the {@code http.status_code} span attribute.
@@ -70,9 +75,14 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
    *
    * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, only when
    * {@code response} is non-{@code null}.
+   *
+   * @deprecated This method is deprecated and will be removed in the next release.
    */
+  @Deprecated
   @Nullable
-  Long responseContentLengthUncompressed(REQUEST request, RESPONSE response);
+  default Long responseContentLengthUncompressed(REQUEST request, RESPONSE response) {
+    throw new UnsupportedOperationException("This method is deprecated and will be removed");
+  }
 
   /**
    * Extracts all values of header named {@code name} from the response, or an empty list if there

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -49,13 +49,6 @@ class HttpClientAttributesExtractorTest {
     }
 
     @Override
-    public Long requestContentLengthUncompressed(
-        Map<String, String> request, Map<String, String> response) {
-      String value = request.get("requestContentLengthUncompressed");
-      return value == null ? null : Long.parseLong(value);
-    }
-
-    @Override
     public Integer statusCode(Map<String, String> request, Map<String, String> response) {
       return Integer.parseInt(response.get("statusCode"));
     }
@@ -68,13 +61,6 @@ class HttpClientAttributesExtractorTest {
     @Override
     public Long responseContentLength(Map<String, String> request, Map<String, String> response) {
       String value = response.get("responseContentLength");
-      return value == null ? null : Long.parseLong(value);
-    }
-
-    @Override
-    public Long responseContentLengthUncompressed(
-        Map<String, String> request, Map<String, String> response) {
-      String value = response.get("responseContentLengthUncompressed");
       return value == null ? null : Long.parseLong(value);
     }
 
@@ -92,7 +78,6 @@ class HttpClientAttributesExtractorTest {
     request.put("method", "POST");
     request.put("url", "http://github.com");
     request.put("requestContentLength", "10");
-    request.put("requestContentLengthUncompressed", "11");
     request.put("flavor", "http/2");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.custom-request-header", "123,456");
@@ -100,7 +85,6 @@ class HttpClientAttributesExtractorTest {
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");
     response.put("responseContentLength", "20");
-    response.put("responseContentLengthUncompressed", "21");
     response.put("header.custom-response-header", "654,321");
 
     HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
@@ -130,11 +114,9 @@ class HttpClientAttributesExtractorTest {
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
-            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, 11L),
             entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
             entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
-            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, 21L),
             entry(
                 AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
                 asList("654", "321")));

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -65,13 +65,6 @@ class HttpServerAttributesExtractorTest {
     }
 
     @Override
-    public Long requestContentLengthUncompressed(
-        Map<String, String> request, Map<String, String> response) {
-      String value = request.get("requestContentLengthUncompressed");
-      return value == null ? null : Long.parseLong(value);
-    }
-
-    @Override
     public Integer statusCode(Map<String, String> request, Map<String, String> response) {
       String value = response.get("statusCode");
       return value == null ? null : Integer.parseInt(value);
@@ -85,13 +78,6 @@ class HttpServerAttributesExtractorTest {
     @Override
     public Long responseContentLength(Map<String, String> request, Map<String, String> response) {
       String value = response.get("responseContentLength");
-      return value == null ? null : Long.parseLong(value);
-    }
-
-    @Override
-    public Long responseContentLengthUncompressed(
-        Map<String, String> request, Map<String, String> response) {
-      String value = response.get("responseContentLengthUncompressed");
       return value == null ? null : Long.parseLong(value);
     }
 
@@ -111,7 +97,6 @@ class HttpServerAttributesExtractorTest {
     request.put("target", "/repositories/1");
     request.put("scheme", "http");
     request.put("requestContentLength", "10");
-    request.put("requestContentLengthUncompressed", "11");
     request.put("flavor", "http/2");
     request.put("route", "/repositories/{id}");
     request.put("serverName", "server");
@@ -123,7 +108,6 @@ class HttpServerAttributesExtractorTest {
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");
     response.put("responseContentLength", "20");
-    response.put("responseContentLengthUncompressed", "21");
     response.put("header.custom-response-header", "654,321");
 
     Function<Context, String> routeFromContext = ctx -> "/repositories/{repoId}";
@@ -168,11 +152,9 @@ class HttpServerAttributesExtractorTest {
                 asList("123", "456")),
             entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
-            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED, 11L),
             entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
             entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
-            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED, 21L),
             entry(
                 AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
                 asList("654", "321")));

--- a/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
+++ b/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
@@ -86,12 +86,6 @@ public class InstrumenterBenchmark {
     }
 
     @Override
-    @Nullable
-    public Long requestContentLengthUncompressed(Void unused, @Nullable Void unused2) {
-      return null;
-    }
-
-    @Override
     public String flavor(Void unused, @Nullable Void unused2) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
@@ -104,12 +98,6 @@ public class InstrumenterBenchmark {
     @Override
     public Long responseContentLength(Void unused, Void unused2) {
       return 100L;
-    }
-
-    @Override
-    @Nullable
-    public Long responseContentLengthUncompressed(Void unused, Void unused2) {
-      return null;
     }
 
     @Override

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientAttributesGetter.java
@@ -42,13 +42,6 @@ class AkkaHttpClientAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequest httpRequest, HttpResponse httpResponse) {
     return httpResponse.status().intValue();
   }
@@ -56,13 +49,6 @@ class AkkaHttpClientAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(HttpRequest httpRequest, HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
-      HttpRequest httpRequest, HttpResponse httpResponse) {
     return null;
   }
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
@@ -33,13 +33,6 @@ class AkkaHttpServerAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpRequest request, @Nullable HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequest request, HttpResponse httpResponse) {
     return httpResponse.status().intValue();
   }
@@ -47,12 +40,6 @@ class AkkaHttpServerAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(HttpRequest request, HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(HttpRequest request, HttpResponse httpResponse) {
     return null;
   }
 

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesGetter.java
@@ -40,13 +40,6 @@ final class ApacheHttpAsyncClientHttpAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(
-      ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public Integer statusCode(ApacheHttpClientRequest request, HttpResponse response) {
     StatusLine statusLine = response.getStatusLine();
     return statusLine != null ? statusLine.getStatusCode() : null;
@@ -61,13 +54,6 @@ final class ApacheHttpAsyncClientHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(ApacheHttpClientRequest request, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
-      ApacheHttpClientRequest request, HttpResponse response) {
     return null;
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
@@ -45,12 +45,6 @@ final class ApacheHttpClientHttpAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(HttpMethod request, @Nullable HttpMethod response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public Integer statusCode(HttpMethod request, HttpMethod response) {
     StatusLine statusLine = response.getStatusLine();
     return statusLine == null ? null : statusLine.getStatusCode();
@@ -70,12 +64,6 @@ final class ApacheHttpClientHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(HttpMethod request, HttpMethod response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(HttpMethod request, HttpMethod response) {
     return null;
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesGetter.java
@@ -38,13 +38,6 @@ final class ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(ApacheHttpClientRequest request, HttpResponse response) {
     return response.getStatusLine().getStatusCode();
   }
@@ -58,13 +51,6 @@ final class ApacheHttpClientHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(ApacheHttpClientRequest request, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
-      ApacheHttpClientRequest request, HttpResponse response) {
     return null;
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesGetter.java
@@ -40,13 +40,6 @@ enum ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(ApacheHttpClientRequest request, HttpResponse response) {
     return response.getStatusLine().getStatusCode();
   }
@@ -60,13 +53,6 @@ enum ApacheHttpClientHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(ApacheHttpClientRequest request, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
-      ApacheHttpClientRequest request, HttpResponse response) {
     return null;
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
@@ -75,13 +75,6 @@ final class ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequest request, HttpResponse response) {
     return response.getCode();
   }
@@ -115,12 +108,6 @@ final class ApacheHttpClientHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(HttpRequest request, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(HttpRequest request, HttpResponse response) {
     return null;
   }
 

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
@@ -45,13 +45,6 @@ enum ArmeriaHttpClientAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(
-      RequestContext ctx, @Nullable RequestLog requestLog) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public Integer statusCode(RequestContext ctx, RequestLog requestLog) {
     HttpStatus status = requestLog.responseHeaders().status();
     if (!status.equals(HttpStatus.UNKNOWN)) {
@@ -73,12 +66,6 @@ enum ArmeriaHttpClientAttributesGetter
   @Override
   public Long responseContentLength(RequestContext ctx, RequestLog requestLog) {
     return requestLog.responseLength();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(RequestContext ctx, RequestLog requestLog) {
-    return null;
   }
 
   @Override

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
@@ -52,13 +52,6 @@ enum ArmeriaHttpServerAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(
-      RequestContext ctx, @Nullable RequestLog requestLog) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public Integer statusCode(RequestContext ctx, RequestLog requestLog) {
     HttpStatus status = requestLog.responseHeaders().status();
     if (!status.equals(HttpStatus.UNKNOWN)) {
@@ -80,12 +73,6 @@ enum ArmeriaHttpServerAttributesGetter
   @Override
   public Long responseContentLength(RequestContext ctx, RequestLog requestLog) {
     return requestLog.responseLength();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(RequestContext ctx, RequestLog requestLog) {
-    return null;
   }
 
   @Override

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesGetter.java
@@ -38,12 +38,6 @@ final class AsyncHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request request, Response response) {
     return response.getStatusCode();
   }
@@ -56,12 +50,6 @@ final class AsyncHttpClientHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(Request request, Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
   }
 

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesGetter.java
@@ -48,13 +48,6 @@ final class AsyncHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      RequestContext requestContext, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(RequestContext requestContext, Response response) {
     return response.getStatusCode();
   }
@@ -75,12 +68,6 @@ final class AsyncHttpClientHttpAttributesGetter
         // ignore
       }
     }
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(RequestContext requestContext, Response response) {
     return null;
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkHttpAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkHttpAttributesGetter.java
@@ -46,12 +46,6 @@ class AwsSdkHttpAttributesGetter implements HttpClientAttributesGetter<Request<?
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(Request<?> request, @Nullable Response<?> response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request<?> request, Response<?> response) {
     return response.getHttpResponse().getStatusCode();
   }
@@ -59,12 +53,6 @@ class AwsSdkHttpAttributesGetter implements HttpClientAttributesGetter<Request<?
   @Override
   @Nullable
   public Long responseContentLength(Request<?> request, Response<?> response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(Request<?> request, Response<?> response) {
     return null;
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpAttributesGetter.java
@@ -54,13 +54,6 @@ class AwsSdkHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      ExecutionAttributes request, @Nullable SdkHttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(ExecutionAttributes request, SdkHttpResponse response) {
     return response.statusCode();
   }
@@ -68,13 +61,6 @@ class AwsSdkHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(
-      ExecutionAttributes request, @Nullable SdkHttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
       ExecutionAttributes request, @Nullable SdkHttpResponse response) {
     return null;
   }

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesGetter.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesGetter.java
@@ -38,13 +38,6 @@ final class GoogleHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Override
   public String flavor(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
@@ -57,13 +50,6 @@ final class GoogleHttpClientHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(HttpRequest httpRequest, HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
-      HttpRequest httpRequest, HttpResponse httpResponse) {
     return null;
   }
 

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
@@ -35,13 +35,6 @@ final class GrizzlyHttpAttributesGetter
     return null;
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLengthUncompressed(
-      HttpRequestPacket request, @Nullable HttpResponsePacket response) {
-    return null;
-  }
-
   @Override
   public Integer statusCode(HttpRequestPacket request, HttpResponsePacket response) {
     return response.getStatus();
@@ -50,13 +43,6 @@ final class GrizzlyHttpAttributesGetter
   @Nullable
   @Override
   public Long responseContentLength(HttpRequestPacket request, HttpResponsePacket response) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLengthUncompressed(
-      HttpRequestPacket request, HttpResponsePacket response) {
     return null;
   }
 

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesGetter.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesGetter.java
@@ -40,13 +40,6 @@ class HttpUrlHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpURLConnection connection, @Nullable Integer response) {
-    return null;
-  }
-
-  @Override
   public String flavor(HttpURLConnection connection, @Nullable Integer statusCode) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
@@ -59,12 +52,6 @@ class HttpUrlHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(HttpURLConnection connection, Integer statusCode) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(HttpURLConnection connection, Integer statusCode) {
     return null;
   }
 

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesGetter.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesGetter.java
@@ -38,13 +38,6 @@ class JdkHttpAttributesGetter implements HttpClientAttributesGetter<HttpRequest,
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpRequest httpRequest, @Nullable HttpResponse<?> httpResponse) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequest httpRequest, HttpResponse<?> httpResponse) {
     return httpResponse.statusCode();
   }
@@ -60,13 +53,6 @@ class JdkHttpAttributesGetter implements HttpClientAttributesGetter<HttpRequest,
   @Override
   @Nullable
   public Long responseContentLength(HttpRequest httpRequest, HttpResponse<?> httpResponse) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
-      HttpRequest httpRequest, HttpResponse<?> httpResponse) {
     return null;
   }
 

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesGetter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesGetter.java
@@ -50,13 +50,6 @@ final class JaxRsClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      ClientRequest httpRequest, @Nullable ClientResponse httpResponse) {
-    return null;
-  }
-
-  @Override
   public String flavor(ClientRequest httpRequest, @Nullable ClientResponse httpResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
@@ -71,13 +64,6 @@ final class JaxRsClientHttpAttributesGetter
   public Long responseContentLength(ClientRequest httpRequest, ClientResponse httpResponse) {
     int length = httpResponse.getLength();
     return length != -1 ? (long) length : null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
-      ClientRequest httpRequest, ClientResponse httpResponse) {
-    return null;
   }
 
   @Override

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
@@ -51,12 +51,6 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
   public String flavor(Request request, @Nullable Response response) {
 
     if (response == null) {
@@ -95,12 +89,6 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
       respContentLength = getLongFromJettyHttpField(requestContentLengthField);
     }
     return respContentLength;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(Request request, Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
@@ -27,19 +27,11 @@ internal enum class KtorHttpServerAttributesGetter :
     return null
   }
 
-  override fun requestContentLengthUncompressed(request: ApplicationRequest, response: ApplicationResponse?): Long? {
-    return null
-  }
-
   override fun statusCode(request: ApplicationRequest, response: ApplicationResponse): Int? {
     return response.status()?.value
   }
 
   override fun responseContentLength(request: ApplicationRequest, response: ApplicationResponse): Long? {
-    return null
-  }
-
-  override fun responseContentLengthUncompressed(request: ApplicationRequest, response: ApplicationResponse): Long? {
     return null
   }
 

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpServerAttributesGetter.kt
@@ -27,19 +27,11 @@ internal enum class KtorHttpServerAttributesGetter :
     return null
   }
 
-  override fun requestContentLengthUncompressed(request: ApplicationRequest, response: ApplicationResponse?): Long? {
-    return null
-  }
-
   override fun statusCode(request: ApplicationRequest, response: ApplicationResponse): Int? {
     return response.status()?.value
   }
 
   override fun responseContentLength(request: ApplicationRequest, response: ApplicationResponse): Long? {
-    return null
-  }
-
-  override fun responseContentLengthUncompressed(request: ApplicationRequest, response: ApplicationResponse): Long? {
     return null
   }
 

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesGetter.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesGetter.java
@@ -38,13 +38,6 @@ class KubernetesHttpAttributesGetter
     return null;
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLengthUncompressed(
-      Request request, @Nullable ApiResponse<?> apiResponse) {
-    return null;
-  }
-
   @Override
   public String flavor(Request request, @Nullable ApiResponse<?> apiResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
@@ -58,12 +51,6 @@ class KubernetesHttpAttributesGetter
   @Nullable
   @Override
   public Long responseContentLength(Request request, ApiResponse<?> apiResponse) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLengthUncompressed(Request request, ApiResponse<?> apiResponse) {
     return null;
   }
 

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
@@ -32,13 +32,6 @@ public class LibertyDispatcherHttpAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(
-      LibertyRequest libertyRequest, @Nullable LibertyResponse libertyResponse) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(LibertyRequest libertyRequest) {
     String flavor = libertyRequest.getProtocol();
     if (flavor != null) {
@@ -59,13 +52,6 @@ public class LibertyDispatcherHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(
-      LibertyRequest libertyRequest, LibertyResponse libertyResponse) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
       LibertyRequest libertyRequest, LibertyResponse libertyResponse) {
     return null;
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientAttributesGetter.java
@@ -66,13 +66,6 @@ final class NettyHttpClientAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return response.getStatus().getCode();
   }
@@ -80,13 +73,6 @@ final class NettyHttpClientAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(
-      HttpRequestAndChannel requestAndChannel, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
       HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return null;
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
@@ -34,13 +34,6 @@ final class NettyHttpServerAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return response.getStatus().getCode();
   }
@@ -48,13 +41,6 @@ final class NettyHttpServerAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(
-      HttpRequestAndChannel requestAndChannel, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
       HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return null;
   }

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/client/NettyHttpClientAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/client/NettyHttpClientAttributesGetter.java
@@ -66,13 +66,6 @@ final class NettyHttpClientAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return response.getStatus().code();
   }
@@ -80,13 +73,6 @@ final class NettyHttpClientAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(
-      HttpRequestAndChannel requestAndChannel, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
       HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return null;
   }

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/server/NettyHttpServerAttributesGetter.java
@@ -34,13 +34,6 @@ final class NettyHttpServerAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return response.getStatus().code();
   }
@@ -48,13 +41,6 @@ final class NettyHttpServerAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(
-      HttpRequestAndChannel requestAndChannel, HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
       HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return null;
   }

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesGetter.java
@@ -36,12 +36,6 @@ final class OkHttp2HttpAttributesGetter implements HttpClientAttributesGetter<Re
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request request, Response response) {
     return response.code();
   }
@@ -68,12 +62,6 @@ final class OkHttp2HttpAttributesGetter implements HttpClientAttributesGetter<Re
   @Override
   public Long responseContentLength(Request request, Response response) {
     return response.body().contentLength();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(Request request, Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesGetter.java
@@ -37,12 +37,6 @@ enum OkHttpAttributesGetter implements HttpClientAttributesGetter<Request, Respo
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
   @SuppressWarnings("UnnecessaryDefaultInEnumSwitch")
   @Nullable
   public String flavor(Request request, @Nullable Response response) {
@@ -72,12 +66,6 @@ enum OkHttpAttributesGetter implements HttpClientAttributesGetter<Request, Respo
   @Override
   @Nullable
   public Long responseContentLength(Request request, Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
   }
 

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
@@ -35,12 +35,6 @@ enum MockHttpServerAttributesGetter implements HttpServerAttributesGetter<String
 
   @Nullable
   @Override
-  public Long requestContentLengthUncompressed(String s, @Nullable Void unused) {
-    return null;
-  }
-
-  @Nullable
-  @Override
   public Integer statusCode(String s, Void unused) {
     return null;
   }
@@ -48,12 +42,6 @@ enum MockHttpServerAttributesGetter implements HttpServerAttributesGetter<String
   @Nullable
   @Override
   public Long responseContentLength(String s, Void unused) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLengthUncompressed(String s, Void unused) {
     return null;
   }
 

--- a/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesGetter.java
+++ b/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesGetter.java
@@ -37,12 +37,6 @@ final class PlayWsClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request request, Response response) {
     return response.getStatusCode();
   }
@@ -55,12 +49,6 @@ final class PlayWsClientHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(Request request, Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
   }
 

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesGetter.java
@@ -62,12 +62,6 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(Request request) {
     switch (request.getProtocol()) {
       case "HTTP/1.0":
@@ -96,12 +90,6 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   @Override
   @Nullable
   public Long responseContentLength(Request request, Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
   }
 

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpClientAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpClientAttributesGetter.java
@@ -44,13 +44,6 @@ enum RatpackHttpClientAttributesGetter
     return null;
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLengthUncompressed(
-      RequestSpec requestSpec, @Nullable HttpResponse httpResponse) {
-    return null;
-  }
-
   @Override
   public Integer statusCode(RequestSpec requestSpec, HttpResponse httpResponse) {
     return httpResponse.getStatusCode();
@@ -59,13 +52,6 @@ enum RatpackHttpClientAttributesGetter
   @Nullable
   @Override
   public Long responseContentLength(RequestSpec requestSpec, HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLengthUncompressed(
-      RequestSpec requestSpec, HttpResponse httpResponse) {
     return null;
   }
 

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
@@ -81,13 +81,6 @@ final class ReactorNettyHttpClientAttributesGetter
     return null;
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLengthUncompressed(
-      HttpClientConfig request, @Nullable HttpClientResponse response) {
-    return null;
-  }
-
   @Override
   public Integer statusCode(HttpClientConfig request, HttpClientResponse response) {
     return response.status().code();
@@ -96,13 +89,6 @@ final class ReactorNettyHttpClientAttributesGetter
   @Nullable
   @Override
   public Long responseContentLength(HttpClientConfig request, HttpClientResponse response) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLengthUncompressed(
-      HttpClientConfig request, HttpClientResponse response) {
     return null;
   }
 

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesGetter.java
@@ -65,12 +65,6 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(Request request) {
     String version = (String) request.getAttributes().get("org.restlet.http.version");
     switch (version) {
@@ -100,12 +94,6 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   @Override
   @Nullable
   public Long responseContentLength(Request request, Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
   }
 

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
@@ -67,12 +67,6 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(Request request) {
     switch (request.getProtocol().toString()) {
       case "HTTP/1.0":
@@ -101,12 +95,6 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
   @Override
   @Nullable
   public Long responseContentLength(Request request, Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(Request request, Response response) {
     return null;
   }
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
@@ -62,14 +62,6 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(
-      ServletRequestContext<REQUEST> requestContext,
-      @Nullable ServletResponseContext<RESPONSE> responseContext) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(ServletRequestContext<REQUEST> requestContext) {
     String flavor = accessor.getRequestProtocol(requestContext.request());
     if (flavor != null) {
@@ -112,14 +104,6 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
         // ignore
       }
     }
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
-      ServletRequestContext<REQUEST> requestContext,
-      ServletResponseContext<RESPONSE> responseContext) {
     return null;
   }
 

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebHttpAttributesGetter.java
@@ -44,13 +44,6 @@ enum SpringWebHttpAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpRequest httpRequest, @Nullable ClientHttpResponse clientHttpResponse) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(HttpRequest httpRequest, @Nullable ClientHttpResponse clientHttpResponse) {
     return null;
   }
@@ -67,13 +60,6 @@ enum SpringWebHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(
-      HttpRequest httpRequest, ClientHttpResponse clientHttpResponse) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
       HttpRequest httpRequest, ClientHttpResponse clientHttpResponse) {
     return null;
   }

--- a/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxHttpAttributesGetter.java
@@ -61,13 +61,6 @@ enum SpringWebfluxHttpAttributesGetter
     return null;
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLengthUncompressed(
-      ClientRequest request, @Nullable ClientResponse response) {
-    return null;
-  }
-
   @Override
   public Integer statusCode(ClientRequest request, ClientResponse response) {
     if (RAW_STATUS_CODE != null) {
@@ -86,12 +79,6 @@ enum SpringWebfluxHttpAttributesGetter
   @Nullable
   @Override
   public Long responseContentLength(ClientRequest request, ClientResponse response) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLengthUncompressed(ClientRequest request, ClientResponse response) {
     return null;
   }
 

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcHttpAttributesGetter.java
@@ -40,13 +40,6 @@ enum SpringWebMvcHttpAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpServletRequest request, @Nullable HttpServletResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(HttpServletRequest request) {
     return request.getProtocol();
   }
@@ -61,13 +54,6 @@ enum SpringWebMvcHttpAttributesGetter
   @Override
   @Nullable
   public Long responseContentLength(HttpServletRequest request, HttpServletResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
-      HttpServletRequest request, HttpServletResponse response) {
     return null;
   }
 

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
@@ -52,12 +52,6 @@ public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public Long requestContentLengthUncompressed(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(Request request) {
     String flavor = request.protocol().toString();
     if (flavor != null) {
@@ -80,12 +74,6 @@ public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Re
   public Long responseContentLength(Request request, Response response) {
     long contentLength = response.getContentLengthLong();
     return contentLength != -1 ? contentLength : null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(Request request, Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
@@ -35,13 +35,6 @@ public class UndertowHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLengthUncompressed(
-      HttpServerExchange exchange, @Nullable HttpServerExchange unused) {
-    return null;
-  }
-
-  @Override
   public String flavor(HttpServerExchange exchange) {
     String flavor = exchange.getProtocol().toString();
     // remove HTTP/ prefix to comply with semantic conventions
@@ -61,13 +54,6 @@ public class UndertowHttpAttributesGetter
   public Long responseContentLength(HttpServerExchange exchange, HttpServerExchange unused) {
     long responseContentLength = exchange.getResponseContentLength();
     return responseContentLength != -1 ? responseContentLength : null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLengthUncompressed(
-      HttpServerExchange exchange, HttpServerExchange unused) {
-    return null;
   }
 
   @Override

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/client/AbstractVertxHttpAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/client/AbstractVertxHttpAttributesGetter.java
@@ -32,13 +32,6 @@ public abstract class AbstractVertxHttpAttributesGetter
     return null;
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLengthUncompressed(
-      HttpClientRequest request, @Nullable HttpClientResponse response) {
-    return null;
-  }
-
   @Override
   public Integer statusCode(HttpClientRequest request, HttpClientResponse response) {
     return response.statusCode();
@@ -47,13 +40,6 @@ public abstract class AbstractVertxHttpAttributesGetter
   @Nullable
   @Override
   public Long responseContentLength(HttpClientRequest request, HttpClientResponse response) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLengthUncompressed(
-      HttpClientRequest request, HttpClientResponse response) {
     return null;
   }
 


### PR DESCRIPTION
Removed in spec https://github.com/open-telemetry/opentelemetry-specification/pull/2469