### PR TITLE
Make config file available in early agent initialization phase

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -16,7 +16,6 @@ import static net.bytebuddy.matcher.ElementMatchers.any;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import io.opentelemetry.javaagent.bootstrap.AgentClassLoader;
 import io.opentelemetry.javaagent.bootstrap.BootstrapPackagePrefixesHolder;
@@ -32,6 +31,7 @@ import io.opentelemetry.javaagent.tooling.bootstrap.BootstrapPackagesConfigurer;
 import io.opentelemetry.javaagent.tooling.bytebuddy.SafeTypeStrategy;
 import io.opentelemetry.javaagent.tooling.config.AgentConfig;
 import io.opentelemetry.javaagent.tooling.config.ConfigPropertiesBridge;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredClassLoadersMatcher;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesBuilderImpl;
 import io.opentelemetry.javaagent.tooling.ignore.IgnoredTypesMatcher;
@@ -87,7 +87,8 @@ public class AgentInstaller {
     }
 
     logVersionInfo();
-    if (ConfigPropertiesUtil.getBoolean(JAVAAGENT_ENABLED_CONFIG, true)) {
+    EarlyInitAgentConfig agentConfig = EarlyInitAgentConfig.create();
+    if (agentConfig.getBoolean(JAVAAGENT_ENABLED_CONFIG, true)) {
       setupUnsafe(inst);
       List<AgentListener> agentListeners = loadOrdered(AgentListener.class, extensionClassLoader);
       installBytebuddyAgent(inst, extensionClassLoader, agentListeners);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFileLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFileLoader.java
@@ -30,9 +30,18 @@ public final class ConfigurationFileLoader implements AutoConfigurationCustomize
 
   static final String CONFIGURATION_FILE_PROPERTY = "otel.javaagent.configuration-file";
 
+  private static Map<String, String> configFileContents;
+
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
-    autoConfiguration.addPropertiesSupplier(ConfigurationFileLoader::loadConfigFile);
+    autoConfiguration.addPropertiesSupplier(ConfigurationFileLoader::getConfigFileContents);
+  }
+
+  static Map<String, String> getConfigFileContents() {
+    if (configFileContents == null) {
+      configFileContents = loadConfigFile();
+    }
+    return configFileContents;
   }
 
   // visible for tests

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/EarlyInitAgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/EarlyInitAgentConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.config;
+
+import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
+import java.util.Map;
+
+/**
+ * Agent config class that is only supposed to be used before the SDK (and {@link
+ * io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties}) is initialized.
+ */
+public final class EarlyInitAgentConfig {
+
+  public static EarlyInitAgentConfig create() {
+    return new EarlyInitAgentConfig(ConfigurationFileLoader.getConfigFileContents());
+  }
+
+  private final Map<String, String> configFileContents;
+
+  private EarlyInitAgentConfig(Map<String, String> configFileContents) {
+    this.configFileContents = configFileContents;
+  }
+
+  public boolean getBoolean(String propertyName, boolean defaultValue) {
+    String configFileValueStr = configFileContents.get(propertyName);
+    boolean configFileValue =
+        configFileValueStr == null ? defaultValue : Boolean.parseBoolean(configFileValueStr);
+    return ConfigPropertiesUtil.getBoolean(propertyName, configFileValue);
+  }
+}


### PR DESCRIPTION
Fixes #7540

I think this kind of early config might be useful in general -- for instance, I think I'd like to use it for properties introduced in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7339