### PR TITLE
Add a JDBC-specific sanitizer property

### DIFF
--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcSingletons.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcSingletons.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.SqlClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.instrumentation.jdbc.internal.DbRequest;
 import io.opentelemetry.instrumentation.jdbc.internal.JdbcAttributesGetter;
 import io.opentelemetry.instrumentation.jdbc.internal.JdbcNetAttributesGetter;
@@ -34,7 +35,9 @@ public final class JdbcSingletons {
             .addAttributesExtractor(
                 SqlClientAttributesExtractor.builder(dbAttributesGetter)
                     .setStatementSanitizationEnabled(
-                        CommonConfig.get().isStatementSanitizationEnabled())
+                        ConfigPropertiesUtil.getBoolean(
+                            "otel.instrumentation.jdbc.statement-sanitizer.enabled",
+                            CommonConfig.get().isStatementSanitizationEnabled()))
                     .build())
             .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractor(


### PR DESCRIPTION
I'd like to have a jdbc-specific sanitizer property since disabling the sanitizer is a PII/data sensitivity concern.

I wouldn't mind removing the common property altogether and only supporting instrumentation-specific ones (jedis, lettuce, cassandra, etc), with the thought that users should be very clear about the scope that they are disabling for the sanitizer.

Although I can see the common property being handy in dev environments where there are no data sensitivity concerns.