### PR TITLE
Shade `application.io.opentelemetry` in agent extension class loader

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlConnection.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlConnection.java
@@ -39,9 +39,6 @@ public class RemappingUrlConnection extends URLConnection {
               "#io.opentelemetry.extension.aws",
               "#io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.aws"),
           rule("#application.io.opentelemetry", "#io.opentelemetry"),
-          rule(
-              "#application.io.opentelemetry.instrumentation.api",
-              "#io.opentelemetry.instrumentation.api"),
           rule("#java.util.logging.Logger", "#io.opentelemetry.javaagent.bootstrap.PatchLogger"));
 
   private final JarFile delegateJarFile;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlConnection.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlConnection.java
@@ -38,6 +38,10 @@ public class RemappingUrlConnection extends URLConnection {
           rule(
               "#io.opentelemetry.extension.aws",
               "#io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.aws"),
+          rule("#application.io.opentelemetry", "#io.opentelemetry"),
+          rule(
+              "#application.io.opentelemetry.instrumentation.api",
+              "#io.opentelemetry.instrumentation.api"),
           rule("#java.util.logging.Logger", "#io.opentelemetry.javaagent.bootstrap.PatchLogger"));
 
   private final JarFile delegateJarFile;


### PR DESCRIPTION
Related issue #7518 

Add shade rule `application.io.opentelemetry` in `io.opentelemetry.javaagent.tooling.RemappingUrlConnection` class.

Closed #7518 