### PR TITLE
Spring boot application class should have a public constructor

### DIFF
--- a/.github/workflows/reusable-smoke-test-images.yml
+++ b/.github/workflows/reusable-smoke-test-images.yml
@@ -55,20 +55,20 @@ jobs:
 
       - name: Build Java 8 Docker image
         if: ${{ !inputs.skip-java-8 }}
-        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -Ptag=${{ env.TAG }} -PtargetJDK=8 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 11 Docker image
-        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -Ptag=${{ env.TAG }} -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 17 Docker image
         if: ${{ !inputs.skip-java-17 }}
-        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -Ptag=${{ env.TAG }} -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
 
         # TODO (trask) remove Java 18 test once Java 19 is GA
       - name: Build Java 18 Docker image
         if: ${{ !inputs.skip-java-18 }}
-        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -Ptag=${{ env.TAG }} -PtargetJDK=18 -Djib.httpTimeout=120000 -Djib.console=plain
 
       - name: Build Java 19 Docker image
         if: ${{ !inputs.skip-java-19 }}
-        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -PtargetJDK=19 -Djib.httpTimeout=120000 -Djib.console=plain
+        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -Ptag=${{ env.TAG }} -PtargetJDK=19 -Djib.httpTimeout=120000 -Djib.console=plain

--- a/smoke-tests/images/spring-boot/src/main/java/io/opentelemetry/smoketest/springboot/SpringbootApplication.java
+++ b/smoke-tests/images/spring-boot/src/main/java/io/opentelemetry/smoketest/springboot/SpringbootApplication.java
@@ -15,5 +15,5 @@ public class SpringbootApplication {
     SpringApplication.run(SpringbootApplication.class, args);
   }
 
-  private SpringbootApplication() {}
+  public SpringbootApplication() {}
 }


### PR DESCRIPTION
Another thing I noticed is that in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pkgs/container/opentelemetry-java-instrumentation%2Fsmoke-test-spring-boot/versions all recent images have different tags. Hopefully passing the tag fill fix it. Another issue that I didn't fix is that at least for spring boot the currently built jdk8 image doesn't work because jib generates an entry point that uses argument file for class path which doesn't work on jdk8
```
            "Entrypoint": [
                "java",
                "-cp",
                "@/app/jib-classpath-file",
                "io.opentelemetry.smoketest.springboot.SpringbootApplication"
            ],
```
older version of jib generated
```
            "Entrypoint": [
                "java",
                "-cp",
                "/app/resources:/app/classes:/app/libs/*",
                "io.opentelemetry.smoketest.springboot.SpringbootApplication"
            ],
```