### PR TITLE
Enable testLatestDeps in PRs

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -19,22 +19,8 @@ jobs:
       cache-read-only: true
 
   test-latest-deps:
-    # test-latest-deps is not included in the PR workflow by default
-    # because any time a new library version is released to maven central
-    # it can fail due to test code incompatibility with the new library version,
-    # or due to slight changes in emitted telemetry, which can be confusing for contributors
-    # (muzzle can also fail when a new library version is released to maven central
-    # but that happens much less often)
-    #
-    # the condition is on the steps below instead of here on the job, because skipping the job
-    # causes the job to show up as canceled in the GitHub UI which prevents the build section from
-    # collapsing when everything (else) is green
-    #
-    # and the name is updated when the steps below are skipped which makes what's happening clearer
-    # in the GitHub UI
     uses: ./.github/workflows/reusable-test-latest-deps.yml
     with:
-      skip: ${{ !contains(github.event.pull_request.labels.*.name, 'test latest deps') }}
       cache-read-only: true
 
   smoke-test:
@@ -77,6 +63,12 @@ jobs:
     uses: ./.github/workflows/reusable-misspell-check.yml
 
   required-status-check:
+    # test-latest-deps is not included in the required status checks
+    # because any time a new library version is released to maven central
+    # it can fail due to test code incompatibility with the new library version,
+    # or due to slight changes in emitted telemetry
+    # (muzzle can also fail when a new library version is released to maven central
+    # but that happens much less often)
     needs:
       - assemble
       - test

--- a/.github/workflows/reusable-test-latest-deps.yml
+++ b/.github/workflows/reusable-test-latest-deps.yml
@@ -3,9 +3,6 @@ name: Reusable - Test latest deps
 on:
   workflow_call:
     inputs:
-      skip:
-        type: boolean
-        required: false
       cache-read-only:
         type: boolean
         required: false
@@ -22,19 +19,12 @@ on:
 
 jobs:
   test-latest-deps:
-    # the condition is on the steps below instead of here on the job, because skipping the job
-    # causes the job to show up as canceled in the GitHub UI which prevents the build section from
-    # collapsing when everything (else) is green
-    #
-    # and the name is updated when the steps below are skipped which makes what's happening clearer
-    # in the GitHub UI
-    name: testLatestDeps${{ inputs.skip && ' (skipped)' || '' }}
+    name: testLatestDeps
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up JDK for running Gradle
-        if: ${{ !inputs.skip }}
         uses: actions/setup-java@v3
         with:
           distribution: temurin
@@ -52,7 +42,6 @@ jobs:
           sed -i "s/org.gradle.jvmargs=/org.gradle.jvmargs=-Xmx2g /" gradle.properties
 
       - name: Test
-        if: ${{ !inputs.skip }}
         uses: gradle/gradle-build-action@v2
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}


### PR DESCRIPTION
but do not make it a required check.

The reason for my change of mind here is:

When new library versions are released which break testLatestDeps, the quick fix is to temporarily limit the upper bound, but it's not clear what the quick fix is if we end up merging in a change which breaks testLatestDeps (short of reverting the change, which then potentially requires reengaging the contributor after they have moved on from the PR).