### PR TITLE
Grizzly: capture all matching request & response headers

### DIFF
--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.javaagent.instrumentation.grizzly;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesGetter;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.glassfish.grizzly.http.HttpRequestPacket;
@@ -24,8 +24,16 @@ final class GrizzlyHttpAttributesGetter
 
   @Override
   public List<String> requestHeader(HttpRequestPacket request, String name) {
-    String value = request.getHeader(name);
-    return value == null ? emptyList() : singletonList(value);
+    return toHeaderList(request.getHeaders().values(name));
+  }
+
+  private static List<String> toHeaderList(Iterable<String> values) {
+    if (values.iterator().hasNext()) {
+      List<String> result = new ArrayList<>();
+      values.forEach(result::add);
+      return result;
+    }
+    return emptyList();
   }
 
   @Override
@@ -36,8 +44,7 @@ final class GrizzlyHttpAttributesGetter
   @Override
   public List<String> responseHeader(
       HttpRequestPacket request, HttpResponsePacket response, String name) {
-    String value = response.getHeader(name);
-    return value == null ? emptyList() : singletonList(value);
+    return toHeaderList(response.getHeaders().values(name));
   }
 
   @Override


### PR DESCRIPTION
To be consistent with header capturing on other frameworks capture all matching headers.