### PR TITLE
okhttp: run our interceptor before other interceptors

### DIFF
--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetry.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpTelemetry.java
@@ -66,7 +66,10 @@ public final class OkHttpTelemetry {
    * @return a {@link Call.Factory} for creating new {@link Call} instances.
    */
   public Call.Factory newCallFactory(OkHttpClient baseClient) {
-    OkHttpClient tracingClient = baseClient.newBuilder().addInterceptor(newInterceptor()).build();
+    OkHttpClient.Builder builder = baseClient.newBuilder();
+    // add our interceptor before other interceptors
+    builder.interceptors().add(0, newInterceptor());
+    OkHttpClient tracingClient = builder.build();
     return new TracingCallFactory(tracingClient);
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -140,7 +140,7 @@ public abstract class AbstractHttpClientTest<REQUEST> {
     return READ_TIMEOUT;
   }
 
-  private InstrumentationTestRunner testing;
+  protected InstrumentationTestRunner testing;
   private HttpClientTestServer server;
 
   private final HttpClientTestOptions options = new HttpClientTestOptions();


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6909
If our interceptor runs before other interceptors then other interceptors replacing the request won't affect our interceptor.