### PR TITLE
Remove latest dep restriction from vertx-http-client-4.0

### DIFF
--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/build.gradle.kts
@@ -17,10 +17,6 @@ dependencies {
   // vertx-codegen dependency is needed for Xlint's annotation checking
   library("io.vertx:vertx-codegen:4.0.0")
 
-  // concurrency tests are failing with 4.3.4
-  // tracking at https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6790
-  latestDepTestLibrary("io.vertx:vertx-core:4.3.3")
-
   implementation(project(":instrumentation:vertx:vertx-http-client:vertx-http-client-common:javaagent"))
 
   testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))


### PR DESCRIPTION
Should have been part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6809, forgot to add this file.