### PR TITLE
Fix ktlint warning

### DIFF
--- a/conventions/build.gradle.kts
+++ b/conventions/build.gradle.kts
@@ -12,7 +12,7 @@ spotless {
   }
   kotlinGradle {
     // not sure why it's not using the indent settings from .editorconfig
-    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "disabled_rules" to "no-wildcard-imports"))
+    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "ktlint_disabled_rules" to "no-wildcard-imports"))
     target("**/*.gradle.kts")
   }
 }

--- a/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -26,13 +26,13 @@ spotless {
   plugins.withId("org.jetbrains.kotlin.jvm") {
     kotlin {
       // not sure why it's not using the indent settings from .editorconfig
-      ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "disabled_rules" to "no-wildcard-imports,package-name"))
+      ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "ktlint_disabled_rules" to "no-wildcard-imports,package-name"))
       licenseHeaderFile(rootProject.file("buildscripts/spotless.license.java"), "(package|import|class|// Includes work from:)")
     }
   }
   kotlinGradle {
     // not sure why it's not using the indent settings from .editorconfig
-    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "disabled_rules" to "no-wildcard-imports"))
+    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "ktlint_disabled_rules" to "no-wildcard-imports"))
   }
   format("misc") {
     // not using "**/..." to help keep spotless fast


### PR DESCRIPTION
`Property 'disabled_rules' is deprecated: Rename property 'disabled_rules' to 'ktlint_disabled_rules' in all '.editorconfig' files.`