### PR TITLE
Remove deprecated `http.host` and `http.server_name` attributes

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -76,10 +76,8 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
     String forwardedProto = forwardedProto(request);
     String value = forwardedProto != null ? forwardedProto : getter.scheme(request);
     internalSet(attributes, SemanticAttributes.HTTP_SCHEME, value);
-    internalSet(attributes, SemanticAttributes.HTTP_HOST, host(request));
     internalSet(attributes, SemanticAttributes.HTTP_TARGET, getter.target(request));
     internalSet(attributes, SemanticAttributes.HTTP_ROUTE, getter.route(request));
-    internalSet(attributes, SemanticAttributes.HTTP_SERVER_NAME, getter.serverName(request));
     internalSet(attributes, SemanticAttributes.HTTP_CLIENT_IP, clientIp(request));
   }
 
@@ -93,11 +91,6 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
 
     super.onEnd(attributes, context, request, response, error);
     internalSet(attributes, SemanticAttributes.HTTP_ROUTE, httpRouteHolderGetter.apply(context));
-  }
-
-  @Nullable
-  private String host(REQUEST request) {
-    return firstHeaderValue(getter.requestHeader(request, "host"));
   }
 
   @Nullable

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
@@ -35,7 +35,13 @@ public interface HttpServerAttributesGetter<REQUEST, RESPONSE>
    * The primary server name of the matched virtual host. This should be obtained via configuration,
    * not from the Host header. If no such configuration can be obtained, this method should return
    * {@code null}.
+   *
+   * @deprecated This method is deprecated and will be removed in the next release.
    */
   @Nullable
-  String serverName(REQUEST request);
+  @Deprecated
+  default String serverName(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the next release");
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsView.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsView.java
@@ -40,6 +40,7 @@ final class TemporaryMetricsView {
     Set<AttributeKey> view = new HashSet<>(durationAlwaysInclude);
     view.add(SemanticAttributes.NET_PEER_NAME);
     view.add(SemanticAttributes.NET_PEER_PORT);
+    view.add(AttributeKey.stringKey("net.peer.sock.addr"));
     return view;
   }
 
@@ -51,7 +52,8 @@ final class TemporaryMetricsView {
     // - we prefer http.route (which is scrubbed) over http.target (which is not scrubbed).
     Set<AttributeKey> view = new HashSet<>(durationAlwaysInclude);
     view.add(SemanticAttributes.HTTP_SCHEME);
-    view.add(SemanticAttributes.HTTP_HOST);
+    view.add(SemanticAttributes.NET_HOST_NAME);
+    view.add(SemanticAttributes.NET_HOST_PORT);
     view.add(SemanticAttributes.HTTP_ROUTE);
     return view;
   }
@@ -61,10 +63,10 @@ final class TemporaryMetricsView {
     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#attributes
     Set<AttributeKey> view = new HashSet<>();
     view.add(SemanticAttributes.HTTP_METHOD);
-    view.add(SemanticAttributes.HTTP_HOST);
     view.add(SemanticAttributes.HTTP_SCHEME);
     view.add(SemanticAttributes.HTTP_FLAVOR);
-    view.add(SemanticAttributes.HTTP_SERVER_NAME);
+    view.add(SemanticAttributes.NET_HOST_NAME);
+    // TODO: net host port?
     return view;
   }
 

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 
@@ -35,7 +36,6 @@ class HttpClientMetricsTest {
         Attributes.builder()
             .put("http.method", "GET")
             .put("http.url", "https://localhost:1234/")
-            .put("http.host", "host")
             .put("http.target", "/")
             .put("http.scheme", "https")
             .put("net.peer.name", "localhost")
@@ -46,9 +46,12 @@ class HttpClientMetricsTest {
     Attributes responseAttributes =
         Attributes.builder()
             .put("http.flavor", "2.0")
-            .put("http.server_name", "server")
             .put("http.status_code", 200)
             .put("http.response_content_length", 200)
+            .put("net.sock.family", "inet")
+            .put("net.peer.sock.addr", "1.2.3.4")
+            .put("net.peer.sock.name", "somehost20")
+            .put("net.peer.sock.port", 8080)
             .build();
 
     Context parent =
@@ -84,11 +87,12 @@ class HttpClientMetricsTest {
                                     point
                                         .hasSum(150 /* millis */)
                                         .hasAttributesSatisfying(
+                                            equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
+                                            equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
+                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
                                             equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_PEER_PORT, 1234),
-                                            equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
-                                            equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200))
+                                            equalTo(stringKey("net.peer.sock.addr"), "1.2.3.4"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -105,11 +109,12 @@ class HttpClientMetricsTest {
                                     point
                                         .hasSum(100 /* bytes */)
                                         .hasAttributesSatisfying(
+                                            equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
+                                            equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
+                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
                                             equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_PEER_PORT, 1234),
-                                            equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
-                                            equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200)))),
+                                            equalTo(stringKey("net.peer.sock.addr"), "1.2.3.4")))),
             metric ->
                 assertThat(metric)
                     .hasName("http.client.response.size")
