### PR TITLE
Cap aws-sdk versions to fix testLatestDeps

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -25,14 +25,14 @@ dependencies {
   testImplementation(project(":instrumentation:apache-httpclient:apache-httpclient-4.0:javaagent"))
   testImplementation(project(":instrumentation:netty:netty-4.1:javaagent"))
 
-  latestDepTestLibrary("software.amazon.awssdk:aws-json-protocol:+")
-  latestDepTestLibrary("software.amazon.awssdk:aws-core:+")
-  latestDepTestLibrary("software.amazon.awssdk:dynamodb:+")
-  latestDepTestLibrary("software.amazon.awssdk:ec2:+")
-  latestDepTestLibrary("software.amazon.awssdk:kinesis:+")
-  latestDepTestLibrary("software.amazon.awssdk:rds:+")
-  latestDepTestLibrary("software.amazon.awssdk:s3:+")
-  latestDepTestLibrary("software.amazon.awssdk:sqs:+")
+  latestDepTestLibrary("software.amazon.awssdk:aws-json-protocol:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:aws-core:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:dynamodb:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:ec2:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:kinesis:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:rds:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:s3:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:sqs:2.17.+")
 }
 
 tasks.withType<Test>().configureEach {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
@@ -12,14 +12,14 @@ dependencies {
 
   testImplementation(project(":instrumentation:aws-sdk:aws-sdk-2.2:testing"))
 
-  latestDepTestLibrary("software.amazon.awssdk:aws-core:+")
-  latestDepTestLibrary("software.amazon.awssdk:aws-json-protocol:+")
-  latestDepTestLibrary("software.amazon.awssdk:dynamodb:+")
-  latestDepTestLibrary("software.amazon.awssdk:ec2:+")
-  latestDepTestLibrary("software.amazon.awssdk:kinesis:+")
-  latestDepTestLibrary("software.amazon.awssdk:rds:+")
-  latestDepTestLibrary("software.amazon.awssdk:s3:+")
-  latestDepTestLibrary("software.amazon.awssdk:sqs:+")
+  latestDepTestLibrary("software.amazon.awssdk:aws-core:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:aws-json-protocol:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:dynamodb:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:ec2:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:kinesis:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:rds:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:s3:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:sqs:2.17.+")
 }
 
 tasks {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -10,14 +10,14 @@ dependencies {
 
   testImplementation(project(":instrumentation:aws-sdk:aws-sdk-2.2:testing"))
 
-  latestDepTestLibrary("software.amazon.awssdk:aws-core:+")
-  latestDepTestLibrary("software.amazon.awssdk:aws-json-protocol:+")
-  latestDepTestLibrary("software.amazon.awssdk:dynamodb:+")
-  latestDepTestLibrary("software.amazon.awssdk:ec2:+")
-  latestDepTestLibrary("software.amazon.awssdk:kinesis:+")
-  latestDepTestLibrary("software.amazon.awssdk:rds:+")
-  latestDepTestLibrary("software.amazon.awssdk:s3:+")
-  latestDepTestLibrary("software.amazon.awssdk:sqs:+")
+  latestDepTestLibrary("software.amazon.awssdk:aws-core:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:aws-json-protocol:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:dynamodb:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:ec2:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:kinesis:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:rds:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:s3:2.17.+")
+  latestDepTestLibrary("software.amazon.awssdk:sqs:2.17.+")
 }
 
 tasks {


### PR DESCRIPTION
Opened issue #6945 to track removing the cap.

Resolves #6941 
Resolves #6943 