### PR TITLE
Fix logback appender latest deps test failure

### DIFF
--- a/instrumentation/logback/logback-appender-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/build.gradle.kts
@@ -55,4 +55,6 @@ tasks.withType<Test>().configureEach {
   jvmArgs("-Dotel.instrumentation.logback-appender.experimental.capture-mdc-attributes=*")
   jvmArgs("-Dotel.instrumentation.logback-appender.experimental-log-attributes=true")
   jvmArgs("-Dotel.instrumentation.logback-appender.experimental.capture-code-attributes=true")
+
+  systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
 }

--- a/instrumentation/logback/logback-appender-1.0/javaagent/src/test/groovy/LogbackTest.groovy
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/src/test/groovy/LogbackTest.groovy
@@ -130,7 +130,8 @@ class LogbackTest extends AgentInstrumentationSpecification {
     assertThat(log.getInstrumentationScopeInfo().getName()).isEqualTo("abc")
     assertThat(log.getSeverity()).isEqualTo(Severity.INFO)
     assertThat(log.getSeverityText()).isEqualTo("INFO")
-    assertThat(log.getAttributes().size()).isEqualTo(3 + 3) // 3 code attributes
+    def codeAttributes = Boolean.getBoolean("testLatestDeps") ? 4 : 2
+    assertThat(log.getAttributes().size()).isEqualTo(4 + codeAttributes)
     assertThat(log.getAttributes().get(AttributeKey.stringKey("logback.mdc.key1"))).isEqualTo("val1")
     assertThat(log.getAttributes().get(AttributeKey.stringKey("logback.mdc.key2"))).isEqualTo("val2")
     assertThat(log.getAttributes().get(SemanticAttributes.THREAD_NAME)).isEqualTo(Thread.currentThread().getName())


### PR DESCRIPTION
Hopefully this gets the latest deps test passing. This could use assertions for the expected attributes. The not latest deps configuration reports `code.function="call", code.namespace="org.slf4j.Logger$info"` which isn't probably what it should reprot.