@@ -121,11 +126,12 @@ class HttpClientMetricsTest {
                                     point
                                         .hasSum(200 /* bytes */)
                                         .hasAttributesSatisfying(
+                                            equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
+                                            equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
+                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
                                             equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_PEER_PORT, 1234),
-                                            equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
-                                            equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200)))));
+                                            equalTo(stringKey("net.peer.sock.addr"), "1.2.3.4")))));
 
     listener.onEnd(context2, responseAttributes, nanos(300));
 

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -49,11 +49,6 @@ class HttpServerAttributesExtractorTest {
     }
 
     @Override
-    public String serverName(Map<String, String> request) {
-      return request.get("serverName");
-    }
-
-    @Override
     public List<String> requestHeader(Map<String, String> request, String name) {
       String values = request.get("header." + name);
       return values == null ? emptyList() : asList(values.split(","));
@@ -89,7 +84,6 @@ class HttpServerAttributesExtractorTest {
     request.put("header.content-length", "10");
     request.put("flavor", "http/2");
     request.put("route", "/repositories/{id}");
-    request.put("serverName", "server");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.host", "github.com");
     request.put("header.forwarded", "for=1.1.1.1;proto=https");
@@ -116,11 +110,9 @@ class HttpServerAttributesExtractorTest {
             entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
-            entry(SemanticAttributes.HTTP_HOST, "github.com"),
             entry(SemanticAttributes.HTTP_TARGET, "/repositories/1"),
             entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
             entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
-            entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
             entry(SemanticAttributes.HTTP_CLIENT_IP, "1.1.1.1"),
             entry(
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
@@ -131,17 +123,14 @@ class HttpServerAttributesExtractorTest {
         .containsOnly(
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
-            entry(SemanticAttributes.HTTP_HOST, "github.com"),
             entry(SemanticAttributes.HTTP_TARGET, "/repositories/1"),
             entry(SemanticAttributes.HTTP_USER_AGENT, "okhttp 3.x"),
             entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{repoId}"),
-            entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
             entry(SemanticAttributes.HTTP_CLIENT_IP, "1.1.1.1"),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")),
-            entry(SemanticAttributes.HTTP_SERVER_NAME, "server"),
             entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
             entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.api.instrumenter.http;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_2_0;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -34,19 +36,23 @@ class HttpServerMetricsTest {
     Attributes requestAttributes =
         Attributes.builder()
             .put("http.method", "GET")
-            .put("http.host", "host")
+            .put("http.flavor", HTTP_2_0)
             .put("http.target", "/")
             .put("http.scheme", "https")
+            .put("net.transport", IP_TCP)
             .put("net.host.name", "localhost")
             .put("net.host.port", 1234)
-            .put("http.request_content_length", 100)
+            .put("net.sock.family", "inet")
+            .put("net.peer.sock.addr", "1.2.3.4")
+            .put("net.peer.sock.port", 8080)
+            .put("net.host.sock.addr", "4.3.2.1")
+            .put("net.host.sock.port", 9090)
             .build();
 
     Attributes responseAttributes =
         Attributes.builder()
-            .put("http.flavor", "2.0")
-            .put("http.server_name", "server")
             .put("http.status_code", 200)
+            .put("http.request_content_length", 100)
             .put("http.response_content_length", 200)
             .build();
 
@@ -81,9 +87,10 @@ class HttpServerMetricsTest {
                                     point
                                         .hasValue(1)
                                         .hasAttributesSatisfying(
-                                            equalTo(SemanticAttributes.HTTP_HOST, "host"),
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
-                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"))
+                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
+                                            equalTo(SemanticAttributes.HTTP_FLAVOR, HTTP_2_0),
+                                            equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -105,9 +112,10 @@ class HttpServerMetricsTest {
                                     point
                                         .hasValue(2)
                                         .hasAttributesSatisfying(
-                                            equalTo(SemanticAttributes.HTTP_HOST, "host"),
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
-                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"))
+                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
+                                            equalTo(SemanticAttributes.HTTP_FLAVOR, HTTP_2_0),
+                                            equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -128,9 +136,10 @@ class HttpServerMetricsTest {
                                     point
                                         .hasValue(1)
                                         .hasAttributesSatisfying(
-                                            equalTo(SemanticAttributes.HTTP_HOST, "host"),
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
-                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"))
+                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
+                                            equalTo(SemanticAttributes.HTTP_FLAVOR, HTTP_2_0),
+                                            equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -147,11 +156,12 @@ class HttpServerMetricsTest {
                                     point
                                         .hasSum(150 /* millis */)
                                         .hasAttributesSatisfying(
-                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
-                                            equalTo(SemanticAttributes.HTTP_HOST, "host"),
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"))
+                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
+                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
+                                            equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"),
+                                            equalTo(SemanticAttributes.NET_HOST_PORT, 1234))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -168,11 +178,12 @@ class HttpServerMetricsTest {
                                     point
                                         .hasSum(100 /* bytes */)
                                         .hasAttributesSatisfying(
-                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
-                                            equalTo(SemanticAttributes.HTTP_HOST, "host"),
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0")))),
+                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
+                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
+                                            equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"),
+                                            equalTo(SemanticAttributes.NET_HOST_PORT, 1234)))),
             metric ->
                 assertThat(metric)
                     .hasName("http.server.response.size")
@@ -184,11 +195,12 @@ class HttpServerMetricsTest {
                                     point
                                         .hasSum(200 /* bytes */)
                                         .hasAttributesSatisfying(
-                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
-                                            equalTo(SemanticAttributes.HTTP_HOST, "host"),
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0")))));
+                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
+                                            equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
+                                            equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"),
+                                            equalTo(SemanticAttributes.NET_HOST_PORT, 1234)))));
 
     listener.onEnd(context2, responseAttributes, nanos(300));
 
@@ -237,7 +249,7 @@ class HttpServerMetricsTest {
     OperationListener listener = HttpServerMetrics.get().create(meterProvider.get("test"));
 
     Attributes requestAttributes =
-        Attributes.builder().put("http.host", "host").put("http.scheme", "https").build();
+        Attributes.builder().put("net.host.name", "host").put("http.scheme", "https").build();
 
     Attributes responseAttributes = Attributes.builder().put("http.route", "/test/{id}").build();
 
@@ -262,7 +274,7 @@ class HttpServerMetricsTest {
                                         .hasSum(100 /* millis */)
                                         .hasAttributesSatisfying(
                                             equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
-                                            equalTo(SemanticAttributes.HTTP_HOST, "host"),
+                                            equalTo(SemanticAttributes.NET_HOST_NAME, "host"),
                                             equalTo(
                                                 SemanticAttributes.HTTP_ROUTE, "/test/{id}")))));
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsViewTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsViewTest.java
@@ -5,13 +5,16 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.instrumenter.http.TemporaryMetricsView.applyActiveRequestsView;
 import static io.opentelemetry.instrumentation.api.instrumenter.http.TemporaryMetricsView.applyClientDurationAndSizeView;
 import static io.opentelemetry.instrumentation.api.instrumenter.http.TemporaryMetricsView.applyServerDurationAndSizeView;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_1_1;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.junit.jupiter.api.Test;
 
@@ -26,24 +29,30 @@ class TemporaryMetricsViewTest {
                 "https://somehost/high/cardinality/12345?jsessionId=121454")
             .put(SemanticAttributes.HTTP_METHOD, "GET")
             .put(SemanticAttributes.HTTP_SCHEME, "https")
-            .put(SemanticAttributes.HTTP_HOST, "somehost")
             .put(SemanticAttributes.HTTP_TARGET, "/high/cardinality/12345?jsessionId=121454")
             .build();
 
     Attributes endAttributes =
         Attributes.builder()
             .put(SemanticAttributes.HTTP_STATUS_CODE, 500)
+            .put(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1)
+            .put(SemanticAttributes.NET_TRANSPORT, IP_TCP)
             .put(SemanticAttributes.NET_PEER_NAME, "somehost2")
             .put(SemanticAttributes.NET_PEER_PORT, 443)
+            .put("net.sock.family", "inet")
+            .put("net.peer.sock.addr", "1.2.3.4")
+            .put("net.peer.sock.name", "somehost20")
+            .put("net.peer.sock.port", 8080)
             .build();
 
-    OpenTelemetryAssertions.assertThat(
-            applyClientDurationAndSizeView(startAttributes, endAttributes))
+    assertThat(applyClientDurationAndSizeView(startAttributes, endAttributes))
         .containsOnly(
-            attributeEntry(SemanticAttributes.NET_PEER_NAME.getKey(), "somehost2"),
-            attributeEntry(SemanticAttributes.NET_PEER_PORT.getKey(), 443),
-            attributeEntry(SemanticAttributes.HTTP_METHOD.getKey(), "GET"),
-            attributeEntry(SemanticAttributes.HTTP_STATUS_CODE.getKey(), 500));
+            entry(SemanticAttributes.HTTP_METHOD, "GET"),
+            entry(SemanticAttributes.HTTP_STATUS_CODE, 500L),
+            entry(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1),
+            entry(SemanticAttributes.NET_PEER_NAME, "somehost2"),
+            entry(SemanticAttributes.NET_PEER_PORT, 443L),
+            entry(stringKey("net.peer.sock.addr"), "1.2.3.4"));
   }
 
   @Test
@@ -54,32 +63,36 @@ class TemporaryMetricsViewTest {
             .put(
                 SemanticAttributes.HTTP_URL,
                 "https://somehost/high/cardinality/12345?jsessionId=121454")
+            .put(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1)
+            .put(SemanticAttributes.HTTP_TARGET, "/high/cardinality/12345?jsessionId=121454")
             .put(SemanticAttributes.HTTP_SCHEME, "https")
-            .put(SemanticAttributes.HTTP_HOST, "somehost")
-            .put(SemanticAttributes.HTTP_SERVER_NAME, "somehost")
-            .put(
-                SemanticAttributes.HTTP_TARGET,
-                "/somehost/high/cardinality/12345?jsessionId=121454")
-            .put(SemanticAttributes.HTTP_ROUTE, "/somehost/high/{name}/{id}")
+            .put(SemanticAttributes.NET_TRANSPORT, IP_TCP)
             .put(SemanticAttributes.NET_HOST_NAME, "somehost")
             .put(SemanticAttributes.NET_HOST_PORT, 443)
+            .put("net.sock.family", "inet")
+            .put("net.peer.sock.addr", "1.2.3.4")
+            .put("net.peer.sock.port", 8080)
+            .put("net.host.sock.addr", "4.3.2.1")
+            .put("net.host.sock.port", 9090)
             .build();
 
     Attributes endAttributes =
         Attributes.builder()
+            .put(SemanticAttributes.HTTP_ROUTE, "/somehost/high/{name}/{id}")
             .put(SemanticAttributes.HTTP_STATUS_CODE, 500)
             .put(SemanticAttributes.NET_PEER_NAME, "somehost2")
             .put(SemanticAttributes.NET_PEER_PORT, 443)
             .build();
 
-    OpenTelemetryAssertions.assertThat(
-            applyServerDurationAndSizeView(startAttributes, endAttributes))
+    assertThat(applyServerDurationAndSizeView(startAttributes, endAttributes))
         .containsOnly(
-            attributeEntry(SemanticAttributes.HTTP_SCHEME.getKey(), "https"),
-            attributeEntry(SemanticAttributes.HTTP_HOST.getKey(), "somehost"),
-            attributeEntry(SemanticAttributes.HTTP_ROUTE.getKey(), "/somehost/high/{name}/{id}"),
-            attributeEntry(SemanticAttributes.HTTP_METHOD.getKey(), "GET"),
-            attributeEntry(SemanticAttributes.HTTP_STATUS_CODE.getKey(), 500));
+            entry(SemanticAttributes.HTTP_METHOD, "GET"),
+            entry(SemanticAttributes.HTTP_STATUS_CODE, 500L),
+            entry(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1),
+            entry(SemanticAttributes.HTTP_SCHEME, "https"),
+            entry(SemanticAttributes.NET_HOST_NAME, "somehost"),
+            entry(SemanticAttributes.NET_HOST_PORT, 443L),
+            entry(SemanticAttributes.HTTP_ROUTE, "/somehost/high/{name}/{id}"));
   }
 
   @Test
@@ -87,11 +100,27 @@ class TemporaryMetricsViewTest {
     Attributes attributes =
         Attributes.builder()
             .put(SemanticAttributes.HTTP_METHOD, "GET")
-            .put(SemanticAttributes.HTTP_URL, "/high/cardinality/12345")
-            .put(SemanticAttributes.NET_PEER_NAME, "somehost")
+            .put(
+                SemanticAttributes.HTTP_URL,
+                "https://somehost/high/cardinality/12345?jsessionId=121454")
+            .put(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1)
+            .put(SemanticAttributes.HTTP_TARGET, "/high/cardinality/12345?jsessionId=121454")
+            .put(SemanticAttributes.HTTP_SCHEME, "https")
+            .put(SemanticAttributes.NET_TRANSPORT, IP_TCP)
+            .put(SemanticAttributes.NET_HOST_NAME, "somehost")
+            .put(SemanticAttributes.NET_HOST_PORT, 443)
+            .put("net.sock.family", "inet")
+            .put("net.peer.sock.addr", "1.2.3.4")
+            .put("net.peer.sock.port", 8080)
+            .put("net.host.sock.addr", "4.3.2.1")
+            .put("net.host.sock.port", 9090)
             .build();
 
-    OpenTelemetryAssertions.assertThat(applyActiveRequestsView(attributes))
-        .containsOnly(attributeEntry("http.method", "GET"));
+    assertThat(applyActiveRequestsView(attributes))
+        .containsOnly(
+            entry(SemanticAttributes.HTTP_METHOD, "GET"),
+            entry(SemanticAttributes.HTTP_SCHEME, "https"),
+            entry(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1),
+            entry(SemanticAttributes.NET_HOST_NAME, "somehost"));
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
@@ -62,10 +62,4 @@ class AkkaHttpServerAttributesGetter
   public String scheme(HttpRequest request) {
     return request.uri().scheme();
   }
-
-  @Override
-  @Nullable
-  public String serverName(HttpRequest request) {
-    return null;
-  }
 }

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.groovy
@@ -89,7 +89,6 @@ class RestCamelTest extends AgentInstrumentationSpecification implements RetryOn
           parentSpanId(span(1).spanId)
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" "/api/firstModule/unit/unitOne"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_USER_AGENT" String

--- a/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
+++ b/instrumentation/apache-camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
@@ -126,7 +126,6 @@ class TwoServicesWithDirectClientCamelTest extends AgentInstrumentationSpecifica
             "$SemanticAttributes.HTTP_METHOD" "POST"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "127.0.0.1:$portTwo"
             "$SemanticAttributes.HTTP_TARGET" "/serviceTwo"
             "$SemanticAttributes.HTTP_USER_AGENT" "Jakarta Commons-HttpClient/3.1"
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
@@ -68,15 +68,6 @@ enum ArmeriaHttpServerAttributesGetter
 
   @Override
   @Nullable
-  public String serverName(RequestContext ctx) {
-    if (ctx instanceof ServiceRequestContext) {
-      return ((ServiceRequestContext) ctx).config().virtualHost().defaultHostname();
-    }
-    return null;
-  }
-
-  @Override
-  @Nullable
   public String route(RequestContext ctx) {
     if (ctx instanceof ServiceRequestContext) {
       return ((ServiceRequestContext) ctx).config().route().patternString();

--- a/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpServerTest.java
+++ b/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpServerTest.java
@@ -23,14 +23,10 @@ import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import java.util.HashSet;
-import java.util.Set;
 
 public abstract class AbstractArmeriaHttpServerTest extends AbstractHttpServerTest<Server> {
 
@@ -189,13 +185,6 @@ public abstract class AbstractArmeriaHttpServerTest extends AbstractHttpServerTe
             return "/*";
           }
           return expectedHttpRoute(endpoint);
-        });
-
-    options.setHttpAttributes(
-        endpoint -> {
-          Set<AttributeKey<?>> keys = new HashSet<>(HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES);
-          keys.add(SemanticAttributes.HTTP_SERVER_NAME);
-          return keys;
         });
 
     options.setTestPathParam(true);

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
@@ -78,10 +78,4 @@ final class GrizzlyHttpAttributesGetter
   public String scheme(HttpRequestPacket request) {
     return request.isSecure() ? "https" : "http";
   }
-
-  @Nullable
-  @Override
-  public String serverName(HttpRequestPacket request) {
-    return null;
-  }
 }

--- a/instrumentation/jaxrs/jaxrs-common/testing/src/main/groovy/AbstractJaxRsHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-common/testing/src/main/groovy/AbstractJaxRsHttpServerTest.groovy
@@ -268,13 +268,12 @@ abstract class AbstractJaxRsHttpServerTest<S> extends HttpServerTest<S> implemen
         hasNoParent()
       }
       attributes {
-        "net.host.name" fullUrl.host
-        "net.host.port" fullUrl.port
+        "$SemanticAttributes.NET_HOST_NAME" fullUrl.host
+        "$SemanticAttributes.NET_HOST_PORT" fullUrl.port
         "net.sock.peer.addr" "127.0.0.1"
         "net.sock.peer.port" Long
         "net.sock.host.addr" "127.0.0.1"
         "$SemanticAttributes.HTTP_SCHEME" fullUrl.getScheme()
-        "$SemanticAttributes.HTTP_HOST" fullUrl.getHost() + ":" + fullUrl.getPort()
         "$SemanticAttributes.HTTP_TARGET" fullUrl.getPath() + (fullUrl.getQuery() != null ? "?" + fullUrl.getQuery() : "")
         "$SemanticAttributes.HTTP_METHOD" method
         "$SemanticAttributes.HTTP_STATUS_CODE" statusCode

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/testing/src/main/groovy/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/AbstractJettyClient9Test.groovy
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/testing/src/main/groovy/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/AbstractJettyClient9Test.groovy
@@ -124,7 +124,6 @@ abstract class AbstractJettyClient9Test extends HttpClientTest<Request> {
     Set<AttributeKey<?>> extra = [
       SemanticAttributes.HTTP_SCHEME,
       SemanticAttributes.HTTP_TARGET,
-      SemanticAttributes.HTTP_HOST
     ]
     super.httpAttributes(uri) + extra
   }

--- a/instrumentation/jsf/jsf-common/testing/src/main/groovy/BaseJsfTest.groovy
+++ b/instrumentation/jsf/jsf-common/testing/src/main/groovy/BaseJsfTest.groovy
@@ -105,7 +105,6 @@ abstract class BaseJsfTest extends AgentInstrumentationSpecification implements 
             "net.sock.host.addr" "127.0.0.1"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:$port" }
             "$SemanticAttributes.HTTP_TARGET" "/jetty-context/" + path
             "$SemanticAttributes.HTTP_USER_AGENT" TEST_USER_AGENT
             "$SemanticAttributes.HTTP_FLAVOR" SemanticAttributes.HttpFlavorValues.HTTP_1_1

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
@@ -91,7 +91,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           kind SERVER
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -151,7 +150,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           kind SERVER
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" "$route?$queryString"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -206,7 +204,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           kind SERVER
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "POST"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -271,7 +268,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           }
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 500
@@ -340,7 +336,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           kind SERVER
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -390,7 +385,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           kind SERVER
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -472,7 +466,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           errorEvent(JasperException, String)
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 500
@@ -523,7 +516,6 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
           kind SERVER
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/$staticFile"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
@@ -89,7 +89,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           kind SERVER
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -160,7 +159,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           kind SERVER
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -210,7 +208,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           kind SERVER
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -308,7 +305,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           kind SERVER
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -392,7 +388,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           errorEvent(JasperException, String)
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 500
@@ -455,7 +450,6 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
           status UNSET
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 404

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
@@ -50,8 +50,4 @@ internal enum class KtorHttpServerAttributesGetter :
   override fun scheme(request: ApplicationRequest): String {
     return request.origin.scheme
   }
-
-  override fun serverName(request: ApplicationRequest): String? {
-    return null
-  }
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpServerAttributesGetter.kt
@@ -50,8 +50,4 @@ internal enum class KtorHttpServerAttributesGetter :
   override fun scheme(request: ApplicationRequest): String {
     return request.origin.scheme
   }
-
-  override fun serverName(request: ApplicationRequest): String? {
-    return null
-  }
 }

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
@@ -71,10 +71,4 @@ public class LibertyDispatcherHttpAttributesGetter
   public String route(LibertyRequest libertyRequest) {
     return null;
   }
-
-  @Override
-  @Nullable
-  public String serverName(LibertyRequest libertyRequest) {
-    return null;
-  }
 }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
@@ -62,10 +62,4 @@ final class NettyHttpServerAttributesGetter
   public String scheme(HttpRequestAndChannel requestAndChannel) {
     return getScheme(requestAndChannel);
   }
-
-  @Override
-  @Nullable
-  public String serverName(HttpRequestAndChannel requestAndChannel) {
-    return null;
-  }
 }

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/server/NettyHttpServerAttributesGetter.java
@@ -62,10 +62,4 @@ final class NettyHttpServerAttributesGetter
   public String scheme(HttpRequestAndChannel requestAndChannel) {
     return getScheme(requestAndChannel);
   }
-
-  @Override
-  @Nullable
-  public String serverName(HttpRequestAndChannel requestAndChannel) {
-    return null;
-  }
 }

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
@@ -61,10 +61,4 @@ enum MockHttpServerAttributesGetter implements HttpServerAttributesGetter<String
   public String scheme(String s) {
     return null;
   }
-
-  @Nullable
-  @Override
-  public String serverName(String s) {
-    return null;
-  }
 }

