### PR TITLE
Ignore presto-jdbc shaded okhttp3 connection pool.

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -157,5 +157,9 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
     // Don't instrument the executor's own runnables. These runnables may never return until
     // netty shuts down.
     builder.ignoreTaskClass("io.netty.util.concurrent.SingleThreadEventExecutor$");
+
+    // Presto's presto-jdbc shades the okhttp3 ConnectionPool class. Just like we ignore the pool
+    // in OkHttp3IgnoredTypesConfigurer we need to also ignore it here.
+    builder.ignoreTaskClass("io.prestosql.jdbc.$internal.okhttp3.ConnectionPool$");
   }
 }


### PR DESCRIPTION
This holds onto span context if not ignored. For vanilla `okhttp3` we have an explicit ignore in the `OkHttp3IgnoredTypesConfigurer` class, but `presto-jdbc` repackages okhttp3 when it shades it.