### PR TITLE
Support Spring Kafka 3

### DIFF
--- a/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
@@ -2,14 +2,23 @@ plugins {
   id("otel.javaagent-instrumentation")
 }
 
+// TODO: remove once spring-boot 3 gets released
+repositories {
+  mavenCentral()
+  maven("https://repo.spring.io/milestone")
+  mavenLocal()
+}
+
 muzzle {
   pass {
     group.set("org.springframework.kafka")
     module.set("spring-kafka")
-    versions.set("[2.7.0,3)")
+    versions.set("[2.7.0,)")
     assertInverse.set(true)
   }
 }
+
+val latestDepTest = findProperty("testLatestDeps") as Boolean
 
 dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
@@ -25,23 +34,33 @@ dependencies {
 
   testImplementation(project(":instrumentation:spring:spring-kafka-2.7:testing"))
 
-  testLibrary("org.springframework.boot:spring-boot-starter-test:2.5.3")
-  testLibrary("org.springframework.boot:spring-boot-starter:2.5.3")
-
-  latestDepTestLibrary("org.springframework.kafka:spring-kafka:2.+")
-  // TODO: temp change, will be reverted in #7271
-  latestDepTestLibrary("org.springframework.boot:spring-boot-starter-test:2.+")
-  latestDepTestLibrary("org.springframework.boot:spring-boot-starter:2.+")
+  // TODO: remove once spring-boot 3 gets released
+  if (latestDepTest) {
+    testImplementation("org.springframework.boot:spring-boot-starter-test:3.0.0-RC2")
+    testImplementation("org.springframework.boot:spring-boot-starter:3.0.0-RC2")
+  } else {
+    testLibrary("org.springframework.boot:spring-boot-starter-test:2.5.3")
+    testLibrary("org.springframework.boot:spring-boot-starter:2.5.3")
+  }
 }
 
 testing {
   suites {
     val testNoReceiveTelemetry by registering(JvmTestSuite::class) {
       dependencies {
-        implementation("org.springframework.kafka:spring-kafka:2.7.0")
         implementation(project(":instrumentation:spring:spring-kafka-2.7:testing"))
-        implementation("org.springframework.boot:spring-boot-starter-test:2.5.3")
-        implementation("org.springframework.boot:spring-boot-starter:2.5.3")
+
+        // the "library" configuration is not recognized by the test suite plugin
+        if (latestDepTest) {
+          implementation("org.springframework.kafka:spring-kafka:+")
+          // TODO: use stable spring-boot 3 when it gets released
+          implementation("org.springframework.boot:spring-boot-starter-test:3.0.0-RC2")
+          implementation("org.springframework.boot:spring-boot-starter:3.0.0-RC2")
+        } else {
+          implementation("org.springframework.kafka:spring-kafka:2.7.0")
+          implementation("org.springframework.boot:spring-boot-starter-test:2.5.3")
+          implementation("org.springframework.boot:spring-boot-starter:2.5.3")
+        }
       }
 
       targets {
@@ -71,18 +90,28 @@ tasks {
   }
 }
 
-configurations {
-  listOf(
-    testRuntimeClasspath,
-    named("testNoReceiveTelemetryRuntimeClasspath")
-  )
-    .forEach {
-      it.configure {
-        resolutionStrategy {
-          // requires old logback (and therefore also old slf4j)
-          force("ch.qos.logback:logback-classic:1.2.11")
-          force("org.slf4j:slf4j-api:1.7.36")
+// spring 6 (which spring-kafka 3.+ uses) requires java 17
+if (latestDepTest) {
+  otelJava {
+    minJavaVersionSupported.set(JavaVersion.VERSION_17)
+  }
+}
+
+// spring 6 uses slf4j 2.0
+if (!latestDepTest) {
+  configurations {
+    listOf(
+      testRuntimeClasspath,
+      named("testNoReceiveTelemetryRuntimeClasspath")
+    )
+      .forEach {
+        it.configure {
+          resolutionStrategy {
+            // requires old logback (and therefore also old slf4j)
+            force("ch.qos.logback:logback-classic:1.2.11")
+            force("org.slf4j:slf4j-api:1.7.36")
+          }
         }
       }
-    }
+  }
 }

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
@@ -2,13 +2,6 @@ plugins {
   id("otel.javaagent-instrumentation")
 }
 
-// TODO: remove once spring-boot 3 gets released
-repositories {
-  mavenCentral()
-  maven("https://repo.spring.io/milestone")
-  mavenLocal()
-}
-
 muzzle {
   pass {
     group.set("org.springframework.kafka")
@@ -17,8 +10,6 @@ muzzle {
     assertInverse.set(true)
   }
 }
-
-val latestDepTest = findProperty("testLatestDeps") as Boolean
 
 dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
@@ -34,15 +25,11 @@ dependencies {
 
   testImplementation(project(":instrumentation:spring:spring-kafka-2.7:testing"))
 
-  // TODO: remove once spring-boot 3 gets released
-  if (latestDepTest) {
-    testImplementation("org.springframework.boot:spring-boot-starter-test:3.0.0-RC2")
-    testImplementation("org.springframework.boot:spring-boot-starter:3.0.0-RC2")
-  } else {
-    testLibrary("org.springframework.boot:spring-boot-starter-test:2.5.3")
-    testLibrary("org.springframework.boot:spring-boot-starter:2.5.3")
-  }
+  testLibrary("org.springframework.boot:spring-boot-starter-test:2.5.3")
+  testLibrary("org.springframework.boot:spring-boot-starter:2.5.3")
 }
+
+val latestDepTest = findProperty("testLatestDeps") as Boolean
 
 testing {
   suites {
@@ -53,9 +40,8 @@ testing {
         // the "library" configuration is not recognized by the test suite plugin
         if (latestDepTest) {
           implementation("org.springframework.kafka:spring-kafka:+")
-          // TODO: use stable spring-boot 3 when it gets released
-          implementation("org.springframework.boot:spring-boot-starter-test:3.0.0-RC2")
-          implementation("org.springframework.boot:spring-boot-starter:3.0.0-RC2")
+          implementation("org.springframework.boot:spring-boot-starter-test:+")
+          implementation("org.springframework.boot:spring-boot-starter:+")
         } else {
           implementation("org.springframework.kafka:spring-kafka:2.7.0")
           implementation("org.springframework.boot:spring-boot-starter-test:2.5.3")

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/SpringKafkaTest.java
@@ -49,7 +49,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         () -> {
           kafkaTemplate.executeInTransaction(
               ops -> {
-                ops.send("testSingleTopic", "10", "testSpan");
+                send("testSingleTopic", "10", "testSpan");
                 return 0;
               });
         });
@@ -113,7 +113,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         () -> {
           kafkaTemplate.executeInTransaction(
               ops -> {
-                ops.send("testSingleTopic", "10", "error");
+                send("testSingleTopic", "10", "error");
                 return 0;
               });
         });
@@ -240,7 +240,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         () -> {
           kafkaTemplate.executeInTransaction(
               ops -> {
-                ops.send("testBatchTopic", "10", "error");
+                send("testBatchTopic", "10", "error");
                 return 0;
               });
         });

--- a/instrumentation/spring/spring-kafka-2.7/library/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/library/build.gradle.kts
@@ -2,15 +2,6 @@ plugins {
   id("otel.library-instrumentation")
 }
 
-// TODO: remove once spring-boot 3 gets released
-repositories {
-  mavenCentral()
-  maven("https://repo.spring.io/milestone")
-  mavenLocal()
-}
-
-val latestDepTest = findProperty("testLatestDeps") as Boolean
-
 dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
@@ -25,15 +16,11 @@ dependencies {
   // 2.7.0 has a bug that makes decorating a Kafka Producer impossible
   testLibrary("org.springframework.kafka:spring-kafka:2.7.1")
 
-  // TODO: remove once spring-boot 3 gets released
-  if (latestDepTest) {
-    testImplementation("org.springframework.boot:spring-boot-starter-test:3.0.0-RC2")
-    testImplementation("org.springframework.boot:spring-boot-starter:3.0.0-RC2")
-  } else {
-    testLibrary("org.springframework.boot:spring-boot-starter-test:2.5.3")
-    testLibrary("org.springframework.boot:spring-boot-starter:2.5.3")
-  }
+  testLibrary("org.springframework.boot:spring-boot-starter-test:2.5.3")
+  testLibrary("org.springframework.boot:spring-boot-starter:2.5.3")
 }
+
+val latestDepTest = findProperty("testLatestDeps") as Boolean
 
 // spring 6 (which spring-kafka 3.+ uses) requires java 17
 if (latestDepTest) {

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedRecordInterceptor.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedRecordInterceptor.java
@@ -53,9 +53,8 @@ final class InstrumentedRecordInterceptor<K, V> implements RecordInterceptor<K, 
   @SuppressWarnings({
     "deprecation",
     "unchecked"
-  }) // implementing deprecated method for better compatibility
-  // deprecated method removed in 3.0
-  // @Override
+  }) // implementing deprecated method (removed in 3.0) for better compatibility
+  @Override
   public ConsumerRecord<K, V> intercept(ConsumerRecord<K, V> record) {
     if (interceptRecord == null) {
       return null;

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedRecordInterceptor.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedRecordInterceptor.java
@@ -66,8 +66,9 @@ final class InstrumentedRecordInterceptor<K, V> implements RecordInterceptor<K, 
     }
     try {
       return (ConsumerRecord<K, V>) interceptRecord.invoke(decorated, record);
-    } catch (Throwable ignored) {
-      return record;
+    } catch (Throwable e) {
+      rethrow(e);
+      return null; // unreachable
     }
   }
 
@@ -75,6 +76,11 @@ final class InstrumentedRecordInterceptor<K, V> implements RecordInterceptor<K, 
   public ConsumerRecord<K, V> intercept(ConsumerRecord<K, V> record, Consumer<K, V> consumer) {
     start(record);
     return decorated == null ? record : decorated.intercept(record, consumer);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <E extends Throwable> void rethrow(Throwable e) throws E {
+    throw (E) e;
   }
 
   private void start(ConsumerRecord<K, V> record) {

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedRecordInterceptor.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedRecordInterceptor.java
@@ -9,6 +9,9 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import javax.annotation.Nullable;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -20,6 +23,22 @@ final class InstrumentedRecordInterceptor<K, V> implements RecordInterceptor<K, 
       VirtualField.find(ConsumerRecord.class, Context.class);
   private static final VirtualField<ConsumerRecord<?, ?>, State<ConsumerRecord<?, ?>>> stateField =
       VirtualField.find(ConsumerRecord.class, State.class);
+  private static final MethodHandle interceptRecord;
+
+  static {
+    MethodHandle interceptRecordHandle;
+    try {
+      interceptRecordHandle =
+          MethodHandles.lookup()
+              .findVirtual(
+                  RecordInterceptor.class,
+                  "intercept",
+                  MethodType.methodType(ConsumerRecord.class, ConsumerRecord.class));
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      interceptRecordHandle = null;
+    }
+    interceptRecord = interceptRecordHandle;
+  }
 
   private final Instrumenter<ConsumerRecord<?, ?>, Void> processInstrumenter;
   @Nullable private final RecordInterceptor<K, V> decorated;
@@ -31,11 +50,25 @@ final class InstrumentedRecordInterceptor<K, V> implements RecordInterceptor<K, 
     this.decorated = decorated;
   }
 
-  @SuppressWarnings("deprecation") // implementing deprecated method for better compatibility
-  @Override
+  @SuppressWarnings({
+    "deprecation",
+    "unchecked"
+  }) // implementing deprecated method for better compatibility
+  // deprecated method removed in 3.0
+  // @Override
   public ConsumerRecord<K, V> intercept(ConsumerRecord<K, V> record) {
+    if (interceptRecord == null) {
+      return null;
+    }
     start(record);
-    return decorated == null ? record : decorated.intercept(record);
+    if (decorated == null) {
+      return null;
+    }
+    try {
+      return (ConsumerRecord<K, V>) interceptRecord.invoke(decorated, record);
+    } catch (Throwable ignored) {
+      return record;
+    }
   }
 
   @Override

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
             () -> {
               kafkaTemplate.executeInTransaction(
                   ops -> {
-                    ops.send("testSingleTopic", "10", "testSpan");
+                    send("testSingleTopic", "10", "testSpan");
                     return 0;
                   });
             });
@@ -75,7 +75,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
             () -> {
               kafkaTemplate.executeInTransaction(
                   ops -> {
-                    ops.send("testSingleTopic", "10", "error");
+                    send("testSingleTopic", "10", "error");
                     return 0;
                   });
             });
@@ -177,7 +177,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
             () -> {
               kafkaTemplate.executeInTransaction(
                   ops -> {
-                    ops.send("testBatchTopic", "10", "error");
+                    send("testBatchTopic", "10", "error");
                     return 0;
                   });
             });


### PR DESCRIPTION
Fixes #7265

I took a look at the new Observation API, and I think that it still makes sense to continue using the interceptors to implement this instrumentation: they implement the OTel spec (which includes way more attributes than the default observation convention implemented in Spring), and cooperate with the Kafka client instrumentation and link the receive and process spans together. And it's quite a simple change in one of our interceptors, instead of rewriting everything.

(Draft because Spring Boot 3 hasn't released yet, and it is required to run the tests. If we're not in a hurry this PR can wait a bit for that)