### PR TITLE
Fix default-enabled config

### DIFF
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
@@ -98,7 +98,7 @@ public abstract class InstrumentationModule implements Ordered {
    * themselves on some other condition.
    */
   public boolean defaultEnabled(ConfigProperties config) {
-    return defaultEnabled();
+    return config.getBoolean("otel.instrumentation.common.default-enabled", true);
   }
 
   /**


### PR DESCRIPTION
Workaround for now is to set it as system property in distro, or use deprecated config spi, so I don't think patch is necessary.

UPDATE: setting as a system property is too late, at least to do that in the new "ConfigCustomizer", but using the deprecated config spi works