### PR TITLE
Consolidate dependabot updates

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -41,29 +41,37 @@ val DEPENDENCY_BOMS = listOf(
   "org.spockframework:spock-bom:2.3-groovy-4.0"
 )
 
+val autoServiceVersion = "1.0.1"
+val autoValueVersion = "1.10"
+val errorProneVersion = "2.16"
+val byteBuddyVersion = "1.12.18"
+val jmhVersion = "1.36"
+val mockitoVersion = "4.8.1"
+val slf4jVersion = "2.0.2"
+
 val CORE_DEPENDENCIES = listOf(
-  "com.google.auto.service:auto-service:1.0.1",
-  "com.google.auto.service:auto-service-annotations:1.0.1",
-  "com.google.auto.value:auto-value:1.10",
-  "com.google.auto.value:auto-value-annotations:1.10",
-  "com.google.errorprone:error_prone_annotations:2.16",
-  "com.google.errorprone:error_prone_core:2.16",
-  "com.google.errorprone:error_prone_test_helpers:2.16",
+  "com.google.auto.service:auto-service:${autoServiceVersion}",
+  "com.google.auto.service:auto-service-annotations:${autoServiceVersion}",
+  "com.google.auto.value:auto-value:${autoValueVersion}",
+  "com.google.auto.value:auto-value-annotations:${autoValueVersion}",
+  "com.google.errorprone:error_prone_annotations:${errorProneVersion}",
+  "com.google.errorprone:error_prone_core:${errorProneVersion}",
+  "com.google.errorprone:error_prone_test_helpers:${errorProneVersion}",
   // When updating, also update conventions/build.gradle.kts
-  "net.bytebuddy:byte-buddy:1.12.18",
-  "net.bytebuddy:byte-buddy-dep:1.12.18",
-  "net.bytebuddy:byte-buddy-agent:1.12.18",
-  "net.bytebuddy:byte-buddy-gradle-plugin:1.12.18",
-  "org.openjdk.jmh:jmh-core:1.36",
-  "org.openjdk.jmh:jmh-generator-bytecode:1.36",
-  "org.mockito:mockito-core:4.8.1",
-  "org.mockito:mockito-junit-jupiter:4.8.1",
-  "org.mockito:mockito-inline:4.8.1",
-  "org.slf4j:slf4j-api:2.0.2",
-  "org.slf4j:slf4j-simple:2.0.2",
-  "org.slf4j:log4j-over-slf4j:2.0.2",
-  "org.slf4j:jcl-over-slf4j:2.0.2",
-  "org.slf4j:jul-to-slf4j:2.0.2"
+  "net.bytebuddy:byte-buddy:${byteBuddyVersion}",
+  "net.bytebuddy:byte-buddy-dep:${byteBuddyVersion}",
+  "net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}",
+  "net.bytebuddy:byte-buddy-gradle-plugin:${byteBuddyVersion}",
+  "org.openjdk.jmh:jmh-core:${jmhVersion}",
+  "org.openjdk.jmh:jmh-generator-bytecode:${jmhVersion}",
+  "org.mockito:mockito-core:${mockitoVersion}",
+  "org.mockito:mockito-junit-jupiter:${mockitoVersion}",
+  "org.mockito:mockito-inline:${mockitoVersion}",
+  "org.slf4j:slf4j-api:${slf4jVersion}",
+  "org.slf4j:slf4j-simple:${slf4jVersion}",
+  "org.slf4j:log4j-over-slf4j:${slf4jVersion}",
+  "org.slf4j:jcl-over-slf4j:${slf4jVersion}",
+  "org.slf4j:jul-to-slf4j:${slf4jVersion}"
 )
 
 // See the comment above about why we keep this rather large list.

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -46,7 +46,7 @@ val autoValueVersion = "1.10"
 val errorProneVersion = "2.16"
 val byteBuddyVersion = "1.12.18"
 val jmhVersion = "1.36"
-val mockitoVersion = "4.8.1"
+val mockitoVersion = "4.9.0"
 val slf4jVersion = "2.0.2"
 
 val CORE_DEPENDENCIES = listOf(


### PR DESCRIPTION
I did some testing, and it looks like dependabot understands this kind of variable usage, and will update the variable, which should save us several updates (and resulting conflicting merges).