### PR TITLE
Revert "Bump dependency-check-gradle from 7.4.4 to 8.0.0 (#7592)"

### DIFF
--- a/conventions/build.gradle.kts
+++ b/conventions/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
   implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
   implementation("org.apache.httpcomponents:httpclient:4.5.14")
   implementation("com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.1")
-  implementation("org.owasp:dependency-check-gradle:8.0.0")
+  implementation("org.owasp:dependency-check-gradle:7.4.4")
   implementation("ru.vyarus:gradle-animalsniffer-plugin:1.6.0")
   // When updating, also update dependencyManagement/build.gradle.kts
   implementation("net.bytebuddy:byte-buddy-gradle-plugin:1.12.20")


### PR DESCRIPTION
This reverts commit 3c6b7b35bb672006a5ad80f0ab054a11c1f10d5a.

Just until 8.0.1 is released, see https://github.com/jeremylong/DependencyCheck/issues/5306