### PR TITLE
Don't bundle slf4j-api inside testing-commons

### DIFF
--- a/testing-common/build.gradle.kts
+++ b/testing-common/build.gradle.kts
@@ -47,13 +47,13 @@ dependencies {
   api("org.awaitility:awaitility")
   api("com.google.guava:guava")
   api("org.mockito:mockito-core")
+  api("org.slf4j:slf4j-api")
 
   compileOnly(project(":testing:armeria-shaded-for-testing", configuration = "shadow"))
 
   implementation("io.opentelemetry.proto:opentelemetry-proto")
 
   implementation("net.bytebuddy:byte-buddy")
-  implementation("org.slf4j:slf4j-api")
   implementation("ch.qos.logback:logback-classic")
   implementation("org.slf4j:log4j-over-slf4j")
   implementation("org.slf4j:jcl-over-slf4j")

--- a/testing/armeria-shaded-for-testing/build.gradle.kts
+++ b/testing/armeria-shaded-for-testing/build.gradle.kts
@@ -10,6 +10,10 @@ dependencies {
 
 tasks {
   shadowJar {
+    dependencies {
+      exclude(dependency("org.slf4j:slf4j-api"))
+    }
+
     // Ensures tests are not affected by Armeria instrumentation
     relocate("com.linecorp.armeria", "io.opentelemetry.testing.internal.armeria")
     relocate("com.fasterxml.jackson", "io.opentelemetry.testing.internal.jackson")


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6518
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6519
Currently testing-commons includes slf4j-api classes that it gets from armeria-shaded-for-testing. This doesn't allow using slfj4-api 2.0.0 in tests.