### PR TITLE
Add gradle plugin for SDK extensions

### DIFF
--- a/conventions/src/main/kotlin/otel.sdk-extension.gradle.kts
+++ b/conventions/src/main/kotlin/otel.sdk-extension.gradle.kts
@@ -1,0 +1,14 @@
+// SDK extensions are very similar to library instrumentations, they can be used without the javaagent
+// but since they depend on the SDK they must be loaded by the agent CL in the javaagent
+
+plugins {
+  id("io.opentelemetry.instrumentation.library-instrumentation")
+
+  id("otel.jacoco-conventions")
+  id("otel.java-conventions")
+  id("otel.publish-conventions")
+}
+
+extra["mavenGroupId"] = "io.opentelemetry.instrumentation"
+
+base.archivesName.set(projectDir.parentFile.name)

--- a/instrumentation/spring/spring-boot-resources/library/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-resources/library/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("otel.library-instrumentation")
+  id("otel.sdk-extension")
 }
 
 dependencies {

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -108,6 +108,12 @@ project(":instrumentation").subprojects {
       add(javaagentLibs.name, project(subProj.path))
     }
   }
+
+  plugins.withId("otel.sdk-extension") {
+    javaagentDependencies.run {
+      add(javaagentLibs.name, project(subProj.path))
+    }
+  }
 }
 
 tasks {


### PR DESCRIPTION
Resolves #6534

I didn't really have any good idea on how to name it, I called it `otel.sdk-extension` (since that was the name for this kind of modules in the SDK repo). 