### PR TITLE
Fix the build

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ pluginManagement {
 plugins {
   id("com.gradle.enterprise") version "3.11.1"
   id("com.github.burrunan.s3-build-cache") version "1.3"
-  id("com.gradle.common-custom-user-data-gradle-plugin") version "1.8.0"
+  id("com.gradle.common-custom-user-data-gradle-plugin") version "1.8"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Not sure how dependabot got this wrong (see #6473), but version is 1.8 not 1.8.0, and build is failing

```
Plugin [id: 'com.gradle.common-custom-user-data-gradle-plugin', version: '1.8.0'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Plugin Repositories (could not resolve plugin artifact 'com.gradle.common-custom-user-data-gradle-plugin:com.gradle.common-custom-user-data-gradle-plugin.gradle.plugin:1.8.0')
  Searched in the following repositories:
    Gradle Central Plugin Repository
    MavenRepo
```
