### PR TITLE
Fix sporadically failing uploads

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -196,7 +196,7 @@ jobs:
           gradle-home-cache-excludes: caches/build-cache-1
 
       - name: Upload deadlock detector artifacts if any
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: deadlock-detector-test-${{ matrix.test-java-version }}-${{ matrix.vm }}
@@ -204,7 +204,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload jvm crash dump files if any
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: javacore-test-${{ matrix.test-java-version }}
@@ -274,7 +274,7 @@ jobs:
         run: ./gradlew :smoke-tests:test -PsmokeTestSuite=${{ matrix.smoke-test-suite }}${{ inputs.no-build-cache && ' --no-build-cache' || '' }}
 
       - name: Upload jvm crash dump files if any
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: javacore-smoke-test-${{ matrix.smoke-test-suite }}-${{ matrix.os }}


### PR DESCRIPTION
I've seen CI fail several times lately on something like

```
An error was encountered when uploading deadlock-detector-test-19-hotspot
```

e.g. https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/3466878562/jobs/5791191014

when otherwise the job would have succeeded.