### PR TITLE
Don't use rocketmq trace context

### DIFF
--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/TracingConsumeMessageHookImpl.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/TracingConsumeMessageHookImpl.java
@@ -34,6 +34,10 @@ final class TracingConsumeMessageHookImpl implements ConsumeMessageHook {
     Context parentContext = Context.current();
     Context newContext = instrumenter.start(parentContext, context.getMsgList());
 
+    // it's safe to store the scope in the rocketMq message context, both before() and after()
+    // methods are always called from the same thread; see:
+    // - ConsumeMessageConcurrentlyService$ConsumeRequest#run()
+    // - ConsumeMessageOrderlyService$ConsumeRequest#run()
     if (newContext != parentContext) {
       contextAndScopeField.set(
           context, ContextAndScope.create(newContext, newContext.makeCurrent()));

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/TracingConsumeMessageHookImpl.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/TracingConsumeMessageHookImpl.java
@@ -6,10 +6,14 @@
 package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
 import org.apache.rocketmq.client.hook.ConsumeMessageContext;
 import org.apache.rocketmq.client.hook.ConsumeMessageHook;
 
 final class TracingConsumeMessageHookImpl implements ConsumeMessageHook {
+
+  private static final VirtualField<ConsumeMessageContext, ContextAndScope> contextAndScopeField =
+      VirtualField.find(ConsumeMessageContext.class, ContextAndScope.class);
 
   private final RocketMqConsumerInstrumenter instrumenter;
 
@@ -30,12 +34,9 @@ final class TracingConsumeMessageHookImpl implements ConsumeMessageHook {
     Context parentContext = Context.current();
     Context newContext = instrumenter.start(parentContext, context.getMsgList());
 
-    // it's safe to store the scope in the rocketMq trace context, both before() and after() methods
-    // are always called from the same thread; see:
-    // - ConsumeMessageConcurrentlyService$ConsumeRequest#run()
-    // - ConsumeMessageOrderlyService$ConsumeRequest#run()
     if (newContext != parentContext) {
-      context.setMqTraceContext(ContextAndScope.create(newContext, newContext.makeCurrent()));
+      contextAndScopeField.set(
+          context, ContextAndScope.create(newContext, newContext.makeCurrent()));
     }
   }
 
@@ -44,8 +45,8 @@ final class TracingConsumeMessageHookImpl implements ConsumeMessageHook {
     if (context == null || context.getMsgList() == null || context.getMsgList().isEmpty()) {
       return;
     }
-    if (context.getMqTraceContext() instanceof ContextAndScope) {
-      ContextAndScope contextAndScope = (ContextAndScope) context.getMqTraceContext();
+    ContextAndScope contextAndScope = contextAndScopeField.get(context);
+    if (contextAndScope != null) {
       contextAndScope.close();
       instrumenter.end(contextAndScope.getContext(), context.getMsgList());
     }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6934
As described in the linked issue our usage of rocketmq trace context can conflict with other hooks that also use `setMqTraceContext`.