### PR TITLE
Link RabbitMQ receive span with the producer span

### DIFF
--- a/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
@@ -32,5 +32,7 @@ dependencies {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.rabbitmq.experimental-span-attributes=true")
+  jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+
   usesService(gradle.sharedServices.registrations["testcontainersBuildService"].getService())
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/ReceiveRequestTextMapGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/ReceiveRequestTextMapGetter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.GetResponse;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+enum ReceiveRequestTextMapGetter implements TextMapGetter<ReceiveRequest> {
+  INSTANCE;
+
+  @Override
+  public Iterable<String> keys(ReceiveRequest carrier) {
+    return Optional.of(carrier)
+        .map(ReceiveRequest::getResponse)
+        .map(GetResponse::getProps)
+        .map(AMQP.BasicProperties::getHeaders)
+        .map(Map::keySet)
+        .orElse(Collections.emptySet());
+  }
+
+  @Nullable
+  @Override
+  public String get(@Nullable ReceiveRequest carrier, String key) {
+    return Optional.ofNullable(carrier)
+        .map(ReceiveRequest::getResponse)
+        .map(GetResponse::getProps)
+        .map(AMQP.BasicProperties::getHeaders)
+        .map(headers -> headers.get(key))
+        .map(Object::toString)
+        .orElse(null);
+  }
+}


### PR DESCRIPTION
Similar to #6804, but for RabbitMQ.
Also changed the span kind of the receive span to `CONSUMER`, to match the spec.