### PR TITLE
[release/v1.20.x] Update api diffs

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-annotations.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-annotations.txt
@@ -1,20 +1,2 @@
 Comparing source compatibility of  against 
-+++  NEW ANNOTATION: PUBLIC(+) ABSTRACT(+) io.opentelemetry.instrumentation.annotations.SpanAttribute  (not serializable)
-	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW INTERFACE: java.lang.annotation.Annotation
-	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.lang.String value()
-	+++  NEW ANNOTATION: java.lang.annotation.Target
-		+++  NEW ELEMENT: value=java.lang.annotation.ElementType.PARAMETER (+)
-	+++  NEW ANNOTATION: java.lang.annotation.Retention
-		+++  NEW ELEMENT: value=java.lang.annotation.RetentionPolicy.RUNTIME (+)
-+++  NEW ANNOTATION: PUBLIC(+) ABSTRACT(+) io.opentelemetry.instrumentation.annotations.WithSpan  (not serializable)
-	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
-	+++  NEW INTERFACE: java.lang.annotation.Annotation
-	+++  NEW SUPERCLASS: java.lang.Object
-	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) io.opentelemetry.api.trace.SpanKind kind()
-	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) java.lang.String value()
-	+++  NEW ANNOTATION: java.lang.annotation.Target
-		+++  NEW ELEMENT: value=java.lang.annotation.ElementType.METHOD,java.lang.annotation.ElementType.CONSTRUCTOR (+)
-	+++  NEW ANNOTATION: java.lang.annotation.Retention
-		+++  NEW ELEMENT: value=java.lang.annotation.RetentionPolicy.RUNTIME (+)
+No changes.


### PR DESCRIPTION
It's not clear to me what's the right approach for patch releases, alternative is to disable apidiff in release branches as done recently in core repo. I've added this as SIG topic to discuss around broader discussion of apidiff (see also #7213).