### PR TITLE
Sync suppression keys

### DIFF
--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsAnnotationsInstrumentationModule.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsAnnotationsInstrumentationModule.java
@@ -17,7 +17,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(InstrumentationModule.class)
 public class JaxrsAnnotationsInstrumentationModule extends InstrumentationModule {
   public JaxrsAnnotationsInstrumentationModule() {
-    super("jaxrs-annotations", "jaxrs-2.0-annotations");
+    super("jaxrs", "jaxrs-2.0", "jaxrs-annotations", "jaxrs-2.0-annotations");
   }
 
   // require jax-rs 2

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/JaxrsAnnotationsInstrumentationModule.java
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/JaxrsAnnotationsInstrumentationModule.java
@@ -17,7 +17,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(InstrumentationModule.class)
 public class JaxrsAnnotationsInstrumentationModule extends InstrumentationModule {
   public JaxrsAnnotationsInstrumentationModule() {
-    super("jaxrs-annotations", "jaxrs-3.0-annotations");
+    super("jaxrs", "jaxrs-3.0", "jaxrs-annotations", "jaxrs-3.0-annotations");
   }
 
   // require jax-rs 3


### PR DESCRIPTION
All of the other JAX-RS instrumentation can be suppressed with both generic `jaxrs` and more specific names, seems these should too.