### PR TITLE
fix spring-webflux cast to PathPattern throws ClassCastException

### DIFF
--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/WebfluxSingletons.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/server/WebfluxSingletons.java
@@ -41,9 +41,14 @@ public final class WebfluxSingletons {
 
   public static HttpRouteGetter<ServerWebExchange> httpRouteGetter() {
     return (context, exchange) -> {
-      PathPattern bestPattern =
-          exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
-      return bestPattern == null ? null : bestPattern.getPatternString();
+      Object bestPatternObj = exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+      if (bestPatternObj == null) {
+        return null;
+      }
+      if (bestPatternObj instanceof PathPattern) {
+        return ((PathPattern) bestPatternObj).getPatternString();
+      }
+      return bestPatternObj.toString();
     };
   }
 


### PR DESCRIPTION
when ServerWebExchange.getAttributes().put(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, "path string type").
opentelemetry javaagent will throw exception.
[企业微信截图_76344afd-4541-482c-a90f-0606ad720351](https://user-images.githubusercontent.com/15957476/195615160-45559fb5-5e0c-4c25-8678-7d8aa603f346.png)


