### PR TITLE
Preserve original exception in jetty http client wrappers

### DIFF
--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientWrapUtil.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientWrapUtil.java
@@ -9,6 +9,7 @@ import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,6 +72,8 @@ public final class JettyClientWrapUtil {
             (proxy, method, args) -> {
               try (Scope ignored = context.makeCurrent()) {
                 return method.invoke(listener, args);
+              } catch (InvocationTargetException exception) {
+                throw exception.getCause();
               }
             });
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClient9TracingInterceptor.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClient9TracingInterceptor.java
@@ -10,6 +10,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
@@ -118,6 +119,8 @@ public class JettyHttpClient9TracingInterceptor
                   (proxy, method, args) -> {
                     try (Scope ignored = context.makeCurrent()) {
                       return method.invoke(listener, args);
+                    } catch (InvocationTargetException exception) {
+                      throw exception.getCause();
                     }
                   });
 


### PR DESCRIPTION
Same issue as in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7452