### PR TITLE
docs(okhttp): fix class name in README

### DIFF
--- a/instrumentation/okhttp/okhttp-3.0/library/README.md
+++ b/instrumentation/okhttp/okhttp-3.0/library/README.md
@@ -35,7 +35,7 @@ propagation.
 
 ```java
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTracing;
+import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTelemetry;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 
@@ -45,7 +45,7 @@ public class OkHttpConfiguration {
 
   //Use this Call.Factory implementation for making standard http client calls.
   public Call.Factory createTracedClient(OpenTelemetry openTelemetry) {
-    return OkHttpTracing.builder(openTelemetry).build().newCallFactory(createClient());
+    return OkHttpTelemetry.builder(openTelemetry).build().newCallFactory(createClient());
   }
 
   //your configuration of the OkHttpClient goes here:


### PR DESCRIPTION
for okhttp-3.0 instrumentation, the README uses `OkHttpTracing`:
```java
import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTracing;
...
return OkHttpTracing.builder(openTelemetry).build().newCallFactory(createClient());
```

#5624 changed `OkHttpTracing` to `OkHttpTelemetry` but the docs still show the previous value which no longer works