### PR TITLE
Deprecate RocketMQ propagation setting

### DIFF
--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/README.md
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/README.md
@@ -3,4 +3,3 @@
 | System property | Type | Default | Description |
 |---|---|---|---|
 | `otel.instrumentation.rocketmq-client.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |
-| `otel.instrumentation.rocketmq-client.propagation` | Boolean | `true` | Enables remote context propagation via RocketMQ message headers. |

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v4_8/RocketMqClientHooks.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v4_8/RocketMqClientHooks.java
@@ -9,11 +9,15 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.rocketmqclient.v4_8.RocketMqTelemetry;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
+import java.util.logging.Logger;
 import org.apache.rocketmq.client.hook.ConsumeMessageHook;
 import org.apache.rocketmq.client.hook.SendMessageHook;
 
 public final class RocketMqClientHooks {
 
+  private static final Logger logger = Logger.getLogger(RocketMqClientHooks.class.getName());
+
+  @SuppressWarnings("deprecation") // call to deprecated method will be removed in the future
   private static final RocketMqTelemetry TELEMETRY =
       RocketMqTelemetry.builder(GlobalOpenTelemetry.get())
           .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
@@ -25,6 +29,18 @@ public final class RocketMqClientHooks {
                   .getBoolean(
                       "otel.instrumentation.rocketmq-client.experimental-span-attributes", false))
           .build();
+
+  static {
+    if (InstrumentationConfig.get().getString("otel.instrumentation.rocketmq-client.propagation")
+        != null) {
+      logger.warning(
+          "The \"otel.instrumentation.rocketmq-client.propagation\" configuration property has"
+              + " been deprecated and will be removed in a future version."
+              + " If you have a need for this configuration property, please open an issue in the"
+              + " opentelemetry-java-instrumentation repository:"
+              + " https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues");
+    }
+  }
 
   public static final ConsumeMessageHook CONSUME_MESSAGE_HOOK =
       TELEMETRY.newTracingConsumeMessageHook();

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqTelemetryBuilder.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqTelemetryBuilder.java
@@ -39,7 +39,12 @@ public final class RocketMqTelemetryBuilder {
   /**
    * Sets whether the trace context should be written from producers / read from consumers for
    * propagating through messaging.
+   *
+   * @deprecated if you have a need for this configuration option please open an issue in the <a
+   *     href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues">opentelemetry-java-instrumentation</a>
+   *     repository.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   public RocketMqTelemetryBuilder setPropagationEnabled(boolean propagationEnabled) {
     this.propagationEnabled = propagationEnabled;


### PR DESCRIPTION
I suspect that this was added in the original RocketMQ instrumentation because it existed in the Kafka instrumentation, and not because there was a need for it(?)

See #6957 for documentation on why it is needed in Kafka