### PR TITLE
Revert "Bump org.jetbrains.kotlin.jvm from 1.7.22 to 1.8.0 (#7481)"

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
     id("com.google.cloud.tools.jib") version "3.3.1"
     id("com.gradle.plugin-publish") version "1.1.0"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-    id("org.jetbrains.kotlin.jvm") version "1.8.0"
+    id("org.jetbrains.kotlin.jvm") version "1.7.22"
     id("org.unbroken-dome.test-sets") version "4.0.0"
     id("org.xbib.gradle.plugin.jflex") version "1.7.0"
     id("org.unbroken-dome.xjc") version "2.0.0"


### PR DESCRIPTION
This reverts commit 516938e2a4f0f8d41951d9ca8c6bb70414c98c6c.

Turns out CodeQL cannot work with Kotlin 1.8 (because it is too new 🙈 ):
```
> Task :instrumentation:ktor:ktor-common:library:compileKotlin FAILED
e: com.semmle.extractor.java.interceptors.KotlinInterceptor$KotlinVersionTooRecentError: Kotlin version 1.8.0 is too recent. CodeQL currently supports versions below 1.7.30
	at com.semmle.extractor.java.interceptors.KotlinInterceptor.getExtractorJarPath(KotlinInterceptor.java:148)
	at com.semmle.extractor.java.interceptors.KotlinInterceptor.beforeKotlinExecute(KotlinInterceptor.java:398)
```

Resolves #7487
Resolves #7491
Resolves #7492 
Resolves #7493 