### PR TITLE
Add some comment-driven automations for PRs

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - if: >
+      - if: |
           needs.common.result != 'success' ||
           (!startsWith(github.base_ref, 'release/') && needs.muzzle.result != 'success')
         run: exit 1

--- a/.github/workflows/comment-driven-automation.yml
+++ b/.github/workflows/comment-driven-automation.yml
@@ -1,0 +1,113 @@
+name: Comment driven automations
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  comment-driven-automation:
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@opentelemetrybot ')
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get command
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          # intentionally only looking at the first line of the body
+          command=$(echo "$BODY" | head -1 | sed "s/^@opentelemetrybot //")
+          echo "COMMAND=$command" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+        with:
+          # history is needed for the update command to run "git merge"
+          fetch-depth: ${{ env.COMMAND == 'update' && '0' || '1' }}
+
+      - name: Check out PR branch
+        if: |
+          env.COMMAND == 'spotless' ||
+          env.COMMAND == 'license' ||
+          env.COMMAND == 'apidiff' ||
+          env.COMMAND == 'update'
+        env:
+          NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr checkout $NUMBER
+
+      - name: Set up Gradle cache
+        if: |
+          env.COMMAND == 'spotless' ||
+          env.COMMAND == 'license' ||
+          env.COMMAND == 'apidiff'
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: true
+
+      - name: Use CLA approved github bot
+        if: |
+          env.COMMAND == 'spotless' ||
+          env.COMMAND == 'license' ||
+          env.COMMAND == 'apidiff' ||
+          env.COMMAND == 'update'
+        run: .github/scripts/use-cla-approved-github-bot.sh
+
+      - name: Run command
+        env:
+          NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          available_commands="Available commands:
+            * \`@opentelemetrybot spotless\` - runs \`./gradlew spotlessApply\`
+            * \`@opentelemetrybot license\` - runs \`./gradlew generateLicenseReport\`
+            * \`@opentelemetrybot apidiff\` - runs \`./gradlew jApiCmp\`
+            * \`@opentelemetrybot update\` - updates branch with merge commit
+            * \`@opentelemetrybot rerun\` - re-runs failed checks (NOT IMPLEMENTED YET)
+            * \`@opentelemetrybot help\` - displays available commands
+          "
+          # TODO add thumbs up on triggering comment
+          if [[ "$COMMAND" == "spotless" ]]; then
+            ./gradlew spotlessApply
+            if git diff --quiet; then
+              gh pr comment $NUMBER --body "Already up-to-date"
+              exit 0 # success
+            fi
+            git commit -a -m "./gradlew spotlessApply"
+            git push
+          elif [[ "$COMMAND" == "license" ]]; then
+            ./gradlew generateLicenseReport
+            git add licenses
+            # there's always going to one line difference due to the timestamp included in the report
+            if [[ $(git diff --cached --shortstat licenses) == " 1 file changed, 1 insertion(+), 1 deletion(-)" ]]
+            then
+              gh pr comment $NUMBER --body "Already up-to-date"
+              exit 0 # success
+            fi
+            git commit -m "./gradlew generateLicenseReport"
+            git push
+          elif [[ "$COMMAND" == "apidiff" ]]; then
+            ./gradlew jApiCmp
+            git add docs/apidiffs
+            if git diff --cached --quiet; then
+              gh pr comment $NUMBER --body "Already up-to-date"
+              exit 0 # success
+            fi
+            git commit -m "./gradlew jApiCmp"
+            git push
+          elif [[ "$COMMAND" == "update" ]]; then
+            # TODO check for up-to-date
+            git merge --no-edit origin/main
+            git push
+          elif [[ "$COMMAND" == "rerun" ]]; then
+            echo TODO
+            # gh run rerun  --failed
+          elif [[ "$COMMAND" == "help" ]]; then
+            gh pr comment $NUMBER --body "$available_commands"
+          else
+            body="Unknown command: \`$COMMAND\`
+
+            $available_commands
+            "
+            gh pr comment $NUMBER --body "$body"
+          fi


### PR DESCRIPTION
Available commands:
* `@opentelemetrybot spotless` - runs `./gradlew spotlessApply`
* `@opentelemetrybot license` - runs `./gradlew generateLicenseReport`
* `@opentelemetrybot apidiff` - runs `./gradlew jApiCmp`
* `@opentelemetrybot update` - updates branch with merge commit
* `@opentelemetrybot rerun` - re-runs failed checks (NOT IMPLEMENTED YET)
* `@opentelemetrybot help` - displays available commands

see #7290