### PR TITLE
Fix regression in webflux http client concurrency test

### DIFF
--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyClientTelemetry.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyClientTelemetry.java
@@ -72,6 +72,6 @@ public final class NettyClientTelemetry {
    * request executed on a {@link Channel}.
    */
   public static void setChannelContext(Channel channel, Context context) {
-    channel.attr(AttributeKeys.WRITE_CONTEXT).compareAndSet(null, context);
+    channel.attr(AttributeKeys.WRITE_CONTEXT).set(context);
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6857
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6856
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6854
Looks like a regression from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6836