### PR TITLE
Split out separate spotless CI check

### DIFF
--- a/.github/workflows/build-daily-no-build-cache.yml
+++ b/.github/workflows/build-daily-no-build-cache.yml
@@ -7,6 +7,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  spotless:
+    uses: ./.github/workflows/reusable-spotless.yml
+    with:
+      no-build-cache: true
+    secrets:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
   assemble:
     uses: ./.github/workflows/reusable-assemble.yml
     with:

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -7,6 +7,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  spotless:
+    uses: ./.github/workflows/reusable-spotless.yml
+    secrets:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
+      GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
+
   assemble:
     uses: ./.github/workflows/reusable-assemble.yml
     secrets:

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -8,6 +8,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  spotless:
+    uses: ./.github/workflows/reusable-spotless.yml
+    with:
+      cache-read-only: true
+
   assemble:
     uses: ./.github/workflows/reusable-assemble.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  spotless:
+    uses: ./.github/workflows/reusable-spotless.yml
+    secrets:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
+      GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
+
   assemble:
     uses: ./.github/workflows/reusable-assemble.yml
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  spotless:
+    uses: ./.github/workflows/reusable-spotless.yml
+
   assemble:
     uses: ./.github/workflows/reusable-assemble.yml
 

--- a/.github/workflows/reusable-spotless.yml
+++ b/.github/workflows/reusable-spotless.yml
@@ -1,0 +1,42 @@
+name: Reusable - Spotless
+
+on:
+  workflow_call:
+    inputs:
+      cache-read-only:
+        type: boolean
+        required: false
+      no-build-cache:
+        type: boolean
+        required: false
+    secrets:
+      GRADLE_ENTERPRISE_ACCESS_KEY:
+        required: false
+      GE_CACHE_USERNAME:
+        required: false
+      GE_CACHE_PASSWORD:
+        required: false
+
+jobs:
+  assemble:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Spotless
+        uses: gradle/gradle-build-action@v2
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
+          GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
+        with:
+          arguments: spotlessCheck ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
+          cache-read-only: ${{ inputs.cache-read-only }}
+          # gradle enterprise is used for the build cache
+          gradle-home-cache-excludes: caches/build-cache-1

--- a/.github/workflows/reusable-spotless.yml
+++ b/.github/workflows/reusable-spotless.yml
@@ -18,7 +18,7 @@ on:
         required: false
 
 jobs:
-  assemble:
+  spotless:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -68,6 +68,7 @@ jobs:
           GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
         uses: gradle/gradle-build-action@v2
         with:
+          # spotless is checked separately since it's a common source of failure
           arguments: >
             check
             -x spotlessCheck

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -68,7 +68,14 @@ jobs:
           GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: check -PtestJavaVersion=${{ matrix.test-java-version }} -PtestJavaVM=${{ matrix.vm }} -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }} -Porg.gradle.java.installations.auto-download=false ${{ inputs.no-build-cache && ' --no-build-cache' || '' }}
+          arguments: >
+            check
+            -x spotlessCheck
+            -PtestJavaVersion=${{ matrix.test-java-version }}
+            -PtestJavaVM=${{ matrix.vm }}
+            -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }}
+            -Porg.gradle.java.installations.auto-download=false
+            ${{ inputs.no-build-cache && ' --no-build-cache' || '' }}
           # only push cache for one matrix option since github action cache space is limited
           cache-read-only: ${{ inputs.cache-read-only || matrix.test-java-version != 11 || matrix.vm != 'hotspot' }}
           # gradle enterprise is used for the build cache


### PR DESCRIPTION
To make it clearer when the only problem with a PR is spotless (and may follow-up with a comment-driven automation to apply spotless to a PR)