### PR TITLE
Remove a method from instrumenter api

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBuilder.java
@@ -22,7 +22,6 @@ import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProp
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -118,14 +117,6 @@ public final class InstrumenterBuilder<REQUEST, RESPONSE> {
           attributesExtractors) {
     attributesExtractors.forEach(this::addAttributesExtractor);
     return this;
-  }
-
-  /** Adds {@link AttributesExtractor}s that will extract attributes from requests and responses. */
-  @SafeVarargs
-  @SuppressWarnings("varargs")
-  public final InstrumenterBuilder<REQUEST, RESPONSE> addAttributesExtractors(
-      AttributesExtractor<? super REQUEST, ? super RESPONSE>... attributesExtractors) {
-    return addAttributesExtractors(Arrays.asList(attributesExtractors));
   }
 
   /** Adds a {@link SpanLinksExtractor} that will extract span links from requests. */

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -154,7 +154,8 @@ class InstrumenterTest {
     Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
-            .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
+            .addAttributesExtractor(new AttributesExtractor1())
+            .addAttributesExtractor(new AttributesExtractor2())
             .addSpanLinksExtractor(new LinksExtractor())
             .buildServerInstrumenter(new MapGetter());
 
@@ -195,7 +196,8 @@ class InstrumenterTest {
     Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
-            .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
+            .addAttributesExtractor(new AttributesExtractor1())
+            .addAttributesExtractor(new AttributesExtractor2())
             .buildServerInstrumenter(new MapGetter());
 
     Context context = instrumenter.start(Context.root(), REQUEST);
@@ -216,7 +218,8 @@ class InstrumenterTest {
     Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
-            .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
+            .addAttributesExtractor(new AttributesExtractor1())
+            .addAttributesExtractor(new AttributesExtractor2())
             .buildServerInstrumenter(new MapGetter());
 
     Map<String, String> request = new HashMap<>(REQUEST);
@@ -256,7 +259,8 @@ class InstrumenterTest {
     Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
-            .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
+            .addAttributesExtractor(new AttributesExtractor1())
+            .addAttributesExtractor(new AttributesExtractor2())
             .addSpanLinksExtractor(new LinksExtractor())
             .buildClientInstrumenter(Map::put);
 
@@ -300,7 +304,8 @@ class InstrumenterTest {
     Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
-            .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
+            .addAttributesExtractor(new AttributesExtractor1())
+            .addAttributesExtractor(new AttributesExtractor2())
             .buildClientInstrumenter(Map::put);
 
     Map<String, String> request = new HashMap<>(REQUEST);
@@ -325,7 +330,8 @@ class InstrumenterTest {
     Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
-            .addAttributesExtractors(new AttributesExtractor1(), new AttributesExtractor2())
+            .addAttributesExtractor(new AttributesExtractor1())
+            .addAttributesExtractor(new AttributesExtractor2())
             .buildClientInstrumenter(Map::put);
 
     Context parent =
@@ -560,11 +566,10 @@ class InstrumenterTest {
     Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
         Instrumenter.<Map<String, String>, Map<String, String>>builder(
                 otelTesting.getOpenTelemetry(), "test", unused -> "span")
-            .addAttributesExtractors(
-                new AttributesExtractor2(),
-                mockHttpClientAttributes,
-                mockNetClientAttributes,
-                mockDbClientAttributes)
+            .addAttributesExtractor(new AttributesExtractor2())
+            .addAttributesExtractor(mockHttpClientAttributes)
+            .addAttributesExtractor(mockNetClientAttributes)
+            .addAttributesExtractor(mockDbClientAttributes)
             .buildInstrumenter();
 
     Context context = instrumenter.start(Context.root(), REQUEST);

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
@@ -64,7 +64,7 @@ public final class DubboTelemetryBuilder {
     InstrumenterBuilder<DubboRequest, Result> serverInstrumenterBuilder =
         Instrumenter.<DubboRequest, Result>builder(
                 openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
-            .addAttributesExtractors(RpcServerAttributesExtractor.create(rpcAttributesGetter))
+            .addAttributesExtractor(RpcServerAttributesExtractor.create(rpcAttributesGetter))
             .addAttributesExtractor(
                 NetServerAttributesExtractor.create(new DubboNetServerAttributesGetter()))
             .addAttributesExtractors(attributesExtractors);

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/AwsLambdaFunctionInstrumenterFactory.java
@@ -23,7 +23,7 @@ public final class AwsLambdaFunctionInstrumenterFactory {
                 openTelemetry,
                 "io.opentelemetry.aws-lambda-core-1.0",
                 AwsLambdaFunctionInstrumenterFactory::spanName)
-            .addAttributesExtractors(new AwsLambdaFunctionAttributesExtractor())
+            .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor())
             .buildInstrumenter(SpanKindExtractor.alwaysServer()));
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/AwsLambdaEventsInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/AwsLambdaEventsInstrumenterFactory.java
@@ -26,9 +26,8 @@ public final class AwsLambdaEventsInstrumenterFactory {
                 openTelemetry,
                 "io.opentelemetry.aws-lambda-events-2.2",
                 AwsLambdaEventsInstrumenterFactory::spanName)
-            .addAttributesExtractors(
-                new AwsLambdaFunctionAttributesExtractor(),
-                new ApiGatewayProxyAttributesExtractor())
+            .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor())
+            .addAttributesExtractor(new ApiGatewayProxyAttributesExtractor())
             .buildInstrumenter(SpanKindExtractor.alwaysServer()));
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/AwsLambdaSqsInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/AwsLambdaSqsInstrumenterFactory.java
@@ -22,7 +22,7 @@ public final class AwsLambdaSqsInstrumenterFactory {
             openTelemetry,
             "io.opentelemetry.aws-lambda-events-2.2",
             AwsLambdaSqsInstrumenterFactory::spanName)
-        .addAttributesExtractors(new SqsEventAttributesExtractor())
+        .addAttributesExtractor(new SqsEventAttributesExtractor())
         .addSpanLinksExtractor(new SqsEventSpanLinksExtractor())
         .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
@@ -32,7 +32,7 @@ public final class AwsLambdaSqsInstrumenterFactory {
             openTelemetry,
             "io.opentelemetry.aws-lambda-events-2.2",
             message -> message.getEventSource() + " process")
-        .addAttributesExtractors(new SqsMessageAttributesExtractor())
+        .addAttributesExtractor(new SqsMessageAttributesExtractor())
         .addSpanLinksExtractor(new SqsMessageSpanLinksExtractor())
         .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }


### PR DESCRIPTION
This overload doesn't seem to be pulling its weight, so think we could remove it.

Not going through deprecation cycle so we can still target 1.18.0 for stable instrumentation-api release.