### PR TITLE
Remove snapshot repository

### DIFF
--- a/conventions/build.gradle.kts
+++ b/conventions/build.gradle.kts
@@ -20,9 +20,6 @@ spotless {
 repositories {
   mavenCentral()
   gradlePluginPortal()
-  maven {
-    url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-  }
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
I suspect it is not needed. Should avoid dependabot trying to use snapshot dependencies like in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6658