### PR TITLE
Change log4j MapMessage attribute names

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/README.md
@@ -1,0 +1,10 @@
+# Settings for the Log4j Appender instrumentation
+
+| System property | Type    | Default | Description                                          |
+|---|---------|--|------------------------------------------------------|
+| `otel.instrumentation.log4j-appender.experimental-log-attributes` | Boolean | `false` | Enable the capture of experimental span attributes `thread.name` and `thread.id`. |
+| `otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes` | Boolean | `false` | Enable the capture of `MapMessage` attributes. |
+| `otel.instrumentation.log4j-appender.experimental.capture-marker-attribute` | Boolean | `false` | Enable the capture of Log4j markers as attributes. |
+| `otel.instrumentation.log4j-appender.experimental.capture-context-data-attributes` | String  |  | List of context data attributes to capture. Use the wildcard character `*` to capture all attributes. |
+
+[source code attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#source-code-attributes

--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/src/test/groovy/Log4j2Test.groovy
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/src/test/groovy/Log4j2Test.groovy
@@ -146,8 +146,8 @@ class Log4j2Test extends AgentInstrumentationSpecification {
     assertThat(log.getSeverity()).isEqualTo(Severity.INFO)
     assertThat(log.getSeverityText()).isEqualTo("INFO")
     assertThat(log.getAttributes().size()).isEqualTo(4)
-    OpenTelemetryAssertions.assertThat(log.getAttributes()).containsEntry("key1", "val1")
-    OpenTelemetryAssertions.assertThat(log.getAttributes()).containsEntry("key2", "val2")
+    OpenTelemetryAssertions.assertThat(log.getAttributes()).containsEntry("log4j.map_message.key1", "val1")
+    OpenTelemetryAssertions.assertThat(log.getAttributes()).containsEntry("log4j.map_message.key2", "val2")
     OpenTelemetryAssertions.assertThat(log.getAttributes()).containsEntry(SemanticAttributes.THREAD_NAME, Thread.currentThread().getName())
     OpenTelemetryAssertions.assertThat(log.getAttributes()).containsEntry(SemanticAttributes.THREAD_ID, Thread.currentThread().getId())
   }
@@ -172,7 +172,7 @@ class Log4j2Test extends AgentInstrumentationSpecification {
     assertThat(log.getSeverity()).isEqualTo(Severity.INFO)
     assertThat(log.getSeverityText()).isEqualTo("INFO")
     assertThat(log.getAttributes().size()).isEqualTo(3)
-    OpenTelemetryAssertions.assertThat(log.getAttributes()).containsEntry("key1", "val1")
+    OpenTelemetryAssertions.assertThat(log.getAttributes()).containsEntry("log4j.map_message.key1", "val1")
     OpenTelemetryAssertions.assertThat(log.getAttributes()).containsEntry(SemanticAttributes.THREAD_NAME, Thread.currentThread().getName())
     OpenTelemetryAssertions.assertThat(log.getAttributes()).containsEntry(SemanticAttributes.THREAD_ID, Thread.currentThread().getId())
   }
@@ -198,8 +198,8 @@ class Log4j2Test extends AgentInstrumentationSpecification {
     assertThat(log.getSeverityText()).isEqualTo("INFO")
     assertThat(log.getAttributes().size()).isEqualTo(4)
     OpenTelemetryAssertions.assertThat(log.getAttributes())
-        .containsEntry("key1","val1")
-        .containsEntry("key2", "val2")
+        .containsEntry("log4j.map_message.key1","val1")
+        .containsEntry("log4j.map_message.key2", "val2")
         .containsEntry(SemanticAttributes.THREAD_NAME, Thread.currentThread().getName())
         .containsEntry(SemanticAttributes.THREAD_ID, Thread.currentThread().getId())
   }

--- a/instrumentation/log4j/log4j-appender-2.17/library/build.gradle.kts
+++ b/instrumentation/log4j/log4j-appender-2.17/library/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-logs")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-logs-testing")
 }

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapper.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapper.java
@@ -146,9 +146,7 @@ public final class LogEventMapper<T> {
                 if (value != null
                     && (!checkSpecialMapMessageAttribute
                         || !key.equals(SPECIAL_MAP_MESSAGE_ATTRIBUTE))) {
-                  attributes.put(
-                      mapMessageAttributeKeyCache.computeIfAbsent(key, AttributeKey::stringKey),
-                      value.toString());
+                  attributes.put(getMapMessageAttributeKey(key), value.toString());
                 }
               });
     }
@@ -179,6 +177,11 @@ public final class LogEventMapper<T> {
   public static AttributeKey<String> getContextDataAttributeKey(String key) {
     return contextDataAttributeKeyCache.computeIfAbsent(
         key, k -> AttributeKey.stringKey("log4j.context_data." + k));
+  }
+
+  public static AttributeKey<String> getMapMessageAttributeKey(String key) {
+    return mapMessageAttributeKeyCache.computeIfAbsent(
+        key, k -> AttributeKey.stringKey("log4j.map_message." + k));
   }
 
   private static void setThrowable(AttributesBuilder attributes, Throwable throwable) {

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderConfigTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppenderConfigTest.java
@@ -122,9 +122,7 @@ class OpenTelemetryAppenderConfigTest {
         .hasAttributesSatisfyingExactly(
             equalTo(SemanticAttributes.EXCEPTION_TYPE, IllegalStateException.class.getName()),
             equalTo(SemanticAttributes.EXCEPTION_MESSAGE, "Error!"),
-            satisfies(SemanticAttributes.EXCEPTION_STACKTRACE,
-                v -> v.contains("logWithExtras"))
-        );
+            satisfies(SemanticAttributes.EXCEPTION_STACKTRACE, v -> v.contains("logWithExtras")));
 
     assertThat(logDataList.get(0).getEpochNanos())
         .isGreaterThanOrEqualTo(TimeUnit.MILLISECONDS.toNanos(start.toEpochMilli()))
@@ -149,8 +147,7 @@ class OpenTelemetryAppenderConfigTest {
         .hasBody("log message 1")
         .hasAttributesSatisfyingExactly(
             equalTo(stringKey("log4j.context_data.key1"), "val1"),
-            equalTo(stringKey("log4j.context_data.key2"), "val2")
-        );
+            equalTo(stringKey("log4j.context_data.key2"), "val2"));
   }
 
   @Test
@@ -167,8 +164,7 @@ class OpenTelemetryAppenderConfigTest {
         .hasInstrumentationScope(instrumentationScopeInfo)
         .hasAttributesSatisfyingExactly(
             equalTo(stringKey("log4j.map_message.key1"), "val1"),
-            equalTo(stringKey("log4j.map_message.key2"), "val2")
-        );
+            equalTo(stringKey("log4j.map_message.key2"), "val2"));
   }
 
   @Test
