### PR TITLE
Add Spring GraphQL Instrumentation Module

### DIFF
--- a/instrumentation/spring/spring-graphql-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-graphql-1.0/javaagent/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+  id("otel.javaagent-instrumentation")
+}
+
+muzzle {
+  pass {
+    group.set("org.springframework")
+    module.set("spring-graphql")
+    versions.set("(,)")
+    assertInverse.set(true)
+  }
+}
+
+dependencies {
+  library("org.springframework.graphql:spring-graphql:1.0.0")
+
+  compileOnly("com.google.auto.value:auto-value-annotations")
+  annotationProcessor("com.google.auto.value:auto-value")
+
+  testLibrary("org.springframework.boot:spring-boot-starter-web:2.7.0")
+  testLibrary("org.springframework.boot:spring-boot-starter-webflux:2.7.0")
+  testLibrary("org.springframework.graphql:spring-graphql-test:1.0.0")
+
+  testInstrumentation(project(":instrumentation:servlet:servlet-3.0:javaagent"))
+}
+
+tasks.withType<Test>().configureEach {
+  // required on jdk17
+  jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+  jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+}

--- a/instrumentation/spring/spring-graphql-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/graphql/SpringGraphQLInstrumentationModule.java
+++ b/instrumentation/spring/spring-graphql-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/graphql/SpringGraphQLInstrumentationModule.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.graphql;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.instrumentation.spring.graphql.mapping.SchemaMappingInstrumentation;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+
+@AutoService(InstrumentationModule.class)
+public class SpringGraphQLInstrumentationModule extends InstrumentationModule {
+
+  public SpringGraphQLInstrumentationModule() {
+    super("spring-graphql", "spring-graphql-1.0");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("org.springframework.graphql.server.WebGraphQlHandler");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return Arrays.asList(
+        new SchemaMappingInstrumentation()
+    );
+  }
+
+}

--- a/instrumentation/spring/spring-graphql-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/graphql/mapping/SchemaMappingCodeAttributesGetter.java
+++ b/instrumentation/spring/spring-graphql-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/graphql/mapping/SchemaMappingCodeAttributesGetter.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.graphql.mapping;
+
+import io.opentelemetry.instrumentation.api.instrumenter.code.CodeAttributesGetter;
+
+public class SchemaMappingCodeAttributesGetter implements CodeAttributesGetter<SchemaMappingRequest> {
+
+  @Override
+  public Class<?> codeClass(SchemaMappingRequest request) {
+    return request.getCodeClass();
+  }
+
+  @Override
+  public String methodName(SchemaMappingRequest request) {
+    return request.getMethodName();
+  }
+
+}

--- a/instrumentation/spring/spring-graphql-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/graphql/mapping/SchemaMappingInstrumentation.java
+++ b/instrumentation/spring/spring-graphql-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/graphql/mapping/SchemaMappingInstrumentation.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.graphql.mapping;
+
+import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static io.opentelemetry.javaagent.instrumentation.spring.graphql.mapping.SchemaMappingSingletons.instrumenter;
+import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class SchemaMappingInstrumentation implements TypeInstrumentation {
+
+  private static final String[] ANNOTATION_CLASSES =
+      new String[] {
+          "org.springframework.graphql.data.method.annotation.SchemaMapping",
+          "org.springframework.graphql.data.method.annotation.QueryMapping",
+          "org.springframework.graphql.data.method.annotation.MutationMapping",
+          "org.springframework.graphql.data.method.annotation.SubscriptionMapping"
+      };
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderOptimization() {
+    return hasClassesNamed("org.springframework.graphql.server.WebGraphQlHandler");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return declaresMethod(isAnnotatedWith(namedOneOf(ANNOTATION_CLASSES)));
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isMethod().and(isAnnotatedWith(namedOneOf(ANNOTATION_CLASSES))),
+        this.getClass().getName() + "$SchemaMappingAdvice"
+    );
+  }
+
+  @SuppressWarnings("unused")
+  public static class SchemaMappingAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void startSpan(
+        @Advice.Origin("#t") Class<?> codeClass,
+        @Advice.Origin("#m") String methodName,
+        @Advice.Local("otelRequest") SchemaMappingRequest request,
+        @Advice.Local("otelContext") Context context,
+        @Advice.Local("otelScope") Scope scope) {
+
+      Context parentContext = currentContext();
+      request = SchemaMappingRequest.create(codeClass, methodName);
+      if (!instrumenter().shouldStart(parentContext, request)) {
+        return;
+      }
+
+      context = instrumenter().start(parentContext, request);
+      scope = context.makeCurrent();
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void stopSpan(
+        @Advice.Thrown Throwable throwable,
+        @Advice.Local("otelRequest") SchemaMappingRequest request,
+        @Advice.Local("otelContext") Context context,
+        @Advice.Local("otelScope") Scope scope) {
+
+      if (scope == null) {
+        return;
+      }
+
+      scope.close();
+      instrumenter().end(context, request, null, throwable);
+    }
+
+  }
+
+}

