### PR TITLE
Fix CI

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -202,7 +202,10 @@ tasks {
       charSet = "UTF-8"
       breakIterator(true)
 
-      links("https://docs.oracle.com/javase/8/docs/api/")
+      // TODO (trask) revisit to see if url is fixed
+      // currently broken because https://docs.oracle.com/javase/8/docs/api/element-list is missing
+      // and redirects
+      // links("https://docs.oracle.com/javase/8/docs/api/")
 
       addStringOption("Xdoclint:none", "-quiet")
       // non-standard option to fail on warnings, see https://bugs.openjdk.java.net/browse/JDK-8200363


### PR DESCRIPTION
CI on `main` is failing on publishing snapshot, because javadoc is emitting a warning and we fail on warnings. See code comment for more explanation.

I tried pointing to `https://docs.oracle.com/en/java/javase/11/docs/api/`, but that gives a different error:

> warning: The code being documented uses packages in the unnamed module, but the packages defined in https://docs.oracle.com/en/java/javase/11/docs/api/ are in named modules.
