### PR TITLE
Allow auto-merge on PRs

### DIFF
--- a/docs/contributing/repository-settings.md
+++ b/docs/contributing/repository-settings.md
@@ -7,6 +7,8 @@ to https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-n
 
 * Allow squash merging > Default to pull request title and description
 
+* Allow auto-merge
+
 * Automatically delete head branches: CHECKED
 
   So that bot PR branches will be deleted.


### PR DESCRIPTION
This seems nice for after pushing `spotlessApply` on an otherwise approved and passing PR. I just enabled it and tried it on #6774.

(somewhat related to #6743)

Btw, I thought this was helpful explanation

> After you enable auto-merge for a pull request, if someone who does not have write permissions to the repository pushes new changes to the head branch or switches the base branch of the pull request, auto-merge will be disabled. For example, if a maintainer enables auto-merge for a pull request from a fork, auto-merge will be disabled after a contributor pushes new changes to the pull request.

https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request#about-auto-merge