--- a/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
+++ b/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
@@ -96,8 +96,8 @@ abstract class AbstractRatpackRoutesTest extends InstrumentationSpecification {
           hasNoParent()
           attributes {
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
-            "$SemanticAttributes.NET_HOST_NAME" { it == "localhost" || it == null }
-            "$SemanticAttributes.NET_HOST_PORT" { it instanceof Long || it == null }
+            "$SemanticAttributes.NET_HOST_NAME" "localhost"
+            "$SemanticAttributes.NET_HOST_PORT" app.bindPort
             "net.sock.peer.addr" { it == "127.0.0.1" || it == null }
             "net.sock.peer.port" { it instanceof Long || it == null }
             "net.sock.host.addr" { it == "127.0.0.1" || it == null }
@@ -107,7 +107,6 @@ abstract class AbstractRatpackRoutesTest extends InstrumentationSpecification {
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:${app.bindPort}"
             "$SemanticAttributes.HTTP_TARGET" "/$path"
             "$SemanticAttributes.HTTP_ROUTE" "/$route"
             "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long

--- a/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
+++ b/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
@@ -96,8 +96,8 @@ abstract class AbstractRatpackRoutesTest extends InstrumentationSpecification {
           hasNoParent()
           attributes {
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
-            "$SemanticAttributes.NET_HOST_NAME" "localhost"
-            "$SemanticAttributes.NET_HOST_PORT" app.bindPort
+            "$SemanticAttributes.NET_HOST_NAME" { it == "localhost" || it == null }
+            "$SemanticAttributes.NET_HOST_PORT" { it == app.bindPort || it == null }
             "net.sock.peer.addr" { it == "127.0.0.1" || it == null }
             "net.sock.peer.port" { it instanceof Long || it == null }
             "net.sock.host.addr" { it == "127.0.0.1" || it == null }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesGetter.java
@@ -71,12 +71,6 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   }
 
   @Override
-  @Nullable
-  public String serverName(Request request) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatus().getCode();
   }

--- a/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_0/RestletHttpAttributesGetter.java
@@ -75,12 +75,6 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   }
 
   @Override
-  @Nullable
-  public String serverName(Request request) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatus().getCode();
   }

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
@@ -76,12 +76,6 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
   }
 
   @Override
