### PR TITLE
Revert removing the mavenCentral repo from the muzzle check plugin

### DIFF
--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -172,7 +172,7 @@ if (hasRelevantTask) {
 }
 
 fun getProjectRepositories(project: Project): List<RemoteRepository> {
-  return project.repositories
+  val projectRepositories = project.repositories
     .filterIsInstance<MavenArtifactRepository>()
     .map {
       RemoteRepository.Builder(
@@ -181,6 +181,17 @@ fun getProjectRepositories(project: Project): List<RemoteRepository> {
         it.url.toString())
         .build()
     }
+  // dependencyResolutionManagement.repositories are not being added to project.repositories,
+  // they need to be queries separately
+  if (projectRepositories.isEmpty()) {
+    // Manually add mavenCentral until https://github.com/gradle/gradle/issues/17295
+    // Adding mavenLocal is much more complicated but hopefully isn't required for normal usage of
+    // Muzzle.
+    return listOf(RemoteRepository.Builder(
+      "MavenCentral", "default", "https://repo.maven.apache.org/maven2/")
+      .build())
+  }
+  return projectRepositories
 }
 
 fun createInstrumentationClassloader(): ClassLoader {


### PR DESCRIPTION
Fixes #6932 
Replaces #6933 

@aaron-ai I finally understood what you meant in #6796 after seeing your PR - initially I thought you were talking about some custom extension, that's outside of this repository.
I added back the maven central fallback to the muzzle check plugin: after investigating a bit, I found out that the repositories defined in `settings.dependencyResolutionManagement` are not propagated at all (no matter whether it's `afterEvaluate` or not) to the `project.repositories`, and that the gradle issue https://github.com/gradle/gradle/issues/17295 is still valid. 