@@ -184,9 +180,7 @@ class OpenTelemetryAppenderConfigTest {
         .hasResource(resource)
         .hasInstrumentationScope(instrumentationScopeInfo)
         .hasBody("val2")
-        .hasAttributesSatisfyingExactly(
-            equalTo(stringKey("log4j.map_message.key1"), "val1")
-        );
+        .hasAttributesSatisfyingExactly(equalTo(stringKey("log4j.map_message.key1"), "val1"));
   }
 
   @Test
@@ -198,8 +192,7 @@ class OpenTelemetryAppenderConfigTest {
 
     List<LogRecordData> logDataList = logRecordExporter.getFinishedLogItems();
     LogRecordData logData = logDataList.get(0);
-    assertThat(logData.getAttributes().get(stringKey("log4j.marker")))
-        .isEqualTo(markerName);
+    assertThat(logData.getAttributes().get(stringKey("log4j.marker"))).isEqualTo(markerName);
   }
 
   @Test
@@ -217,7 +210,6 @@ class OpenTelemetryAppenderConfigTest {
         .hasBody("a message")
         .hasAttributesSatisfyingExactly(
             equalTo(stringKey("log4j.map_message.key1"), "val1"),
-            equalTo(stringKey("log4j.map_message.key2"), "val2")
-        );
+            equalTo(stringKey("log4j.map_message.key2"), "val2"));
   }
 }

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapperTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapperTest.java
@@ -6,15 +6,14 @@
 package io.opentelemetry.instrumentation.log4j.appender.v2_17.internal;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.logs.LogRecordBuilder;
@@ -61,7 +60,7 @@ class LogEventMapperTest {
 
     // then
     assertThat(attributes.build())
-        .containsOnly(entry(AttributeKey.stringKey("log4j.context_data.key2"), "value2"));
+        .containsOnly(attributeEntry("log4j.context_data.key2", "value2"));
   }
 
   @Test
@@ -81,8 +80,8 @@ class LogEventMapperTest {
     // then
     assertThat(attributes.build())
         .containsOnly(
-            entry(AttributeKey.stringKey("log4j.context_data.key1"), "value1"),
-            entry(AttributeKey.stringKey("log4j.context_data.key2"), "value2"));
+            attributeEntry("log4j.context_data.key1", "value1"),
+            attributeEntry("log4j.context_data.key2", "value2"));
   }
 
   @Test
@@ -126,7 +125,8 @@ class LogEventMapperTest {
 
     // then
     verify(logRecordBuilder).setBody("value2");
-    assertThat(attributes.build()).containsOnly(entry(AttributeKey.stringKey("key1"), "value1"));
+    assertThat(attributes.build()).containsOnly(
+        attributeEntry("log4j.map_message.key1", "value1"));
   }
 
   @Test
@@ -150,8 +150,8 @@ class LogEventMapperTest {
     verify(logRecordBuilder, never()).setBody(anyString());
     assertThat(attributes.build())
         .containsOnly(
-            entry(AttributeKey.stringKey("key1"), "value1"),
-            entry(AttributeKey.stringKey("key2"), "value2"));
+            attributeEntry("log4j.map_message.key1", "value1"),
+            attributeEntry("log4j.map_message.key2", "value2"));
   }
 
   @Test
@@ -175,8 +175,8 @@ class LogEventMapperTest {
     verify(logRecordBuilder).setBody("a message");
     assertThat(attributes.build())
         .containsOnly(
-            entry(AttributeKey.stringKey("key1"), "value1"),
-            entry(AttributeKey.stringKey("message"), "value2"));
+            attributeEntry("log4j.map_message.key1", "value1"),
+            attributeEntry("log4j.map_message.message", "value2"));
   }
 
   private enum ContextDataAccessorImpl implements ContextDataAccessor<Map<String, String>> {

--- a/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapperTest.java
+++ b/instrumentation/log4j/log4j-appender-2.17/library/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/internal/LogEventMapperTest.java
@@ -125,8 +125,7 @@ class LogEventMapperTest {
 
     // then
     verify(logRecordBuilder).setBody("value2");
-    assertThat(attributes.build()).containsOnly(
-        attributeEntry("log4j.map_message.key1", "value1"));
+    assertThat(attributes.build()).containsOnly(attributeEntry("log4j.map_message.key1", "value1"));
   }
 
   @Test


### PR DESCRIPTION
Changed them from standalone top-level attributes to move them under `log4j.map_message.*` (e.g. similar to `log4j.context_data.*` and others).

Also adds doc for log4j javaagent properties.

Also cleans up related tests.