### PR TITLE
Fix flaky jersey jaxrs async test

### DIFF
--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsAnnotationsInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsAnnotationsInstrumentation.java
@@ -151,18 +151,13 @@ public class JaxrsAnnotationsInstrumentation implements TypeInstrumentation {
 
       CompletionStage<?> asyncReturnValue =
           returnValue instanceof CompletionStage ? (CompletionStage<?>) returnValue : null;
-
-      if (asyncResponse != null && !asyncResponse.isSuspended()) {
-        // Clear span from the asyncResponse. Logically this should never happen. Added to be safe.
-        VirtualField.find(AsyncResponse.class, AsyncResponseData.class).set(asyncResponse, null);
-      }
       if (asyncReturnValue != null) {
         // span finished by CompletionStageFinishCallback
         asyncReturnValue =
             asyncReturnValue.handle(
                 new CompletionStageFinishCallback<>(instrumenter(), context, handlerData));
       }
-      if ((asyncResponse == null || !asyncResponse.isSuspended()) && asyncReturnValue == null) {
+      if (asyncResponse == null && asyncReturnValue == null) {
         instrumenter().end(context, handlerData, null, null);
       }
       // else span finished by AsyncResponse*Advice

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/JaxrsAnnotationsInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/JaxrsAnnotationsInstrumentation.java
@@ -151,18 +151,13 @@ public class JaxrsAnnotationsInstrumentation implements TypeInstrumentation {
 
       CompletionStage<?> asyncReturnValue =
           returnValue instanceof CompletionStage ? (CompletionStage<?>) returnValue : null;
-
-      if (asyncResponse != null && !asyncResponse.isSuspended()) {
-        // Clear span from the asyncResponse. Logically this should never happen. Added to be safe.
-        VirtualField.find(AsyncResponse.class, AsyncResponseData.class).set(asyncResponse, null);
-      }
       if (asyncReturnValue != null) {
         // span finished by CompletionStageFinishCallback
         asyncReturnValue =
             asyncReturnValue.handle(
                 new CompletionStageFinishCallback<>(instrumenter(), context, handlerData));
       }
-      if ((asyncResponse == null || !asyncResponse.isSuspended()) && asyncReturnValue == null) {
+      if (asyncResponse == null && asyncReturnValue == null) {
         instrumenter().end(context, handlerData, null, null);
       }
       // else span finished by AsyncResponse*Advice


### PR DESCRIPTION
https://ge.opentelemetry.io/s/tr2jbhq7r4r2g/tests/:instrumentation:jaxrs:jaxrs-2.0:jaxrs-2.0-jersey-2.0:javaagent:test/JerseyJettyHttpServerTest/should%20handle%20failing%20AsyncResponse?expanded-stacktrace=WyIwLTEiXQ&top-execution=1
See tested endpoint https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/c04a6a347174b7049e9eb1a21a0b1f1dae8f56a2/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/testing/src/main/groovy/test/JaxRsTestResource.groovy#L119-L139 and test class https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/c04a6a347174b7049e9eb1a21a0b1f1dae8f56a2/instrumentation/jaxrs/jaxrs-common/testing/src/main/groovy/AbstractJaxRsHttpServerTest.groovy#L120-L159
For the `failed` test span should be ended in https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/c04a6a347174b7049e9eb1a21a0b1f1dae8f56a2/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsAsyncResponseInstrumentation.java#L73-L83 when `response.resume(new Exception("failure"))` call exits. Apparently it is possible that this call from `CompletableFuture.runAsync` thread runs concurrently with the main thread that is exiting the `JaxRsTestResource.asyncOp` method and the span is ended in https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/c04a6a347174b7049e9eb1a21a0b1f1dae8f56a2/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsAnnotationsInstrumentation.java#L166
This change makes it so that when a jax-rs method has async response span is only ended when the async response is resumed or canceled. Exiting the jax-rs method will not end the span if the method has an async response.

Hopefully also fixes similar failure in resteasy tests
https://ge.opentelemetry.io/s/be55uszpcc2fk/tests/:instrumentation:jaxrs:jaxrs-3.0:jaxrs-3.0-resteasy-6.0:javaagent:test/ResteasyHttpServerTest/should%20handle%20failing%20AsyncResponse?expanded-stacktrace=WyIwIiwiMC0xIl0&top-execution=1
