### PR TITLE
Hopefully fix wildfly smoke test on windows

### DIFF
--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
@@ -47,7 +47,8 @@ abstract class WildflyJdk8SmokeTest extends WildflySmokeTest {
     // https://github.com/openjdk/jdk8u/commit/d72d28967d732ba32e02178b828255378c5a8938
     // introduces a changes that causes wildfly to throw java.io.FileNotFoundException: Invalid file
     // path on windows
-    return Collections.singletonMap("JAVA_OPTS", "-Djdk.io.File.enableADS=true")
+    return Collections.singletonMap("JAVA_OPTS", "-Djdk.io.File.enableADS=true " +
+      "-Djava.net.preferIPv4Stack=true -Djava.awt.headless=true")
   }
 }
 

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
@@ -41,8 +41,18 @@ abstract class WildflySmokeTest extends AppServerTest {
   }
 }
 
+class WildflyJdk8SmokeTest extends WildflySmokeTest {
+  @Override
+  protected Map<String, String> getExtraEnv() {
+    // https://github.com/openjdk/jdk8u/commit/d72d28967d732ba32e02178b828255378c5a8938
+    // introduces a changes that causes wildfly to throw java.io.FileNotFoundException: Invalid file
+    // path on windows
+    return Collections.singletonMap("JAVA_OPTS", "-Djdk.io.File.enableADS=true")
+  }
+}
+
 @AppServer(version = "13.0.0.Final", jdk = "8")
-class Wildfly13Jdk8 extends WildflySmokeTest {
+class Wildfly13Jdk8 extends WildflyJdk8SmokeTest {
 }
 
 @AppServer(version = "13.0.0.Final", jdk = "8-openj9")
@@ -50,7 +60,7 @@ class Wildfly13Jdk8Openj9 extends WildflySmokeTest {
 }
 
 @AppServer(version = "17.0.1.Final", jdk = "8")
-class Wildfly17Jdk8 extends WildflySmokeTest {
+class Wildfly17Jdk8 extends WildflyJdk8SmokeTest {
 }
 
 @AppServer(version = "17.0.1.Final", jdk = "11")
@@ -71,7 +81,7 @@ class Wildfly17Jdk19 extends WildflySmokeTest {
 }
 
 @AppServer(version = "21.0.0.Final", jdk = "8")
-class Wildfly21Jdk8 extends WildflySmokeTest {
+class Wildfly21Jdk8 extends WildflyJdk8SmokeTest {
 }
 
 @AppServer(version = "21.0.0.Final", jdk = "11")
@@ -92,7 +102,7 @@ class Wildfly21Jdk19 extends WildflySmokeTest {
 }
 
 @AppServer(version = "25.0.1.Final", jdk = "8")
-class Wildfly25Jdk8 extends WildflySmokeTest {
+class Wildfly25Jdk8 extends WildflyJdk8SmokeTest {
 }
 
 @AppServer(version = "25.0.1.Final", jdk = "11")

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
@@ -41,7 +41,7 @@ abstract class WildflySmokeTest extends AppServerTest {
   }
 }
 
-class WildflyJdk8SmokeTest extends WildflySmokeTest {
+abstract class WildflyJdk8SmokeTest extends WildflySmokeTest {
   @Override
   protected Map<String, String> getExtraEnv() {
     // https://github.com/openjdk/jdk8u/commit/d72d28967d732ba32e02178b828255378c5a8938
@@ -73,7 +73,7 @@ class Wildfly17Jdk17 extends WildflySmokeTest {
 
 // TODO (trask) remove Java 18 test once Java 19 is GA
 @AppServer(version = "17.0.1.Final", jdk = "18")
-class Wildfly17Jdk18 extends WildflySmokeTest {
+class Wildfly17Jdk18 extends WildflyJdk8SmokeTest {
 }
 
 @AppServer(version = "17.0.1.Final", jdk = "19")
@@ -94,7 +94,7 @@ class Wildfly21Jdk17 extends WildflySmokeTest {
 
 // TODO (trask) remove Java 18 test once Java 19 is GA
 @AppServer(version = "21.0.0.Final", jdk = "18")
-class Wildfly21Jdk18 extends WildflySmokeTest {
+class Wildfly21Jdk18 extends WildflyJdk8SmokeTest {
 }
 
 @AppServer(version = "21.0.0.Final", jdk = "19")
@@ -115,7 +115,7 @@ class Wildfly25Jdk17 extends WildflySmokeTest {
 
 // TODO (trask) remove Java 18 test once Java 19 is GA
 @AppServer(version = "25.0.1.Final", jdk = "18")
-class Wildfly25Jdk18 extends WildflySmokeTest {
+class Wildfly25Jdk18 extends WildflyJdk8SmokeTest {
 }
 
 @AppServer(version = "25.0.1.Final", jdk = "19")


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6413
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6412
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6404
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6402
Looks like a jdk change makes wildfly smoke tests on windows fail. Currently I added a work around (`-Djdk.io.File.enableADS=true`) only to the configurations that failed, could consider always adding it.