-  @Nullable
-  public String serverName(Request request) {
-    return null;
-  }
-
-  @Override
   public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatus().getCode();
   }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
@@ -93,10 +93,4 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
   public String route(ServletRequestContext<REQUEST> requestContext) {
     return null;
   }
-
-  @Override
-  @Nullable
-  public String serverName(ServletRequestContext<REQUEST> requestContext) {
-    return null;
-  }
 }

--- a/instrumentation/spark-2.3/javaagent/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/instrumentation/spark-2.3/javaagent/src/test/groovy/SparkJavaBasedTest.groovy
@@ -48,7 +48,6 @@ class SparkJavaBasedTest extends AgentInstrumentationSpecification {
           hasNoParent()
           attributes {
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_HOST" "localhost:$port"
             "$SemanticAttributes.HTTP_TARGET" "/param/asdf1234"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/test/groovy/SpringWebfluxTest.groovy
@@ -85,7 +85,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "net.sock.peer.port" Long
             "net.sock.host.addr" "127.0.0.1"
             "net.sock.host.port" Long
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
             "$SemanticAttributes.HTTP_TARGET" urlPath
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -155,7 +154,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "net.sock.peer.port" Long
             "net.sock.host.addr" "127.0.0.1"
             "net.sock.host.port" Long
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
             "$SemanticAttributes.HTTP_TARGET" urlPath
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -245,7 +243,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "net.sock.peer.port" Long
             "net.sock.host.addr" "127.0.0.1"
             "net.sock.host.port" Long
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
             "$SemanticAttributes.HTTP_TARGET" urlPath
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -313,7 +310,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "net.sock.peer.port" Long
             "net.sock.host.addr" "127.0.0.1"
             "net.sock.host.port" Long
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
             "$SemanticAttributes.HTTP_TARGET" "/notfoundgreet"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 404
@@ -360,7 +356,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "net.sock.peer.port" Long
             "net.sock.host.addr" "127.0.0.1"
             "net.sock.host.port" Long
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
             "$SemanticAttributes.HTTP_TARGET" "/echo"
             "$SemanticAttributes.HTTP_METHOD" "POST"
             "$SemanticAttributes.HTTP_STATUS_CODE" 202
@@ -412,7 +407,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "net.sock.peer.port" Long
             "net.sock.host.addr" "127.0.0.1"
             "net.sock.host.port" Long
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
             "$SemanticAttributes.HTTP_TARGET" urlPath
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 500
@@ -479,7 +473,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "net.sock.peer.port" Long
             "net.sock.host.addr" "127.0.0.1"
             "net.sock.host.port" Long
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
             "$SemanticAttributes.HTTP_TARGET" "/double-greet-redirect"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 307
@@ -511,7 +504,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
             "net.sock.peer.port" Long
             "net.sock.host.addr" "127.0.0.1"
             "net.sock.host.port" Long
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
             "$SemanticAttributes.HTTP_TARGET" "/double-greet"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -561,7 +553,6 @@ class SpringWebfluxTest extends AgentInstrumentationSpecification {
               "net.sock.peer.port" Long
               "net.sock.host.addr" "127.0.0.1"
               "net.sock.host.port" Long
-              "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
               "$SemanticAttributes.HTTP_TARGET" urlPath
               "$SemanticAttributes.HTTP_METHOD" "GET"
               "$SemanticAttributes.HTTP_STATUS_CODE" 200

--- a/instrumentation/spring/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
@@ -98,10 +98,4 @@ enum SpringWebMvcHttpAttributesGetter
   public String scheme(HttpServletRequest request) {
     return request.getScheme();
   }
-
-  @Override
-  @Nullable
-  public String serverName(HttpServletRequest request) {
-    return null;
-  }
 }

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
@@ -72,10 +72,4 @@ public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Re
   public String route(Request request) {
     return null;
   }
-
-  @Override
-  @Nullable
-  public String serverName(Request request) {
-    return null;
-  }
 }

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
@@ -71,10 +71,4 @@ public class UndertowHttpAttributesGetter
   public String route(HttpServerExchange exchange) {
     return null;
   }
-
-  @Override
-  @Nullable
-  public String serverName(HttpServerExchange exchange) {
-    return null;
-  }
 }

