### PR TITLE
Remove wildcard + dependency

### DIFF
--- a/instrumentation/hibernate/hibernate-3.3/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-3.3/javaagent/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
   testInstrumentation(project(":instrumentation:hibernate:hibernate-4.0:javaagent"))
   testInstrumentation(project(":instrumentation:hibernate:hibernate-procedure-call-4.3:javaagent"))
 
-  testLibrary("org.hibernate:hibernate-core:3.3.0.SP1")
   testImplementation("org.hibernate:hibernate-annotations:3.4.0.GA")
-  testImplementation("javassist:javassist:+")
+  testImplementation("javassist:javassist:3.4.GA")
   testImplementation("com.h2database:h2:1.4.197")
   testImplementation("javax.xml.bind:jaxb-api:2.2.11")
   testImplementation("com.sun.xml.bind:jaxb-core:2.2.11")


### PR DESCRIPTION
Should help with maven central sporadic failure:

```
Could not determine the dependencies of task ':instrumentation:hibernate:hibernate-3.3:javaagent:test'.
> Could not resolve all task dependencies for configuration ':instrumentation:hibernate:hibernate-3.3:javaagent:testRuntimeClasspath'.
   > Could not resolve javassist:javassist:+.
```