### PR TITLE
Ignore trino shaded okhttp pool

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -161,5 +161,8 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
     // Presto's presto-jdbc shades the okhttp3 ConnectionPool class. Just like we ignore the pool
     // in OkHttp3IgnoredTypesConfigurer we need to also ignore it here.
     builder.ignoreTaskClass("io.prestosql.jdbc.$internal.okhttp3.ConnectionPool$");
+
+    // Presto turned into trino, and so the package changed.
+    builder.ignoreTaskClass("io.trino.jdbc.$internal.okhttp3.ConnectionPool$");
   }
 }


### PR DESCRIPTION
This is basically the same thing as #7301 but for the project successor to presto (trino).

Without this exclude,  we get long-running spans holding onto a long scope.