### PR TITLE
Update the usage of set-output command in GH actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
                             v$VERSION \
                             opentelemetry-javaagent.jar
 
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   merge-change-log-to-main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates the usage of set-output command in GH actions.

Reference : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

CHANGELOG entry is not required