### PR TITLE
Fix spring boot @WithSpan handling

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/TraceAspectAutoConfiguration.java
@@ -32,7 +32,7 @@ public class TraceAspectAutoConfiguration {
 
   @Bean
   @ConditionalOnClass(WithSpan.class)
-  public WithSpanAspect instrumentationWithSpanAspect(
+  public InstrumentationWithSpanAspect instrumentationWithSpanAspect(
       OpenTelemetry openTelemetry, ParameterNameDiscoverer parameterNameDiscoverer) {
     return new InstrumentationWithSpanAspect(openTelemetry, parameterNameDiscoverer);
   }
@@ -40,7 +40,7 @@ public class TraceAspectAutoConfiguration {
   @Bean
   @SuppressWarnings("deprecation") // instrumenting deprecated class for backwards compatibility
   @ConditionalOnClass(io.opentelemetry.extension.annotations.WithSpan.class)
-  public WithSpanAspect sdkExtensionWithSpanAspect(
+  public SdkExtensionWithSpanAspect sdkExtensionWithSpanAspect(
       OpenTelemetry openTelemetry, ParameterNameDiscoverer parameterNameDiscoverer) {
     return new SdkExtensionWithSpanAspect(openTelemetry, parameterNameDiscoverer);
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6617
Spring detects aspects by checking whether predicted bean type is annotated with `@Aspect`. WithSpanAspect isn't, but the subclasses are.