### PR TITLE
Extract `net.peer.{name,port}` on start for CLIENT spans

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
@@ -37,7 +37,16 @@ public final class NetClientAttributesExtractor<REQUEST, RESPONSE>
   }
 
   @Override
-  public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {}
+  public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
+    String peerName = getter.peerName(request);
+    Integer peerPort = getter.peerPort(request);
+    if (peerName != null) {
+      internalSet(attributes, SemanticAttributes.NET_PEER_NAME, peerName);
+      if (peerPort != null && peerPort > 0) {
+        internalSet(attributes, SemanticAttributes.NET_PEER_PORT, (long) peerPort);
+      }
+    }
+  }
 
   @Override
   public void onEnd(
@@ -49,14 +58,8 @@ public final class NetClientAttributesExtractor<REQUEST, RESPONSE>
 
     internalSet(attributes, SemanticAttributes.NET_TRANSPORT, getter.transport(request, response));
 
-    String peerName = getter.peerName(request, response);
-    Integer peerPort = getter.peerPort(request, response);
-    if (peerName != null) {
-      internalSet(attributes, SemanticAttributes.NET_PEER_NAME, peerName);
-      if (peerPort != null && peerPort > 0) {
-        internalSet(attributes, SemanticAttributes.NET_PEER_PORT, (long) peerPort);
-      }
-    }
+    String peerName = getter.peerName(request);
+    Integer peerPort = getter.peerPort(request);
 
     String sockPeerAddr = getter.sockPeerAddr(request, response);
     if (sockPeerAddr != null && !sockPeerAddr.equals(peerName)) {

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesGetter.java
@@ -20,13 +20,39 @@ public interface NetClientAttributesGetter<REQUEST, RESPONSE> {
   @Nullable
   String transport(REQUEST request, @Nullable RESPONSE response);
 
-  // TODO: peerName and peerPort should be extracted onStart
+  /**
+   * Logical remote hostname.
+   *
+   * @deprecated This method is deprecated and will be removed in the next release.
+   */
+  @Deprecated
+  @Nullable
+  default String peerName(REQUEST request, @Nullable RESPONSE response) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the next release");
+  }
 
   @Nullable
-  String peerName(REQUEST request, @Nullable RESPONSE response);
+  default String peerName(REQUEST request) {
+    return peerName(request, null);
+  }
+
+  /**
+   * Logical remote port number.
+   *
+   * @deprecated This method is deprecated and will be removed in the next release.
+   */
+  @Deprecated
+  @Nullable
+  default Integer peerPort(REQUEST request, @Nullable RESPONSE response) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the next release");
+  }
 
   @Nullable
-  Integer peerPort(REQUEST request, @Nullable RESPONSE response);
+  default Integer peerPort(REQUEST request) {
+    return peerPort(request, null);
+  }
 
   @Nullable
   default String sockFamily(REQUEST request, @Nullable RESPONSE response) {

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractor.java
@@ -57,7 +57,7 @@ public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
       return;
     }
 
-    String peerName = attributesGetter.peerName(request, response);
+    String peerName = attributesGetter.peerName(request);
     String peerService = mapToPeerService(peerName);
     if (peerService != null) {
       attributes.put(SemanticAttributes.PEER_SERVICE, peerService);

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetterTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetterTest.java
@@ -30,13 +30,13 @@ class InetSocketAddressNetClientAttributesGetterTest {
             }
 
             @Override
-            public String peerName(InetSocketAddress request, InetSocketAddress response) {
+            public String peerName(InetSocketAddress request) {
               // net.peer.name and net.peer.port are tested in NetClientAttributesExtractorTest
               return null;
             }
 
             @Override
-            public Integer peerPort(InetSocketAddress request, InetSocketAddress response) {
+            public Integer peerPort(InetSocketAddress request) {
               // net.peer.name and net.peer.port are tested in NetClientAttributesExtractorTest
               return null;
             }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorTest.java
@@ -31,13 +31,13 @@ class NetClientAttributesExtractorTest {
     }
 
     @Override
-    public String peerName(Map<String, String> request, Map<String, String> response) {
-      return response.get("peerName");
+    public String peerName(Map<String, String> request) {
+      return request.get("peerName");
     }
 
     @Override
-    public Integer peerPort(Map<String, String> request, Map<String, String> response) {
-      String peerPort = response.get("peerPort");
+    public Integer peerPort(Map<String, String> request) {
+      String peerPort = request.get("peerPort");
       return peerPort == null ? null : Integer.valueOf(peerPort);
     }
 
@@ -88,13 +88,14 @@ class NetClientAttributesExtractorTest {
     extractor.onEnd(endAttributes, context, map, map, null);
 
     // then
-    assertThat(startAttributes.build()).isEmpty();
+    assertThat(startAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"),
+            entry(SemanticAttributes.NET_PEER_PORT, 42L));
 
     assertThat(endAttributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_TRANSPORT, IP_TCP),
-            entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"),
-            entry(SemanticAttributes.NET_PEER_PORT, 42L),
             entry(NetAttributes.NET_SOCK_FAMILY, "inet6"),
             entry(NetAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"),
             entry(NetAttributes.NET_SOCK_PEER_NAME, "proxy.opentelemetry.io"),
@@ -141,13 +142,12 @@ class NetClientAttributesExtractorTest {
     extractor.onEnd(endAttributes, context, map, map, null);
 
     // then
-    assertThat(startAttributes.build()).isEmpty();
-
-    assertThat(endAttributes.build())
+    assertThat(startAttributes.build())
         .containsOnly(
-            entry(SemanticAttributes.NET_TRANSPORT, IP_TCP),
             entry(SemanticAttributes.NET_PEER_NAME, "1:2:3:4::"),
             entry(SemanticAttributes.NET_PEER_PORT, 42L));
+
+    assertThat(endAttributes.build()).containsOnly(entry(SemanticAttributes.NET_TRANSPORT, IP_TCP));
   }
 
   @Test
@@ -174,13 +174,14 @@ class NetClientAttributesExtractorTest {
     extractor.onEnd(endAttributes, context, map, map, null);
 
     // then
-    assertThat(startAttributes.build()).isEmpty();
+    assertThat(startAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"),
+            entry(SemanticAttributes.NET_PEER_PORT, 42L));
 
     assertThat(endAttributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_TRANSPORT, IP_TCP),
-            entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"),
-            entry(SemanticAttributes.NET_PEER_PORT, 42L),
             entry(NetAttributes.NET_SOCK_FAMILY, "inet6"),
             entry(NetAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"));
   }
@@ -204,12 +205,11 @@ class NetClientAttributesExtractorTest {
     extractor.onEnd(endAttributes, context, map, map, null);
 
     // then
-    assertThat(startAttributes.build()).isEmpty();
+    assertThat(startAttributes.build())
+        .containsOnly(entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"));
 
     assertThat(endAttributes.build())
-        .containsOnly(
-            entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"),
-            entry(NetAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"));
+        .containsOnly(entry(NetAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"));
   }
 
   @Test
@@ -230,11 +230,10 @@ class NetClientAttributesExtractorTest {
     extractor.onEnd(endAttributes, context, map, map, null);
 
     // then
-    assertThat(startAttributes.build()).isEmpty();
+    assertThat(startAttributes.build())
+        .containsOnly(entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"));
 
     assertThat(endAttributes.build())
-        .containsOnly(
-            entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"),
-            entry(NetAttributes.NET_SOCK_PEER_ADDR, "1.2.3.4"));
+        .containsOnly(entry(NetAttributes.NET_SOCK_PEER_ADDR, "1.2.3.4"));
   }
 }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractorTest.java
@@ -54,7 +54,7 @@ class PeerServiceAttributesExtractorTest {
     PeerServiceAttributesExtractor<String, String> underTest =
         new PeerServiceAttributesExtractor<>(netAttributesExtractor, peerServiceMapping);
 
-    when(netAttributesExtractor.peerName(any(), any())).thenReturn("example2.com");
+    when(netAttributesExtractor.peerName(any())).thenReturn("example2.com");
 
     Context context = Context.root();
 
@@ -79,7 +79,7 @@ class PeerServiceAttributesExtractorTest {
     PeerServiceAttributesExtractor<String, String> underTest =
         new PeerServiceAttributesExtractor<>(netAttributesExtractor, peerServiceMapping);
 
-    when(netAttributesExtractor.peerName(any(), any())).thenReturn("example.com");
+    when(netAttributesExtractor.peerName(any())).thenReturn("example.com");
 
     Context context = Context.root();
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpNetAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpNetAttributesGetter.java
@@ -19,12 +19,12 @@ class AkkaHttpNetAttributesGetter implements NetClientAttributesGetter<HttpReque
   }
 
   @Override
-  public String peerName(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
+  public String peerName(HttpRequest httpRequest) {
     return httpRequest.uri().authority().host().address();
   }
 
   @Override
-  public Integer peerPort(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
+  public Integer peerPort(HttpRequest httpRequest) {
     return httpRequest.uri().authority().port();
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetClientAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetClientAttributesGetter.java
@@ -26,12 +26,12 @@ public final class DubboNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(DubboRequest request, @Nullable Result result) {
+  public String peerName(DubboRequest request) {
     return request.url().getHost();
   }
 
   @Override
-  public Integer peerPort(DubboRequest request, @Nullable Result result) {
+  public Integer peerPort(DubboRequest request) {
     return request.url().getPort();
   }
 

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesGetter.java
@@ -21,12 +21,12 @@ final class ApacheHttpAsyncClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String peerName(ApacheHttpClientRequest request) {
     return request.getPeerName();
   }
 
   @Override
-  public Integer peerPort(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public Integer peerPort(ApacheHttpClientRequest request) {
     return request.getPeerPort();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesGetter.java
@@ -21,14 +21,14 @@ final class ApacheHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(HttpMethod request, @Nullable HttpMethod response) {
+  public String peerName(HttpMethod request) {
     HostConfiguration hostConfiguration = request.getHostConfiguration();
     return hostConfiguration != null ? hostConfiguration.getHost() : null;
   }
 
   @Override
   @Nullable
-  public Integer peerPort(HttpMethod request, @Nullable HttpMethod response) {
+  public Integer peerPort(HttpMethod request) {
     HostConfiguration hostConfiguration = request.getHostConfiguration();
     return hostConfiguration != null ? hostConfiguration.getPort() : null;
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientNetAttributesGetter.java
@@ -20,12 +20,12 @@ final class ApacheHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String peerName(ApacheHttpClientRequest request) {
     return request.getPeerName();
   }
 
   @Override
-  public Integer peerPort(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public Integer peerPort(ApacheHttpClientRequest request) {
     return request.getPeerPort();
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesGetter.java
@@ -21,13 +21,13 @@ final class ApacheHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String peerName(ApacheHttpClientRequest request) {
     return request.getPeerName();
   }
 
   @Override
   @Nullable
-  public Integer peerPort(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public Integer peerPort(ApacheHttpClientRequest request) {
     return request.getPeerPort();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
@@ -26,12 +26,12 @@ final class ApacheHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(HttpRequest request, @Nullable HttpResponse response) {
+  public String peerName(HttpRequest request) {
     return request.getAuthority().getHostName();
   }
 
   @Override
-  public Integer peerPort(HttpRequest request, @Nullable HttpResponse response) {
+  public Integer peerPort(HttpRequest request) {
     int port = request.getAuthority().getPort();
     if (port != -1) {
       return port;

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetClientAttributesGetter.java
@@ -28,12 +28,12 @@ public final class ArmeriaNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(RequestContext ctx, @Nullable RequestLog requestLog) {
+  public String peerName(RequestContext ctx) {
     return request(ctx).uri().getHost();
   }
 
   @Override
-  public Integer peerPort(RequestContext ctx, @Nullable RequestLog requestLog) {
+  public Integer peerPort(RequestContext ctx) {
     return request(ctx).uri().getPort();
   }
 

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientNetAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientNetAttributesGetter.java
@@ -20,12 +20,12 @@ final class AsyncHttpClientNetAttributesGetter
   }
 
   @Override
-  public String peerName(Request request, @Nullable Response response) {
+  public String peerName(Request request) {
     return request.getUri().getHost();
   }
 
   @Override
-  public Integer peerPort(Request request, @Nullable Response response) {
+  public Integer peerPort(Request request) {
     return request.getUri().getPort();
   }
 }

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesGetter.java
@@ -21,12 +21,12 @@ final class AsyncHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(RequestContext requestContext, @Nullable Response response) {
+  public String peerName(RequestContext requestContext) {
     return requestContext.getRequest().getUri().getHost();
   }
 
   @Override
-  public Integer peerPort(RequestContext requestContext, @Nullable Response response) {
+  public Integer peerPort(RequestContext requestContext) {
     return requestContext.getRequest().getUri().getPort();
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkNetAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkNetAttributesGetter.java
@@ -20,12 +20,12 @@ class AwsSdkNetAttributesGetter implements NetClientAttributesGetter<Request<?>,
 
   @Override
   @Nullable
-  public String peerName(Request<?> request, @Nullable Response<?> response) {
+  public String peerName(Request<?> request) {
     return request.getEndpoint().getHost();
   }
 
   @Override
-  public Integer peerPort(Request<?> request, @Nullable Response<?> response) {
+  public Integer peerPort(Request<?> request) {
     return request.getEndpoint().getPort();
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkNetAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkNetAttributesGetter.java
@@ -22,14 +22,14 @@ class AwsSdkNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(ExecutionAttributes request, @Nullable SdkHttpResponse response) {
+  public String peerName(ExecutionAttributes request) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     return httpRequest.host();
   }
 
   @Override
-  public Integer peerPort(ExecutionAttributes request, @Nullable SdkHttpResponse response) {
+  public Integer peerPort(ExecutionAttributes request) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     return httpRequest.port();

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetAttributesGetter.java
@@ -21,13 +21,13 @@ final class CassandraNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
+  public String peerName(CassandraRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
+  public Integer peerPort(CassandraRequest request) {
     return null;
   }
 

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetAttributesGetter.java
@@ -23,13 +23,13 @@ final class CassandraNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
+  public String peerName(CassandraRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
+  public Integer peerPort(CassandraRequest request) {
     return null;
   }
 

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseNetAttributesGetter.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseNetAttributesGetter.java
@@ -23,13 +23,13 @@ public class CouchbaseNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(CouchbaseRequestInfo couchbaseRequest, @Nullable Void unused) {
+  public String peerName(CouchbaseRequestInfo couchbaseRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(CouchbaseRequestInfo couchbaseRequest, @Nullable Void unused) {
+  public Integer peerPort(CouchbaseRequestInfo couchbaseRequest) {
     return null;
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/ElasticsearchRest5Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/groovy/ElasticsearchRest5Test.groovy
@@ -80,8 +80,6 @@ class ElasticsearchRest5Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.DB_OPERATION" "GET"
             "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
-            "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
-            "$SemanticAttributes.NET_PEER_PORT" httpHost.port
           }
         }
         span(1) {
@@ -155,8 +153,6 @@ class ElasticsearchRest5Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.DB_OPERATION" "GET"
             "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
-            "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
-            "$SemanticAttributes.NET_PEER_PORT" httpHost.port
           }
         }
         span(2) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/ElasticsearchRest6Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/groovy/ElasticsearchRest6Test.groovy
@@ -74,8 +74,6 @@ class ElasticsearchRest6Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.DB_OPERATION" "GET"
             "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
-            "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
-            "$SemanticAttributes.NET_PEER_PORT" httpHost.port
           }
         }
         span(1) {
@@ -148,8 +146,6 @@ class ElasticsearchRest6Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.DB_OPERATION" "GET"
             "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
-            "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
-            "$SemanticAttributes.NET_PEER_PORT" httpHost.port
           }
         }
         span(2) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/groovy/ElasticsearchRest7Test.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/groovy/ElasticsearchRest7Test.groovy
@@ -73,8 +73,6 @@ class ElasticsearchRest7Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.DB_OPERATION" "GET"
             "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
-            "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
-            "$SemanticAttributes.NET_PEER_PORT" httpHost.port
           }
         }
         span(1) {
@@ -147,8 +145,6 @@ class ElasticsearchRest7Test extends AgentInstrumentationSpecification {
             "$SemanticAttributes.DB_OPERATION" "GET"
             "$SemanticAttributes.DB_STATEMENT" "GET _cluster/health"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
-            "$SemanticAttributes.NET_PEER_NAME" httpHost.hostName
-            "$SemanticAttributes.NET_PEER_PORT" httpHost.port
           }
         }
         span(2) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestNetResponseAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestNetResponseAttributesGetter.java
@@ -21,28 +21,13 @@ final class ElasticsearchRestNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(ElasticsearchRestRequest request, @Nullable Response response) {
-    if (response != null) {
-      return response.getHost().getHostName();
-    }
+  public String peerName(ElasticsearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public Integer peerPort(ElasticsearchRestRequest request, @Nullable Response response) {
-    if (response != null) {
-      return response.getHost().getPort();
-    }
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public String sockPeerAddr(ElasticsearchRestRequest request, @Nullable Response response) {
-    if (response != null && response.getHost().getAddress() != null) {
-      return response.getHost().getAddress().getHostAddress();
-    }
+  public Integer peerPort(ElasticsearchRestRequest request) {
     return null;
   }
 
@@ -52,6 +37,15 @@ final class ElasticsearchRestNetResponseAttributesGetter
       ElasticsearchRestRequest elasticsearchRestRequest, @Nullable Response response) {
     if (response != null && response.getHost().getAddress() instanceof Inet6Address) {
       return "inet6";
+    }
+    return null;
+  }
+
+  @Override
+  @Nullable
+  public String sockPeerAddr(ElasticsearchRestRequest request, @Nullable Response response) {
+    if (response != null && response.getHost().getAddress() != null) {
+      return response.getHost().getAddress().getHostAddress();
     }
     return null;
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportNetAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportNetAttributesGetter.java
@@ -21,13 +21,13 @@ public class Elasticsearch6TransportNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(ElasticTransportRequest request, @Nullable ActionResponse response) {
+  public String peerName(ElasticTransportRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(ElasticTransportRequest request, @Nullable ActionResponse response) {
+  public Integer peerPort(ElasticTransportRequest request) {
     return null;
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticTransportNetResponseAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticTransportNetResponseAttributesGetter.java
@@ -20,13 +20,13 @@ public class ElasticTransportNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(ElasticTransportRequest request, @Nullable ActionResponse response) {
+  public String peerName(ElasticTransportRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public Integer peerPort(ElasticTransportRequest request, @Nullable ActionResponse response) {
+  public Integer peerPort(ElasticTransportRequest request) {
     return null;
   }
 

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientNetAttributesGetter.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientNetAttributesGetter.java
@@ -21,12 +21,12 @@ final class GoogleHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(HttpRequest request, @Nullable HttpResponse response) {
+  public String peerName(HttpRequest request) {
     return request.getUrl().getHost();
   }
 
   @Override
-  public Integer peerPort(HttpRequest request, @Nullable HttpResponse response) {
+  public Integer peerPort(HttpRequest request) {
     return request.getUrl().getPort();
   }
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetClientAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetClientAttributesGetter.java
@@ -27,12 +27,12 @@ public final class GrpcNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(GrpcRequest grpcRequest, @Nullable Status status) {
+  public String peerName(GrpcRequest grpcRequest) {
     return grpcRequest.getLogicalHost();
   }
 
   @Override
-  public Integer peerPort(GrpcRequest grpcRequest, @Nullable Status status) {
+  public Integer peerPort(GrpcRequest grpcRequest) {
     return grpcRequest.getLogicalPort();
   }
 

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlNetAttributesGetter.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlNetAttributesGetter.java
@@ -19,12 +19,12 @@ class HttpUrlNetAttributesGetter implements NetClientAttributesGetter<HttpURLCon
   }
 
   @Override
-  public String peerName(HttpURLConnection connection, @Nullable Integer status) {
+  public String peerName(HttpURLConnection connection) {
     return connection.getURL().getHost();
   }
 
   @Override
-  public Integer peerPort(HttpURLConnection connection, @Nullable Integer status) {
+  public Integer peerPort(HttpURLConnection connection) {
     return connection.getURL().getPort();
   }
 }

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesGetter.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesGetter.java
@@ -26,13 +26,13 @@ public class JdkHttpNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(HttpRequest httpRequest, @Nullable HttpResponse<?> response) {
+  public String peerName(HttpRequest httpRequest) {
     return httpRequest.uri().getHost();
   }
 
   @Override
   @Nullable
-  public Integer peerPort(HttpRequest httpRequest, @Nullable HttpResponse<?> response) {
+  public Integer peerPort(HttpRequest httpRequest) {
     int port = httpRequest.uri().getPort();
     if (port != -1) {
       return port;

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientNetAttributesGetter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientNetAttributesGetter.java
@@ -21,12 +21,12 @@ final class JaxRsClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(ClientRequest request, @Nullable ClientResponse response) {
+  public String peerName(ClientRequest request) {
     return request.getURI().getHost();
   }
 
   @Override
-  public Integer peerPort(ClientRequest request, @Nullable ClientResponse response) {
+  public Integer peerPort(ClientRequest request) {
     return request.getURI().getPort();
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcNetAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcNetAttributesGetter.java
@@ -22,13 +22,13 @@ public final class JdbcNetAttributesGetter implements NetClientAttributesGetter<
 
   @Nullable
   @Override
-  public String peerName(DbRequest request, @Nullable Void unused) {
+  public String peerName(DbRequest request) {
     return request.getDbInfo().getHost();
   }
 
   @Nullable
   @Override
-  public Integer peerPort(DbRequest request, @Nullable Void unused) {
+  public Integer peerPort(DbRequest request) {
     return request.getDbInfo().getPort();
   }
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetAttributesGetter.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetAttributesGetter.java
@@ -17,12 +17,12 @@ final class JedisNetAttributesGetter implements NetClientAttributesGetter<JedisR
   }
 
   @Override
-  public String peerName(JedisRequest request, @Nullable Void unused) {
+  public String peerName(JedisRequest request) {
     return request.getConnection().getHost();
   }
 
   @Override
-  public Integer peerPort(JedisRequest request, @Nullable Void unused) {
+  public Integer peerPort(JedisRequest request) {
     return request.getConnection().getPort();
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetAttributesGetter.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetAttributesGetter.java
@@ -21,12 +21,12 @@ final class JedisNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(JedisRequest jedisRequest, @Nullable Void unused) {
+  public String peerName(JedisRequest jedisRequest) {
     return jedisRequest.getConnection().getHost();
   }
 
   @Override
-  public Integer peerPort(JedisRequest jedisRequest, @Nullable Void unused) {
+  public Integer peerPort(JedisRequest jedisRequest) {
     return jedisRequest.getConnection().getPort();
   }
 

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisNetAttributesGetter.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisNetAttributesGetter.java
@@ -21,13 +21,13 @@ final class JedisNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(JedisRequest jedisRequest, @Nullable Void unused) {
+  public String peerName(JedisRequest jedisRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(JedisRequest jedisRequest, @Nullable Void unused) {
+  public Integer peerPort(JedisRequest jedisRequest) {
     return null;
   }
 

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClientNetAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClientNetAttributesGetter.java
@@ -25,13 +25,13 @@ public class JettyHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(Request request, @Nullable Response response) {
+  public String peerName(Request request) {
     return request.getHost();
   }
 
   @Override
   @Nullable
-  public Integer peerPort(Request request, @Nullable Response response) {
+  public Integer peerPort(Request request) {
     return request.getPort();
   }
 }

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesNetAttributesGetter.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesNetAttributesGetter.java
@@ -19,12 +19,12 @@ class KubernetesNetAttributesGetter implements NetClientAttributesGetter<Request
   }
 
   @Override
-  public String peerName(Request request, @Nullable ApiResponse<?> response) {
+  public String peerName(Request request) {
     return request.url().host();
   }
 
   @Override
-  public Integer peerPort(Request request, @Nullable ApiResponse<?> response) {
+  public Integer peerPort(Request request) {
     return request.url().port();
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetAttributesGetter.java
@@ -18,12 +18,12 @@ final class LettuceConnectNetAttributesGetter implements NetClientAttributesGett
   }
 
   @Override
-  public String peerName(RedisURI redisUri, @Nullable Void unused) {
+  public String peerName(RedisURI redisUri) {
     return redisUri.getHost();
   }
 
   @Override
-  public Integer peerPort(RedisURI redisUri, @Nullable Void unused) {
+  public Integer peerPort(RedisURI redisUri) {
     return redisUri.getPort();
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetAttributesGetter.java
@@ -18,12 +18,12 @@ final class LettuceConnectNetAttributesGetter implements NetClientAttributesGett
   }
 
   @Override
-  public String peerName(RedisURI redisUri, @Nullable Void unused) {
+  public String peerName(RedisURI redisUri) {
     return redisUri.getHost();
   }
 
   @Override
-  public Integer peerPort(RedisURI redisUri, @Nullable Void unused) {
+  public Integer peerPort(RedisURI redisUri) {
     return redisUri.getPort();
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceNetAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceNetAttributesGetter.java
@@ -22,13 +22,13 @@ final class LettuceNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(OpenTelemetryEndpoint openTelemetryEndpoint, @Nullable Void unused) {
+  public String peerName(OpenTelemetryEndpoint openTelemetryEndpoint) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(OpenTelemetryEndpoint openTelemetryEndpoint, @Nullable Void unused) {
+  public Integer peerPort(OpenTelemetryEndpoint openTelemetryEndpoint) {
     return null;
   }
 

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoNetAttributesGetter.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoNetAttributesGetter.java
@@ -19,7 +19,7 @@ class MongoNetAttributesGetter implements NetClientAttributesGetter<CommandStart
 
   @Nullable
   @Override
-  public String peerName(CommandStartedEvent event, @Nullable Void unused) {
+  public String peerName(CommandStartedEvent event) {
     if (event.getConnectionDescription() != null
         && event.getConnectionDescription().getServerAddress() != null) {
       return event.getConnectionDescription().getServerAddress().getHost();
@@ -29,7 +29,7 @@ class MongoNetAttributesGetter implements NetClientAttributesGetter<CommandStart
 
   @Nullable
   @Override
-  public Integer peerPort(CommandStartedEvent event, @Nullable Void unused) {
+  public Integer peerPort(CommandStartedEvent event) {
     if (event.getConnectionDescription() != null
         && event.getConnectionDescription().getServerAddress() != null) {
       return event.getConnectionDescription().getServerAddress().getPort();

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectNetAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectNetAttributesGetter.java
@@ -26,7 +26,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(NettyConnectionRequest request, @Nullable Channel channel) {
+  public String peerName(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getHostString();
@@ -36,7 +36,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public Integer peerPort(NettyConnectionRequest request, @Nullable Channel channel) {
+  public Integer peerPort(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getPort();

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyNetClientAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyNetClientAttributesGetter.java
@@ -27,15 +27,13 @@ final class NettyNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse httpResponse) {
+  public String peerName(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse httpResponse) {
+  public Integer peerPort(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectNetAttributesGetter.java
@@ -26,7 +26,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(NettyConnectionRequest request, @Nullable Channel channel) {
+  public String peerName(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getHostString();
@@ -36,7 +36,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public Integer peerPort(NettyConnectionRequest request, @Nullable Channel channel) {
+  public Integer peerPort(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getPort();

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyNetClientAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyNetClientAttributesGetter.java
@@ -27,15 +27,13 @@ final class NettyNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse httpResponse) {
+  public String peerName(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(
-      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse httpResponse) {
+  public Integer peerPort(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
@@ -23,13 +23,13 @@ final class NettySslNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(NettySslRequest nettySslRequest, @Nullable Void unused) {
+  public String peerName(NettySslRequest nettySslRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(NettySslRequest nettySslRequest, @Nullable Void unused) {
+  public Integer peerPort(NettySslRequest nettySslRequest) {
     return null;
   }
 

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2NetAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2NetAttributesGetter.java
@@ -21,12 +21,12 @@ public final class OkHttp2NetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(Request request, @Nullable Response response) {
+  public String peerName(Request request) {
     return request.url().getHost();
   }
 
   @Override
-  public Integer peerPort(Request request, @Nullable Response response) {
+  public Integer peerPort(Request request) {
     return request.url().getPort();
   }
 }

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpNetAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpNetAttributesGetter.java
@@ -25,12 +25,12 @@ public final class OkHttpNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(Request request, @Nullable Response response) {
+  public String peerName(Request request) {
     return request.url().host();
   }
 
   @Override
-  public Integer peerPort(Request request, @Nullable Response response) {
+  public Integer peerPort(Request request) {
     return request.url().port();
   }
 }

--- a/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientNetAttributesGetter.java
+++ b/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientNetAttributesGetter.java
@@ -22,12 +22,12 @@ final class PlayWsClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(Request request, @Nullable Response response) {
+  public String peerName(Request request) {
     return request.getUri().getHost();
   }
 
   @Override
-  public Integer peerPort(Request request, @Nullable Response response) {
+  public Integer peerPort(Request request) {
     return request.getUri().getPort();
   }
 

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelNetAttributesGetter.java
@@ -20,13 +20,13 @@ public class RabbitChannelNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+  public String peerName(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+  public Integer peerPort(ChannelAndMethod channelAndMethod) {
     return null;
   }
 

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitReceiveNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitReceiveNetAttributesGetter.java
@@ -21,13 +21,13 @@ public class RabbitReceiveNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(ReceiveRequest request, @Nullable GetResponse response) {
+  public String peerName(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(ReceiveRequest request, @Nullable GetResponse response) {
+  public Integer peerPort(ReceiveRequest request) {
     return null;
   }
 

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/internal/RatpackHttpNetAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/internal/RatpackHttpNetAttributesGetter.java
@@ -25,12 +25,12 @@ public final class RatpackHttpNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(RequestSpec request, @Nullable HttpResponse response) {
+  public String peerName(RequestSpec request) {
     return request.getUri().getHost();
   }
 
   @Override
-  public Integer peerPort(RequestSpec request, @Nullable HttpResponse response) {
+  public Integer peerPort(RequestSpec request) {
     return request.getUri().getPort();
   }
 }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyNetClientAttributesGetter.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyNetClientAttributesGetter.java
@@ -24,13 +24,13 @@ final class ReactorNettyNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(HttpClientConfig request, @Nullable HttpClientResponse response) {
+  public String peerName(HttpClientConfig request) {
     return getHost(request);
   }
 
   @Nullable
   @Override
-  public Integer peerPort(HttpClientConfig request, @Nullable HttpClientResponse response) {
+  public Integer peerPort(HttpClientConfig request) {
     return getPort(request);
   }
 

--- a/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonNetAttributesGetter.java
+++ b/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonNetAttributesGetter.java
@@ -20,13 +20,13 @@ final class RedissonNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(RedissonRequest redissonRequest, @Nullable Void unused) {
+  public String peerName(RedissonRequest redissonRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(RedissonRequest redissonRequest, @Nullable Void unused) {
+  public Integer peerPort(RedissonRequest redissonRequest) {
     return null;
   }
 

--- a/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebNetAttributesGetter.java
+++ b/instrumentation/spring/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/SpringWebNetAttributesGetter.java
@@ -21,12 +21,12 @@ final class SpringWebNetAttributesGetter
 
   @Override
   @Nullable
-  public String peerName(HttpRequest httpRequest, @Nullable ClientHttpResponse response) {
+  public String peerName(HttpRequest httpRequest) {
     return httpRequest.getURI().getHost();
   }
 
   @Override
-  public Integer peerPort(HttpRequest httpRequest, @Nullable ClientHttpResponse response) {
+  public Integer peerPort(HttpRequest httpRequest) {
     return httpRequest.getURI().getPort();
   }
 }

--- a/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/internal/SpringWebfluxNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/client/internal/SpringWebfluxNetAttributesGetter.java
@@ -25,12 +25,12 @@ public final class SpringWebfluxNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(ClientRequest request, @Nullable ClientResponse response) {
+  public String peerName(ClientRequest request) {
     return request.url().getHost();
   }
 
   @Override
-  public Integer peerPort(ClientRequest request, @Nullable ClientResponse response) {
+  public Integer peerPort(ClientRequest request) {
     return request.url().getPort();
   }
 }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4NetAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4NetAttributesGetter.java
@@ -23,12 +23,12 @@ final class Vertx4NetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String peerName(HttpClientRequest request) {
     return request.getHost();
   }
 
   @Override
-  public Integer peerPort(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public Integer peerPort(HttpClientRequest request) {
     return request.getPort();
   }
 


### PR DESCRIPTION
The [HTTP spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-client) says these two attributes must be provided at span creation time - I think it makes sense to extend it over to all `net`-related instrumentations, cause these are supposed to be the logical peer name/port, which are supposed to be known before the connection is started/exchange is made. 