### PR TITLE
Fix release contributors script

### DIFF
--- a/.github/scripts/generate-release-contributors.sh
+++ b/.github/scripts/generate-release-contributors.sh
@@ -72,7 +72,7 @@ query($q: String!, $endCursor: String) {
   }
 }
 ' --jq '.data.search.edges.[].node.body' \
-  | grep -oE "#[0-9]{4,}|$GITHUB_REPOSITORY/issues/[0-9]{4,}" \
+  | grep -oE "#[0-9]{4,}$|#[0-9]{4,}[^0-9<]|$GITHUB_REPOSITORY/issues/[0-9]{4,}" \
   | grep -oE "[0-9]{4,}" \
   | xargs -I{} gh issue view {} --json 'author,url' --jq '[.author.login,.url]' \
   | grep -v '/pull/' \


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-java-contrib/pull/530.

Also, I fixed the contributor list in the release notes which was incorrect due to this bug (I believe only in this latest release due to introduction of dependabot).