### PR TITLE
Temporarily limit latest dependency tests for spring-integration

### DIFF
--- a/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
   testLibrary("org.springframework.cloud:spring-cloud-stream-binder-rabbit:2.2.1.RELEASE")
 
   testImplementation("javax.servlet:javax.servlet-api:3.1.0")
+
+  latestDepTestLibrary("org.springframework.integration:spring-integration-core:5.+")
 }
 
 tasks {

--- a/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
   testLibrary("org.springframework.boot:spring-boot-starter:1.5.22.RELEASE")
   testLibrary("org.springframework.cloud:spring-cloud-stream:2.2.1.RELEASE")
   testLibrary("org.springframework.cloud:spring-cloud-stream-binder-rabbit:2.2.1.RELEASE")
+
+  latestDepTestLibrary("org.springframework.integration:spring-integration-core:5.+")
 }
 
 tasks {


### PR DESCRIPTION
Created tracking issue for supporting version 6+: #7277

Resolves #7276
Resolves #7286