### PR TITLE
Add deprecation cycle for removed methods

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -36,11 +36,35 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
         REQUEST, RESPONSE, HttpServerAttributesGetter<REQUEST, RESPONSE>>
     implements SpanKeyProvider {
 
+  /**
+   * Creates the HTTP server attributes extractor with default configuration.
+   *
+   * @deprecated Use {@link #create(HttpServerAttributesGetter, NetServerAttributesGetter)} instead.
+   */
+  @Deprecated
+  public static <REQUEST, RESPONSE> HttpServerAttributesExtractor<REQUEST, RESPONSE> create(
+      HttpServerAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter) {
+    return create(httpAttributesGetter, new NoopNetServerAttributesGetter<>());
+  }
+
   /** Creates the HTTP server attributes extractor with default configuration. */
   public static <REQUEST, RESPONSE> HttpServerAttributesExtractor<REQUEST, RESPONSE> create(
       HttpServerAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter,
       NetServerAttributesGetter<REQUEST> netAttributesGetter) {
     return builder(httpAttributesGetter, netAttributesGetter).build();
+  }
+
+  /**
+   * Returns a new {@link HttpServerAttributesExtractorBuilder} that can be used to configure the
+   * HTTP client attributes extractor.
+   *
+   * @deprecated Use {@link #builder(HttpServerAttributesGetter, NetServerAttributesGetter)}
+   *     instead.
+   */
+  @Deprecated
+  public static <REQUEST, RESPONSE> HttpServerAttributesExtractorBuilder<REQUEST, RESPONSE> builder(
+      HttpServerAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter) {
+    return builder(httpAttributesGetter, new NoopNetServerAttributesGetter<>());
   }
 
   /**
@@ -161,5 +185,27 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
   @Override
   public SpanKey internalGetSpanKey() {
     return SpanKey.HTTP_SERVER;
+  }
+
+  private static class NoopNetServerAttributesGetter<REQUEST>
+      implements NetServerAttributesGetter<REQUEST> {
+
+    @Nullable
+    @Override
+    public String transport(REQUEST request) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public String hostName(REQUEST request) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Integer hostPort(REQUEST request) {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Methods were removed in #6892, which was backported to the 1.19.x branch and included in the 1.19.1 release.