### PR TITLE
Split out license check as separate github action

### DIFF
--- a/.github/workflows/build-daily-no-build-cache.yml
+++ b/.github/workflows/build-daily-no-build-cache.yml
@@ -14,6 +14,13 @@ jobs:
     secrets:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
+  license-check:
+    uses: ./.github/workflows/reusable-license-check.yml
+    with:
+      no-build-cache: true
+    secrets:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
   assemble:
     uses: ./.github/workflows/reusable-assemble.yml
     with:
@@ -60,6 +67,8 @@ jobs:
 
   open-issue-on-failure:
     needs:
+      - spotless
+      - license-check
       - assemble
       - test
       - test-latest-deps

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -14,6 +14,13 @@ jobs:
       GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
       GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
 
+  license-check:
+    uses: ./.github/workflows/reusable-license-check.yml
+    secrets:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
+      GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
+
   assemble:
     uses: ./.github/workflows/reusable-assemble.yml
     secrets:
@@ -59,6 +66,8 @@ jobs:
 
   open-issue-on-failure:
     needs:
+      - spotless
+      - license-check
       - assemble
       - test
       - test-latest-deps

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -13,6 +13,11 @@ jobs:
     with:
       cache-read-only: true
 
+  license-check:
+    uses: ./.github/workflows/reusable-license-check.yml
+    with:
+      cache-read-only: true
+
   assemble:
     uses: ./.github/workflows/reusable-assemble.yml
     with:
@@ -75,6 +80,8 @@ jobs:
     # (muzzle can also fail when a new library version is released to maven central
     # but that happens much less often)
     needs:
+      - spotless
+      - license-check
       - assemble
       - test
       - smoke-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,13 @@ jobs:
       GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
       GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
 
+  license-check:
+    uses: ./.github/workflows/reusable-license-check.yml
+    secrets:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
+      GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
+
   assemble:
     uses: ./.github/workflows/reusable-assemble.yml
     secrets:
@@ -77,6 +84,8 @@ jobs:
     needs:
       # intentionally not blocking snapshot publishing on test-latest-deps, muzzle,
       # markdown-link-check, or misspell-check
+      - spotless
+      - license-check
       - assemble
       - test
       - smoke-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ jobs:
   spotless:
     uses: ./.github/workflows/reusable-spotless.yml
 
+  license-check:
+    uses: ./.github/workflows/reusable-license-check.yml
+
   assemble:
     uses: ./.github/workflows/reusable-assemble.yml
 
@@ -32,6 +35,8 @@ jobs:
 
   release:
     needs:
+      - spotless
+      - license-check
       - assemble
       - test
       - smoke-test

--- a/.github/workflows/reusable-license-check.yml
+++ b/.github/workflows/reusable-license-check.yml
@@ -1,4 +1,4 @@
-name: Reusable - Assemble
+name: Reusable - License check
 
 on:
   workflow_call:
@@ -18,7 +18,7 @@ on:
         required: false
 
 jobs:
-  assemble:
+  license-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -29,27 +29,33 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Assemble
+      - name: Generate license report
         uses: gradle/gradle-build-action@v2
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
           GE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
         with:
-          # javadoc task fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
-          arguments: assemble -x javadoc ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
+          # currently ignoring inputs.no-build-cache and always running with --no-build-cache
+          # see https://github.com/jk1/Gradle-License-Report/issues/231
+          arguments: generateLicenseReport --no-build-cache
           cache-read-only: ${{ inputs.cache-read-only }}
           # gradle enterprise is used for the build cache
           gradle-home-cache-excludes: caches/build-cache-1
 
-      - name: Check for jApiCmp diffs
+      - name: Check licenses
         run: |
-          if git diff --quiet
+          # add any untracked folders that may have been added by generateLicenseReport
+          git add licenses
+          # there's always going to one line difference due to the timestamp included in the report
+          if [[ $(git diff --cached --shortstat licenses) == " 1 file changed, 1 insertion(+), 1 deletion(-)" ]]
           then
-            echo "No diff detected."
+            echo "Licenses are up-to-date."
           else
-            echo "Diff detected - did you run './gradlew jApiCmp'?"
-            echo $(git diff --name-only)
-            echo $(git diff)
+            echo "Licenses are not up-to-date, please run './gradlew generateLicenseReport' locally and commit."
+            echo
+            echo "$(git diff --cached --stat licenses)"
+            echo
+            echo "$(git diff --cached licenses)"
             exit 1
           fi


### PR DESCRIPTION
I've been having a bit of trouble with the license check in our distro repo, and I think it's helpful for it to be a separate github action (also for visibility).