### PR TITLE
Ratpack services OpenTelemetry

### DIFF
--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryHttpClient.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryHttpClient.java
@@ -28,7 +28,7 @@ final class OpenTelemetryHttpClient {
         httpClientSpec -> {
           httpClientSpec.requestIntercept(
               requestSpec -> {
-                Context parentOtelCtx = Context.current();
+                Context parentOtelCtx = Execution.current().maybeGet(Context.class).orElse(Context.current());
                 if (!instrumenter.shouldStart(parentOtelCtx, requestSpec)) {
                   return;
                 }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryHttpClient.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/OpenTelemetryHttpClient.java
@@ -28,7 +28,8 @@ final class OpenTelemetryHttpClient {
         httpClientSpec -> {
           httpClientSpec.requestIntercept(
               requestSpec -> {
-                Context parentOtelCtx = Execution.current().maybeGet(Context.class).orElse(Context.current());
+                Context parentOtelCtx =
+                    Execution.current().maybeGet(Context.class).orElse(Context.current());
                 if (!instrumenter.shouldStart(parentOtelCtx, requestSpec)) {
                   return;
                 }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/client/InstrumentedHttpClientTest.groovy
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/client/InstrumentedHttpClientTest.groovy
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.ratpack.client
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.ContextPropagators
@@ -312,7 +313,7 @@ class BarService implements Service {
     this.opentelemetry = opentelemetry
   }
 
-  private def tracer = opentelemetry.tracerProvider.tracerBuilder("testing").build()
+  private Tracer tracer = opentelemetry.tracerProvider.tracerBuilder("testing").build()
 
   void onStart(StartEvent event) {
     def parentContext = Context.current()
@@ -346,7 +347,7 @@ class BarForkService implements Service {
     this.opentelemetry = opentelemetry
   }
 
-  private def tracer = opentelemetry.tracerProvider.tracerBuilder("testing").build()
+  private Tracer tracer = opentelemetry.tracerProvider.tracerBuilder("testing").build()
 
   void onStart(StartEvent event) {
     Execution.fork().start {

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/client/InstrumentedHttpClientTest.groovy
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/client/InstrumentedHttpClientTest.groovy
@@ -369,4 +369,3 @@ class BarForkService implements Service {
     }
   }
 }
-


### PR DESCRIPTION
While using Ratpack Handlers, the context is added by the `OpenTelemetryServerHandler`

While using Ratpack Services, we might need to add manually the OT Context into the Ratpack Execution and try to get it from the Execution in the Ratpack `HttpClient`

