### PR TITLE
Run context customizers before span start instead of after

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/ContextCustomizer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/ContextCustomizer.java
@@ -18,5 +18,5 @@ import io.opentelemetry.context.Context;
 public interface ContextCustomizer<REQUEST> {
 
   /** Allows to customize the operation {@link Context}. */
-  Context onStart(Context context, REQUEST request, Attributes startAttributes);
+  Context onStart(Context parentContext, REQUEST request, Attributes startAttributes);
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -160,10 +160,7 @@ public class Instrumenter<REQUEST, RESPONSE> {
   private Context doStart(Context parentContext, REQUEST request, @Nullable Instant startTime) {
     SpanKind spanKind = spanKindExtractor.extract(request);
     SpanBuilder spanBuilder =
-        tracer
-            .spanBuilder(spanNameExtractor.extract(request))
-            .setSpanKind(spanKind)
-            .setParent(parentContext);
+        tracer.spanBuilder(spanNameExtractor.extract(request)).setSpanKind(spanKind);
 
     if (startTime != null) {
       spanBuilder.setStartTimestamp(startTime);
@@ -195,7 +192,7 @@ public class Instrumenter<REQUEST, RESPONSE> {
     boolean localRoot = LocalRootSpan.isLocalRoot(context);
 
     spanBuilder.setAllAttributes(attributes);
-    Span span = spanBuilder.startSpan();
+    Span span = spanBuilder.setParent(context).startSpan();
     context = context.with(span);
 
     if (localRoot) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -181,10 +181,6 @@ public class Instrumenter<REQUEST, RESPONSE> {
 
     Context context = parentContext;
 
-    spanBuilder.setAllAttributes(attributes);
-    Span span = spanBuilder.startSpan();
-    context = context.with(span);
-
     for (ContextCustomizer<? super REQUEST> contextCustomizer : contextCustomizers) {
       context = contextCustomizer.onStart(context, request, attributes);
     }
@@ -196,7 +192,13 @@ public class Instrumenter<REQUEST, RESPONSE> {
       }
     }
 
-    if (LocalRootSpan.isLocalRoot(parentContext)) {
+    boolean localRoot = LocalRootSpan.isLocalRoot(context);
+
+    spanBuilder.setAllAttributes(attributes);
+    Span span = spanBuilder.startSpan();
+    context = context.with(span);
+
+    if (localRoot) {
       context = LocalRootSpan.store(context, span);
     }
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -426,7 +426,7 @@ class InstrumenterTest {
     Context context = instrumenter.start(Context.root(), REQUEST);
     instrumenter.end(context, REQUEST, RESPONSE, null);
 
-    assertThat(Span.fromContext(startContext.get()).getSpanContext().isValid()).isTrue();
+    // assertThat(Span.fromContext(startContext.get()).getSpanContext().isValid()).isTrue();
     assertThat(Span.fromContext(endContext.get()).getSpanContext().isValid()).isTrue();
   }
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -426,7 +426,7 @@ class InstrumenterTest {
     Context context = instrumenter.start(Context.root(), REQUEST);
     instrumenter.end(context, REQUEST, RESPONSE, null);
 
-    // assertThat(Span.fromContext(startContext.get()).getSpanContext().isValid()).isTrue();
+    assertThat(Span.fromContext(startContext.get()).getSpanContext().isValid()).isTrue();
     assertThat(Span.fromContext(endContext.get()).getSpanContext().isValid()).isTrue();
   }
 


### PR DESCRIPTION
...so that they can have access to the parent span context, and so that their additions to the context will be visible to span processors