### PR TITLE
Fix markdown link check

### DIFF
--- a/.github/scripts/markdown-link-check-config.json
+++ b/.github/scripts/markdown-link-check-config.json
@@ -1,6 +1,11 @@
 {
-  "retryOn429": true,
-  "aliveStatusCodes": [
+  "ignorePatterns" : [
+    {
+      "pattern" : "^https://kotlinlang\\.org/docs/coroutines-overview\\.html$"
+    }
+  ],
+  "retryOn429" : true,
+  "aliveStatusCodes" : [
     200,
     403
   ]


### PR DESCRIPTION
https://kotlinlang.org/docs/coroutines-overview.html appears to be bot-aware, I can go to it in my browser, but can't curl it