### PR TITLE
spring-webmvc-6.0: skip muzzle check of broken versions

### DIFF
--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/build.gradle.kts
@@ -7,6 +7,11 @@ muzzle {
     group.set("org.springframework")
     module.set("spring-webmvc")
     versions.set("[6.0.0,)")
+    // these versions depend on org.springframework:spring-web which has a bad dependency on
+    // javax.faces:jsf-api:1.1 which was released as pom only
+    skip("1.2.1", "1.2.2", "1.2.3", "1.2.4")
+    // 3.2.1.RELEASE has transitive dependencies like spring-web as "provided" instead of "compile"
+    skip("3.2.1.RELEASE")
     extraDependency("jakarta.servlet:jakarta.servlet-api:5.0.0")
     assertInverse.set(true)
   }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/3679126152/jobs/6223205591
copied the excludes from spring-webmvc-3.1