### PR TITLE
[release/v1.19.x] Update repo settings (#6862)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,7 +33,7 @@ jobs:
           commit=$(gh pr view $NUMBER --json mergeCommit --jq .mergeCommit.oid)
           title=$(gh pr view $NUMBER --json title --jq .title)
 
-          branch="backport-${NUMBER}-to-${GITHUB_REF_NAME//\//-}"
+          branch="opentelemetrybot/backport-${NUMBER}-to-${GITHUB_REF_NAME//\//-}"
 
           git cherry-pick $commit
           git push origin HEAD:$branch

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           message="Prepare release $VERSION"
-          branch="prepare-release-${VERSION}"
+          branch="opentelemetrybot/prepare-release-${VERSION}"
 
           git commit -a -m "$message"
           git push origin HEAD:$branch

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -62,7 +62,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           message="Prepare release $VERSION"
-          branch="prepare-release-${VERSION}"
+          branch="opentelemetrybot/prepare-release-${VERSION}"
 
           git commit -a -m "$message"
           git push origin HEAD:$branch
@@ -111,7 +111,7 @@ jobs:
         run: |
           message="Update version to $NEXT_VERSION"
           body="Update version to \`$NEXT_VERSION\`."
-          branch="update-version-to-${NEXT_VERSION}"
+          branch="opentelemetrybot/update-version-to-${NEXT_VERSION}"
 
           git commit -a -m "$message"
           git push origin HEAD:$branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
         run: |
           message="Copy change log updates from $GITHUB_REF_NAME"
           body="Copy log updates from \`$GITHUB_REF_NAME\`."
-          branch="copy-change-log-updates-from-${GITHUB_REF_NAME//\//-}"
+          branch="opentelemetrybot/copy-change-log-updates-from-${GITHUB_REF_NAME//\//-}"
 
           if [[ $VERSION == *.0 ]]; then
             if git diff --quiet; then

--- a/docs/contributing/repository-settings.md
+++ b/docs/contributing/repository-settings.md
@@ -54,11 +54,11 @@ Same settings as above for new release branches (`release/**`), except:
   [Nightly overhead benchmark](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/nightly-benchmark-overhead.yml)
   job.
 
-### `dependabot/**/*`
+### `dependabot/**/*` and `opentelemetrybot/**/*`
 
 * Require status checks to pass before merging: unchecked
 
-  So that dependabot can rebase its PR branches
+  So the bots can push directly to these branches in order to submit PRs
 
 * Allow force pushes > Everyone
 
@@ -66,7 +66,7 @@ Same settings as above for new release branches (`release/**`), except:
 
 * Allow deletions: CHECKED
 
-  So that dependabot PR branches can be deleted
+  So that PR branches can be deleted
 
 ### `**/**`
 


### PR DESCRIPTION
Clean cherry-pick of #6862 to `release/v1.19.x`

(see #6911 for why this can't be backported using automation)