### PR TITLE
Don't call Thread#setContextClassLoader()

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/OpenTelemetryInstaller.java
@@ -5,11 +5,9 @@
 
 package io.opentelemetry.javaagent.tooling;
 
-import io.opentelemetry.javaagent.bootstrap.AgentInitializer;
 import io.opentelemetry.javaagent.bootstrap.OpenTelemetrySdkAccess;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import java.util.Arrays;
 
@@ -21,17 +19,14 @@ public final class OpenTelemetryInstaller {
    *
    * @return the {@link AutoConfiguredOpenTelemetrySdk}
    */
-  public static AutoConfiguredOpenTelemetrySdk installOpenTelemetrySdk() {
-    AutoConfiguredOpenTelemetrySdkBuilder builder =
-        AutoConfiguredOpenTelemetrySdk.builder().setResultAsGlobal(true);
+  public static AutoConfiguredOpenTelemetrySdk installOpenTelemetrySdk(
+      ClassLoader extensionClassLoader) {
 
-    ClassLoader classLoader = AgentInitializer.getExtensionsClassLoader();
-    if (classLoader != null) {
-      // May be null in unit tests.
-      builder.setServiceClassLoader(classLoader);
-    }
-
-    AutoConfiguredOpenTelemetrySdk autoConfiguredSdk = builder.build();
+    AutoConfiguredOpenTelemetrySdk autoConfiguredSdk =
+        AutoConfiguredOpenTelemetrySdk.builder()
+            .setResultAsGlobal(true)
+            .setServiceClassLoader(extensionClassLoader)
+            .build();
     OpenTelemetrySdk sdk = autoConfiguredSdk.getOpenTelemetrySdk();
 
     OpenTelemetrySdkAccess.internalSetForceFlush(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/SafeServiceLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/SafeServiceLoader.java
@@ -30,9 +30,9 @@ public final class SafeServiceLoader {
    */
   // Because we want to catch exception per iteration
   @SuppressWarnings("ForEachIterable")
-  public static <T> List<T> load(Class<T> serviceClass) {
+  public static <T> List<T> load(Class<T> serviceClass, ClassLoader classLoader) {
     List<T> result = new ArrayList<>();
-    ServiceLoader<T> services = ServiceLoader.load(serviceClass);
+    ServiceLoader<T> services = ServiceLoader.load(serviceClass, classLoader);
     for (Iterator<T> iterator = new SafeIterator<>(services.iterator()); iterator.hasNext(); ) {
       T service = iterator.next();
       if (service != null) {
@@ -43,11 +43,12 @@ public final class SafeServiceLoader {
   }
 
   /**
-   * Same as {@link #load(Class)}, but also orders the returned implementations by comparing their
-   * {@link Ordered#order()}.
+   * Same as {@link #load(Class, ClassLoader)}, but also orders the returned implementations by
+   * comparing their {@link Ordered#order()}.
    */
-  public static <T extends Ordered> List<T> loadOrdered(Class<T> serviceClass) {
-    List<T> result = load(serviceClass);
+  public static <T extends Ordered> List<T> loadOrdered(
+      Class<T> serviceClass, ClassLoader classLoader) {
+    List<T> result = load(serviceClass, classLoader);
     result.sort(Comparator.comparing(Ordered::order));
     return result;
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationLoader.java
@@ -13,6 +13,7 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.bootstrap.InstrumentationHolder;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.tooling.AgentExtension;
+import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.logging.Logger;
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -27,7 +28,8 @@ public class InstrumentationLoader implements AgentExtension {
   @Override
   public AgentBuilder extend(AgentBuilder agentBuilder, ConfigProperties config) {
     int numberOfLoadedModules = 0;
-    for (InstrumentationModule instrumentationModule : loadOrdered(InstrumentationModule.class)) {
+    for (InstrumentationModule instrumentationModule :
+        loadOrdered(InstrumentationModule.class, Utils.getExtensionsClassLoader())) {
       if (logger.isLoggable(FINE)) {
         logger.log(
             FINE,

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/test/HelperInjectionTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/test/HelperInjectionTest.groovy
@@ -61,7 +61,7 @@ class HelperInjectionTest extends Specification {
   def "helpers injected on bootstrap classloader"() {
     setup:
     ByteBuddyAgent.install()
-    AgentInstaller.installBytebuddyAgent(ByteBuddyAgent.getInstrumentation())
+    AgentInstaller.installBytebuddyAgent(ByteBuddyAgent.getInstrumentation(), this.class.classLoader)
     String helperClassName = HelperInjectionTest.getPackage().getName() + '.HelperClass'
     HelperInjector injector = new HelperInjector("test", [helperClassName], [], this.class.classLoader, ByteBuddyAgent.getInstrumentation())
     URLClassLoader bootstrapChild = new URLClassLoader(new URL[0], (ClassLoader) null)

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/OpenTelemetryInstallerTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/OpenTelemetryInstallerTest.groovy
@@ -24,7 +24,7 @@ class OpenTelemetryInstallerTest extends Specification {
 
   def "should initialize GlobalOpenTelemetry"() {
     when:
-    def otelInstaller = OpenTelemetryInstaller.installOpenTelemetrySdk()
+    def otelInstaller = OpenTelemetryInstaller.installOpenTelemetrySdk(OpenTelemetryInstaller.classLoader)
 
     then:
     otelInstaller != null

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFileLoaderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFileLoaderTest.java
@@ -46,7 +46,7 @@ class ConfigurationFileLoaderTest {
 
     // when
     AutoConfiguredOpenTelemetrySdk autoConfiguredSdk =
-        OpenTelemetryInstaller.installOpenTelemetrySdk();
+        OpenTelemetryInstaller.installOpenTelemetrySdk(this.getClass().getClassLoader());
 
     // then
     assertThat(autoConfiguredSdk.getConfig().getString("custom.key")).isEqualTo("42");

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentTooling.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentTooling.java
@@ -32,7 +32,8 @@ public final class AgentTooling {
 
   private static ClassLoader getBootstrapProxy() {
     Iterator<BootstrapProxyProvider> iterator =
-        ServiceLoader.load(BootstrapProxyProvider.class).iterator();
+        ServiceLoader.load(BootstrapProxyProvider.class, AgentTooling.class.getClassLoader())
+            .iterator();
     if (iterator.hasNext()) {
       BootstrapProxyProvider bootstrapProxyProvider = iterator.next();
       return bootstrapProxyProvider.getBootstrapProxy();

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ClassLoaderMatcher.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ClassLoaderMatcher.java
@@ -33,7 +33,7 @@ public class ClassLoaderMatcher {
   public static Map<String, List<Mismatch>> matchesAll(
       ClassLoader classLoader, boolean injectHelpers, Set<String> excludedInstrumentationNames) {
     Map<String, List<Mismatch>> result = new HashMap<>();
-    ServiceLoader.load(InstrumentationModule.class)
+    ServiceLoader.load(InstrumentationModule.class, ClassLoaderMatcher.class.getClassLoader())
         .forEach(
             module -> {
               if (module.instrumentationNames().stream()

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferencesPrinter.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferencesPrinter.java
@@ -26,7 +26,7 @@ public final class ReferencesPrinter {
    */
   public static void printMuzzleReferences() {
     for (InstrumentationModule instrumentationModule :
-        ServiceLoader.load(InstrumentationModule.class)) {
+        ServiceLoader.load(InstrumentationModule.class, ReferencesPrinter.class.getClassLoader())) {
       try {
         System.out.println(instrumentationModule.getClass().getName());
         for (ClassRef ref :

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
@@ -10,6 +10,7 @@ import static java.util.logging.Level.SEVERE;
 import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
 import io.opentelemetry.javaagent.tooling.EmptyConfigProperties;
 import io.opentelemetry.javaagent.tooling.SafeServiceLoader;
+import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.javaagent.tooling.ignore.AdditionalLibraryIgnoredTypesConfigurer;
 import io.opentelemetry.javaagent.tooling.ignore.GlobalIgnoredTypesConfigurer;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoreAllow;
@@ -51,7 +52,8 @@ public class TestAgentListener implements AgentBuilder.Listener {
   private static Trie<IgnoreAllow> buildOtherConfiguredIgnores() {
     IgnoredTypesBuilderImpl builder = new IgnoredTypesBuilderImpl();
     for (IgnoredTypesConfigurer configurer :
-        SafeServiceLoader.loadOrdered(IgnoredTypesConfigurer.class)) {
+        SafeServiceLoader.loadOrdered(
+            IgnoredTypesConfigurer.class, Utils.getExtensionsClassLoader())) {
       // skip built-in agent ignores
       if (configurer instanceof AdditionalLibraryIgnoredTypesConfigurer
           || configurer instanceof GlobalIgnoredTypesConfigurer) {


### PR DESCRIPTION
Related to #7220

Unfortunately it doesn't fix the aforementioned issue; while the CL used is no longer the agent classloader, gauge collection still throws that error.
Still, I think this is a good change that removes one source of agent's CL leaking into application runtime.