### PR TITLE
Add null check for the return value of `ReferenceQueue#remove()`

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/cache/weaklockfree/AbstractWeakConcurrentMap.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/cache/weaklockfree/AbstractWeakConcurrentMap.java
@@ -258,7 +258,9 @@ abstract class AbstractWeakConcurrentMap<K, V, L> implements Iterable<Map.Entry<
     try {
       while (!Thread.interrupted()) {
         Reference<?> reference = REFERENCE_QUEUE.remove();
-        removeWeakKey((WeakKey<?>) reference);
+        if (reference != null) {
+          removeWeakKey((WeakKey<?>) reference);
+        }
       }
     } catch (InterruptedException ignored) {
       // do nothing


### PR DESCRIPTION
Resolves #7301 

I think that openj9's implementation of the `ReferenceQueue#remove()` method might actually return a null value: https://github.com/eclipse-openj9/openj9/blob/78038a17db84716d97cb57e1b76bec7975a00bf7/jcl/src/java.base/share/classes/java/lang/ref/ReferenceQueue.java#L139-L162