### PR TITLE
Don't assign PRs to component owners

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -13,3 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: dyladan/component-owners@main
+        with:
+          # this repository is using this action to request doc review
+          assign-owners: false


### PR DESCRIPTION
It will still assign @theletterf as a reviewer