### PR TITLE
Propagate client span context in doOnRequest

### DIFF
--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/HttpClientInstrumentation.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/HttpClientInstrumentation.java
@@ -85,7 +85,7 @@ public class HttpClientInstrumentation implements TypeInstrumentation {
             BiConsumer<? super HttpClientRequest, ? super Connection> callback) {
 
       if (DecoratorFunctions.shouldDecorate(callback.getClass())) {
-        callback = new DecoratorFunctions.OnMessageDecorator<>(callback, PropagatedContext.PARENT);
+        callback = new DecoratorFunctions.OnMessageDecorator<>(callback, PropagatedContext.CLIENT);
       }
     }
   }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/AbstractReactorNettyHttpClientTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/AbstractReactorNettyHttpClientTest.java
@@ -179,7 +179,7 @@ abstract class AbstractReactorNettyHttpClientTest
               span -> span.hasName("HTTP GET").hasKind(CLIENT).hasParent(parentSpan),
               span -> span.hasName("test-http-server").hasKind(SERVER).hasParent(nettyClientSpan));
 
-          assertSameSpan(parentSpan, onRequestSpan);
+          assertSameSpan(nettyClientSpan, onRequestSpan);
           assertSameSpan(nettyClientSpan, afterRequestSpan);
           assertSameSpan(nettyClientSpan, onResponseSpan);
           assertSameSpan(parentSpan, afterResponseSpan);


### PR DESCRIPTION
Currently the code is propagating the PARENT span in reactor.netty.http.client.HttpClient doOnRequest, however that means that any other code written in doOnRequest hook can not access the CLIENT span. I makes sense that code written in that method would want access to the CLIENT span and not the PARENT span. For example, if you wanted to enrich that span or create a child. I have spoken with @mateuszrzeszutek and reviewed code behavior regarding this issue and PR.