### PR TITLE
Revert JUnit version to 4.8.2

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -36,7 +36,7 @@ val DEPENDENCY_BOMS = listOf(
   "org.apache.groovy:groovy-bom:${groovyVersion}",
   "io.opentelemetry:opentelemetry-bom:${otelVersion}",
   "io.opentelemetry:opentelemetry-bom-alpha:${otelVersion}-alpha",
-  "org.junit:junit-bom:5.9.0",
+  "org.junit:junit-bom:5.8.2",
   "org.testcontainers:testcontainers-bom:1.17.3",
 )
 


### PR DESCRIPTION
5.9.0 breaks running test locally with errors like this:

```
java.lang.NoSuchMethodError: 'org.junit.jupiter.api.Timeout$ThreadMode org.junit.jupiter.api.Timeout.threadMode() 
```