### PR TITLE
#7099 Resolve class transformation errors with Contrast Java Agent

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -39,7 +39,8 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
         .ignoreClass("com.nr.agent.")
         .ignoreClass("com.singularity.")
         .ignoreClass("com.jinspired.")
-        .ignoreClass("org.jinspired.");
+        .ignoreClass("org.jinspired.")
+        .ignoreClass("com.contrastsecurity.");
 
     // allow JDK HttpClient
     builder.allowClass("jdk.internal.net.http.");


### PR DESCRIPTION
Resolves issue opened here: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7099

The following change filters out Contrast classes improving performance for OpenTelemetry when placed before Contrast in the command-line arguments and preventing an incorrect `ClassLoader` issue that causes OpenTelemetry to fail to find it's classes when OpenTelemetry is placed after.