### PR TITLE
Add toString on BridgedTraceFlags

### DIFF
--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/BridgedTraceFlags.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/BridgedTraceFlags.java
@@ -42,6 +42,11 @@ final class BridgedTraceFlags implements TraceFlags, io.opentelemetry.api.trace.
     return delegate.asByte();
   }
 
+  @Override
+  public String toString() {
+    return delegate.toString();
+  }
+
   private static BridgedTraceFlags[] buildInstances() {
     BridgedTraceFlags[] instances = new BridgedTraceFlags[256];
     for (int i = 0; i < 256; i++) {


### PR DESCRIPTION
to improve the situation when logging/debugging `Span.current().getSpanContext()`, currently:

> ImmutableSpanContext{traceId=115a2de6dffb17eaafd13a66d7aec660, spanId=56af5c30e85bfb08, traceFlags=**io.opentelemetry.javaagent.instrumentation.opentelemetryapi.trace.BridgedTraceFlags@20ea6fa6**, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=true}
