### PR TITLE
Add additional groovy classloaders to ignore list.

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -110,7 +110,9 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
 
   private static void configureIgnoredClassLoaders(IgnoredTypesBuilder builder) {
     builder
+        .ignoreClassLoader("groovy.lang.GroovyClassLoader")
         .ignoreClassLoader("org.codehaus.groovy.runtime.callsite.CallSiteClassLoader")
+        .ignoreClassLoader("org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyClassLoader")
         .ignoreClassLoader("sun.reflect.DelegatingClassLoader")
         .ignoreClassLoader("jdk.internal.reflect.DelegatingClassLoader")
         .ignoreClassLoader("clojure.lang.DynamicClassLoader")


### PR DESCRIPTION
Groovy apps that parse a lot of scripts can generate a lot of classloaders that will ultimately end up causing the agent to cache a LOT of memory. For example, some java code that uses the Gremlin groovy script engine to dynamically create and execute scripts can reproduce this:

```
    GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine();
    Bindings bindings = new SimpleBindings();
    TinkerGraph graph = TinkerGraph.open();
    GraphTraversalSource g = graph.traversal();
    bindings.put("g", g);
    for (int i = 0; i < 100000; i++) {
      engine.eval("g.V(" + i + ")", bindings);
      if(i % 250 == 0) System.out.println("Iteration " + i);
    }
```

I have manually confirmed that ignoring the groovy classloaders (in this PR) prevent the agent from exploding the cache and holding onto memory. I could use another brain in deciding if there could be other unintended consequences.