### PR TITLE
Move extractFromRequest() to internal

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanLinksExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanLinksExtractor.java
@@ -7,8 +7,6 @@ package io.opentelemetry.instrumentation.api.instrumenter;
 
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.context.propagation.TextMapGetter;
-import io.opentelemetry.context.propagation.TextMapPropagator;
 
 /** Extractor of span links for a request. */
 @FunctionalInterface
@@ -19,13 +17,4 @@ public interface SpanLinksExtractor<REQUEST> {
    * {@code spanLinks}.
    */
   void extract(SpanLinksBuilder spanLinks, Context parentContext, REQUEST request);
-
-  /**
-   * Returns a new {@link SpanLinksExtractor} that will extract a {@link SpanContext} from the
-   * request using configured {@link TextMapPropagator}.
-   */
-  static <REQUEST> SpanLinksExtractor<REQUEST> extractFromRequest(
-      TextMapPropagator propagator, TextMapGetter<REQUEST> getter) {
-    return new PropagatorBasedSpanLinksExtractor<>(propagator, getter);
-  }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/PropagatorBasedSpanLinksExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/PropagatorBasedSpanLinksExtractor.java
@@ -3,18 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.api.instrumenter;
+package io.opentelemetry.instrumentation.api.internal;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksExtractor;
 
-final class PropagatorBasedSpanLinksExtractor<REQUEST> implements SpanLinksExtractor<REQUEST> {
+public final class PropagatorBasedSpanLinksExtractor<REQUEST>
+    implements SpanLinksExtractor<REQUEST> {
+
   private final TextMapPropagator propagator;
   private final TextMapGetter<REQUEST> getter;
 
-  PropagatorBasedSpanLinksExtractor(TextMapPropagator propagator, TextMapGetter<REQUEST> getter) {
+  public PropagatorBasedSpanLinksExtractor(
+      TextMapPropagator propagator, TextMapGetter<REQUEST> getter) {
     this.propagator = propagator;
     this.getter = getter;
   }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/PropagatorBasedSpanLinksExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/PropagatorBasedSpanLinksExtractorTest.java
@@ -17,6 +17,7 @@ import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +37,7 @@ class PropagatorBasedSpanLinksExtractorTest {
     TextMapPropagator propagator = W3CTraceContextPropagator.getInstance();
 
     SpanLinksExtractor<Map<String, String>> underTest =
-        SpanLinksExtractor.extractFromRequest(propagator, new MapGetter());
+        new PropagatorBasedSpanLinksExtractor<>(propagator, new MapGetter());
 
     Map<String, String> request =
         singletonMap("traceparent", String.format("00-%s-%s-01", TRACE_ID, SPAN_ID));

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaBatchProcessSpanLinksExtractor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaBatchProcessSpanLinksExtractor.java
@@ -9,6 +9,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksExtractor;
+import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 
@@ -19,7 +20,7 @@ final class KafkaBatchProcessSpanLinksExtractor
 
   KafkaBatchProcessSpanLinksExtractor(TextMapPropagator propagator) {
     this.singleRecordLinkExtractor =
-        SpanLinksExtractor.extractFromRequest(propagator, KafkaConsumerRecordGetter.INSTANCE);
+        new PropagatorBasedSpanLinksExtractor<>(propagator, KafkaConsumerRecordGetter.INSTANCE);
   }
 
   @Override

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
@@ -13,11 +13,11 @@ import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import java.util.Collections;
 import java.util.List;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -135,7 +135,7 @@ public final class KafkaInstrumenterFactory {
       return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
     } else if (messagingReceiveInstrumentationEnabled) {
       builder.addSpanLinksExtractor(
-          SpanLinksExtractor.extractFromRequest(
+          new PropagatorBasedSpanLinksExtractor<ConsumerRecord<?, ?>>(
               openTelemetry.getPropagators().getTextMapPropagator(),
               KafkaConsumerRecordGetter.INSTANCE));
       return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());

--- a/instrumentation/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmq/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmq/RocketMqInstrumenterFactory.java
@@ -18,6 +18,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperat
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import java.util.List;
 import org.apache.rocketmq.client.hook.SendMessageContext;
 import org.apache.rocketmq.common.message.MessageExt;
@@ -110,7 +111,7 @@ class RocketMqInstrumenterFactory {
 
     if (batch) {
       SpanLinksExtractor<MessageExt> spanLinksExtractor =
-          SpanLinksExtractor.extractFromRequest(
+          new PropagatorBasedSpanLinksExtractor<>(
               openTelemetry.getPropagators().getTextMapPropagator(),
               TextMapExtractAdapter.INSTANCE);
 


### PR DESCRIPTION
In case messaging semantics decide that consumers of a single message should use parent instead of a link.