--- a/instrumentation/spring/spring-graphql-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/graphql/mapping/SchemaMappingRequest.java
+++ b/instrumentation/spring/spring-graphql-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/graphql/mapping/SchemaMappingRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.graphql.mapping;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class SchemaMappingRequest {
+
+  public static SchemaMappingRequest create(Class<?> codeClass, String methodName) {
+    return new AutoValue_SchemaMappingRequest(codeClass, methodName);
+  }
+
+  public abstract Class<?> getCodeClass();
+
+  public abstract String getMethodName();
+
+}

--- a/instrumentation/spring/spring-graphql-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/graphql/mapping/SchemaMappingSingletons.java
+++ b/instrumentation/spring/spring-graphql-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/graphql/mapping/SchemaMappingSingletons.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.graphql.mapping;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.code.CodeAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.code.CodeSpanNameExtractor;
+
+public class SchemaMappingSingletons {
+
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-graphql-1.0";
+
+  private static final Instrumenter<SchemaMappingRequest, Void> INSTRUMENTER;
+
+  static {
+    SchemaMappingCodeAttributesGetter codeAttributesGetter = new SchemaMappingCodeAttributesGetter();
+
+    INSTRUMENTER = Instrumenter.<SchemaMappingRequest, Void>builder(
+            GlobalOpenTelemetry.get(),
+            INSTRUMENTATION_NAME,
+            CodeSpanNameExtractor.create(codeAttributesGetter))
+        .addAttributesExtractor(CodeAttributesExtractor.create(codeAttributesGetter))
+        .buildInstrumenter();
+  }
+
+  public static Instrumenter<SchemaMappingRequest, Void> instrumenter() {
+    return INSTRUMENTER;
+  }
+
+  private SchemaMappingSingletons() {}
+
+}

--- a/instrumentation/spring/spring-graphql-1.0/javaagent/src/test/groovy/test/boot/AppConfig.groovy
+++ b/instrumentation/spring/spring-graphql-1.0/javaagent/src/test/groovy/test/boot/AppConfig.groovy
@@ -1,0 +1,32 @@
+package test.boot
+
+import org.springframework.beans.BeansException
+import org.springframework.beans.factory.config.BeanPostProcessor
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.graphql.data.method.annotation.support.AnnotatedControllerConfigurer
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+import java.util.concurrent.Executors
+
+@SpringBootApplication
+class AppConfig implements WebMvcConfigurer {
+
+  @Bean
+  BeanPostProcessor executorAnnotatedControllerConfigurer() {
+    return new BeanPostProcessor() {
+
+      @Override
+      Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (!(bean instanceof AnnotatedControllerConfigurer)) {
+          return bean
+        }
+
+        ((AnnotatedControllerConfigurer) bean).setExecutor(Executors.newSingleThreadExecutor())
+        return bean
+      }
+
+    }
+  }
+
+}

--- a/instrumentation/spring/spring-graphql-1.0/javaagent/src/test/groovy/test/boot/HelloController.groovy
+++ b/instrumentation/spring/spring-graphql-1.0/javaagent/src/test/groovy/test/boot/HelloController.groovy
@@ -1,0 +1,35 @@
+package test.boot
+
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+import java.util.concurrent.Callable
+
+@Controller
+@SchemaMapping(typeName = "Query")
+@SuppressWarnings("unused")
+class HelloController {
+
+  @SchemaMapping
+  String helloWorldAsValue() {
+    return "Hello World!"
+  }
+
+  @SchemaMapping
+  Mono<String> helloWorldAsMono() {
+    return Mono.just("Hello World!")
+  }
+
+  @SchemaMapping
+  Flux<String> helloWorldAsFlux() {
+    return Mono.just("Hello World!").flux()
+  }
+
+  @SchemaMapping
+  Callable<String> helloWorldAsCallable() {
+    return () -> "Hello World!"
+  }
+
+}

