### PR TITLE
Update annotation instrumentation property name

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/README.md
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/README.md
@@ -2,4 +2,4 @@
 
 | Environment variable 	| Type 	| Default 	| Description 	|
 |-----------------	|------	|---------	|-------------	|
-| `otel.instrumentation.opentelemetry-annotations.exclude-methods` | String |  | All methods to be excluded from auto-instrumentation by annotation-based advices. |
+| `otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods` | String |  | All methods to be excluded from auto-instrumentation by annotation-based advices. |

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/build.gradle.kts
@@ -35,6 +35,6 @@ tasks {
     options.compilerArgs.add("-parameters")
   }
   test {
-    jvmArgs("-Dotel.instrumentation.opentelemetry-annotations.exclude-methods=io.opentelemetry.test.annotation.TracedWithSpan[ignored]")
+    jvmArgs("-Dotel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods=io.opentelemetry.test.annotation.TracedWithSpan[ignored]")
   }
 }

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/WithSpanInstrumentation.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/WithSpanInstrumentation.java
@@ -41,7 +41,7 @@ import net.bytebuddy.matcher.ElementMatchers;
 public class WithSpanInstrumentation implements TypeInstrumentation {
 
   private static final String TRACE_ANNOTATED_METHODS_EXCLUDE_CONFIG =
-      "otel.instrumentation.opentelemetry-annotations.exclude-methods";
+      "otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods";
 
   private final ElementMatcher.Junction<AnnotationSource> annotatedMethodMatcher;
   private final ElementMatcher.Junction<MethodDescription> annotatedParametersMatcher;


### PR DESCRIPTION
Missed this when copying over the instrumentation for the old annotations to the instrumentation for the new annotations.