--- a/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
+++ b/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
@@ -140,13 +140,11 @@ class UndertowServerTest extends HttpServerTest<Undertow> implements AgentTestTr
           attributes {
             "$SemanticAttributes.HTTP_CLIENT_IP" TEST_CLIENT_IP
             "$SemanticAttributes.HTTP_SCHEME" uri.getScheme()
-            "$SemanticAttributes.HTTP_HOST" uri.getHost() + ":" + uri.getPort()
             "$SemanticAttributes.HTTP_TARGET" uri.getPath()
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" TEST_USER_AGENT
-            "$SemanticAttributes.HTTP_HOST" "localhost:${port}"
             "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_TARGET" "/sendResponse"
@@ -196,13 +194,11 @@ class UndertowServerTest extends HttpServerTest<Undertow> implements AgentTestTr
           attributes {
             "$SemanticAttributes.HTTP_CLIENT_IP" TEST_CLIENT_IP
             "$SemanticAttributes.HTTP_SCHEME" uri.getScheme()
-            "$SemanticAttributes.HTTP_HOST" uri.getHost() + ":" + uri.getPort()
             "$SemanticAttributes.HTTP_TARGET" uri.getPath()
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" TEST_USER_AGENT
-            "$SemanticAttributes.HTTP_HOST" "localhost:${port}"
             "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_TARGET" "/sendResponseWithException"

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/groovy/VertxReactivePropagationTest.groovy
@@ -68,7 +68,6 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
             "net.sock.peer.port" Long
             "net.sock.host.addr" "127.0.0.1"
             "net.sock.host.port" Long
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
             "$SemanticAttributes.HTTP_TARGET" "/listProducts"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -161,7 +160,6 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
               "net.sock.peer.port" Long
               "net.sock.host.addr" "127.0.0.1"
               "net.sock.host.port" Long
-              "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
               "$SemanticAttributes.HTTP_TARGET" "$baseUrl?$TEST_REQUEST_ID_PARAMETER=$requestId"
               "$SemanticAttributes.HTTP_METHOD" "GET"
               "$SemanticAttributes.HTTP_STATUS_CODE" 200

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/version35Test/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/version35Test/groovy/VertxReactivePropagationTest.groovy
@@ -68,7 +68,6 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
             "net.sock.peer.port" Long
             "net.sock.host.addr" "127.0.0.1"
             "net.sock.host.port" Long
-            "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
             "$SemanticAttributes.HTTP_TARGET" "/listProducts"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
@@ -161,7 +160,6 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
               "net.sock.peer.port" Long
               "net.sock.host.addr" "127.0.0.1"
               "net.sock.host.port" Long
-              "$SemanticAttributes.HTTP_HOST" { it == "localhost" || it == "localhost:${port}" }
               "$SemanticAttributes.HTTP_TARGET" "$baseUrl?$TEST_REQUEST_ID_PARAMETER=$requestId"
               "$SemanticAttributes.HTTP_METHOD" "GET"
               "$SemanticAttributes.HTTP_STATUS_CODE" 200

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -596,10 +596,6 @@ public abstract class AbstractHttpServerTest<SERVER> {
           assertThat(attrs).containsEntry(SemanticAttributes.HTTP_USER_AGENT, TEST_USER_AGENT);
 
           assertThat(attrs).containsEntry(SemanticAttributes.HTTP_SCHEME, "http");
-          assertThat(attrs)
-              .hasEntrySatisfying(
-                  SemanticAttributes.HTTP_HOST,
-                  entry -> assertThat(entry).isIn("localhost", "localhost:" + port));
           if (endpoint != INDEXED_CHILD) {
             assertThat(attrs)
                 .containsEntry(
@@ -619,12 +615,6 @@ public abstract class AbstractHttpServerTest<SERVER> {
                 .hasEntrySatisfying(
                     SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,
                     entry -> assertThat(entry).isNotNegative());
-          }
-          if (httpAttributes.contains(SemanticAttributes.HTTP_SERVER_NAME)) {
-            assertThat(attrs)
-                .hasEntrySatisfying(
-                    SemanticAttributes.HTTP_SERVER_NAME,
-                    entry -> assertThat(entry).isInstanceOf(String.class));
           }
           if (httpAttributes.contains(SemanticAttributes.HTTP_ROUTE) && expectedRoute != null) {
             assertThat(attrs).containsEntry(SemanticAttributes.HTTP_ROUTE, expectedRoute);


### PR DESCRIPTION
... and make sure the `TemporaryMetricsView` follows the current spec