### PR TITLE
Fix potential startup failure

### DIFF
--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetector.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetector.java
@@ -15,6 +15,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.internal.ConditionalResourceProvid
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -101,15 +102,25 @@ public final class JarServiceNameDetector implements ConditionalResourceProvider
     while (true) {
       int nextSpace = programArguments.indexOf(' ', next);
       if (nextSpace == -1) {
-        Path candidate = Paths.get(programArguments);
-        return fileExists.test(candidate) ? candidate : null;
+        return pathIfExists(programArguments);
       }
-      Path candidate = Paths.get(programArguments.substring(0, nextSpace));
+      Path path = pathIfExists(programArguments.substring(0, nextSpace));
       next = nextSpace + 1;
-      if (fileExists.test(candidate)) {
-        return candidate;
+      if (path != null) {
+        return path;
       }
     }
+  }
+
+  @Nullable
+  private Path pathIfExists(String programArguments) {
+    Path candidate;
+    try {
+      candidate = Paths.get(programArguments);
+    } catch (InvalidPathException e) {
+      return null;
+    }
+    return fileExists.test(candidate) ? candidate : null;
   }
 
   private static String getServiceName(Path jarPath) {

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetectorTest.java
@@ -98,6 +98,22 @@ class JarServiceNameDetectorTest {
         .containsEntry(ResourceAttributes.SERVICE_NAME, "my-service");
   }
 
+  // regression test for
+  // https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7567
+  @Test
+  void createResource_sunCommandLineProblematicArgs() {
+    Function<String, String> getProperty =
+        key -> key.equals("sun.java.command") ? "one C:/two" : null;
+    Predicate<Path> fileExists = path -> false;
+
+    JarServiceNameDetector serviceNameProvider =
+        new JarServiceNameDetector(() -> new String[0], getProperty, fileExists);
+
+    Resource resource = serviceNameProvider.createResource(config);
+
+    assertThat(resource.getAttributes()).isEmpty();
+  }
+
   static final class SunCommandLineProvider implements ArgumentsProvider {
 
     @Override


### PR DESCRIPTION
Can be reproduce (at least on Windows) using

```
java -javaagent:opentelemetry-javaagent.jar anything C:\one
```

producing

```
[otel.javaagent 2023-01-13 11:38:47:978 -0800] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 1.22.0
OpenTelemetry Javaagent failed to start
java.nio.file.InvalidPathException: Illegal char <:> at index 10: anything C:\one
        at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
        at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
        at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:229)
        at java.base/java.nio.file.Path.of(Path.java:147)
        at java.base/java.nio.file.Paths.get(Paths.java:69)
        at io.opentelemetry.instrumentation.resources.JarServiceNameDetector.getJarPathFromSunCommandLine(JarServiceNameDetector.java:104)
        at io.opentelemetry.instrumentation.resources.JarServiceNameDetector.createResource(JarServiceNameDetector.java:59)
        at io.opentelemetry.sdk.autoconfigure.ResourceConfiguration.configureResource(ResourceConfiguration.java:59)
        at io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder.build(AutoConfiguredOpenTelemetrySdkBuilder.java:332)
        at io.opentelemetry.javaagent.tooling.OpenTelemetryInstaller.installOpenTelemetrySdk(OpenTelemetryInstaller.java:29)
        at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:114)
        at io.opentelemetry.javaagent.tooling.AgentInstaller.installBytebuddyAgent(AgentInstaller.java:94)
        at io.opentelemetry.javaagent.tooling.AgentStarterImpl.start(AgentStarterImpl.java:78)
        at io.opentelemetry.javaagent.bootstrap.AgentInitializer.initialize(AgentInitializer.java:35)
        at io.opentelemetry.javaagent.OpenTelemetryAgent.startAgent(OpenTelemetryAgent.java:57)
        at io.opentelemetry.javaagent.OpenTelemetryAgent.premain(OpenTelemetryAgent.java:45)
```