### PR TITLE
Refine required checks

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -21,39 +21,24 @@ jobs:
       cache-read-only: true
 
   muzzle:
-    # release branch PRs are excluded
-    # because any time a new library version is released to maven central it can fail
-    # which requires unnecessary release branch maintenance, especially for patches
-    if: "!startsWith(github.base_ref, 'release/')"
     uses: ./.github/workflows/reusable-muzzle.yml
     with:
       cache-read-only: true
 
-  # this is not a required check to avoid blocking pull requests if new shell checks are added
   shell-script-check:
-    # release branches are excluded to avoid unnecessary maintenance if new shell checks are added
-    if: "!startsWith(github.ref_name, 'release/')"
     uses: ./.github/workflows/reusable-shell-script-check.yml
 
   # this is not a required check to avoid blocking pull requests if external links break
   markdown-link-check:
-    # release branches are excluded to avoid unnecessary maintenance if external links break
-    # (and also because the README.md javaagent download link has to be updated on release branches
-    #  before the release download has been published)
-    if: "!startsWith(github.ref_name, 'release/')"
+    # release branches are excluded because the README.md javaagent download link has to be updated
+    # on release branches before the release download has been published
+    if: "!startsWith(github.ref_name, 'release/') && !startsWith(github.base_ref, 'release/')"
     uses: ./.github/workflows/reusable-markdown-link-check.yml
 
-  # this is a required check to avoid illegal markdown format
   markdown-lint-check:
-    # release branches are excluded to avoid unnecessary maintenance
-    if: ${{ !startsWith(github.ref_name, 'release/') }}
     uses: ./.github/workflows/reusable-markdown-lint-check.yml
 
-  # this is not a required check to avoid blocking pull requests if new misspellings are added
-  # to the misspell dictionary
   misspell-check:
-    # release branches are excluded to avoid unnecessary maintenance
-    if: "!startsWith(github.ref_name, 'release/')"
     uses: ./.github/workflows/reusable-misspell-check.yml
 
   required-status-check:
@@ -63,13 +48,27 @@ jobs:
     # or due to slight changes in emitted telemetry
     # (muzzle can also fail when a new library version is released to maven central
     # but that happens much less often)
+    #
+    # only the "common" checks are required for release branch PRs in order to avoid any unnecessary
+    # release branch maintenance (especially for patches)
     needs:
       - common
       - muzzle
+      - shell-script-check
+      - markdown-lint-check
+      - misspell-check
     runs-on: ubuntu-latest
     if: always()
     steps:
       - if: |
           needs.common.result != 'success' ||
-          (!startsWith(github.base_ref, 'release/') && needs.muzzle.result != 'success')
-        run: exit 1
+          (
+            !startsWith(github.base_ref, 'release/') &&
+            (
+              needs.muzzle.result != 'success' ||
+              needs.shell-script-check.result != 'success' ||
+              needs.markdown-lint-check.result != 'success' ||
+              needs.misspell-check.result != 'success'
+            )
+          )
+        run: exit 1 # fail


### PR DESCRIPTION
Adds these are required checks for PRs (except on release branches where they are still not required):
* shell-script-check
* markdown-lint-check
* misspell-check

This is still NOT a required check:
* markdown-link-check

Also in this PR:
* Avoids running `markdown-link-check` at all on release branches since it's generally expected to be red due to pinning the release download link before tagging