### PR TITLE
Fix directory separator in ProcessResource attributes

### DIFF
--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
@@ -61,9 +61,9 @@ public final class ProcessResource {
     if (javaHome != null) {
       StringBuilder executablePath = new StringBuilder(javaHome);
       executablePath
-          .append(File.pathSeparatorChar)
+          .append(File.separatorChar)
           .append("bin")
-          .append(File.pathSeparatorChar)
+          .append(File.separatorChar)
           .append("java");
       if (osName != null && osName.toLowerCase().startsWith("windows")) {
         executablePath.append(".exe");

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.io.File;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -29,7 +30,7 @@ class ProcessResourceTest {
 
     assertThat(attributes.get(ResourceAttributes.PROCESS_PID)).isGreaterThan(1);
     assertThat(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH))
-        .contains("java")
+        .contains(File.separatorChar + "java")
         .doesNotEndWith(".exe");
     assertThat(attributes.get(ResourceAttributes.PROCESS_COMMAND_LINE))
         .contains(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH));
@@ -44,7 +45,7 @@ class ProcessResourceTest {
 
     assertThat(attributes.get(ResourceAttributes.PROCESS_PID)).isGreaterThan(1);
     assertThat(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH))
-        .contains("java")
+        .contains(File.separatorChar + "java")
         .endsWith(".exe");
     assertThat(attributes.get(ResourceAttributes.PROCESS_COMMAND_LINE))
         .contains(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH));

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-import java.io.File;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -29,9 +28,7 @@ class ProcessResourceTest {
     Attributes attributes = resource.getAttributes();
 
     assertThat(attributes.get(ResourceAttributes.PROCESS_PID)).isGreaterThan(1);
-    assertThat(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH))
-        .contains(File.separatorChar + "java")
-        .doesNotEndWith(".exe");
+    assertThat(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH)).matches(".*[/\\\\]java");
     assertThat(attributes.get(ResourceAttributes.PROCESS_COMMAND_LINE))
         .contains(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH));
   }
@@ -45,8 +42,7 @@ class ProcessResourceTest {
 
     assertThat(attributes.get(ResourceAttributes.PROCESS_PID)).isGreaterThan(1);
     assertThat(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH))
-        .contains(File.separatorChar + "java")
-        .endsWith(".exe");
+        .matches(".*[/\\\\]java\\.exe");
     assertThat(attributes.get(ResourceAttributes.PROCESS_COMMAND_LINE))
         .contains(attributes.get(ResourceAttributes.PROCESS_EXECUTABLE_PATH));
   }


### PR DESCRIPTION
The separator char used to build the Java executable path in ProcessResource is wrong: `File.pathSeparatorChar` is the PATH variable separator (`:` on Linux, `;` on Windows), the right one for directories is `File.separatorChar` (`/` on Linux, `\` on Windows).

Note that this issue was already present in [sdk-extensions-resources](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/resources/src/main/java/io/opentelemetry/sdk/extension/resources/ProcessResource.java#L64) before it was moved here; should it be fixed there too?