### PR TITLE
Extract HTTP request & response content length from headers

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
@@ -42,9 +42,6 @@ abstract class HttpCommonAttributesExtractor<
     internalSet(attributes, SemanticAttributes.HTTP_METHOD, getter.method(request));
     internalSet(attributes, SemanticAttributes.HTTP_USER_AGENT, userAgent(request));
 
-    internalSet(
-        attributes, SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, requestContentLength(request));
-
     for (String name : capturedRequestHeaders) {
       List<String> values = getter.requestHeader(request, name);
       if (!values.isEmpty()) {
@@ -60,6 +57,9 @@ abstract class HttpCommonAttributesExtractor<
       REQUEST request,
       @Nullable RESPONSE response,
       @Nullable Throwable error) {
+
+    internalSet(
+        attributes, SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, requestContentLength(request));
 
     if (response != null) {
       Integer statusCode = getter.statusCode(request, response);

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesGetter.java
@@ -34,9 +34,15 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
    *
    * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, whether
    * {@code response} is {@code null} or not.
+   *
+   * @deprecated Request content length is now being calculated based on the request headers. This
+   *     method is deprecated and will be removed in the next release.
    */
+  @Deprecated
   @Nullable
-  Long requestContentLength(REQUEST request, @Nullable RESPONSE response);
+  default Long requestContentLength(REQUEST request, @Nullable RESPONSE response) {
+    throw new UnsupportedOperationException("This method is deprecated and will be removed");
+  }
 
   /**
    * Extracts the {@code http.request_content_length_uncompressed} span attribute.
@@ -66,9 +72,15 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
    *
    * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, only when
    * {@code response} is non-{@code null}.
+   *
+   * @deprecated Request content length is now being calculated based on the request headers. This
+   *     method is deprecated and will be removed in the next release.
    */
+  @Deprecated
   @Nullable
-  Long responseContentLength(REQUEST request, RESPONSE response);
+  default Long responseContentLength(REQUEST request, RESPONSE response) {
+    throw new UnsupportedOperationException("This method is deprecated and will be removed");
+  }
 
   /**
    * Extracts the {@code http.response_content_length_uncompressed} span attribute.

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -88,7 +88,6 @@ class HttpClientAttributesExtractorTest {
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_URL, "http://github.com"),
             entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
-            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")));

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -43,12 +43,6 @@ class HttpClientAttributesExtractorTest {
     }
 
     @Override
-    public Long requestContentLength(Map<String, String> request, Map<String, String> response) {
-      String value = request.get("requestContentLength");
-      return value == null ? null : Long.parseLong(value);
-    }
-
-    @Override
     public Integer statusCode(Map<String, String> request, Map<String, String> response) {
       return Integer.parseInt(response.get("statusCode"));
     }
@@ -56,12 +50,6 @@ class HttpClientAttributesExtractorTest {
     @Override
     public String flavor(Map<String, String> request, Map<String, String> response) {
       return request.get("flavor");
-    }
-
-    @Override
-    public Long responseContentLength(Map<String, String> request, Map<String, String> response) {
-      String value = response.get("responseContentLength");
-      return value == null ? null : Long.parseLong(value);
     }
 
     @Override
@@ -77,14 +65,14 @@ class HttpClientAttributesExtractorTest {
     Map<String, String> request = new HashMap<>();
     request.put("method", "POST");
     request.put("url", "http://github.com");
-    request.put("requestContentLength", "10");
+    request.put("header.content-length", "10");
     request.put("flavor", "http/2");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.custom-request-header", "123,456");
 
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");
-    response.put("responseContentLength", "20");
+    response.put("header.content-length", "20");
     response.put("header.custom-response-header", "654,321");
 
     HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
@@ -100,6 +88,7 @@ class HttpClientAttributesExtractorTest {
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_URL, "http://github.com"),
             entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
+            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")));

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -120,7 +120,6 @@ class HttpServerAttributesExtractorTest {
             entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
             entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
             entry(SemanticAttributes.HTTP_CLIENT_IP, "1.1.1.1"),
-            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")));

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -59,12 +59,6 @@ class HttpServerAttributesExtractorTest {
     }
 
     @Override
-    public Long requestContentLength(Map<String, String> request, Map<String, String> response) {
-      String value = request.get("requestContentLength");
-      return value == null ? null : Long.parseLong(value);
-    }
-
-    @Override
     public Integer statusCode(Map<String, String> request, Map<String, String> response) {
       String value = response.get("statusCode");
       return value == null ? null : Integer.parseInt(value);
@@ -73,12 +67,6 @@ class HttpServerAttributesExtractorTest {
     @Override
     public String flavor(Map<String, String> request) {
       return request.get("flavor");
-    }
-
-    @Override
-    public Long responseContentLength(Map<String, String> request, Map<String, String> response) {
-      String value = response.get("responseContentLength");
-      return value == null ? null : Long.parseLong(value);
     }
 
     @Override
@@ -96,7 +84,7 @@ class HttpServerAttributesExtractorTest {
     request.put("url", "http://github.com");
     request.put("target", "/repositories/1");
     request.put("scheme", "http");
-    request.put("requestContentLength", "10");
+    request.put("header.content-length", "10");
     request.put("flavor", "http/2");
     request.put("route", "/repositories/{id}");
     request.put("serverName", "server");
@@ -107,7 +95,7 @@ class HttpServerAttributesExtractorTest {
 
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");
-    response.put("responseContentLength", "20");
+    response.put("header.content-length", "20");
     response.put("header.custom-response-header", "654,321");
 
     Function<Context, String> routeFromContext = ctx -> "/repositories/{repoId}";
@@ -132,6 +120,7 @@ class HttpServerAttributesExtractorTest {
             entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
             entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
             entry(SemanticAttributes.HTTP_CLIENT_IP, "1.1.1.1"),
+            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")));
@@ -147,11 +136,11 @@ class HttpServerAttributesExtractorTest {
             entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{repoId}"),
             entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
             entry(SemanticAttributes.HTTP_CLIENT_IP, "1.1.1.1"),
+            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")),
             entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
-            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
             entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),

--- a/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
+++ b/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
@@ -81,11 +81,6 @@ public class InstrumenterBenchmark {
     }
 
     @Override
-    public Long requestContentLength(Void unused, @Nullable Void unused2) {
-      return 100L;
-    }
-
-    @Override
     public String flavor(Void unused, @Nullable Void unused2) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
@@ -93,11 +88,6 @@ public class InstrumenterBenchmark {
     @Override
     public Integer statusCode(Void unused, Void unused2) {
       return 200;
-    }
-
-    @Override
-    public Long responseContentLength(Void unused, Void unused2) {
-      return 100L;
     }
 
     @Override

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientAttributesGetter.java
@@ -36,20 +36,8 @@ class AkkaHttpClientAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequest httpRequest, HttpResponse httpResponse) {
     return httpResponse.status().intValue();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(HttpRequest httpRequest, HttpResponse httpResponse) {
-    return null;
   }
 
   @Override

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
@@ -27,20 +27,8 @@ class AkkaHttpServerAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(HttpRequest request, @Nullable HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequest request, HttpResponse httpResponse) {
     return httpResponse.status().intValue();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(HttpRequest request, HttpResponse httpResponse) {
-    return null;
   }
 
   @Override

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpan.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpan.groovy
@@ -34,7 +34,7 @@ class AwsSpan {
         "http.url" String
         "net.peer.name" String
         "net.transport" IP_TCP
-        "net.peer.port" { it == null || Number }
+        "net.peer.port" { it == null || it instanceof Number }
       }
     }
   }
@@ -60,9 +60,11 @@ class AwsSpan {
         "http.method" "POST"
         "http.status_code" 200
         "http.url" String
-        "http.user_agent" { it == null || String }
+        "http.user_agent" { it == null || it instanceof String }
+        "http.request_content_length" { it == null || it instanceof Long }
+        "http.response_content_length" { it == null || it instanceof Long }
         "net.peer.name" String
-        "net.peer.port" { it == null || Number }
+        "net.peer.port" { it == null || it instanceof Number }
         "net.transport" IP_TCP
       }
     }
@@ -88,7 +90,7 @@ class AwsSpan {
         "http.status_code" 200
         "http.url" String
         "net.peer.name" String
-        "net.peer.port" { it == null || Number }
+        "net.peer.port" { it == null || it instanceof Number }
         "net.transport" IP_TCP
       }
     }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesGetter.java
@@ -33,13 +33,6 @@ final class ApacheHttpAsyncClientHttpAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLength(
-      ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public Integer statusCode(ApacheHttpClientRequest request, HttpResponse response) {
     StatusLine statusLine = response.getStatusLine();
     return statusLine != null ? statusLine.getStatusCode() : null;
@@ -49,12 +42,6 @@ final class ApacheHttpAsyncClientHttpAttributesGetter
   @Nullable
   public String flavor(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getFlavor();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(ApacheHttpClientRequest request, HttpResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
@@ -39,12 +39,6 @@ final class ApacheHttpClientHttpAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLength(HttpMethod request, @Nullable HttpMethod response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public Integer statusCode(HttpMethod request, HttpMethod response) {
     StatusLine statusLine = response.getStatusLine();
     return statusLine == null ? null : statusLine.getStatusCode();
@@ -58,12 +52,6 @@ final class ApacheHttpClientHttpAttributesGetter
           ? SemanticAttributes.HttpFlavorValues.HTTP_1_1
           : SemanticAttributes.HttpFlavorValues.HTTP_1_0;
     }
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(HttpMethod request, HttpMethod response) {
     return null;
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesGetter.java
@@ -31,13 +31,6 @@ final class ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(
-      ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(ApacheHttpClientRequest request, HttpResponse response) {
     return response.getStatusLine().getStatusCode();
   }
@@ -46,12 +39,6 @@ final class ApacheHttpClientHttpAttributesGetter
   @Nullable
   public String flavor(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getFlavor();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(ApacheHttpClientRequest request, HttpResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesGetter.java
@@ -33,13 +33,6 @@ enum ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(
-      ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(ApacheHttpClientRequest request, HttpResponse response) {
     return response.getStatusLine().getStatusCode();
   }
@@ -48,12 +41,6 @@ enum ApacheHttpClientHttpAttributesGetter
   @Nullable
   public String flavor(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getFlavor();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(ApacheHttpClientRequest request, HttpResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
@@ -69,12 +69,6 @@ final class ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(HttpRequest request, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequest request, HttpResponse response) {
     return response.getCode();
   }
@@ -102,12 +96,6 @@ final class ApacheHttpClientHttpAttributesGetter
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
     logger.log(Level.FINE, "unexpected http protocol version: {0}", protocolVersion);
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(HttpRequest request, HttpResponse response) {
     return null;
   }
 

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
@@ -36,15 +36,6 @@ enum ArmeriaHttpClientAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLength(RequestContext ctx, @Nullable RequestLog requestLog) {
-    if (requestLog == null) {
-      return null;
-    }
-    return requestLog.requestLength();
-  }
-
-  @Override
-  @Nullable
   public Integer statusCode(RequestContext ctx, RequestLog requestLog) {
     HttpStatus status = requestLog.responseHeaders().status();
     if (!status.equals(HttpStatus.UNKNOWN)) {
@@ -61,11 +52,6 @@ enum ArmeriaHttpClientAttributesGetter
     } else {
       return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
     }
-  }
-
-  @Override
-  public Long responseContentLength(RequestContext ctx, RequestLog requestLog) {
-    return requestLog.responseLength();
   }
 
   @Override

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
@@ -43,15 +43,6 @@ enum ArmeriaHttpServerAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLength(RequestContext ctx, @Nullable RequestLog requestLog) {
-    if (requestLog == null) {
-      return null;
-    }
-    return requestLog.requestLength();
-  }
-
-  @Override
-  @Nullable
   public Integer statusCode(RequestContext ctx, RequestLog requestLog) {
     HttpStatus status = requestLog.responseHeaders().status();
     if (!status.equals(HttpStatus.UNKNOWN)) {
@@ -68,11 +59,6 @@ enum ArmeriaHttpServerAttributesGetter
     } else {
       return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
     }
-  }
-
-  @Override
-  public Long responseContentLength(RequestContext ctx, RequestLog requestLog) {
-    return requestLog.responseLength();
   }
 
   @Override

--- a/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpClientTest.java
+++ b/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpClientTest.java
@@ -14,14 +14,10 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.util.Exceptions;
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,12 +100,6 @@ public abstract class AbstractArmeriaHttpClientTest extends AbstractHttpClientTe
     // armeria requests can't be reused
     options.disableTestReusedRequest();
     options.enableTestReadTimeout();
-
-    Set<AttributeKey<?>> extra = new HashSet<>();
-    extra.add(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH);
-    extra.add(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH);
-    extra.addAll(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-    options.setHttpAttributes(unused -> extra);
   }
 
   @Test

--- a/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpServerTest.java
+++ b/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpServerTest.java
@@ -194,8 +194,6 @@ public abstract class AbstractArmeriaHttpServerTest extends AbstractHttpServerTe
     options.setHttpAttributes(
         endpoint -> {
           Set<AttributeKey<?>> keys = new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          keys.add(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH);
-          keys.add(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH);
           keys.add(SemanticAttributes.HTTP_SERVER_NAME);
           return keys;
         });

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesGetter.java
@@ -32,12 +32,6 @@ final class AsyncHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request request, Response response) {
     return response.getStatusCode();
   }
@@ -45,12 +39,6 @@ final class AsyncHttpClientHttpAttributesGetter
   @Override
   public String flavor(Request request, @Nullable Response response) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(Request request, Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesGetter.java
@@ -10,7 +10,6 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.asynchttpclient.Response;
-import org.asynchttpclient.netty.request.NettyRequest;
 
 final class AsyncHttpClientHttpAttributesGetter
     implements HttpClientAttributesGetter<RequestContext, Response> {
@@ -31,23 +30,6 @@ final class AsyncHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(RequestContext requestContext, @Nullable Response response) {
-    NettyRequest nettyRequest = requestContext.getNettyRequest();
-    if (nettyRequest != null) {
-      String contentLength = nettyRequest.getHttpRequest().headers().get("Content-Length");
-      if (contentLength != null) {
-        try {
-          return Long.valueOf(contentLength);
-        } catch (NumberFormatException ignored) {
-          // ignore
-        }
-      }
-    }
-    return null;
-  }
-
-  @Override
   public Integer statusCode(RequestContext requestContext, Response response) {
     return response.getStatusCode();
   }
@@ -55,20 +37,6 @@ final class AsyncHttpClientHttpAttributesGetter
   @Override
   public String flavor(RequestContext requestContext, @Nullable Response response) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(RequestContext requestContext, Response response) {
-    String contentLength = response.getHeaders().get("Content-Length");
-    if (contentLength != null) {
-      try {
-        return Long.valueOf(contentLength);
-      } catch (NumberFormatException ignored) {
-        // ignore
-      }
-    }
-    return null;
   }
 
   @Override

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/test/groovy/AsyncHttpClientTest.groovy
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/test/groovy/AsyncHttpClientTest.groovy
@@ -72,14 +72,6 @@ class AsyncHttpClientTest extends HttpClientTest<Request> implements AgentTestTr
       SemanticAttributes.HTTP_SCHEME,
       SemanticAttributes.HTTP_TARGET
     ]
-    switch (uri.toString()) {
-      case "http://localhost:61/": // unopened port
-      case "https://192.0.2.1/": // non routable address
-        break
-      default:
-        extra.add(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH)
-    }
-
     super.httpAttributes(uri) + extra
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/S3TracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/S3TracingTest.groovy
@@ -64,7 +64,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -88,7 +88,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -112,7 +112,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -136,7 +136,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -160,7 +160,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -183,7 +183,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -206,7 +206,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         span(1) {
@@ -228,7 +228,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -256,7 +256,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -279,7 +279,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -302,7 +302,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -325,7 +325,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -348,7 +348,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -401,7 +401,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -424,7 +424,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -447,7 +447,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -469,7 +469,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -491,7 +491,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -514,7 +514,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -536,7 +536,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -559,7 +559,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -583,7 +583,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -606,7 +606,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -633,7 +633,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -657,7 +657,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -680,7 +680,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -703,7 +703,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -726,7 +726,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -749,7 +749,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/S3TracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/S3TracingTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Shared
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
@@ -63,6 +64,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -86,6 +88,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -109,6 +112,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -132,6 +136,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -155,6 +160,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -177,6 +183,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -199,6 +206,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(1) {
@@ -220,6 +228,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -247,6 +256,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -269,6 +279,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -291,6 +302,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -313,6 +325,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -335,6 +348,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -387,6 +401,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -409,6 +424,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -431,6 +447,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -452,6 +469,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -473,6 +491,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -495,6 +514,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -516,6 +536,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -538,6 +559,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -561,6 +583,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -583,6 +606,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -609,6 +633,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -632,6 +657,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -654,6 +680,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -676,6 +703,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -698,6 +726,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -720,6 +749,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SnsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SnsTracingTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import spock.lang.Shared
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
@@ -56,6 +57,7 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -79,6 +81,7 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -102,6 +105,7 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -124,6 +128,7 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -146,6 +151,7 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -167,6 +173,7 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(1) {
@@ -188,6 +195,7 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -214,6 +222,7 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
             "net.peer.name" String
             "net.transport" IP_TCP
             "net.peer.port" { it == null || Number }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -110,6 +110,7 @@ class Aws0ClientTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_METHOD" "$method"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
             "$SemanticAttributes.NET_PEER_PORT" server.httpPort()
             "$SemanticAttributes.NET_PEER_NAME" "127.0.0.1"
             "$SemanticAttributes.RPC_SYSTEM" "aws-api"

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkHttpAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkHttpAttributesGetter.java
@@ -40,20 +40,8 @@ class AwsSdkHttpAttributesGetter implements HttpClientAttributesGetter<Request<?
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(Request<?> request, @Nullable Response<?> response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request<?> request, Response<?> response) {
     return response.getHttpResponse().getStatusCode();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(Request<?> request, Response<?> response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
@@ -108,6 +108,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
             "$SemanticAttributes.HTTP_METHOD" "$method"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
             "$SemanticAttributes.NET_PEER_PORT" server.httpPort()
             "$SemanticAttributes.NET_PEER_NAME" "127.0.0.1"
             "$SemanticAttributes.RPC_SYSTEM" "aws-api"

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.groovy
@@ -14,6 +14,7 @@ import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import com.amazonaws.services.sqs.model.SendMessageRequest
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticmq.rest.sqs.SQSRestServerBuilder
 import spock.lang.Shared
 
@@ -81,6 +82,7 @@ abstract class AbstractSqsTracingTest extends InstrumentationSpecification {
             "net.peer.name" "localhost"
             "net.peer.port" sqsPort
             "net.transport" IP_TCP
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -103,6 +105,7 @@ abstract class AbstractSqsTracingTest extends InstrumentationSpecification {
             "net.peer.name" "localhost"
             "net.peer.port" sqsPort
             "net.transport" IP_TCP
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(1) {
@@ -124,6 +127,7 @@ abstract class AbstractSqsTracingTest extends InstrumentationSpecification {
             "net.peer.name" "localhost"
             "net.peer.port" sqsPort
             "net.transport" IP_TCP
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -150,6 +154,7 @@ abstract class AbstractSqsTracingTest extends InstrumentationSpecification {
             "net.peer.name" "localhost"
             "net.peer.port" sqsPort
             "net.transport" IP_TCP
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpAttributesGetter.java
@@ -47,22 +47,8 @@ class AwsSdkHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(
-      ExecutionAttributes request, @Nullable SdkHttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(ExecutionAttributes request, SdkHttpResponse response) {
     return response.statusCode();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(
-      ExecutionAttributes request, @Nullable SdkHttpResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -169,6 +169,8 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_USER_AGENT" { it.startsWith("aws-sdk-java/") }
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
             "$SemanticAttributes.RPC_SYSTEM" "aws-api"
             "$SemanticAttributes.RPC_SERVICE" "DynamoDb"
             "$SemanticAttributes.RPC_METHOD" "CreateTable"
@@ -204,6 +206,8 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
             "$SemanticAttributes.HTTP_METHOD" "$method"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_USER_AGENT" { it.startsWith("aws-sdk-java/") }
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.RPC_SYSTEM" "aws-api"
             "$SemanticAttributes.RPC_SERVICE" "DynamoDb"
@@ -240,6 +244,8 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_USER_AGENT" { it.startsWith("aws-sdk-java/") }
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
             "$SemanticAttributes.RPC_SYSTEM" "aws-api"
             "$SemanticAttributes.RPC_SERVICE" "$service"
             "$SemanticAttributes.RPC_METHOD" "${operation}"
@@ -353,6 +359,8 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_USER_AGENT" { it.startsWith("aws-sdk-java/") }
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
             "$SemanticAttributes.RPC_SYSTEM" "aws-api"
             "$SemanticAttributes.RPC_SERVICE" "$service"
             "$SemanticAttributes.RPC_METHOD" "${operation}"
@@ -443,6 +451,8 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_USER_AGENT" { it.startsWith("aws-sdk-java/") }
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
             "$SemanticAttributes.RPC_SYSTEM" "aws-api"
             "$SemanticAttributes.RPC_SERVICE" "$service"
             "$SemanticAttributes.RPC_METHOD" "${operation}"

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.groovy
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awssdk.v2_2
 
 import io.opentelemetry.instrumentation.test.InstrumentationSpecification
 import io.opentelemetry.instrumentation.test.utils.PortUtils
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 import org.elasticmq.rest.sqs.SQSRestServerBuilder
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
@@ -104,6 +105,8 @@ abstract class AbstractAws2SqsTracingTest extends InstrumentationSpecification {
             "net.peer.name" "localhost"
             "net.peer.port" sqsPort
             "net.transport" IP_TCP
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -127,6 +130,8 @@ abstract class AbstractAws2SqsTracingTest extends InstrumentationSpecification {
             "net.peer.name" "localhost"
             "net.peer.port" sqsPort
             "net.transport" IP_TCP
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         span(1) {
@@ -145,6 +150,8 @@ abstract class AbstractAws2SqsTracingTest extends InstrumentationSpecification {
             "net.peer.name" "localhost"
             "net.peer.port" sqsPort
             "net.transport" IP_TCP
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }
@@ -172,6 +179,8 @@ abstract class AbstractAws2SqsTracingTest extends InstrumentationSpecification {
             "net.peer.name" "localhost"
             "net.peer.port" sqsPort
             "net.transport" IP_TCP
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
       }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/ElasticsearchRest5Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/ElasticsearchRest5Test.groovy
@@ -96,6 +96,7 @@ class ElasticsearchRest5Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" SemanticAttributes.HttpFlavorValues.HTTP_1_1
             "$SemanticAttributes.HTTP_URL" "${httpHost.toURI()}/_cluster/health"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -170,6 +171,7 @@ class ElasticsearchRest5Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" SemanticAttributes.HttpFlavorValues.HTTP_1_1
             "$SemanticAttributes.HTTP_URL" "${httpHost.toURI()}/_cluster/health"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(3) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/ElasticsearchRest6Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/ElasticsearchRest6Test.groovy
@@ -90,6 +90,7 @@ class ElasticsearchRest6Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" SemanticAttributes.HttpFlavorValues.HTTP_1_1
             "$SemanticAttributes.HTTP_URL" "${httpHost.toURI()}/_cluster/health"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -163,6 +164,7 @@ class ElasticsearchRest6Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" SemanticAttributes.HttpFlavorValues.HTTP_1_1
             "$SemanticAttributes.HTTP_URL" "${httpHost.toURI()}/_cluster/health"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(3) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/groovy/ElasticsearchRest7Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/groovy/ElasticsearchRest7Test.groovy
@@ -89,6 +89,7 @@ class ElasticsearchRest7Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" SemanticAttributes.HttpFlavorValues.HTTP_1_1
             "$SemanticAttributes.HTTP_URL" "${httpHost.toURI()}/_cluster/health"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
       }
@@ -162,6 +163,7 @@ class ElasticsearchRest7Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" SemanticAttributes.HttpFlavorValues.HTTP_1_1
             "$SemanticAttributes.HTTP_URL" "${httpHost.toURI()}/_cluster/health"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(3) {

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesGetter.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesGetter.java
@@ -32,12 +32,6 @@ final class GoogleHttpClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
-    return null;
-  }
-
-  @Override
   public String flavor(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
@@ -45,12 +39,6 @@ final class GoogleHttpClientHttpAttributesGetter
   @Override
   public Integer statusCode(HttpRequest httpRequest, HttpResponse httpResponse) {
     return httpResponse.getStatusCode();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(HttpRequest httpRequest, HttpResponse httpResponse) {
-    return null;
   }
 
   @Override

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/AbstractGoogleHttpClientTest.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/AbstractGoogleHttpClientTest.java
@@ -98,7 +98,7 @@ public abstract class AbstractGoogleHttpClientTest extends AbstractHttpClientTes
                         .hasAttributesSatisfying(
                             attrs ->
                                 assertThat(attrs)
-                                    .hasSize(7)
+                                    .hasSize(8)
                                     .containsEntry(
                                         SemanticAttributes.NET_TRANSPORT,
                                         SemanticAttributes.NetTransportValues.IP_TCP)
@@ -109,6 +109,9 @@ public abstract class AbstractGoogleHttpClientTest extends AbstractHttpClientTes
                                     .containsEntry(SemanticAttributes.HTTP_URL, uri.toString())
                                     .containsEntry(SemanticAttributes.HTTP_METHOD, "GET")
                                     .containsEntry(SemanticAttributes.HTTP_STATUS_CODE, 500)
+                                    .hasEntrySatisfying(
+                                        SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,
+                                        length -> assertThat(length).isPositive())
                                     .containsEntry(
                                         SemanticAttributes.HTTP_FLAVOR,
                                         SemanticAttributes.HttpFlavorValues.HTTP_1_1)),

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
@@ -28,22 +28,9 @@ final class GrizzlyHttpAttributesGetter
     return value == null ? emptyList() : singletonList(value);
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLength(
-      HttpRequestPacket request, @Nullable HttpResponsePacket response) {
-    return null;
-  }
-
   @Override
   public Integer statusCode(HttpRequestPacket request, HttpResponsePacket response) {
     return response.getStatus();
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLength(HttpRequestPacket request, HttpResponsePacket response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesGetter.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesGetter.java
@@ -34,12 +34,6 @@ class HttpUrlHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(HttpURLConnection connection, @Nullable Integer statusCode) {
-    return null;
-  }
-
-  @Override
   public String flavor(HttpURLConnection connection, @Nullable Integer statusCode) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
@@ -47,12 +41,6 @@ class HttpUrlHttpAttributesGetter
   @Override
   public Integer statusCode(HttpURLConnection connection, Integer statusCode) {
     return statusCode;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(HttpURLConnection connection, Integer statusCode) {
-    return null;
   }
 
   @Override

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -119,6 +119,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" STATUS
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(2) {
@@ -140,6 +141,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" STATUS
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(4) {
@@ -156,7 +158,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
     useCaches << [false, true]
   }
 
-  def "test broken API usage"() {
+  def "test broken API usage (#iteration)"() {
     setup:
     def url = resolveAddress("/success").toURL()
     HttpURLConnection connection = runWithSpan("someTrace") {
@@ -188,6 +190,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" STATUS
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         serverSpan(it, 2, span(1))
@@ -246,6 +249,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
             "$SemanticAttributes.HTTP_METHOD" "POST"
             "$SemanticAttributes.HTTP_STATUS_CODE" STATUS
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(2) {
@@ -310,6 +314,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
             "$SemanticAttributes.HTTP_METHOD" "POST"
             "$SemanticAttributes.HTTP_STATUS_CODE" STATUS
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(2) {

--- a/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/javaagent/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -249,6 +249,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
             "$SemanticAttributes.HTTP_METHOD" "POST"
             "$SemanticAttributes.HTTP_STATUS_CODE" STATUS
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" Long
             "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
@@ -314,6 +315,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpURLConnection> implements
             "$SemanticAttributes.HTTP_METHOD" "POST"
             "$SemanticAttributes.HTTP_STATUS_CODE" STATUS
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" Long
             "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesGetter.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesGetter.java
@@ -31,13 +31,6 @@ class JdkHttpAttributesGetter implements HttpClientAttributesGetter<HttpRequest,
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(
-      HttpRequest httpRequest, @Nullable HttpResponse<?> httpResponse) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequest httpRequest, HttpResponse<?> httpResponse) {
     return httpResponse.statusCode();
   }
@@ -48,12 +41,6 @@ class JdkHttpAttributesGetter implements HttpClientAttributesGetter<HttpRequest,
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(HttpRequest httpRequest, HttpResponse<?> httpResponse) {
-    return null;
   }
 
   @Override

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesGetter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesGetter.java
@@ -43,13 +43,6 @@ final class JaxRsClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(
-      ClientRequest httpRequest, @Nullable ClientResponse httpResponse) {
-    return null;
-  }
-
-  @Override
   public String flavor(ClientRequest httpRequest, @Nullable ClientResponse httpResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
@@ -57,13 +50,6 @@ final class JaxRsClientHttpAttributesGetter
   @Override
   public Integer statusCode(ClientRequest httpRequest, ClientResponse httpResponse) {
     return httpResponse.getStatus();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(ClientRequest httpRequest, ClientResponse httpResponse) {
-    int length = httpResponse.getLength();
-    return length != -1 ? (long) length : null;
   }
 
   @Override

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0-testing/src/test/groovy/JaxRsClientTest.groovy
@@ -116,7 +116,8 @@ abstract class JaxRsClientTest extends HttpClientTest<Invocation.Builder> implem
             "$SemanticAttributes.HTTP_METHOD" method
             "$SemanticAttributes.HTTP_STATUS_CODE" statusCode
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
-            "$SemanticAttributes.HTTP_USER_AGENT" { it == null || String }
+            "$SemanticAttributes.HTTP_USER_AGENT" { it == null || it instanceof String }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         serverSpan(it, 1, span(0))

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
@@ -8,22 +8,16 @@ package io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_1_0;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_1_1;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_2_0;
-import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesGetter;
 import java.util.List;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
-import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpVersion;
 
 enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Request, Response> {
   INSTANCE;
-
-  private static final Logger logger =
-      Logger.getLogger(JettyClientHttpAttributesGetter.class.getName());
 
   @Override
   @Nullable
@@ -74,20 +68,5 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
   @Override
   public List<String> responseHeader(Request request, Response response, String name) {
     return response.getHeaders().getValuesList(name);
-  }
-
-  private static Long getLongFromJettyHttpField(HttpField httpField) {
-    Long longFromField = null;
-    try {
-      longFromField = httpField != null ? Long.getLong(httpField.getValue()) : null;
-    } catch (NumberFormatException t) {
-      if (logger.isLoggable(FINE)) {
-        logger.log(
-            FINE,
-            "Value {0} is not valid number format for header field: {1}",
-            new Object[] {httpField.getValue(), httpField.getName()});
-      }
-    }
-    return longFromField;
   }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
@@ -17,7 +17,6 @@ import javax.annotation.Nullable;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.http.HttpField;
-import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpVersion;
 
 enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Request, Response> {
@@ -41,13 +40,6 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
   @Override
   public List<String> requestHeader(Request request, String name) {
     return request.getHeaders().getValuesList(name);
-  }
-
-  @Override
-  @Nullable
-  public Long requestContentLength(Request request, @Nullable Response response) {
-    HttpField requestContentLengthField = request.getHeaders().getField(HttpHeader.CONTENT_LENGTH);
-    return getLongFromJettyHttpField(requestContentLengthField);
   }
 
   @Override
@@ -77,18 +69,6 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
   @Override
   public Integer statusCode(Request request, Response response) {
     return response.getStatus();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(Request request, Response response) {
-    Long respContentLength = null;
-    if (response != null) {
-      HttpField requestContentLengthField =
-          response.getHeaders().getField(HttpHeader.CONTENT_LENGTH);
-      respContentLength = getLongFromJettyHttpField(requestContentLengthField);
-    }
-    return respContentLength;
   }
 
   @Override

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
@@ -23,16 +23,8 @@ internal enum class KtorHttpServerAttributesGetter :
     return request.headers.getAll(name) ?: emptyList()
   }
 
-  override fun requestContentLength(request: ApplicationRequest, response: ApplicationResponse?): Long? {
-    return null
-  }
-
   override fun statusCode(request: ApplicationRequest, response: ApplicationResponse): Int? {
     return response.status()?.value
-  }
-
-  override fun responseContentLength(request: ApplicationRequest, response: ApplicationResponse): Long? {
-    return null
   }
 
   override fun responseHeader(request: ApplicationRequest, response: ApplicationResponse, name: String): List<String> {

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpServerAttributesGetter.kt
@@ -23,16 +23,8 @@ internal enum class KtorHttpServerAttributesGetter :
     return request.headers.getAll(name) ?: emptyList()
   }
 
-  override fun requestContentLength(request: ApplicationRequest, response: ApplicationResponse?): Long? {
-    return null
-  }
-
   override fun statusCode(request: ApplicationRequest, response: ApplicationResponse): Int? {
     return response.status()?.value
-  }
-
-  override fun responseContentLength(request: ApplicationRequest, response: ApplicationResponse): Long? {
-    return null
   }
 
   override fun responseHeader(request: ApplicationRequest, response: ApplicationResponse, name: String): List<String> {

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesGetter.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesGetter.java
@@ -32,12 +32,6 @@ class KubernetesHttpAttributesGetter
     return request.headers(name);
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLength(Request request, @Nullable ApiResponse<?> apiResponse) {
-    return null;
-  }
-
   @Override
   public String flavor(Request request, @Nullable ApiResponse<?> apiResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
@@ -46,12 +40,6 @@ class KubernetesHttpAttributesGetter
   @Override
   public Integer statusCode(Request request, ApiResponse<?> apiResponse) {
     return apiResponse.getStatusCode();
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLength(Request request, ApiResponse<?> apiResponse) {
-    return null;
   }
 
   @Override

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/test/groovy/KubernetesClientTest.groovy
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/test/groovy/KubernetesClientTest.groovy
@@ -202,6 +202,7 @@ class KubernetesClientTest extends AgentInstrumentationSpecification {
         "$SemanticAttributes.NET_TRANSPORT" IP_TCP
         "$SemanticAttributes.NET_PEER_NAME" "127.0.0.1"
         "$SemanticAttributes.NET_PEER_PORT" server.httpPort()
+        "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
         "kubernetes-client.namespace" "namespace"
         "kubernetes-client.name" "name"
       }

--- a/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
@@ -25,13 +25,6 @@ public class LibertyDispatcherHttpAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLength(
-      LibertyRequest libertyRequest, @Nullable LibertyResponse libertyResponse) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(LibertyRequest libertyRequest) {
     String flavor = libertyRequest.getProtocol();
     if (flavor != null) {
@@ -47,13 +40,6 @@ public class LibertyDispatcherHttpAttributesGetter
   @Nullable
   public Integer statusCode(LibertyRequest libertyRequest, LibertyResponse libertyResponse) {
     return libertyResponse.getStatus();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(
-      LibertyRequest libertyRequest, LibertyResponse libertyResponse) {
-    return null;
   }
 
   @Override

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientAttributesGetter.java
@@ -59,22 +59,8 @@ final class NettyHttpClientAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return response.getStatus().getCode();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(
-      HttpRequestAndChannel requestAndChannel, HttpResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
@@ -27,22 +27,8 @@ final class NettyHttpServerAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return response.getStatus().getCode();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(
-      HttpRequestAndChannel requestAndChannel, HttpResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/client/NettyHttpClientAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/client/NettyHttpClientAttributesGetter.java
@@ -59,22 +59,8 @@ final class NettyHttpClientAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return response.getStatus().code();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(
-      HttpRequestAndChannel requestAndChannel, HttpResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/server/NettyHttpServerAttributesGetter.java
@@ -27,22 +27,8 @@ final class NettyHttpServerAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(HttpRequestAndChannel requestAndChannel, HttpResponse response) {
     return response.getStatus().code();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(
-      HttpRequestAndChannel requestAndChannel, HttpResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesGetter.java
@@ -30,12 +30,6 @@ final class OkHttp2HttpAttributesGetter implements HttpClientAttributesGetter<Re
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request request, Response response) {
     return response.code();
   }
@@ -57,11 +51,6 @@ final class OkHttp2HttpAttributesGetter implements HttpClientAttributesGetter<Re
         return SemanticAttributes.HttpFlavorValues.SPDY;
     }
     return null;
-  }
-
-  @Override
-  public Long responseContentLength(Request request, Response response) {
-    return response.body().contentLength();
   }
 
   @Override

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesGetter.java
@@ -31,12 +31,6 @@ enum OkHttpAttributesGetter implements HttpClientAttributesGetter<Request, Respo
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
   @SuppressWarnings("UnnecessaryDefaultInEnumSwitch")
   @Nullable
   public String flavor(Request request, @Nullable Response response) {
@@ -61,12 +55,6 @@ enum OkHttpAttributesGetter implements HttpClientAttributesGetter<Request, Respo
   @Override
   public Integer statusCode(Request request, Response response) {
     return response.code();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(Request request, Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
@@ -29,19 +29,7 @@ enum MockHttpServerAttributesGetter implements HttpServerAttributesGetter<String
 
   @Nullable
   @Override
-  public Long requestContentLength(String s, @Nullable Void unused) {
-    return null;
-  }
-
-  @Nullable
-  @Override
   public Integer statusCode(String s, Void unused) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLength(String s, Void unused) {
     return null;
   }
 

--- a/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesGetter.java
+++ b/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesGetter.java
@@ -31,12 +31,6 @@ final class PlayWsClientHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request request, Response response) {
     return response.getStatusCode();
   }
@@ -44,12 +38,6 @@ final class PlayWsClientHttpAttributesGetter
   @Override
   public String flavor(Request request, @Nullable Response response) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(Request request, Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
+++ b/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
@@ -109,6 +109,7 @@ abstract class AbstractRatpackRoutesTest extends InstrumentationSpecification {
             "$SemanticAttributes.HTTP_HOST" "localhost:${app.bindPort}"
             "$SemanticAttributes.HTTP_TARGET" "/$path"
             "$SemanticAttributes.HTTP_ROUTE" "/$route"
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         if (hasHandlerSpan()) {

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesGetter.java
@@ -56,12 +56,6 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
 
   @Override
   @Nullable
-  public Long requestContentLength(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(Request request) {
     switch (request.getProtocol()) {
       case "HTTP/1.0":
@@ -85,12 +79,6 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   @Override
   public Integer statusCode(Request request, Response response) {
     return response.getStatus().getCode();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(Request request, Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpClientAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpClientAttributesGetter.java
@@ -38,21 +38,9 @@ enum RatpackHttpClientAttributesGetter
     return requestSpec.getHeaders().getAll(name);
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLength(RequestSpec requestSpec, @Nullable HttpResponse httpResponse) {
-    return null;
-  }
-
   @Override
   public Integer statusCode(RequestSpec requestSpec, HttpResponse httpResponse) {
     return httpResponse.getStatusCode();
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLength(RequestSpec requestSpec, HttpResponse httpResponse) {
-    return null;
   }
 
   @Override

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
@@ -74,22 +74,9 @@ final class ReactorNettyHttpClientAttributesGetter
     return request.headers().getAll(name);
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLength(
-      HttpClientConfig request, @Nullable HttpClientResponse response) {
-    return null;
-  }
-
   @Override
   public Integer statusCode(HttpClientConfig request, HttpClientResponse response) {
     return response.status().code();
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLength(HttpClientConfig request, HttpClientResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyClientSslTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyClientSslTest.groovy
@@ -148,6 +148,7 @@ class ReactorNettyClientSslTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_URL" uri
             "$SemanticAttributes.HTTP_FLAVOR" HTTP_1_1
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
             "$SemanticAttributes.NET_PEER_NAME" "localhost"
             "$SemanticAttributes.NET_PEER_PORT" server.httpsPort()
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.groovy
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyConnectionSpanTest.groovy
@@ -71,6 +71,7 @@ class ReactorNettyConnectionSpanTest extends InstrumentationSpecification implem
             "$SemanticAttributes.HTTP_URL" uri
             "$SemanticAttributes.HTTP_FLAVOR" HTTP_1_1
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
             "$SemanticAttributes.NET_PEER_NAME" "localhost"
             "$SemanticAttributes.NET_PEER_PORT" server.httpPort()
             "$SemanticAttributes.NET_PEER_IP" "127.0.0.1"

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesGetter.java
@@ -59,12 +59,6 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
 
   @Override
   @Nullable
-  public Long requestContentLength(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(Request request) {
     String version = (String) request.getAttributes().get("org.restlet.http.version");
     switch (version) {
@@ -89,12 +83,6 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   @Override
   public Integer statusCode(Request request, Response response) {
     return response.getStatus().getCode();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(Request request, Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
@@ -61,12 +61,6 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public Long requestContentLength(Request request, @Nullable Response response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(Request request) {
     switch (request.getProtocol().toString()) {
       case "HTTP/1.0":
@@ -90,12 +84,6 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
   @Override
   public Integer statusCode(Request request, Response response) {
     return response.getStatus().getCode();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(Request request, Response response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Accessor.java
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Accessor.java
@@ -36,11 +36,6 @@ public class Servlet2Accessor extends JavaxServletAccessor<HttpServletResponse> 
   }
 
   @Override
-  public String getResponseHeader(HttpServletResponse httpServletResponse, String name) {
-    return null;
-  }
-
-  @Override
   public List<String> getResponseHeaderValues(
       HttpServletResponse httpServletResponse, String name) {
     return Collections.emptyList();

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Accessor.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Accessor.java
@@ -44,11 +44,6 @@ public class Servlet3Accessor extends JavaxServletAccessor<HttpServletResponse> 
   }
 
   @Override
-  public String getResponseHeader(HttpServletResponse response, String name) {
-    return response.getHeader(name);
-  }
-
-  @Override
   public List<String> getResponseHeaderValues(HttpServletResponse response, String name) {
     Collection<String> values = response.getHeaders(name);
     if (values == null) {

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
@@ -36,16 +36,6 @@ public class Servlet5Accessor implements ServletAccessor<HttpServletRequest, Htt
   }
 
   @Override
-  public String getRequestServerName(HttpServletRequest request) {
-    return request.getServerName();
-  }
-
-  @Override
-  public int getRequestServerPort(HttpServletRequest request) {
-    return request.getServerPort();
-  }
-
-  @Override
   public String getRequestUri(HttpServletRequest request) {
     return request.getRequestURI();
   }
@@ -124,11 +114,6 @@ public class Servlet5Accessor implements ServletAccessor<HttpServletRequest, Htt
   }
 
   @Override
-  public int getRequestContentLength(HttpServletRequest request) {
-    return request.getContentLength();
-  }
-
-  @Override
   public void addRequestAsyncListener(
       HttpServletRequest request,
       ServletAsyncListener<HttpServletResponse> listener,
@@ -143,11 +128,6 @@ public class Servlet5Accessor implements ServletAccessor<HttpServletRequest, Htt
   @Override
   public int getResponseStatus(HttpServletResponse response) {
     return response.getStatus();
-  }
-
-  @Override
-  public String getResponseHeader(HttpServletResponse response, String name) {
-    return response.getHeader(name);
   }
 
   @Override

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletAccessor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletAccessor.java
@@ -23,10 +23,6 @@ public interface ServletAccessor<REQUEST, RESPONSE> {
 
   String getRequestScheme(REQUEST request);
 
-  String getRequestServerName(REQUEST request);
-
-  int getRequestServerPort(REQUEST request);
-
   String getRequestUri(REQUEST request);
 
   String getRequestQueryString(REQUEST request);
@@ -57,14 +53,10 @@ public interface ServletAccessor<REQUEST, RESPONSE> {
 
   Integer getRequestRemotePort(REQUEST request);
 
-  int getRequestContentLength(REQUEST request);
-
   void addRequestAsyncListener(
       REQUEST request, ServletAsyncListener<RESPONSE> listener, Object response);
 
   int getResponseStatus(RESPONSE response);
-
-  String getResponseHeader(RESPONSE response, String name);
 
   List<String> getResponseHeaderValues(RESPONSE response, String name);
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
@@ -50,18 +50,6 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
 
   @Override
   @Nullable
-  public Long requestContentLength(
-      ServletRequestContext<REQUEST> requestContext,
-      @Nullable ServletResponseContext<RESPONSE> responseContext) {
-    int contentLength = accessor.getRequestContentLength(requestContext.request());
-    if (contentLength > -1) {
-      return (long) contentLength;
-    }
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(ServletRequestContext<REQUEST> requestContext) {
     String flavor = accessor.getRequestProtocol(requestContext.request());
     if (flavor != null) {
@@ -89,22 +77,6 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
       return 500;
     }
     return accessor.getResponseStatus(response);
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(
-      ServletRequestContext<REQUEST> requestContext,
-      ServletResponseContext<RESPONSE> responseContext) {
-    String contentLength = accessor.getResponseHeader(responseContext.response(), "Content-Length");
-    if (contentLength != null) {
-      try {
-        return Long.valueOf(contentLength);
-      } catch (NumberFormatException ignored) {
-        // ignore
-      }
-    }
-    return null;
   }
 
   @Override

--- a/instrumentation/servlet/servlet-javax-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/javax/JavaxServletAccessor.java
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/javax/JavaxServletAccessor.java
@@ -26,16 +26,6 @@ public abstract class JavaxServletAccessor<R> implements ServletAccessor<HttpSer
   }
 
   @Override
-  public String getRequestServerName(HttpServletRequest request) {
-    return request.getServerName();
-  }
-
-  @Override
-  public int getRequestServerPort(HttpServletRequest request) {
-    return request.getServerPort();
-  }
-
-  @Override
   public String getRequestUri(HttpServletRequest request) {
     return request.getRequestURI();
   }
@@ -109,11 +99,6 @@ public abstract class JavaxServletAccessor<R> implements ServletAccessor<HttpSer
   @Override
   public Principal getRequestUserPrincipal(HttpServletRequest request) {
     return request.getUserPrincipal();
-  }
-
-  @Override
-  public int getRequestContentLength(HttpServletRequest request) {
-    return request.getContentLength();
   }
 
   @Override

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebHttpAttributesGetter.java
@@ -37,13 +37,6 @@ enum SpringWebHttpAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLength(
-      HttpRequest httpRequest, @Nullable ClientHttpResponse clientHttpResponse) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(HttpRequest httpRequest, @Nullable ClientHttpResponse clientHttpResponse) {
     return null;
   }
@@ -55,13 +48,6 @@ enum SpringWebHttpAttributesGetter
     } catch (IOException e) {
       return HttpStatus.INTERNAL_SERVER_ERROR.value();
     }
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(
-      HttpRequest httpRequest, ClientHttpResponse clientHttpResponse) {
-    return null;
   }
 
   @Override

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -92,6 +92,8 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" urlPathWithVariables
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         span(1) {
@@ -159,6 +161,8 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" urlPathWithVariables
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         span(1) {
@@ -246,6 +250,8 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" urlPathWithVariables
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         span(1) {
@@ -311,6 +317,8 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" "/**"
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         span(1) {
@@ -355,6 +363,8 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" "/echo"
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         span(1) {
@@ -404,6 +414,8 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" urlPathWithVariables
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         span(1) {
@@ -468,6 +480,8 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" "/double-greet-redirect"
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         span(1) {
@@ -500,6 +514,8 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" "/double-greet"
+            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
           }
         }
         span(1) {
@@ -547,6 +563,8 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
               "$SemanticAttributes.HTTP_FLAVOR" "1.1"
               "$SemanticAttributes.HTTP_USER_AGENT" String
               "$SemanticAttributes.HTTP_ROUTE" urlPathWithVariables
+              "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
+              "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
             }
           }
           span(1) {

--- a/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/SpringWebfluxHttpAttributesGetter.java
@@ -55,12 +55,6 @@ enum SpringWebfluxHttpAttributesGetter
     return request.headers().getOrDefault(name, emptyList());
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLength(ClientRequest request, @Nullable ClientResponse response) {
-    return null;
-  }
-
   @Override
   public Integer statusCode(ClientRequest request, ClientResponse response) {
     if (RAW_STATUS_CODE != null) {
@@ -74,12 +68,6 @@ enum SpringWebfluxHttpAttributesGetter
     // prior to webflux 5.1, the best we can get is HttpStatus enum, which only covers standard
     // status codes
     return response.statusCode().value();
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLength(ClientRequest request, ClientResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/SpringWebMvcHttpAttributesGetter.java
@@ -33,13 +33,6 @@ enum SpringWebMvcHttpAttributesGetter
 
   @Override
   @Nullable
-  public Long requestContentLength(
-      HttpServletRequest request, @Nullable HttpServletResponse response) {
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(HttpServletRequest request) {
     return request.getProtocol();
   }
@@ -48,12 +41,6 @@ enum SpringWebMvcHttpAttributesGetter
   @Nullable
   public Integer statusCode(HttpServletRequest request, HttpServletResponse response) {
     // set in StatusCodeExtractor
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(HttpServletRequest request, HttpServletResponse response) {
     return null;
   }
 

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
@@ -45,13 +45,6 @@ public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public Long requestContentLength(Request request, @Nullable Response response) {
-    long contentLength = request.getContentLengthLong();
-    return contentLength != -1 ? contentLength : null;
-  }
-
-  @Override
-  @Nullable
   public String flavor(Request request) {
     String flavor = request.protocol().toString();
     if (flavor != null) {
@@ -67,13 +60,6 @@ public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Re
   @Nullable
   public Integer statusCode(Request request, Response response) {
     return response.getStatus();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(Request request, Response response) {
-    long contentLength = response.getContentLengthLong();
-    return contentLength != -1 ? contentLength : null;
   }
 
   @Override

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
@@ -27,14 +27,6 @@ public class UndertowHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public Long requestContentLength(
-      HttpServerExchange exchange, @Nullable HttpServerExchange unused) {
-    long requestContentLength = exchange.getRequestContentLength();
-    return requestContentLength != -1 ? requestContentLength : null;
-  }
-
-  @Override
   public String flavor(HttpServerExchange exchange) {
     String flavor = exchange.getProtocol().toString();
     // remove HTTP/ prefix to comply with semantic conventions
@@ -47,13 +39,6 @@ public class UndertowHttpAttributesGetter
   @Override
   public Integer statusCode(HttpServerExchange exchange, HttpServerExchange unused) {
     return exchange.getStatusCode();
-  }
-
-  @Override
-  @Nullable
-  public Long responseContentLength(HttpServerExchange exchange, HttpServerExchange unused) {
-    long responseContentLength = exchange.getResponseContentLength();
-    return responseContentLength != -1 ? responseContentLength : null;
   }
 
   @Override

--- a/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerDispatchTest.groovy
+++ b/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerDispatchTest.groovy
@@ -101,7 +101,6 @@ class UndertowServerDispatchTest extends HttpServerTest<Undertow> implements Age
   Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
     def attributes = super.httpAttributes(endpoint)
     attributes.remove(SemanticAttributes.HTTP_ROUTE)
-    attributes.add(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH)
     attributes
   }
 }

--- a/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
+++ b/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
@@ -110,7 +110,6 @@ class UndertowServerTest extends HttpServerTest<Undertow> implements AgentTestTr
   Set<AttributeKey<?>> httpAttributes(ServerEndpoint endpoint) {
     def attributes = super.httpAttributes(endpoint)
     attributes.remove(SemanticAttributes.HTTP_ROUTE)
-    attributes.add(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH)
     attributes
   }
 

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/client/AbstractVertxHttpAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/client/AbstractVertxHttpAttributesGetter.java
@@ -25,22 +25,9 @@ public abstract class AbstractVertxHttpAttributesGetter
     return request.headers().getAll(name);
   }
 
-  @Nullable
-  @Override
-  public Long requestContentLength(
-      HttpClientRequest request, @Nullable HttpClientResponse response) {
-    return null;
-  }
-
   @Override
   public Integer statusCode(HttpClientRequest request, HttpClientResponse response) {
     return response.statusCode();
-  }
-
-  @Nullable
-  @Override
-  public Long responseContentLength(HttpClientRequest request, HttpClientResponse response) {
-    return null;
   }
 
   @Override

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/groovy/VertxReactivePropagationTest.groovy
@@ -75,6 +75,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" "/listProducts"
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(1) {
@@ -166,6 +167,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
               "$SemanticAttributes.HTTP_FLAVOR" "1.1"
               "$SemanticAttributes.HTTP_USER_AGENT" String
               "$SemanticAttributes.HTTP_ROUTE" "/listProducts"
+              "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
               "${TEST_REQUEST_ID_ATTRIBUTE}" requestId
             }
           }

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/version35Test/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/version35Test/groovy/VertxReactivePropagationTest.groovy
@@ -75,6 +75,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" "/listProducts"
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
           }
         }
         span(1) {
@@ -166,6 +167,7 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
               "$SemanticAttributes.HTTP_FLAVOR" "1.1"
               "$SemanticAttributes.HTTP_USER_AGENT" String
               "$SemanticAttributes.HTTP_ROUTE" "/listProducts"
+              "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
               "${TEST_REQUEST_ID_ATTRIBUTE}" requestId
             }
           }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -978,13 +978,13 @@ public abstract class AbstractHttpClientTest<REQUEST> {
                           actual -> assertThat(actual).startsWith(userAgent));
                 }
               }
-              if (httpClientAttributes.contains(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH)) {
+              if (attrs.get(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH) != null) {
                 assertThat(attrs)
                     .hasEntrySatisfying(
                         SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH,
                         length -> assertThat(length).isNotNegative());
               }
-              if (httpClientAttributes.contains(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH)) {
+              if (attrs.get(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH) != null) {
                 assertThat(attrs)
                     .hasEntrySatisfying(
                         SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -560,8 +560,7 @@ public abstract class AbstractHttpServerTest<SERVER> {
                             .isInstanceOf(Long.class)
                             .isNotEqualTo(Long.valueOf(port)));
           }
-          if (httpAttributes.contains(SemanticAttributes.NET_PEER_IP)
-              || attrs.get(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH) != null) {
+          if (httpAttributes.contains(SemanticAttributes.NET_PEER_IP)) {
             assertThat(attrs)
                 .containsEntry(SemanticAttributes.NET_PEER_IP, options.peerIp.apply(endpoint));
           }
@@ -595,19 +594,17 @@ public abstract class AbstractHttpServerTest<SERVER> {
                         + (endpoint == QUERY_PARAM ? "?" + endpoint.body : ""));
           }
 
-          if (httpAttributes.contains(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH)
-              || attrs.get(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH) != null) {
+          if (attrs.get(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH) != null) {
             assertThat(attrs)
                 .hasEntrySatisfying(
                     SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH,
-                    entry -> assertThat(entry).isInstanceOf(Long.class));
+                    entry -> assertThat(entry).isNotNegative());
           }
-          if (httpAttributes.contains(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH)
-              || attrs.get(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH) != null) {
+          if (attrs.get(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH) != null) {
             assertThat(attrs)
                 .hasEntrySatisfying(
                     SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,
-                    entry -> assertThat(entry).isInstanceOf(Long.class));
+                    entry -> assertThat(entry).isNotNegative());
           }
           if (httpAttributes.contains(SemanticAttributes.HTTP_SERVER_NAME)) {
             assertThat(attrs)
@@ -615,10 +612,8 @@ public abstract class AbstractHttpServerTest<SERVER> {
                     SemanticAttributes.HTTP_SERVER_NAME,
                     entry -> assertThat(entry).isInstanceOf(String.class));
           }
-          if (httpAttributes.contains(SemanticAttributes.HTTP_ROUTE)) {
-            if (expectedRoute != null) {
-              assertThat(attrs).containsEntry(SemanticAttributes.HTTP_ROUTE, expectedRoute);
-            }
+          if (httpAttributes.contains(SemanticAttributes.HTTP_ROUTE) && expectedRoute != null) {
+            assertThat(attrs).containsEntry(SemanticAttributes.HTTP_ROUTE, expectedRoute);
           }
 
           if (endpoint == CAPTURE_HEADERS) {


### PR DESCRIPTION
... and deprecate the `requestContentLength()` and `responseContentLength()` methods in the getter interface. I figured that almost all instrumentations (except Armeria) get these from the headers anyway, so we might as well keep the API simple and remove them altogether.