--- a/instrumentation/spring/spring-graphql-1.0/javaagent/src/test/groovy/test/boot/SpringGraphQLTest.groovy
+++ b/instrumentation/spring/spring-graphql-1.0/javaagent/src/test/groovy/test/boot/SpringGraphQLTest.groovy
@@ -1,0 +1,92 @@
+package test.boot
+
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.instrumentation.test.asserts.TraceAssert
+import io.opentelemetry.instrumentation.test.base.HttpServerTestTrait
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import org.springframework.boot.SpringApplication
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.graphql.test.tester.HttpGraphQlTester
+import org.springframework.test.web.reactive.server.WebTestClient
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.StatusCode.ERROR
+
+class SpringGraphQLTest extends AgentInstrumentationSpecification implements HttpServerTestTrait<ConfigurableApplicationContext> {
+
+  def setupSpec() {
+    setupServer()
+  }
+
+  def cleanupSpec() {
+    cleanupServer()
+  }
+
+  @Override
+  ConfigurableApplicationContext startServer(int port) {
+    def app = new SpringApplication(AppConfig)
+    app.setDefaultProperties([
+      "server.port": port
+    ])
+
+    def context = app.run()
+    return context
+  }
+
+  @Override
+  void stopServer(ConfigurableApplicationContext context) {
+    context.close()
+  }
+
+  def "test #methodName"(String methodName) {
+    setup:
+    WebTestClient client = WebTestClient.bindToServer().baseUrl(address.resolve("graphql").toString()).build()
+    HttpGraphQlTester tester = HttpGraphQlTester.create(client)
+    GraphQlTester.Response response = tester.document("{ $methodName }").execute()
+
+    expect:
+    response.path(methodName).hasValue()
+
+    and:
+    assertTraces(1) {
+      trace(0, 2) {
+        serverSpan(it, 0, "/*")
+        graphQlSpan(it, 1, methodName, span(0))
+      }
+    }
+
+    where:
+    methodName << ["helloWorldAsValue", "helloWorldAsMono", "helloWorldAsFlux", "helloWorldAsCallable"]
+  }
+
+  static serverSpan(TraceAssert trace, int index, String operation, Throwable exception = null) {
+    trace.span(index) {
+      hasNoParent()
+      name operation
+      kind SpanKind.SERVER
+      if (exception != null) {
+        status ERROR
+      }
+    }
+  }
+
+  static graphQlSpan(TraceAssert trace, int index, String methodName, Object parentSpan = null, Throwable exception = null) {
+    trace.span(index) {
+      if (parentSpan == null) {
+        hasNoParent()
+      } else {
+        childOf((SpanData) parentSpan)
+      }
+      name "HelloController." + methodName
+      kind INTERNAL
+      attributes {
+        "$SemanticAttributes.CODE_NAMESPACE" "test.boot.HelloController"
+        "$SemanticAttributes.CODE_FUNCTION" methodName
+      }
+    }
+  }
+
+}

--- a/instrumentation/spring/spring-graphql-1.0/javaagent/src/test/resources/graphql/schema.graphqls
+++ b/instrumentation/spring/spring-graphql-1.0/javaagent/src/test/resources/graphql/schema.graphqls
@@ -1,0 +1,6 @@
+type Query {
+  helloWorldAsValue: String!
+  helloWorldAsMono: String!
+  helloWorldAsFlux: String!
+  helloWorldAsCallable: String!
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -432,6 +432,7 @@ include(":instrumentation:spring:spring-boot-actuator-autoconfigure-2.0:javaagen
 include(":instrumentation:spring:spring-boot-resources:library")
 include(":instrumentation:spring:spring-core-2.0:javaagent")
 include(":instrumentation:spring:spring-data-1.8:javaagent")
+include(":instrumentation:spring:spring-graphql-1.0:javaagent")
 include(":instrumentation:spring:spring-integration-4.1:javaagent")
 include(":instrumentation:spring:spring-integration-4.1:library")
 include(":instrumentation:spring:spring-integration-4.1:testing")


### PR DESCRIPTION
I'm attempting to add an instrumentation module for Spring GraphQL to wrap around the SchemaMapping/BatchMapping annotations so that I can get a better understanding of the performance of the application.

Still a work in progress for now, but I have a failing unit test because a global library is being transformed. I'm not sure what causes this to happen and was wondering if someone would be able to give any pointers?

```
SpringGraphQLTest > executionError FAILED
    java.lang.AssertionError: Transformed classes match global libraries ignore matcher: [com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider$1]
        at io.opentelemetry.instrumentation.testing.AgentTestRunner.afterTestClass(AgentTestRunner.java:63)
        at io.opentelemetry.instrumentation.test.InstrumentationSpecification.cleanupSpec(InstrumentationSpecification.groovy:56)
```