### PR TITLE
Fix the boms

### DIFF
--- a/conventions/src/main/kotlin/otel.bom-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.bom-conventions.gradle.kts
@@ -33,3 +33,21 @@ afterEvaluate {
     }
   }
 }
+
+evaluationDependsOn(":dependencyManagement")
+val dependencyManagementConf = configurations.create("dependencyManagement") {
+  isCanBeConsumed = false
+  isCanBeResolved = false
+  isVisible = false
+}
+afterEvaluate {
+  configurations.configureEach {
+    if (isCanBeResolved && !isCanBeConsumed) {
+      extendsFrom(dependencyManagementConf)
+    }
+  }
+}
+
+dependencies {
+  add(dependencyManagementConf.name, platform(project(":dependencyManagement")))
+}

--- a/examples/extension/build.gradle
+++ b/examples/extension/build.gradle
@@ -22,9 +22,6 @@ version '1.0'
 
 ext {
   versions = [
-    // these lines are managed by .github/scripts/update-sdk-version.sh
-    opentelemetry              : "1.20.1",
-
     // these lines are managed by .github/scripts/update-version.sh
     opentelemetryJavaagent     : "1.21.0-SNAPSHOT",
     opentelemetryJavaagentAlpha: "1.21.0-alpha-SNAPSHOT",
@@ -63,13 +60,19 @@ spotless {
 }
 
 dependencies {
+  api(platform("io.opentelemetry:opentelemetry-bom:1.20.1"))
+
+  // these serve as a test of the instrumentation boms
+  api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:${versions.opentelemetryJavaagent}"))
+  api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${versions.opentelemetryJavaagentAlpha}"))
+
   /*
   Interfaces and SPIs that we implement. We use `compileOnly` dependency because during
   runtime all necessary classes are provided by javaagent itself.
    */
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:${versions.opentelemetry}")
-  compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagent}")
-  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
+  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
 
   //Provides @AutoService annotation that makes registration of our SPI implementations much easier
   compileOnly deps.autoservice
@@ -97,7 +100,7 @@ dependencies {
   testImplementation("com.fasterxml.jackson.core:jackson-databind:2.14.0")
   testImplementation("com.google.protobuf:protobuf-java-util:3.21.9")
   testImplementation("com.squareup.okhttp3:okhttp:4.10.0")
-  testImplementation("io.opentelemetry:opentelemetry-api:${versions.opentelemetry}")
+  testImplementation("io.opentelemetry:opentelemetry-api")
   testImplementation("io.opentelemetry.proto:opentelemetry-proto:0.19.0-alpha")
 
   testImplementation("org.junit.jupiter:junit-jupiter-api:${versions.junit}")


### PR DESCRIPTION
the 1.20.1 instrumentation boms are busted, as they are missing versions for their nested boms (sort of surprised maven central didn't reject them), e.g.

```
<dependency>
<groupId>io.opentelemetry</groupId>
<artifactId>opentelemetry-bom</artifactId>
<type>pom</type>
<scope>import</scope>
</dependency>
```

https://repo.maven.apache.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/1.20.1/opentelemetry-instrumentation-bom-1.20.1.pom

deserves another patch release