### PR TITLE
Resource injection for class loader getResourceAsStream

### DIFF
--- a/instrumentation/internal/internal-class-loader/javaagent/src/test/groovy/TomcatClassloadingTest.groovy
+++ b/instrumentation/internal/internal-class-loader/javaagent/src/test/groovy/TomcatClassloadingTest.groovy
@@ -27,7 +27,9 @@ class TomcatClassloadingTest extends AgentInstrumentationSpecification {
       getResources(_) >> []
       getClassLoaderResources(_) >> []
     }
-    classloader = new ParallelWebappClassLoader(null)
+    def parentClassLoader = new ClassLoader(null) {
+    }
+    classloader = new ParallelWebappClassLoader(parentClassLoader)
     classloader.setResources(resources)
     classloader.init()
     classloader.start()

--- a/instrumentation/internal/internal-class-loader/javaagent/src/test/groovy/TomcatClassloadingTest.groovy
+++ b/instrumentation/internal/internal-class-loader/javaagent/src/test/groovy/TomcatClassloadingTest.groovy
@@ -4,28 +4,66 @@
  */
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
+import io.opentelemetry.javaagent.bootstrap.HelperResources
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.stream.Collectors
 import org.apache.catalina.WebResource
 import org.apache.catalina.WebResourceRoot
 import org.apache.catalina.loader.ParallelWebappClassLoader
+import spock.lang.Shared
 
 class TomcatClassloadingTest extends AgentInstrumentationSpecification {
 
-  WebResourceRoot resources = Mock(WebResourceRoot) {
-    getResource(_) >> Mock(WebResource)
-    listResources(_) >> []
-    // Looks like 9.x.x needs this one:
-    getResources(_) >> []
-  }
-  ParallelWebappClassLoader classloader = new ParallelWebappClassLoader(null)
+  @Shared
+  ParallelWebappClassLoader classloader
 
-  def "tomcat class loading delegates to parent for agent classes"() {
-    setup:
+  def setupSpec() {
+    WebResourceRoot resources = Mock(WebResourceRoot) {
+      getResource(_) >> Mock(WebResource)
+      getClassLoaderResource(_) >> Mock(WebResource)
+      listResources(_) >> []
+      // Looks like 9.x.x needs this one:
+      getResources(_) >> []
+      getClassLoaderResources(_) >> []
+    }
+    classloader = new ParallelWebappClassLoader(null)
     classloader.setResources(resources)
     classloader.init()
     classloader.start()
+  }
 
+  def "tomcat class loading delegates to parent for agent classes"() {
     expect:
     // If instrumentation didn't work this would blow up with NPE due to incomplete resources mocking
     classloader.loadClass("io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge")
+  }
+
+  def "test resource injection"() {
+    setup:
+    def tmpFile = Files.createTempFile("hello", "tmp")
+    Files.write(tmpFile, "hello".getBytes(StandardCharsets.UTF_8))
+    def url = tmpFile.toUri().toURL()
+    HelperResources.register(classloader, "hello.txt", Arrays.asList(url))
+
+    expect:
+    classloader.getResource("hello.txt") != null
+
+    and:
+    def resources = classloader.getResources("hello.txt")
+    resources != null
+    resources.hasMoreElements()
+
+    and:
+    def inputStream = classloader.getResourceAsStream("hello.txt")
+    inputStream != null
+    String text = new BufferedReader(
+      new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+      .lines()
+      .collect(Collectors.joining("\n"))
+    text == "hello"
+
+    cleanup:
+    inputStream?.close()
   }
 }


### PR DESCRIPTION
In https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7447 injected resource is opened with class loader getResourceAsStream. This works only in class loaders where getResourceAsStream delegates to getResource. This is not the case with all class loaders, for example tomcat class loader does not do this. Because of this we also need to instrument class loader getResourceAsStream.