### PR TITLE
Rename all methods in all Getters to use the `get*()` naming scheme

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractor.java
@@ -35,11 +35,11 @@ public final class CodeAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    Class<?> cls = getter.codeClass(request);
+    Class<?> cls = getter.getCodeClass(request);
     if (cls != null) {
       internalSet(attributes, SemanticAttributes.CODE_NAMESPACE, cls.getName());
     }
-    internalSet(attributes, SemanticAttributes.CODE_FUNCTION, getter.methodName(request));
+    internalSet(attributes, SemanticAttributes.CODE_FUNCTION, getter.getMethodName(request));
   }
 
   @Override

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesGetter.java
@@ -17,8 +17,36 @@ import javax.annotation.Nullable;
 public interface CodeAttributesGetter<REQUEST> {
 
   @Nullable
-  Class<?> codeClass(REQUEST request);
+  default Class<?> getCodeClass(REQUEST request) {
+    return codeClass(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getCodeClass(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default Class<?> codeClass(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String methodName(REQUEST request);
+  default String getMethodName(REQUEST request) {
+    return methodName(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getMethodName(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String methodName(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeSpanNameExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeSpanNameExtractor.java
@@ -30,14 +30,14 @@ public final class CodeSpanNameExtractor<REQUEST> implements SpanNameExtractor<R
 
   @Override
   public String extract(REQUEST request) {
-    Class<?> cls = getter.codeClass(request);
+    Class<?> cls = getter.getCodeClass(request);
     String className = cls != null ? ClassNames.simpleName(cls) : "<unknown>";
     int lambdaIdx = className.indexOf("$$Lambda$");
     if (lambdaIdx > -1) {
       // need to produce low-cardinality name, since lambda class names change with each restart
       className = className.substring(0, lambdaIdx + "$$Lambda$".length());
     }
-    String methodName = getter.methodName(request);
+    String methodName = getter.getMethodName(request);
     if (methodName == null) {
       return className;
     }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientAttributesExtractor.java
@@ -37,7 +37,7 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
     super.onStart(attributes, parentContext, request);
 
-    internalSet(attributes, SemanticAttributes.DB_STATEMENT, getter.statement(request));
-    internalSet(attributes, SemanticAttributes.DB_OPERATION, getter.operation(request));
+    internalSet(attributes, SemanticAttributes.DB_STATEMENT, getter.getStatement(request));
+    internalSet(attributes, SemanticAttributes.DB_OPERATION, getter.getOperation(request));
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientAttributesGetter.java
@@ -21,8 +21,36 @@ import javax.annotation.Nullable;
 public interface DbClientAttributesGetter<REQUEST> extends DbClientCommonAttributesGetter<REQUEST> {
 
   @Nullable
-  String statement(REQUEST request);
+  default String getStatement(REQUEST request) {
+    return statement(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getStatement(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String statement(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String operation(REQUEST request);
+  default String getOperation(REQUEST request) {
+    return operation(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getOperation(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String operation(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientCommonAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientCommonAttributesExtractor.java
@@ -27,11 +27,11 @@ abstract class DbClientCommonAttributesExtractor<
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    internalSet(attributes, SemanticAttributes.DB_SYSTEM, getter.system(request));
-    internalSet(attributes, SemanticAttributes.DB_USER, getter.user(request));
-    internalSet(attributes, SemanticAttributes.DB_NAME, getter.name(request));
+    internalSet(attributes, SemanticAttributes.DB_SYSTEM, getter.getSystem(request));
+    internalSet(attributes, SemanticAttributes.DB_USER, getter.getUser(request));
+    internalSet(attributes, SemanticAttributes.DB_NAME, getter.getName(request));
     internalSet(
-        attributes, SemanticAttributes.DB_CONNECTION_STRING, getter.connectionString(request));
+        attributes, SemanticAttributes.DB_CONNECTION_STRING, getter.getConnectionString(request));
   }
 
   @Override

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientCommonAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientCommonAttributesGetter.java
@@ -11,14 +11,70 @@ import javax.annotation.Nullable;
 public interface DbClientCommonAttributesGetter<REQUEST> {
 
   @Nullable
-  String system(REQUEST request);
+  default String getSystem(REQUEST request) {
+    return system(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSystem(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String system(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String user(REQUEST request);
+  default String getUser(REQUEST request) {
+    return user(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getUser(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String user(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String name(REQUEST request);
+  default String getName(REQUEST request) {
+    return name(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getName(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String name(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String connectionString(REQUEST request);
+  default String getConnectionString(REQUEST request) {
+    return connectionString(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getConnectionString(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String connectionString(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientSpanNameExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientSpanNameExtractor.java
@@ -15,8 +15,8 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
    * Returns a {@link SpanNameExtractor} that constructs the span name according to DB semantic
    * conventions: {@code <db.operation> <db.name>}.
    *
-   * @see DbClientAttributesGetter#operation(Object) used to extract {@code <db.operation>}.
-   * @see DbClientAttributesGetter#name(Object) used to extract {@code <db.name>}.
+   * @see DbClientAttributesGetter#getOperation(Object) used to extract {@code <db.operation>}.
+   * @see DbClientAttributesGetter#getName(Object) used to extract {@code <db.name>}.
    */
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
       DbClientAttributesGetter<REQUEST> getter) {
@@ -28,7 +28,7 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
    * conventions: {@code <db.operation> <db.name>.<identifier>}.
    *
    * @see SqlStatementInfo#getOperation() used to extract {@code <db.operation>}.
-   * @see DbClientAttributesGetter#name(Object) used to extract {@code <db.name>}.
+   * @see DbClientAttributesGetter#getName(Object) used to extract {@code <db.name>}.
    * @see SqlStatementInfo#getMainIdentifier() used to extract {@code <db.table>} or stored
    *     procedure name.
    */
@@ -74,8 +74,8 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
 
     @Override
     public String extract(REQUEST request) {
-      String dbName = getter.name(request);
-      String operation = getter.operation(request);
+      String dbName = getter.getName(request);
+      String operation = getter.getOperation(request);
       return computeSpanName(dbName, operation, null);
     }
   }
@@ -94,8 +94,8 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
 
     @Override
     public String extract(REQUEST request) {
-      String dbName = getter.name(request);
-      SqlStatementInfo sanitizedStatement = sanitizer.sanitize(getter.rawStatement(request));
+      String dbName = getter.getName(request);
+      SqlStatementInfo sanitizedStatement = sanitizer.sanitize(getter.getRawStatement(request));
       return computeSpanName(
           dbName, sanitizedStatement.getOperation(), sanitizedStatement.getMainIdentifier());
     }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesExtractor.java
@@ -21,7 +21,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
  *
  * <p>It sets the same set of attributes as {@link DbClientAttributesExtractor} plus an additional
  * <code>{@linkplain SemanticAttributes#DB_SQL_TABLE db.sql.table}</code> attribute. The raw SQL
- * statements returned by the {@link SqlClientAttributesGetter#rawStatement(Object)} method are
+ * statements returned by the {@link SqlClientAttributesGetter#getRawStatement(Object)} method are
  * sanitized before use, all statement parameters are removed.
  */
 public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
@@ -61,7 +61,7 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
     super.onStart(attributes, parentContext, request);
 
-    SqlStatementInfo sanitizedStatement = sanitizer.sanitize(getter.rawStatement(request));
+    SqlStatementInfo sanitizedStatement = sanitizer.sanitize(getter.getRawStatement(request));
     String operation = sanitizedStatement.getOperation();
     internalSet(attributes, SemanticAttributes.DB_STATEMENT, sanitizedStatement.getFullStatement());
     internalSet(attributes, SemanticAttributes.DB_OPERATION, operation);

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesGetter.java
@@ -26,5 +26,22 @@ public interface SqlClientAttributesGetter<REQUEST>
    * SqlClientAttributesExtractor} before being set as span attribute.
    */
   @Nullable
-  String rawStatement(REQUEST request);
+  default String getRawStatement(REQUEST request) {
+    return rawStatement(request);
+  }
+
+  /**
+   * Get the raw SQL statement. The value returned by this method is later sanitized by the {@link
+   * SqlClientAttributesExtractor} before being set as span attribute.
+   *
+   * <p>This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getRawStatement(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String rawStatement(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
@@ -91,13 +91,14 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
     super.onStart(attributes, parentContext, request);
 
-    internalSet(attributes, SemanticAttributes.HTTP_URL, stripSensitiveData(getter.url(request)));
+    internalSet(
+        attributes, SemanticAttributes.HTTP_URL, stripSensitiveData(getter.getUrl(request)));
 
     internalNetExtractor.onStart(attributes, request);
   }
 
   private boolean shouldCapturePeerPort(int port, REQUEST request) {
-    String url = getter.url(request);
+    String url = getter.getUrl(request);
     if (url == null) {
       return true;
     }
@@ -160,7 +161,7 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
       @Nullable Throwable error) {
     super.onEnd(attributes, context, request, response, error);
 
-    internalSet(attributes, SemanticAttributes.HTTP_FLAVOR, getter.flavor(request, response));
+    internalSet(attributes, SemanticAttributes.HTTP_FLAVOR, getter.getFlavor(request, response));
 
     internalNetExtractor.onEnd(attributes, request, response);
   }
@@ -179,19 +180,19 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
 
     @Nullable
     @Override
-    public String transport(REQUEST request, @Nullable RESPONSE response) {
+    public String getTransport(REQUEST request, @Nullable RESPONSE response) {
       return null;
     }
 
     @Nullable
     @Override
-    public String peerName(REQUEST request) {
+    public String getPeerName(REQUEST request) {
       return null;
     }
 
     @Nullable
     @Override
-    public Integer peerPort(REQUEST request) {
+    public Integer getPeerPort(REQUEST request) {
       return null;
     }
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesGetter.java
@@ -22,7 +22,21 @@ public interface HttpClientAttributesGetter<REQUEST, RESPONSE>
   // Attributes that always exist in a request
 
   @Nullable
-  String url(REQUEST request);
+  default String getUrl(REQUEST request) {
+    return url(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getUrl(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String url(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   // Attributes which are not always available when the request is ready.
 
@@ -33,5 +47,24 @@ public interface HttpClientAttributesGetter<REQUEST, RESPONSE>
    * {@code response} is {@code null} or not.
    */
   @Nullable
-  String flavor(REQUEST request, @Nullable RESPONSE response);
+  default String getFlavor(REQUEST request, @Nullable RESPONSE response) {
+    return flavor(request, response);
+  }
+
+  /**
+   * Extracts the {@code http.flavor} span attribute.
+   *
+   * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, whether
+   * {@code response} is {@code null} or not.
+   *
+   * <p>This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getFlavor(Object, Object)}.
+   */
+  @Deprecated
+  @Nullable
+  default String flavor(REQUEST request, @Nullable RESPONSE response) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
@@ -44,11 +44,11 @@ abstract class HttpCommonAttributesExtractor<
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    internalSet(attributes, SemanticAttributes.HTTP_METHOD, getter.method(request));
+    internalSet(attributes, SemanticAttributes.HTTP_METHOD, getter.getMethod(request));
     internalSet(attributes, SemanticAttributes.HTTP_USER_AGENT, userAgent(request));
 
     for (String name : capturedRequestHeaders) {
-      List<String> values = getter.requestHeader(request, name);
+      List<String> values = getter.getRequestHeader(request, name);
       if (!values.isEmpty()) {
         internalSet(attributes, requestAttributeKey(name), values);
       }
@@ -67,7 +67,7 @@ abstract class HttpCommonAttributesExtractor<
         attributes, SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, requestContentLength(request));
 
     if (response != null) {
-      Integer statusCode = getter.statusCode(request, response, error);
+      Integer statusCode = getter.getStatusCode(request, response, error);
       if (statusCode != null && statusCode > 0) {
         internalSet(attributes, SemanticAttributes.HTTP_STATUS_CODE, (long) statusCode);
       }
@@ -78,7 +78,7 @@ abstract class HttpCommonAttributesExtractor<
           responseContentLength(request, response));
 
       for (String name : capturedResponseHeaders) {
-        List<String> values = getter.responseHeader(request, response, name);
+        List<String> values = getter.getResponseHeader(request, response, name);
         if (!values.isEmpty()) {
           internalSet(attributes, responseAttributeKey(name), values);
         }
@@ -88,18 +88,18 @@ abstract class HttpCommonAttributesExtractor<
 
   @Nullable
   private String userAgent(REQUEST request) {
-    return firstHeaderValue(getter.requestHeader(request, "user-agent"));
+    return firstHeaderValue(getter.getRequestHeader(request, "user-agent"));
   }
 
   @Nullable
   private Long requestContentLength(REQUEST request) {
-    return parseNumber(firstHeaderValue(getter.requestHeader(request, "content-length")));
+    return parseNumber(firstHeaderValue(getter.getRequestHeader(request, "content-length")));
   }
 
   @Nullable
   private Long responseContentLength(REQUEST request, RESPONSE response) {
     return parseNumber(
-        firstHeaderValue(getter.responseHeader(request, response, "content-length")));
+        firstHeaderValue(getter.getResponseHeader(request, response, "content-length")));
   }
 
   @Nullable
@@ -131,7 +131,7 @@ abstract class HttpCommonAttributesExtractor<
     @Nullable
     @Override
     public String name(REQUEST request) {
-      String host = firstHeaderValue(getter.requestHeader(request, "host"));
+      String host = firstHeaderValue(getter.getRequestHeader(request, "host"));
       if (host == null) {
         return null;
       }
@@ -142,7 +142,7 @@ abstract class HttpCommonAttributesExtractor<
     @Nullable
     @Override
     public Integer port(REQUEST request) {
-      String host = firstHeaderValue(getter.requestHeader(request, "host"));
+      String host = firstHeaderValue(getter.getRequestHeader(request, "host"));
       if (host == null) {
         return null;
       }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesGetter.java
@@ -16,7 +16,21 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
   // Attributes that always exist in a request
 
   @Nullable
-  String method(REQUEST request);
+  default String getMethod(REQUEST request) {
+    return method(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getMethod(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String method(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   /**
    * Extracts all values of header named {@code name} from the request, or an empty list if there
@@ -25,7 +39,26 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
    * <p>Implementations of this method <b>must not</b> return a null value; an empty list should be
    * returned instead.
    */
-  List<String> requestHeader(REQUEST request, String name);
+  default List<String> getRequestHeader(REQUEST request, String name) {
+    return requestHeader(request, name);
+  }
+
+  /**
+   * Extracts all values of header named {@code name} from the request, or an empty list if there
+   * were none.
+   *
+   * <p>Implementations of this method <b>must not</b> return a null value; an empty list should be
+   * returned instead.
+   *
+   * <p>This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getRequestHeader(Object, String)} instead.
+   */
+  @Deprecated
+  default List<String> requestHeader(REQUEST request, String name) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   // Attributes which are not always available when the request is ready.
 
@@ -36,7 +69,26 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
    * {@code response} is non-{@code null}.
    */
   @Nullable
-  Integer statusCode(REQUEST request, RESPONSE response, @Nullable Throwable error);
+  default Integer getStatusCode(REQUEST request, RESPONSE response, @Nullable Throwable error) {
+    return statusCode(request, response, error);
+  }
+
+  /**
+   * Extracts the {@code http.status_code} span attribute.
+   *
+   * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, only when
+   * {@code response} is non-{@code null}.
+   *
+   * <p>This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getStatusCode(Object, Object, Throwable)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default Integer statusCode(REQUEST request, RESPONSE response, @Nullable Throwable error) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   /**
    * Extracts all values of header named {@code name} from the response, or an empty list if there
@@ -48,5 +100,27 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
    * <p>Implementations of this method <b>must not</b> return a null value; an empty list should be
    * returned instead.
    */
-  List<String> responseHeader(REQUEST request, RESPONSE response, String name);
+  default List<String> getResponseHeader(REQUEST request, RESPONSE response, String name) {
+    return responseHeader(request, response, name);
+  }
+
+  /**
+   * Extracts all values of header named {@code name} from the response, or an empty list if there
+   * were none.
+   *
+   * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, only when
+   * {@code response} is non-{@code null}.
+   *
+   * <p>Implementations of this method <b>must not</b> return a null value; an empty list should be
+   * returned instead.
+   *
+   * <p>This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getResponseHeader(Object, Object, String)} instead.
+   */
+  @Deprecated
+  default List<String> responseHeader(REQUEST request, RESPONSE response, String name) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -89,19 +89,19 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
     super.onStart(attributes, parentContext, request);
 
-    internalSet(attributes, SemanticAttributes.HTTP_FLAVOR, getter.flavor(request));
+    internalSet(attributes, SemanticAttributes.HTTP_FLAVOR, getter.getFlavor(request));
     String forwardedProto = forwardedProto(request);
-    String value = forwardedProto != null ? forwardedProto : getter.scheme(request);
+    String value = forwardedProto != null ? forwardedProto : getter.getScheme(request);
     internalSet(attributes, SemanticAttributes.HTTP_SCHEME, value);
-    internalSet(attributes, SemanticAttributes.HTTP_TARGET, getter.target(request));
-    internalSet(attributes, SemanticAttributes.HTTP_ROUTE, getter.route(request));
+    internalSet(attributes, SemanticAttributes.HTTP_TARGET, getter.getTarget(request));
+    internalSet(attributes, SemanticAttributes.HTTP_ROUTE, getter.getRoute(request));
     internalSet(attributes, SemanticAttributes.HTTP_CLIENT_IP, clientIp(request));
 
     internalNetExtractor.onStart(attributes, request);
   }
 
   private boolean shouldCaptureHostPort(int port, REQUEST request) {
-    String scheme = getter.scheme(request);
+    String scheme = getter.getScheme(request);
     if (scheme == null) {
       return true;
     }
@@ -127,7 +127,7 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
   @Nullable
   private String forwardedProto(REQUEST request) {
     // try Forwarded
-    String forwarded = firstHeaderValue(getter.requestHeader(request, "forwarded"));
+    String forwarded = firstHeaderValue(getter.getRequestHeader(request, "forwarded"));
     if (forwarded != null) {
       forwarded = extractProtoFromForwardedHeader(forwarded);
       if (forwarded != null) {
@@ -136,7 +136,7 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
     }
 
     // try X-Forwarded-Proto
-    forwarded = firstHeaderValue(getter.requestHeader(request, "x-forwarded-proto"));
+    forwarded = firstHeaderValue(getter.getRequestHeader(request, "x-forwarded-proto"));
     if (forwarded != null) {
       return extractProtoFromForwardedProtoHeader(forwarded);
     }
@@ -147,7 +147,7 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
   @Nullable
   private String clientIp(REQUEST request) {
     // try Forwarded
-    String forwarded = firstHeaderValue(getter.requestHeader(request, "forwarded"));
+    String forwarded = firstHeaderValue(getter.getRequestHeader(request, "forwarded"));
     if (forwarded != null) {
       forwarded = extractClientIpFromForwardedHeader(forwarded);
       if (forwarded != null) {
@@ -156,7 +156,7 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
     }
 
     // try X-Forwarded-For
-    forwarded = firstHeaderValue(getter.requestHeader(request, "x-forwarded-for"));
+    forwarded = firstHeaderValue(getter.getRequestHeader(request, "x-forwarded-for"));
     if (forwarded != null) {
       return extractClientIpFromForwardedForHeader(forwarded);
     }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
@@ -20,14 +20,70 @@ public interface HttpServerAttributesGetter<REQUEST, RESPONSE>
   // Attributes that always exist in a request
 
   @Nullable
-  String flavor(REQUEST request);
+  default String getFlavor(REQUEST request) {
+    return flavor(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getFlavor(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String flavor(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String target(REQUEST request);
+  default String getTarget(REQUEST request) {
+    return target(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getTarget(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String target(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String route(REQUEST request);
+  default String getRoute(REQUEST request) {
+    return route(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getRoute(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String route(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String scheme(REQUEST request);
+  default String getScheme(REQUEST request) {
+    return scheme(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getScheme(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String scheme(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanNameExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanNameExtractor.java
@@ -37,7 +37,7 @@ public final class HttpSpanNameExtractor<REQUEST> implements SpanNameExtractor<R
     if (route != null) {
       return route;
     }
-    String method = getter.method(request);
+    String method = getter.getMethod(request);
     if (method != null) {
       return "HTTP " + method;
     }
@@ -47,7 +47,7 @@ public final class HttpSpanNameExtractor<REQUEST> implements SpanNameExtractor<R
   @Nullable
   private String extractRoute(REQUEST request) {
     if (getter instanceof HttpServerAttributesGetter) {
-      return ((HttpServerAttributesGetter<REQUEST, ?>) getter).route(request);
+      return ((HttpServerAttributesGetter<REQUEST, ?>) getter).getRoute(request);
     }
     return null;
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractor.java
@@ -57,7 +57,7 @@ public final class HttpSpanStatusExtractor<REQUEST, RESPONSE>
       @Nullable Throwable error) {
 
     if (response != null) {
-      Integer statusCode = getter.statusCode(request, response, error);
+      Integer statusCode = getter.getStatusCode(request, response, error);
       if (statusCode != null) {
         StatusCode statusCodeObj = statusConverter.statusFromHttpStatus(statusCode);
         if (statusCodeObj == StatusCode.ERROR) {

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractor.java
@@ -67,31 +67,37 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   @SuppressWarnings("deprecation") // operationName
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    internalSet(attributes, SemanticAttributes.MESSAGING_SYSTEM, getter.system(request));
+    internalSet(attributes, SemanticAttributes.MESSAGING_SYSTEM, getter.getSystem(request));
     internalSet(
-        attributes, SemanticAttributes.MESSAGING_DESTINATION_KIND, getter.destinationKind(request));
-    boolean isTemporaryDestination = getter.temporaryDestination(request);
+        attributes,
+        SemanticAttributes.MESSAGING_DESTINATION_KIND,
+        getter.getDestinationKind(request));
+    boolean isTemporaryDestination = getter.isTemporaryDestination(request);
     if (isTemporaryDestination) {
       internalSet(attributes, SemanticAttributes.MESSAGING_TEMP_DESTINATION, true);
       internalSet(attributes, SemanticAttributes.MESSAGING_DESTINATION, TEMP_DESTINATION_NAME);
     } else {
       internalSet(
-          attributes, SemanticAttributes.MESSAGING_DESTINATION, getter.destination(request));
+          attributes, SemanticAttributes.MESSAGING_DESTINATION, getter.getDestination(request));
     }
-    internalSet(attributes, SemanticAttributes.MESSAGING_PROTOCOL, getter.protocol(request));
+    internalSet(attributes, SemanticAttributes.MESSAGING_PROTOCOL, getter.getProtocol(request));
     internalSet(
-        attributes, SemanticAttributes.MESSAGING_PROTOCOL_VERSION, getter.protocolVersion(request));
-    internalSet(attributes, SemanticAttributes.MESSAGING_URL, getter.url(request));
+        attributes,
+        SemanticAttributes.MESSAGING_PROTOCOL_VERSION,
+        getter.getProtocolVersion(request));
+    internalSet(attributes, SemanticAttributes.MESSAGING_URL, getter.getUrl(request));
     internalSet(
-        attributes, SemanticAttributes.MESSAGING_CONVERSATION_ID, getter.conversationId(request));
+        attributes,
+        SemanticAttributes.MESSAGING_CONVERSATION_ID,
+        getter.getConversationId(request));
     internalSet(
         attributes,
         SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES,
-        getter.messagePayloadSize(request));
+        getter.getMessagePayloadSize(request));
     internalSet(
         attributes,
         SemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES,
-        getter.messagePayloadCompressedSize(request));
+        getter.getMessagePayloadCompressedSize(request));
     if (operation == RECEIVE || operation == PROCESS) {
       internalSet(attributes, SemanticAttributes.MESSAGING_OPERATION, operation.operationName());
     }
@@ -105,10 +111,12 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
       @Nullable RESPONSE response,
       @Nullable Throwable error) {
     internalSet(
-        attributes, SemanticAttributes.MESSAGING_MESSAGE_ID, getter.messageId(request, response));
+        attributes,
+        SemanticAttributes.MESSAGING_MESSAGE_ID,
+        getter.getMessageId(request, response));
 
     for (String name : capturedHeaders) {
-      List<String> values = getter.header(request, name);
+      List<String> values = getter.getMessageHeader(request, name);
       if (!values.isEmpty()) {
         internalSet(attributes, attributeKey(name), values);
       }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesGetter.java
@@ -19,36 +19,189 @@ import javax.annotation.Nullable;
 public interface MessagingAttributesGetter<REQUEST, RESPONSE> {
 
   @Nullable
-  String system(REQUEST request);
+  default String getSystem(REQUEST request) {
+    return system(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSystem(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String system(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String destinationKind(REQUEST request);
+  default String getDestinationKind(REQUEST request) {
+    return destinationKind(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getDestinationKind(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String destinationKind(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String destination(REQUEST request);
+  default String getDestination(REQUEST request) {
+    return destination(request);
+  }
 
-  boolean temporaryDestination(REQUEST request);
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getDestination(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String destination(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
+
+  default boolean isTemporaryDestination(REQUEST request) {
+    return temporaryDestination(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #isTemporaryDestination(Object)} instead.
+   */
+  @Deprecated
+  default boolean temporaryDestination(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String protocol(REQUEST request);
+  default String getProtocol(REQUEST request) {
+    return protocol(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getProtocol(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String protocol(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String protocolVersion(REQUEST request);
+  default String getProtocolVersion(REQUEST request) {
+    return protocolVersion(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getProtocolVersion(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String protocolVersion(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String url(REQUEST request);
+  default String getUrl(REQUEST request) {
+    return url(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getUrl(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String url(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String conversationId(REQUEST request);
+  default String getConversationId(REQUEST request) {
+    return conversationId(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getConversationId(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String conversationId(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  Long messagePayloadSize(REQUEST request);
+  default Long getMessagePayloadSize(REQUEST request) {
+    return messagePayloadSize(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getMessagePayloadSize(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default Long messagePayloadSize(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  Long messagePayloadCompressedSize(REQUEST request);
+  default Long getMessagePayloadCompressedSize(REQUEST request) {
+    return messagePayloadCompressedSize(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getMessagePayloadCompressedSize(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default Long messagePayloadCompressedSize(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String messageId(REQUEST request, @Nullable RESPONSE response);
+  default String getMessageId(REQUEST request, @Nullable RESPONSE response) {
+    return messageId(request, response);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getMessageId(Object, Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String messageId(REQUEST request, @Nullable RESPONSE response) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   /**
    * Extracts all values of header named {@code name} from the request, or an empty list if there
@@ -57,6 +210,23 @@ public interface MessagingAttributesGetter<REQUEST, RESPONSE> {
    * <p>Implementations of this method <b>must not</b> return a null value; an empty list should be
    * returned instead.
    */
+  // TODO: when removing header(), make sure this method returns emptyList() by default
+  default List<String> getMessageHeader(REQUEST request, String name) {
+    return header(request, name);
+  }
+
+  /**
+   * Extracts all values of header named {@code name} from the request, or an empty list if there
+   * were none.
+   *
+   * <p>Implementations of this method <b>must not</b> return a null value; an empty list should be
+   * returned instead.
+   *
+   * <p>This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getMessageHeader(Object, String)} instead.
+   */
+  @Deprecated
   default List<String> header(REQUEST request, String name) {
     return Collections.emptyList();
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingSpanNameExtractor.java
@@ -14,7 +14,8 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
    * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#span-name">
    * messaging semantic conventions</a>: {@code <destination name> <operation name>}.
    *
-   * @see MessagingAttributesGetter#destination(Object) used to extract {@code <destination name>}.
+   * @see MessagingAttributesGetter#getDestination(Object) used to extract {@code <destination
+   *     name>}.
    * @see MessageOperation used to extract {@code <operation name>}.
    */
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
@@ -35,9 +36,9 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
   @Override
   public String extract(REQUEST request) {
     String destinationName =
-        getter.temporaryDestination(request)
+        getter.isTemporaryDestination(request)
             ? MessagingAttributesExtractor.TEMP_DESTINATION_NAME
-            : getter.destination(request);
+            : getter.getDestination(request);
     if (destinationName == null) {
       destinationName = "unknown";
     }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetter.java
@@ -26,7 +26,7 @@ public abstract class InetSocketAddressNetClientAttributesGetter<REQUEST, RESPON
 
   @Nullable
   @Override
-  public String sockFamily(REQUEST request, @Nullable RESPONSE response) {
+  public String getSockFamily(REQUEST request, @Nullable RESPONSE response) {
     InetSocketAddress address = getPeerSocketAddress(request, response);
     if (address == null) {
       return null;
@@ -40,7 +40,7 @@ public abstract class InetSocketAddressNetClientAttributesGetter<REQUEST, RESPON
 
   @Override
   @Nullable
-  public final String sockPeerAddr(REQUEST request, @Nullable RESPONSE response) {
+  public final String getSockPeerAddr(REQUEST request, @Nullable RESPONSE response) {
     InetSocketAddress address = getPeerSocketAddress(request, response);
     if (address == null) {
       return null;
@@ -54,7 +54,7 @@ public abstract class InetSocketAddressNetClientAttributesGetter<REQUEST, RESPON
 
   @Override
   @Nullable
-  public String sockPeerName(REQUEST request, @Nullable RESPONSE response) {
+  public String getSockPeerName(REQUEST request, @Nullable RESPONSE response) {
     InetSocketAddress address = getPeerSocketAddress(request, response);
     if (address == null) {
       return null;
@@ -64,7 +64,7 @@ public abstract class InetSocketAddressNetClientAttributesGetter<REQUEST, RESPON
 
   @Nullable
   @Override
-  public Integer sockPeerPort(REQUEST request, @Nullable RESPONSE response) {
+  public Integer getSockPeerPort(REQUEST request, @Nullable RESPONSE response) {
     InetSocketAddress address = getPeerSocketAddress(request, response);
     if (address == null) {
       return null;

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetter.java
@@ -29,7 +29,7 @@ public abstract class InetSocketAddressNetServerAttributesGetter<REQUEST>
 
   @Nullable
   @Override
-  public String sockFamily(REQUEST request) {
+  public String getSockFamily(REQUEST request) {
     InetSocketAddress address = getPeerSocketAddress(request);
     if (address == null) {
       address = getHostSocketAddress(request);
@@ -46,25 +46,25 @@ public abstract class InetSocketAddressNetServerAttributesGetter<REQUEST>
 
   @Override
   @Nullable
-  public final String sockPeerAddr(REQUEST request) {
+  public final String getSockPeerAddr(REQUEST request) {
     return getAddress(getPeerSocketAddress(request));
   }
 
   @Override
   @Nullable
-  public final Integer sockPeerPort(REQUEST request) {
+  public final Integer getSockPeerPort(REQUEST request) {
     return getPort(getPeerSocketAddress(request));
   }
 
   @Nullable
   @Override
-  public String sockHostAddr(REQUEST request) {
+  public String getSockHostAddr(REQUEST request) {
     return getAddress(getHostSocketAddress(request));
   }
 
   @Nullable
   @Override
-  public Integer sockHostPort(REQUEST request) {
+  public Integer getSockHostPort(REQUEST request) {
     return getPort(getHostSocketAddress(request));
   }
 

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesGetter.java
@@ -18,29 +18,119 @@ import javax.annotation.Nullable;
 public interface NetClientAttributesGetter<REQUEST, RESPONSE> {
 
   @Nullable
-  String transport(REQUEST request, @Nullable RESPONSE response);
+  default String getTransport(REQUEST request, @Nullable RESPONSE response) {
+    return transport(request, response);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getTransport(Object, Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String transport(REQUEST request, @Nullable RESPONSE response) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String peerName(REQUEST request);
+  default String getPeerName(REQUEST request) {
+    return peerName(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getPeerName(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String peerName(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  Integer peerPort(REQUEST request);
+  default Integer getPeerPort(REQUEST request) {
+    return peerPort(request);
+  }
 
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getPeerPort(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default Integer peerPort(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
+
+  // TODO: when removing sockFamily(), make sure this method returns null by default
+  @Nullable
+  default String getSockFamily(REQUEST request, @Nullable RESPONSE response) {
+    return sockFamily(request, response);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSockFamily(Object, Object)} instead.
+   */
+  @Deprecated
   @Nullable
   default String sockFamily(REQUEST request, @Nullable RESPONSE response) {
     return null;
   }
 
+  // TODO: when removing sockPeerAddr(), make sure this method returns null by default
+  @Nullable
+  default String getSockPeerAddr(REQUEST request, @Nullable RESPONSE response) {
+    return sockPeerAddr(request, response);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSockPeerAddr(Object, Object)} instead.
+   */
+  @Deprecated
   @Nullable
   default String sockPeerAddr(REQUEST request, @Nullable RESPONSE response) {
     return null;
   }
 
+  // TODO: when removing sockPeerName(), make sure this method returns null by default
+  @Nullable
+  default String getSockPeerName(REQUEST request, @Nullable RESPONSE response) {
+    return sockPeerName(request, response);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSockPeerName(Object, Object)} instead.
+   */
+  @Deprecated
   @Nullable
   default String sockPeerName(REQUEST request, @Nullable RESPONSE response) {
     return null;
   }
 
+  // TODO: when removing sockPeerPort(), make sure this method returns null by default
+  @Nullable
+  default Integer getSockPeerPort(REQUEST request, @Nullable RESPONSE response) {
+    return sockPeerPort(request, response);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSockPeerName(Object, Object)} instead.
+   */
+  @Deprecated
   @Nullable
   default Integer sockPeerPort(REQUEST request, @Nullable RESPONSE response) {
     return null;

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
@@ -18,34 +18,136 @@ import javax.annotation.Nullable;
 public interface NetServerAttributesGetter<REQUEST> {
 
   @Nullable
-  String transport(REQUEST request);
+  default String getTransport(REQUEST request) {
+    return transport(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getTransport(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String transport(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String hostName(REQUEST request);
+  default String getHostName(REQUEST request) {
+    return hostName(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getHostName(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String hostName(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  Integer hostPort(REQUEST request);
+  default Integer getHostPort(REQUEST request) {
+    return hostPort(request);
+  }
 
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getHostPort(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default Integer hostPort(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
+
+  // TODO: when removing sockFamily(), make sure this method returns null by default
+  @Nullable
+  default String getSockFamily(REQUEST request) {
+    return sockFamily(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSockFamily(Object)} instead.
+   */
+  @Deprecated
   @Nullable
   default String sockFamily(REQUEST request) {
     return null;
   }
 
+  // TODO: when removing sockPeerAddr(), make sure this method returns null by default
+  @Nullable
+  default String getSockPeerAddr(REQUEST request) {
+    return sockPeerAddr(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSockPeerAddr(Object)} instead.
+   */
+  @Deprecated
   @Nullable
   default String sockPeerAddr(REQUEST request) {
     return null;
   }
 
+  // TODO: when removing sockPeerPort(), make sure this method returns null by default
+  @Nullable
+  default Integer getSockPeerPort(REQUEST request) {
+    return sockPeerPort(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSockPeerPort(Object)} instead.
+   */
+  @Deprecated
   @Nullable
   default Integer sockPeerPort(REQUEST request) {
     return null;
   }
 
+  // TODO: when removing sockHostAddr(), make sure this method returns null by default
+  @Nullable
+  default String getSockHostAddr(REQUEST request) {
+    return sockHostAddr(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSockHostAddr(Object)} instead.
+   */
+  @Deprecated
   @Nullable
   default String sockHostAddr(REQUEST request) {
     return null;
   }
 
+  // TODO: when removing sockHostPort(), make sure this method returns null by default
+  @Nullable
+  default Integer getSockHostPort(REQUEST request) {
+    return sockHostPort(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSockHostPort(Object)} instead.
+   */
+  @Deprecated
   @Nullable
   default Integer sockHostPort(REQUEST request) {
     return null;

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractor.java
@@ -57,7 +57,7 @@ public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
       return;
     }
 
-    String peerName = attributesGetter.peerName(request);
+    String peerName = attributesGetter.getPeerName(request);
     String peerService = mapToPeerService(peerName);
     if (peerService != null) {
       attributes.put(SemanticAttributes.PEER_SERVICE, peerService);

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetClientAttributesExtractor.java
@@ -47,26 +47,27 @@ public final class InternalNetClientAttributesExtractor<REQUEST, RESPONSE> {
 
   public void onEnd(AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {
 
-    internalSet(attributes, SemanticAttributes.NET_TRANSPORT, getter.transport(request, response));
+    internalSet(
+        attributes, SemanticAttributes.NET_TRANSPORT, getter.getTransport(request, response));
 
     String peerName = extractPeerName(request);
 
-    String sockPeerAddr = getter.sockPeerAddr(request, response);
+    String sockPeerAddr = getter.getSockPeerAddr(request, response);
     if (sockPeerAddr != null && !sockPeerAddr.equals(peerName)) {
       internalSet(attributes, SemanticAttributes.NET_SOCK_PEER_ADDR, sockPeerAddr);
 
       Integer peerPort = extractPeerPort(request);
-      Integer sockPeerPort = getter.sockPeerPort(request, response);
+      Integer sockPeerPort = getter.getSockPeerPort(request, response);
       if (sockPeerPort != null && sockPeerPort > 0 && !sockPeerPort.equals(peerPort)) {
         internalSet(attributes, SemanticAttributes.NET_SOCK_PEER_PORT, (long) sockPeerPort);
       }
 
-      String sockFamily = getter.sockFamily(request, response);
+      String sockFamily = getter.getSockFamily(request, response);
       if (sockFamily != null && !SemanticAttributes.NetSockFamilyValues.INET.equals(sockFamily)) {
         internalSet(attributes, SemanticAttributes.NET_SOCK_FAMILY, sockFamily);
       }
 
-      String sockPeerName = getter.sockPeerName(request, response);
+      String sockPeerName = getter.getSockPeerName(request, response);
       if (sockPeerName != null && !sockPeerName.equals(peerName)) {
         internalSet(attributes, SemanticAttributes.NET_SOCK_PEER_NAME, sockPeerName);
       }
@@ -74,7 +75,7 @@ public final class InternalNetClientAttributesExtractor<REQUEST, RESPONSE> {
   }
 
   private String extractPeerName(REQUEST request) {
-    String peerName = getter.peerName(request);
+    String peerName = getter.getPeerName(request);
     if (peerName == null) {
       peerName = fallbackNamePortGetter.name(request);
     }
@@ -82,7 +83,7 @@ public final class InternalNetClientAttributesExtractor<REQUEST, RESPONSE> {
   }
 
   private Integer extractPeerPort(REQUEST request) {
-    Integer peerPort = getter.peerPort(request);
+    Integer peerPort = getter.getPeerPort(request);
     if (peerPort == null) {
       peerPort = fallbackNamePortGetter.port(request);
     }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetServerAttributesExtractor.java
@@ -32,17 +32,17 @@ public final class InternalNetServerAttributesExtractor<REQUEST> {
   }
 
   public void onStart(AttributesBuilder attributes, REQUEST request) {
-    internalSet(attributes, SemanticAttributes.NET_TRANSPORT, getter.transport(request));
+    internalSet(attributes, SemanticAttributes.NET_TRANSPORT, getter.getTransport(request));
 
     boolean setSockFamily = false;
 
-    String sockPeerAddr = getter.sockPeerAddr(request);
+    String sockPeerAddr = getter.getSockPeerAddr(request);
     if (sockPeerAddr != null) {
       setSockFamily = true;
 
       internalSet(attributes, SemanticAttributes.NET_SOCK_PEER_ADDR, sockPeerAddr);
 
-      Integer sockPeerPort = getter.sockPeerPort(request);
+      Integer sockPeerPort = getter.getSockPeerPort(request);
       if (sockPeerPort != null && sockPeerPort > 0) {
         internalSet(attributes, SemanticAttributes.NET_SOCK_PEER_PORT, (long) sockPeerPort);
       }
@@ -59,20 +59,20 @@ public final class InternalNetServerAttributesExtractor<REQUEST> {
       }
     }
 
-    String sockHostAddr = getter.sockHostAddr(request);
+    String sockHostAddr = getter.getSockHostAddr(request);
     if (sockHostAddr != null && !sockHostAddr.equals(hostName)) {
       setSockFamily = true;
 
       internalSet(attributes, SemanticAttributes.NET_SOCK_HOST_ADDR, sockHostAddr);
 
-      Integer sockHostPort = getter.sockHostPort(request);
+      Integer sockHostPort = getter.getSockHostPort(request);
       if (sockHostPort != null && sockHostPort > 0 && !sockHostPort.equals(hostPort)) {
         internalSet(attributes, SemanticAttributes.NET_SOCK_HOST_PORT, (long) sockHostPort);
       }
     }
 
     if (setSockFamily) {
-      String sockFamily = getter.sockFamily(request);
+      String sockFamily = getter.getSockFamily(request);
       if (sockFamily != null && !SemanticAttributes.NetSockFamilyValues.INET.equals(sockFamily)) {
         internalSet(attributes, SemanticAttributes.NET_SOCK_FAMILY, sockFamily);
       }
@@ -80,7 +80,7 @@ public final class InternalNetServerAttributesExtractor<REQUEST> {
   }
 
   private String extractHostName(REQUEST request) {
-    String peerName = getter.hostName(request);
+    String peerName = getter.getHostName(request);
     if (peerName == null) {
       peerName = fallbackNamePortGetter.name(request);
     }
@@ -88,7 +88,7 @@ public final class InternalNetServerAttributesExtractor<REQUEST> {
   }
 
   private Integer extractHostPort(REQUEST request) {
-    Integer peerPort = getter.hostPort(request);
+    Integer peerPort = getter.getHostPort(request);
     if (peerPort == null) {
       peerPort = fallbackNamePortGetter.port(request);
     }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcAttributesGetter.java
@@ -17,11 +17,53 @@ import javax.annotation.Nullable;
 public interface RpcAttributesGetter<REQUEST> {
 
   @Nullable
-  String system(REQUEST request);
+  default String getSystem(REQUEST request) {
+    return system(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getSystem(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String system(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String service(REQUEST request);
+  default String getService(REQUEST request) {
+    return service(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getService(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String service(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 
   @Nullable
-  String method(REQUEST request);
+  default String getMethod(REQUEST request) {
+    return method(request);
+  }
+
+  /**
+   * This method is deprecated and will be removed in the subsequent release.
+   *
+   * @deprecated Use {@link #getMethod(Object)} instead.
+   */
+  @Deprecated
+  @Nullable
+  default String method(REQUEST request) {
+    throw new UnsupportedOperationException(
+        "This method is deprecated and will be removed in the subsequent release.");
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcCommonAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcCommonAttributesExtractor.java
@@ -24,9 +24,9 @@ abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
 
   @Override
   public final void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    internalSet(attributes, SemanticAttributes.RPC_SYSTEM, getter.system(request));
-    internalSet(attributes, SemanticAttributes.RPC_SERVICE, getter.service(request));
-    internalSet(attributes, SemanticAttributes.RPC_METHOD, getter.method(request));
+    internalSet(attributes, SemanticAttributes.RPC_SYSTEM, getter.getSystem(request));
+    internalSet(attributes, SemanticAttributes.RPC_SERVICE, getter.getService(request));
+    internalSet(attributes, SemanticAttributes.RPC_METHOD, getter.getMethod(request));
   }
 
   @Override

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcSpanNameExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcSpanNameExtractor.java
@@ -27,8 +27,8 @@ public final class RpcSpanNameExtractor<REQUEST> implements SpanNameExtractor<RE
 
   @Override
   public String extract(REQUEST request) {
-    String service = getter.service(request);
-    String method = getter.method(request);
+    String service = getter.getService(request);
+    String method = getter.getMethod(request);
     if (service == null || method == null) {
       return "RPC request";
     }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/util/ClassAndMethodAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/util/ClassAndMethodAttributesGetter.java
@@ -13,13 +13,13 @@ enum ClassAndMethodAttributesGetter implements CodeAttributesGetter<ClassAndMeth
 
   @Nullable
   @Override
-  public Class<?> codeClass(ClassAndMethod classAndMethod) {
+  public Class<?> getCodeClass(ClassAndMethod classAndMethod) {
     return classAndMethod.declaringClass();
   }
 
   @Nullable
   @Override
-  public String methodName(ClassAndMethod classAndMethod) {
+  public String getMethodName(ClassAndMethod classAndMethod) {
     return classAndMethod.methodName();
   }
 }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractorTest.java
@@ -21,7 +21,7 @@ class CodeAttributesExtractorTest {
 
   static final class TestAttributesGetter implements CodeAttributesGetter<Map<String, String>> {
     @Override
-    public Class<?> codeClass(Map<String, String> request) {
+    public Class<?> getCodeClass(Map<String, String> request) {
       try {
         String className = request.get("class");
         return className == null ? null : Class.forName(className);
@@ -31,7 +31,7 @@ class CodeAttributesExtractorTest {
     }
 
     @Override
-    public String methodName(Map<String, String> request) {
+    public String getMethodName(Map<String, String> request) {
       return request.get("methodName");
     }
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeSpanNameExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeSpanNameExtractorTest.java
@@ -23,8 +23,8 @@ class CodeSpanNameExtractorTest {
     // given
     Object request = new Object();
 
-    doReturn(TestClass.class).when(getter).codeClass(request);
-    doReturn("doSomething").when(getter).methodName(request);
+    doReturn(TestClass.class).when(getter).getCodeClass(request);
+    doReturn("doSomething").when(getter).getMethodName(request);
 
     SpanNameExtractor<Object> underTest = CodeSpanNameExtractor.create(getter);
 
@@ -41,8 +41,8 @@ class CodeSpanNameExtractorTest {
     AnonymousBaseClass anon = new AnonymousBaseClass() {};
     Object request = new Object();
 
-    doReturn(anon.getClass()).when(getter).codeClass(request);
-    doReturn("doSomething").when(getter).methodName(request);
+    doReturn(anon.getClass()).when(getter).getCodeClass(request);
+    doReturn("doSomething").when(getter).getMethodName(request);
 
     SpanNameExtractor<Object> underTest = CodeSpanNameExtractor.create(getter);
 
@@ -59,8 +59,8 @@ class CodeSpanNameExtractorTest {
     Runnable lambda = () -> {};
     Object request = new Object();
 
-    doReturn(lambda.getClass()).when(getter).codeClass(request);
-    doReturn("doSomething").when(getter).methodName(request);
+    doReturn(lambda.getClass()).when(getter).getCodeClass(request);
+    doReturn("doSomething").when(getter).getMethodName(request);
 
     SpanNameExtractor<Object> underTest = CodeSpanNameExtractor.create(getter);
 

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientAttributesExtractorTest.java
@@ -21,32 +21,32 @@ class DbClientAttributesExtractorTest {
 
   static final class TestAttributesGetter implements DbClientAttributesGetter<Map<String, String>> {
     @Override
-    public String system(Map<String, String> map) {
+    public String getSystem(Map<String, String> map) {
       return map.get("db.system");
     }
 
     @Override
-    public String user(Map<String, String> map) {
+    public String getUser(Map<String, String> map) {
       return map.get("db.user");
     }
 
     @Override
-    public String name(Map<String, String> map) {
+    public String getName(Map<String, String> map) {
       return map.get("db.name");
     }
 
     @Override
-    public String connectionString(Map<String, String> map) {
+    public String getConnectionString(Map<String, String> map) {
       return map.get("db.connection_string");
     }
 
     @Override
-    public String statement(Map<String, String> map) {
+    public String getStatement(Map<String, String> map) {
       return map.get("db.statement");
     }
 
     @Override
-    public String operation(Map<String, String> map) {
+    public String getOperation(Map<String, String> map) {
       return map.get("db.operation");
     }
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientSpanNameExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientSpanNameExtractorTest.java
@@ -24,8 +24,8 @@ class DbClientSpanNameExtractorTest {
     // given
     DbRequest dbRequest = new DbRequest();
 
-    when(sqlAttributesGetter.rawStatement(dbRequest)).thenReturn("SELECT * from table");
-    when(sqlAttributesGetter.name(dbRequest)).thenReturn("database");
+    when(sqlAttributesGetter.getRawStatement(dbRequest)).thenReturn("SELECT * from table");
+    when(sqlAttributesGetter.getName(dbRequest)).thenReturn("database");
 
     SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(sqlAttributesGetter);
 
@@ -41,8 +41,8 @@ class DbClientSpanNameExtractorTest {
     // given
     DbRequest dbRequest = new DbRequest();
 
-    when(sqlAttributesGetter.rawStatement(dbRequest)).thenReturn("SELECT * from another.table");
-    when(sqlAttributesGetter.name(dbRequest)).thenReturn("database");
+    when(sqlAttributesGetter.getRawStatement(dbRequest)).thenReturn("SELECT * from another.table");
+    when(sqlAttributesGetter.getName(dbRequest)).thenReturn("database");
 
     SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(sqlAttributesGetter);
 
@@ -58,7 +58,7 @@ class DbClientSpanNameExtractorTest {
     // given
     DbRequest dbRequest = new DbRequest();
 
-    when(sqlAttributesGetter.rawStatement(dbRequest)).thenReturn("SELECT * from table");
+    when(sqlAttributesGetter.getRawStatement(dbRequest)).thenReturn("SELECT * from table");
 
     SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(sqlAttributesGetter);
 
@@ -74,8 +74,8 @@ class DbClientSpanNameExtractorTest {
     // given
     DbRequest dbRequest = new DbRequest();
 
-    when(dbAttributesGetter.operation(dbRequest)).thenReturn("SELECT");
-    when(dbAttributesGetter.name(dbRequest)).thenReturn("database");
+    when(dbAttributesGetter.getOperation(dbRequest)).thenReturn("SELECT");
+    when(dbAttributesGetter.getName(dbRequest)).thenReturn("database");
 
     SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(dbAttributesGetter);
 
@@ -91,7 +91,7 @@ class DbClientSpanNameExtractorTest {
     // given
     DbRequest dbRequest = new DbRequest();
 
-    when(dbAttributesGetter.operation(dbRequest)).thenReturn("SELECT");
+    when(dbAttributesGetter.getOperation(dbRequest)).thenReturn("SELECT");
 
     SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(dbAttributesGetter);
 
@@ -107,7 +107,7 @@ class DbClientSpanNameExtractorTest {
     // given
     DbRequest dbRequest = new DbRequest();
 
-    when(dbAttributesGetter.name(dbRequest)).thenReturn("database");
+    when(dbAttributesGetter.getName(dbRequest)).thenReturn("database");
 
     SpanNameExtractor<DbRequest> underTest = DbClientSpanNameExtractor.create(dbAttributesGetter);
 

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesExtractorTest.java
@@ -23,27 +23,27 @@ class SqlClientAttributesExtractorTest {
       implements SqlClientAttributesGetter<Map<String, String>> {
 
     @Override
-    public String rawStatement(Map<String, String> map) {
+    public String getRawStatement(Map<String, String> map) {
       return map.get("db.statement");
     }
 
     @Override
-    public String system(Map<String, String> map) {
+    public String getSystem(Map<String, String> map) {
       return map.get("db.system");
     }
 
     @Override
-    public String user(Map<String, String> map) {
+    public String getUser(Map<String, String> map) {
       return map.get("db.user");
     }
 
     @Override
-    public String name(Map<String, String> map) {
+    public String getName(Map<String, String> map) {
       return map.get("db.name");
     }
 
     @Override
-    public String connectionString(Map<String, String> map) {
+    public String getConnectionString(Map<String, String> map) {
       return map.get("db.connection_string");
     }
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -37,34 +37,34 @@ class HttpClientAttributesExtractorTest {
       implements HttpClientAttributesGetter<Map<String, String>, Map<String, String>> {
 
     @Override
-    public String method(Map<String, String> request) {
+    public String getMethod(Map<String, String> request) {
       return request.get("method");
     }
 
     @Override
-    public String url(Map<String, String> request) {
+    public String getUrl(Map<String, String> request) {
       return request.get("url");
     }
 
     @Override
-    public List<String> requestHeader(Map<String, String> request, String name) {
+    public List<String> getRequestHeader(Map<String, String> request, String name) {
       String value = request.get("header." + name);
       return value == null ? emptyList() : asList(value.split(","));
     }
 
     @Override
-    public Integer statusCode(
+    public Integer getStatusCode(
         Map<String, String> request, Map<String, String> response, @Nullable Throwable error) {
       return Integer.parseInt(response.get("statusCode"));
     }
 
     @Override
-    public String flavor(Map<String, String> request, Map<String, String> response) {
+    public String getFlavor(Map<String, String> request, Map<String, String> response) {
       return request.get("flavor");
     }
 
     @Override
-    public List<String> responseHeader(
+    public List<String> getResponseHeader(
         Map<String, String> request, Map<String, String> response, String name) {
       String value = response.get("header." + name);
       return value == null ? emptyList() : asList(value.split(","));
@@ -76,19 +76,20 @@ class HttpClientAttributesExtractorTest {
 
     @Nullable
     @Override
-    public String transport(Map<String, String> request, @Nullable Map<String, String> response) {
+    public String getTransport(
+        Map<String, String> request, @Nullable Map<String, String> response) {
       return response.get("transport");
     }
 
     @Nullable
     @Override
-    public String peerName(Map<String, String> request) {
+    public String getPeerName(Map<String, String> request) {
       return request.get("peerName");
     }
 
     @Nullable
     @Override
-    public Integer peerPort(Map<String, String> request) {
+    public Integer getPeerPort(Map<String, String> request) {
       String statusCode = request.get("peerPort");
       return statusCode == null ? null : Integer.parseInt(statusCode);
     }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -37,45 +37,45 @@ class HttpServerAttributesExtractorTest {
       implements HttpServerAttributesGetter<Map<String, Object>, Map<String, Object>> {
 
     @Override
-    public String method(Map<String, Object> request) {
+    public String getMethod(Map<String, Object> request) {
       return (String) request.get("method");
     }
 
     @Override
-    public String target(Map<String, Object> request) {
+    public String getTarget(Map<String, Object> request) {
       return (String) request.get("target");
     }
 
     @Override
-    public String route(Map<String, Object> request) {
+    public String getRoute(Map<String, Object> request) {
       return (String) request.get("route");
     }
 
     @Override
-    public String scheme(Map<String, Object> request) {
+    public String getScheme(Map<String, Object> request) {
       return (String) request.get("scheme");
     }
 
     @Override
-    public List<String> requestHeader(Map<String, Object> request, String name) {
+    public List<String> getRequestHeader(Map<String, Object> request, String name) {
       String values = (String) request.get("header." + name);
       return values == null ? emptyList() : asList(values.split(","));
     }
 
     @Override
-    public Integer statusCode(
+    public Integer getStatusCode(
         Map<String, Object> request, Map<String, Object> response, @Nullable Throwable error) {
       String value = (String) response.get("statusCode");
       return value == null ? null : Integer.parseInt(value);
     }
 
     @Override
-    public String flavor(Map<String, Object> request) {
+    public String getFlavor(Map<String, Object> request) {
       return (String) request.get("flavor");
     }
 
     @Override
-    public List<String> responseHeader(
+    public List<String> getResponseHeader(
         Map<String, Object> request, Map<String, Object> response, String name) {
       String values = (String) response.get("header." + name);
       return values == null ? emptyList() : asList(values.split(","));
@@ -86,19 +86,19 @@ class HttpServerAttributesExtractorTest {
       implements NetServerAttributesGetter<Map<String, Object>> {
     @Nullable
     @Override
-    public String transport(Map<String, Object> request) {
+    public String getTransport(Map<String, Object> request) {
       return (String) request.get("transport");
     }
 
     @Nullable
     @Override
-    public String hostName(Map<String, Object> request) {
+    public String getHostName(Map<String, Object> request) {
       return (String) request.get("hostName");
     }
 
     @Nullable
     @Override
-    public Integer hostPort(Map<String, Object> request) {
+    public Integer getHostPort(Map<String, Object> request) {
       return (Integer) request.get("hostPort");
     }
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanNameExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanNameExtractorTest.java
@@ -28,15 +28,15 @@ class HttpSpanNameExtractorTest {
 
   @Test
   void routeAndMethod() {
-    when(serverGetter.route(anyMap())).thenReturn("/cats/{id}");
-    when(serverGetter.method(anyMap())).thenReturn("GET");
+    when(serverGetter.getRoute(anyMap())).thenReturn("/cats/{id}");
+    when(serverGetter.getMethod(anyMap())).thenReturn("GET");
     assertThat(HttpSpanNameExtractor.create(serverGetter).extract(Collections.emptyMap()))
         .isEqualTo("/cats/{id}");
   }
 
   @Test
   void method() {
-    when(clientGetter.method(anyMap())).thenReturn("GET");
+    when(clientGetter.getMethod(anyMap())).thenReturn("GET");
     assertThat(HttpSpanNameExtractor.create(clientGetter).extract(Collections.emptyMap()))
         .isEqualTo("HTTP GET");
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpSpanStatusExtractorTest.java
@@ -35,7 +35,7 @@ class HttpSpanStatusExtractorTest {
   @ValueSource(ints = {1, 100, 101, 200, 201, 300, 301, 500, 501, 600, 601})
   void hasServerStatus(int statusCode) {
     StatusCode expectedStatusCode = HttpStatusConverter.SERVER.statusFromHttpStatus(statusCode);
-    when(serverGetter.statusCode(anyMap(), anyMap(), isNull())).thenReturn(statusCode);
+    when(serverGetter.getStatusCode(anyMap(), anyMap(), isNull())).thenReturn(statusCode);
 
     HttpSpanStatusExtractor.create(serverGetter)
         .extract(spanStatusBuilder, Collections.emptyMap(), Collections.emptyMap(), null);
@@ -51,7 +51,7 @@ class HttpSpanStatusExtractorTest {
   @ValueSource(ints = {1, 100, 101, 200, 201, 300, 301, 400, 401, 500, 501, 600, 601})
   void hasClientStatus(int statusCode) {
     StatusCode expectedStatusCode = HttpStatusConverter.CLIENT.statusFromHttpStatus(statusCode);
-    when(clientGetter.statusCode(anyMap(), anyMap(), isNull())).thenReturn(statusCode);
+    when(clientGetter.getStatusCode(anyMap(), anyMap(), isNull())).thenReturn(statusCode);
 
     HttpSpanStatusExtractor.create(clientGetter)
         .extract(spanStatusBuilder, Collections.emptyMap(), Collections.emptyMap(), null);
@@ -67,7 +67,7 @@ class HttpSpanStatusExtractorTest {
   @ValueSource(ints = {1, 100, 101, 200, 201, 300, 301, 400, 401, 500, 501, 600, 601})
   void hasServerStatusAndException(int statusCode) {
     Throwable error = new IllegalStateException("test");
-    when(serverGetter.statusCode(anyMap(), anyMap(), same(error))).thenReturn(statusCode);
+    when(serverGetter.getStatusCode(anyMap(), anyMap(), same(error))).thenReturn(statusCode);
 
     // Presence of exception overshadows the HTTP status
     HttpSpanStatusExtractor.create(serverGetter)
@@ -80,7 +80,7 @@ class HttpSpanStatusExtractorTest {
   @ValueSource(ints = {1, 100, 101, 200, 201, 300, 301, 400, 401, 500, 501, 600, 601})
   void hasClientStatusAndException(int statusCode) {
     Throwable error = new IllegalStateException("test");
-    when(clientGetter.statusCode(anyMap(), anyMap(), same(error))).thenReturn(statusCode);
+    when(clientGetter.getStatusCode(anyMap(), anyMap(), same(error))).thenReturn(statusCode);
 
     // Presence of exception overshadows the HTTP status
     HttpSpanStatusExtractor.create(clientGetter)
@@ -91,7 +91,7 @@ class HttpSpanStatusExtractorTest {
 
   @Test
   void hasNoServerStatus_fallsBackToDefault_unset() {
-    when(serverGetter.statusCode(anyMap(), anyMap(), isNull())).thenReturn(null);
+    when(serverGetter.getStatusCode(anyMap(), anyMap(), isNull())).thenReturn(null);
 
     HttpSpanStatusExtractor.create(serverGetter)
         .extract(spanStatusBuilder, Collections.emptyMap(), Collections.emptyMap(), null);
@@ -101,7 +101,7 @@ class HttpSpanStatusExtractorTest {
 
   @Test
   void hasNoClientStatus_fallsBackToDefault_unset() {
-    when(clientGetter.statusCode(anyMap(), anyMap(), isNull())).thenReturn(null);
+    when(clientGetter.getStatusCode(anyMap(), anyMap(), isNull())).thenReturn(null);
 
     HttpSpanStatusExtractor.create(clientGetter)
         .extract(spanStatusBuilder, Collections.emptyMap(), Collections.emptyMap(), null);
@@ -112,7 +112,7 @@ class HttpSpanStatusExtractorTest {
   @Test
   void hasNoServerStatus_fallsBackToDefault_error() {
     Throwable error = new IllegalStateException("test");
-    when(serverGetter.statusCode(anyMap(), anyMap(), same(error))).thenReturn(null);
+    when(serverGetter.getStatusCode(anyMap(), anyMap(), same(error))).thenReturn(null);
 
     HttpSpanStatusExtractor.create(serverGetter)
         .extract(spanStatusBuilder, Collections.emptyMap(), Collections.emptyMap(), error);
@@ -123,7 +123,7 @@ class HttpSpanStatusExtractorTest {
   @Test
   void hasNoClientStatus_fallsBackToDefault_error() {
     IllegalStateException error = new IllegalStateException("test");
-    when(clientGetter.statusCode(anyMap(), anyMap(), same(error))).thenReturn(null);
+    when(clientGetter.getStatusCode(anyMap(), anyMap(), same(error))).thenReturn(null);
 
     HttpSpanStatusExtractor.create(clientGetter)
         .extract(spanStatusBuilder, Collections.emptyMap(), Collections.emptyMap(), error);

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractorTest.java
@@ -119,59 +119,59 @@ class MessagingAttributesExtractorTest {
     INSTANCE;
 
     @Override
-    public String system(Map<String, String> request) {
+    public String getSystem(Map<String, String> request) {
       return request.get("system");
     }
 
     @Override
-    public String destinationKind(Map<String, String> request) {
+    public String getDestinationKind(Map<String, String> request) {
       return request.get("destinationKind");
     }
 
     @Override
-    public String destination(Map<String, String> request) {
+    public String getDestination(Map<String, String> request) {
       return request.get("destination");
     }
 
     @Override
-    public boolean temporaryDestination(Map<String, String> request) {
+    public boolean isTemporaryDestination(Map<String, String> request) {
       return request.containsKey("temporaryDestination");
     }
 
     @Override
-    public String protocol(Map<String, String> request) {
+    public String getProtocol(Map<String, String> request) {
       return request.get("protocol");
     }
 
     @Override
-    public String protocolVersion(Map<String, String> request) {
+    public String getProtocolVersion(Map<String, String> request) {
       return request.get("protocolVersion");
     }
 
     @Override
-    public String url(Map<String, String> request) {
+    public String getUrl(Map<String, String> request) {
       return request.get("url");
     }
 
     @Override
-    public String conversationId(Map<String, String> request) {
+    public String getConversationId(Map<String, String> request) {
       return request.get("conversationId");
     }
 
     @Override
-    public Long messagePayloadSize(Map<String, String> request) {
+    public Long getMessagePayloadSize(Map<String, String> request) {
       String payloadSize = request.get("payloadSize");
       return payloadSize == null ? null : Long.valueOf(payloadSize);
     }
 
     @Override
-    public Long messagePayloadCompressedSize(Map<String, String> request) {
+    public Long getMessagePayloadCompressedSize(Map<String, String> request) {
       String payloadSize = request.get("payloadCompressedSize");
       return payloadSize == null ? null : Long.valueOf(payloadSize);
     }
 
     @Override
-    public String messageId(Map<String, String> request, String response) {
+    public String getMessageId(Map<String, String> request, String response) {
       return response;
     }
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingSpanNameExtractorTest.java
@@ -33,9 +33,9 @@ class MessagingSpanNameExtractorTest {
     Message message = new Message();
 
     if (isTemporaryQueue) {
-      when(getter.temporaryDestination(message)).thenReturn(true);
+      when(getter.isTemporaryDestination(message)).thenReturn(true);
     } else {
-      when(getter.destination(message)).thenReturn(destinationName);
+      when(getter.getDestination(message)).thenReturn(destinationName);
     }
 
     SpanNameExtractor<Message> underTest = MessagingSpanNameExtractor.create(getter, operation);

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetterTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetterTest.java
@@ -25,18 +25,18 @@ class InetSocketAddressNetClientAttributesGetterTest {
       getter =
           new InetSocketAddressNetClientAttributesGetter<InetSocketAddress, InetSocketAddress>() {
             @Override
-            public String transport(InetSocketAddress request, InetSocketAddress response) {
+            public String getTransport(InetSocketAddress request, InetSocketAddress response) {
               return SemanticAttributes.NetTransportValues.IP_TCP;
             }
 
             @Override
-            public String peerName(InetSocketAddress request) {
+            public String getPeerName(InetSocketAddress request) {
               // net.peer.name and net.peer.port are tested in NetClientAttributesExtractorTest
               return null;
             }
 
             @Override
-            public Integer peerPort(InetSocketAddress request) {
+            public Integer getPeerPort(InetSocketAddress request) {
               // net.peer.name and net.peer.port are tested in NetClientAttributesExtractorTest
               return null;
             }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
@@ -25,18 +25,18 @@ class InetSocketAddressNetServerAttributesGetterTest {
       new InetSocketAddressNetServerAttributesGetter<Addresses>() {
 
         @Override
-        public String transport(Addresses request) {
+        public String getTransport(Addresses request) {
           return SemanticAttributes.NetTransportValues.IP_TCP;
         }
 
         @Override
-        public String hostName(Addresses request) {
+        public String getHostName(Addresses request) {
           // net.host.name and net.host.port are tested in NetClientAttributesExtractorTest
           return null;
         }
 
         @Override
-        public Integer hostPort(Addresses request) {
+        public Integer getHostPort(Addresses request) {
           // net.host.name and net.host.port are tested in NetClientAttributesExtractorTest
           return null;
         }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorTest.java
@@ -26,38 +26,38 @@ class NetClientAttributesExtractorTest {
       implements NetClientAttributesGetter<Map<String, String>, Map<String, String>> {
 
     @Override
-    public String transport(Map<String, String> request, Map<String, String> response) {
+    public String getTransport(Map<String, String> request, Map<String, String> response) {
       return response.get("transport");
     }
 
     @Override
-    public String peerName(Map<String, String> request) {
+    public String getPeerName(Map<String, String> request) {
       return request.get("peerName");
     }
 
     @Override
-    public Integer peerPort(Map<String, String> request) {
+    public Integer getPeerPort(Map<String, String> request) {
       String peerPort = request.get("peerPort");
       return peerPort == null ? null : Integer.valueOf(peerPort);
     }
 
     @Override
-    public String sockFamily(Map<String, String> request, Map<String, String> response) {
+    public String getSockFamily(Map<String, String> request, Map<String, String> response) {
       return response.get("sockFamily");
     }
 
     @Override
-    public String sockPeerAddr(Map<String, String> request, Map<String, String> response) {
+    public String getSockPeerAddr(Map<String, String> request, Map<String, String> response) {
       return response.get("sockPeerAddr");
     }
 
     @Override
-    public String sockPeerName(Map<String, String> request, Map<String, String> response) {
+    public String getSockPeerName(Map<String, String> request, Map<String, String> response) {
       return response.get("sockPeerName");
     }
 
     @Override
-    public Integer sockPeerPort(Map<String, String> request, Map<String, String> response) {
+    public Integer getSockPeerPort(Map<String, String> request, Map<String, String> response) {
       String sockPeerPort = response.get("sockPeerPort");
       return sockPeerPort == null ? null : Integer.valueOf(sockPeerPort);
     }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorTest.java
@@ -26,49 +26,49 @@ class NetServerAttributesExtractorTest {
       implements NetServerAttributesGetter<Map<String, String>> {
 
     @Override
-    public String transport(Map<String, String> request) {
+    public String getTransport(Map<String, String> request) {
       return request.get("transport");
     }
 
     @Nullable
     @Override
-    public String hostName(Map<String, String> request) {
+    public String getHostName(Map<String, String> request) {
       return request.get("hostName");
     }
 
     @Nullable
     @Override
-    public Integer hostPort(Map<String, String> request) {
+    public Integer getHostPort(Map<String, String> request) {
       String hostPort = request.get("hostPort");
       return hostPort == null ? null : Integer.valueOf(hostPort);
     }
 
     @Nullable
     @Override
-    public String sockFamily(Map<String, String> request) {
+    public String getSockFamily(Map<String, String> request) {
       return request.get("sockFamily");
     }
 
     @Override
-    public String sockPeerAddr(Map<String, String> request) {
+    public String getSockPeerAddr(Map<String, String> request) {
       return request.get("sockPeerAddr");
     }
 
     @Override
-    public Integer sockPeerPort(Map<String, String> request) {
+    public Integer getSockPeerPort(Map<String, String> request) {
       String sockPeerPort = request.get("sockPeerPort");
       return sockPeerPort == null ? null : Integer.valueOf(sockPeerPort);
     }
 
     @Nullable
     @Override
-    public String sockHostAddr(Map<String, String> request) {
+    public String getSockHostAddr(Map<String, String> request) {
       return request.get("sockHostAddr");
     }
 
     @Nullable
     @Override
-    public Integer sockHostPort(Map<String, String> request) {
+    public Integer getSockHostPort(Map<String, String> request) {
       String sockHostPort = request.get("sockHostPort");
       return sockHostPort == null ? null : Integer.valueOf(sockHostPort);
     }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractorTest.java
@@ -54,7 +54,7 @@ class PeerServiceAttributesExtractorTest {
     PeerServiceAttributesExtractor<String, String> underTest =
         new PeerServiceAttributesExtractor<>(netAttributesExtractor, peerServiceMapping);
 
-    when(netAttributesExtractor.peerName(any())).thenReturn("example2.com");
+    when(netAttributesExtractor.getPeerName(any())).thenReturn("example2.com");
 
     Context context = Context.root();
 
@@ -79,7 +79,7 @@ class PeerServiceAttributesExtractorTest {
     PeerServiceAttributesExtractor<String, String> underTest =
         new PeerServiceAttributesExtractor<>(netAttributesExtractor, peerServiceMapping);
 
-    when(netAttributesExtractor.peerName(any())).thenReturn("example.com");
+    when(netAttributesExtractor.getPeerName(any())).thenReturn("example.com");
 
     Context context = Context.root();
 

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcAttributesExtractorTest.java
@@ -23,17 +23,17 @@ class RpcAttributesExtractorTest {
     INSTANCE;
 
     @Override
-    public String system(Map<String, String> request) {
+    public String getSystem(Map<String, String> request) {
       return "test";
     }
 
     @Override
-    public String service(Map<String, String> request) {
+    public String getService(Map<String, String> request) {
       return request.get("service");
     }
 
     @Override
-    public String method(Map<String, String> request) {
+    public String getMethod(Map<String, String> request) {
       return request.get("method");
     }
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcSpanNameExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcSpanNameExtractorTest.java
@@ -23,8 +23,8 @@ class RpcSpanNameExtractorTest {
   void normal() {
     RpcRequest request = new RpcRequest();
 
-    when(getter.service(request)).thenReturn("my.Service");
-    when(getter.method(request)).thenReturn("Method");
+    when(getter.getService(request)).thenReturn("my.Service");
+    when(getter.getMethod(request)).thenReturn("Method");
 
     SpanNameExtractor<RpcRequest> extractor = RpcSpanNameExtractor.create(getter);
     assertThat(extractor.extract(request)).isEqualTo("my.Service/Method");
@@ -34,7 +34,7 @@ class RpcSpanNameExtractorTest {
   void serviceNull() {
     RpcRequest request = new RpcRequest();
 
-    when(getter.method(request)).thenReturn("Method");
+    when(getter.getMethod(request)).thenReturn("Method");
 
     SpanNameExtractor<RpcRequest> extractor = RpcSpanNameExtractor.create(getter);
     assertThat(extractor.extract(request)).isEqualTo("RPC request");
@@ -44,7 +44,7 @@ class RpcSpanNameExtractorTest {
   void methodNull() {
     RpcRequest request = new RpcRequest();
 
-    when(getter.service(request)).thenReturn("my.Service");
+    when(getter.getService(request)).thenReturn("my.Service");
 
     SpanNameExtractor<RpcRequest> extractor = RpcSpanNameExtractor.create(getter);
     assertThat(extractor.extract(request)).isEqualTo("RPC request");

--- a/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
+++ b/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
@@ -61,17 +61,17 @@ public class InstrumenterBenchmark {
     INSTANCE;
 
     @Override
-    public String method(Void unused) {
+    public String getMethod(Void unused) {
       return "GET";
     }
 
     @Override
-    public String url(Void unused) {
+    public String getUrl(Void unused) {
       return "https://opentelemetry.io/benchmark";
     }
 
     @Override
-    public List<String> requestHeader(Void unused, String name) {
+    public List<String> getRequestHeader(Void unused, String name) {
       if (name.equalsIgnoreCase("user-agent")) {
         return Collections.singletonList("OpenTelemetryBot");
       }
@@ -79,17 +79,17 @@ public class InstrumenterBenchmark {
     }
 
     @Override
-    public String flavor(Void unused, @Nullable Void unused2) {
+    public String getFlavor(Void unused, @Nullable Void unused2) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
 
     @Override
-    public Integer statusCode(Void unused, Void unused2, @Nullable Throwable error) {
+    public Integer getStatusCode(Void unused, Void unused2, @Nullable Throwable error) {
       return 200;
     }
 
     @Override
-    public List<String> responseHeader(Void unused, Void unused2, String name) {
+    public List<String> getResponseHeader(Void unused, Void unused2, String name) {
       return Collections.emptyList();
     }
   }
@@ -102,19 +102,19 @@ public class InstrumenterBenchmark {
 
     @Nullable
     @Override
-    public String transport(Void request, @Nullable Void response) {
+    public String getTransport(Void request, @Nullable Void response) {
       return SemanticAttributes.NetTransportValues.IP_TCP;
     }
 
     @Nullable
     @Override
-    public String peerName(Void request) {
+    public String getPeerName(Void request) {
       return null;
     }
 
     @Nullable
     @Override
-    public Integer peerPort(Void request) {
+    public Integer getPeerPort(Void request) {
       return null;
     }
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientAttributesGetter.java
@@ -16,33 +16,33 @@ class AkkaHttpClientAttributesGetter
     implements HttpClientAttributesGetter<HttpRequest, HttpResponse> {
 
   @Override
-  public String url(HttpRequest httpRequest) {
+  public String getUrl(HttpRequest httpRequest) {
     return httpRequest.uri().toString();
   }
 
   @Override
-  public String flavor(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
+  public String getFlavor(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
     return AkkaHttpUtil.flavor(httpRequest);
   }
 
   @Override
-  public String method(HttpRequest httpRequest) {
+  public String getMethod(HttpRequest httpRequest) {
     return httpRequest.method().value();
   }
 
   @Override
-  public List<String> requestHeader(HttpRequest httpRequest, String name) {
+  public List<String> getRequestHeader(HttpRequest httpRequest, String name) {
     return AkkaHttpUtil.requestHeader(httpRequest, name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpRequest httpRequest, HttpResponse httpResponse, @Nullable Throwable error) {
     return httpResponse.status().intValue();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpRequest httpRequest, HttpResponse httpResponse, String name) {
     return AkkaHttpUtil.responseHeader(httpResponse, name);
   }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpNetAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpNetAttributesGetter.java
@@ -14,17 +14,17 @@ import javax.annotation.Nullable;
 class AkkaHttpNetAttributesGetter implements NetClientAttributesGetter<HttpRequest, HttpResponse> {
 
   @Override
-  public String transport(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
+  public String getTransport(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
-  public String peerName(HttpRequest httpRequest) {
+  public String getPeerName(HttpRequest httpRequest) {
     return httpRequest.uri().authority().host().address();
   }
 
   @Override
-  public Integer peerPort(HttpRequest httpRequest) {
+  public Integer getPeerPort(HttpRequest httpRequest) {
     return httpRequest.uri().authority().port();
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
@@ -17,33 +17,34 @@ class AkkaHttpServerAttributesGetter
     implements HttpServerAttributesGetter<HttpRequest, HttpResponse> {
 
   @Override
-  public String method(HttpRequest request) {
+  public String getMethod(HttpRequest request) {
     return request.method().value();
   }
 
   @Override
-  public List<String> requestHeader(HttpRequest request, String name) {
+  public List<String> getRequestHeader(HttpRequest request, String name) {
     return AkkaHttpUtil.requestHeader(request, name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpRequest request, HttpResponse httpResponse, @Nullable Throwable error) {
     return httpResponse.status().intValue();
   }
 
   @Override
-  public List<String> responseHeader(HttpRequest request, HttpResponse httpResponse, String name) {
+  public List<String> getResponseHeader(
+      HttpRequest request, HttpResponse httpResponse, String name) {
     return AkkaHttpUtil.responseHeader(httpResponse, name);
   }
 
   @Override
-  public String flavor(HttpRequest request) {
+  public String getFlavor(HttpRequest request) {
     return AkkaHttpUtil.flavor(request);
   }
 
   @Override
-  public String target(HttpRequest request) {
+  public String getTarget(HttpRequest request) {
     String target = request.uri().path().toString();
     Option<String> queryString = request.uri().rawQueryString();
     if (queryString.isDefined()) {
@@ -54,12 +55,12 @@ class AkkaHttpServerAttributesGetter
 
   @Override
   @Nullable
-  public String route(HttpRequest request) {
+  public String getRoute(HttpRequest request) {
     return null;
   }
 
   @Override
-  public String scheme(HttpRequest request) {
+  public String getScheme(HttpRequest request) {
     return request.uri().scheme();
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaNetServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaNetServerAttributesGetter.java
@@ -14,19 +14,19 @@ class AkkaNetServerAttributesGetter implements NetServerAttributesGetter<HttpReq
 
   @Nullable
   @Override
-  public String transport(HttpRequest httpRequest) {
+  public String getTransport(HttpRequest httpRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public String hostName(HttpRequest httpRequest) {
+  public String getHostName(HttpRequest httpRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer hostPort(HttpRequest httpRequest) {
+  public Integer getHostPort(HttpRequest httpRequest) {
     return null;
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboRpcAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboRpcAttributesGetter.java
@@ -11,17 +11,17 @@ enum DubboRpcAttributesGetter implements RpcAttributesGetter<DubboRequest> {
   INSTANCE;
 
   @Override
-  public String system(DubboRequest request) {
+  public String getSystem(DubboRequest request) {
     return "apache_dubbo";
   }
 
   @Override
-  public String service(DubboRequest request) {
+  public String getService(DubboRequest request) {
     return request.invocation().getInvoker().getInterface().getName();
   }
 
   @Override
-  public String method(DubboRequest request) {
+  public String getMethod(DubboRequest request) {
     return request.invocation().getMethodName();
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetClientAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetClientAttributesGetter.java
@@ -20,18 +20,18 @@ public final class DubboNetClientAttributesGetter
 
   @Override
   @Nullable
-  public String transport(DubboRequest request, @Nullable Result response) {
+  public String getTransport(DubboRequest request, @Nullable Result response) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(DubboRequest request) {
+  public String getPeerName(DubboRequest request) {
     return request.url().getHost();
   }
 
   @Override
-  public Integer peerPort(DubboRequest request) {
+  public Integer getPeerPort(DubboRequest request) {
     return request.url().getPort();
   }
 

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetServerAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetServerAttributesGetter.java
@@ -19,19 +19,19 @@ public final class DubboNetServerAttributesGetter
 
   @Override
   @Nullable
-  public String transport(DubboRequest request) {
+  public String getTransport(DubboRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String hostName(DubboRequest request) {
+  public String getHostName(DubboRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer hostPort(DubboRequest request) {
+  public Integer getHostPort(DubboRequest request) {
     return null;
   }
 

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesGetter.java
@@ -17,23 +17,23 @@ final class ApacheHttpAsyncClientHttpAttributesGetter
     implements HttpClientAttributesGetter<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
-  public String method(ApacheHttpClientRequest request) {
+  public String getMethod(ApacheHttpClientRequest request) {
     return request.getMethod();
   }
 
   @Override
-  public String url(ApacheHttpClientRequest request) {
+  public String getUrl(ApacheHttpClientRequest request) {
     return request.getUrl();
   }
 
   @Override
-  public List<String> requestHeader(ApacheHttpClientRequest request, String name) {
+  public List<String> getRequestHeader(ApacheHttpClientRequest request, String name) {
     return request.getHeader(name);
   }
 
   @Override
   @Nullable
-  public Integer statusCode(
+  public Integer getStatusCode(
       ApacheHttpClientRequest request, HttpResponse response, @Nullable Throwable error) {
     StatusLine statusLine = response.getStatusLine();
     return statusLine != null ? statusLine.getStatusCode() : null;
@@ -41,12 +41,12 @@ final class ApacheHttpAsyncClientHttpAttributesGetter
 
   @Override
   @Nullable
-  public String flavor(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String getFlavor(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getFlavor();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       ApacheHttpClientRequest request, HttpResponse response, String name) {
     return headersToList(response.getHeaders(name));
   }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesGetter.java
@@ -15,18 +15,18 @@ final class ApacheHttpAsyncClientNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
-  public String transport(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String getTransport(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(ApacheHttpClientRequest request) {
+  public String getPeerName(ApacheHttpClientRequest request) {
     return request.getPeerName();
   }
 
   @Override
-  public Integer peerPort(ApacheHttpClientRequest request) {
+  public Integer getPeerPort(ApacheHttpClientRequest request) {
     return request.getPeerPort();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
@@ -22,47 +22,13 @@ final class ApacheHttpClientHttpAttributesGetter
     implements HttpClientAttributesGetter<HttpMethod, HttpMethod> {
 
   @Override
-  public String method(HttpMethod request) {
+  public String getMethod(HttpMethod request) {
     return request.getName();
   }
 
-  @Override
-  public String url(HttpMethod request) {
-    return getUrl(request);
-  }
-
-  @Override
-  public List<String> requestHeader(HttpMethod request, String name) {
-    Header header = request.getRequestHeader(name);
-    return header == null ? emptyList() : singletonList(header.getValue());
-  }
-
-  @Override
-  @Nullable
-  public Integer statusCode(HttpMethod request, HttpMethod response, @Nullable Throwable error) {
-    StatusLine statusLine = response.getStatusLine();
-    return statusLine == null ? null : statusLine.getStatusCode();
-  }
-
-  @Override
-  @Nullable
-  public String flavor(HttpMethod request, @Nullable HttpMethod response) {
-    if (request instanceof HttpMethodBase) {
-      return ((HttpMethodBase) request).isHttp11()
-          ? SemanticAttributes.HttpFlavorValues.HTTP_1_1
-          : SemanticAttributes.HttpFlavorValues.HTTP_1_0;
-    }
-    return null;
-  }
-
-  @Override
-  public List<String> responseHeader(HttpMethod request, HttpMethod response, String name) {
-    Header header = response.getResponseHeader(name);
-    return header == null ? emptyList() : singletonList(header.getValue());
-  }
-
   // mirroring implementation HttpMethodBase.getURI(), to avoid converting to URI and back to String
-  private static String getUrl(HttpMethod request) {
+  @Override
+  public String getUrl(HttpMethod request) {
     HostConfiguration hostConfiguration = request.getHostConfiguration();
     if (hostConfiguration == null || hostConfiguration.getProtocol() == null) {
       String queryString = request.getQueryString();
@@ -89,5 +55,35 @@ final class ApacheHttpClientHttpAttributesGetter
       }
       return url.toString();
     }
+  }
+
+  @Override
+  public List<String> getRequestHeader(HttpMethod request, String name) {
+    Header header = request.getRequestHeader(name);
+    return header == null ? emptyList() : singletonList(header.getValue());
+  }
+
+  @Override
+  @Nullable
+  public Integer getStatusCode(HttpMethod request, HttpMethod response, @Nullable Throwable error) {
+    StatusLine statusLine = response.getStatusLine();
+    return statusLine == null ? null : statusLine.getStatusCode();
+  }
+
+  @Override
+  @Nullable
+  public String getFlavor(HttpMethod request, @Nullable HttpMethod response) {
+    if (request instanceof HttpMethodBase) {
+      return ((HttpMethodBase) request).isHttp11()
+          ? SemanticAttributes.HttpFlavorValues.HTTP_1_1
+          : SemanticAttributes.HttpFlavorValues.HTTP_1_0;
+    }
+    return null;
+  }
+
+  @Override
+  public List<String> getResponseHeader(HttpMethod request, HttpMethod response, String name) {
+    Header header = response.getResponseHeader(name);
+    return header == null ? emptyList() : singletonList(header.getValue());
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesGetter.java
@@ -15,20 +15,20 @@ final class ApacheHttpClientNetAttributesGetter
     implements NetClientAttributesGetter<HttpMethod, HttpMethod> {
 
   @Override
-  public String transport(HttpMethod request, @Nullable HttpMethod response) {
+  public String getTransport(HttpMethod request, @Nullable HttpMethod response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(HttpMethod request) {
+  public String getPeerName(HttpMethod request) {
     HostConfiguration hostConfiguration = request.getHostConfiguration();
     return hostConfiguration != null ? hostConfiguration.getHost() : null;
   }
 
   @Override
   @Nullable
-  public Integer peerPort(HttpMethod request) {
+  public Integer getPeerPort(HttpMethod request) {
     HostConfiguration hostConfiguration = request.getHostConfiguration();
     return hostConfiguration != null ? hostConfiguration.getPort() : null;
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesGetter.java
@@ -16,34 +16,34 @@ final class ApacheHttpClientHttpAttributesGetter
     implements HttpClientAttributesGetter<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
-  public String method(ApacheHttpClientRequest request) {
+  public String getMethod(ApacheHttpClientRequest request) {
     return request.getMethod();
   }
 
   @Override
-  public String url(ApacheHttpClientRequest request) {
+  public String getUrl(ApacheHttpClientRequest request) {
     return request.getUrl();
   }
 
   @Override
-  public List<String> requestHeader(ApacheHttpClientRequest request, String name) {
+  public List<String> getRequestHeader(ApacheHttpClientRequest request, String name) {
     return request.getHeader(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       ApacheHttpClientRequest request, HttpResponse response, @Nullable Throwable error) {
     return response.getStatusLine().getStatusCode();
   }
 
   @Override
   @Nullable
-  public String flavor(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String getFlavor(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getFlavor();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       ApacheHttpClientRequest request, HttpResponse response, String name) {
     return headersToList(response.getHeaders(name));
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientNetAttributesGetter.java
@@ -14,18 +14,18 @@ final class ApacheHttpClientNetAttributesGetter
     implements NetClientAttributesGetter<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
-  public String transport(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String getTransport(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(ApacheHttpClientRequest request) {
+  public String getPeerName(ApacheHttpClientRequest request) {
     return request.getPeerName();
   }
 
   @Override
-  public Integer peerPort(ApacheHttpClientRequest request) {
+  public Integer getPeerPort(ApacheHttpClientRequest request) {
     return request.getPeerPort();
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesGetter.java
@@ -17,35 +17,35 @@ enum ApacheHttpClientHttpAttributesGetter
   INSTANCE;
 
   @Override
-  public String method(ApacheHttpClientRequest request) {
+  public String getMethod(ApacheHttpClientRequest request) {
     return request.getMethod();
   }
 
   @Override
   @Nullable
-  public String url(ApacheHttpClientRequest request) {
+  public String getUrl(ApacheHttpClientRequest request) {
     return request.getUrl();
   }
 
   @Override
-  public List<String> requestHeader(ApacheHttpClientRequest request, String name) {
+  public List<String> getRequestHeader(ApacheHttpClientRequest request, String name) {
     return request.getHeader(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       ApacheHttpClientRequest request, HttpResponse response, @Nullable Throwable error) {
     return response.getStatusLine().getStatusCode();
   }
 
   @Override
   @Nullable
-  public String flavor(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String getFlavor(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getFlavor();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       ApacheHttpClientRequest request, HttpResponse response, String name) {
     return headersToList(response.getHeaders(name));
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesGetter.java
@@ -15,19 +15,19 @@ final class ApacheHttpClientNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
-  public String transport(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String getTransport(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(ApacheHttpClientRequest request) {
+  public String getPeerName(ApacheHttpClientRequest request) {
     return request.getPeerName();
   }
 
   @Override
   @Nullable
-  public Integer peerPort(ApacheHttpClientRequest request) {
+  public Integer getPeerPort(ApacheHttpClientRequest request) {
     return request.getPeerPort();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
@@ -26,12 +26,12 @@ final class ApacheHttpClientHttpAttributesGetter
       Logger.getLogger(ApacheHttpClientHttpAttributesGetter.class.getName());
 
   @Override
-  public String method(HttpRequest request) {
+  public String getMethod(HttpRequest request) {
     return request.getMethod();
   }
 
   @Override
-  public String url(HttpRequest request) {
+  public String getUrl(HttpRequest request) {
     // similar to org.apache.hc.core5.http.message.BasicHttpRequest.getUri()
     // not calling getUri() to avoid unnecessary conversion
     StringBuilder url = new StringBuilder();
@@ -64,18 +64,19 @@ final class ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  public List<String> requestHeader(HttpRequest request, String name) {
+  public List<String> getRequestHeader(HttpRequest request, String name) {
     return getHeader(request, name);
   }
 
   @Override
-  public Integer statusCode(HttpRequest request, HttpResponse response, @Nullable Throwable error) {
+  public Integer getStatusCode(
+      HttpRequest request, HttpResponse response, @Nullable Throwable error) {
     return response.getCode();
   }
 
   @Override
   @Nullable
-  public String flavor(HttpRequest request, @Nullable HttpResponse response) {
+  public String getFlavor(HttpRequest request, @Nullable HttpResponse response) {
     ProtocolVersion protocolVersion = getVersion(request, response);
     if (protocolVersion == null) {
       return null;
@@ -100,7 +101,7 @@ final class ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  public List<String> responseHeader(HttpRequest request, HttpResponse response, String name) {
+  public List<String> getResponseHeader(HttpRequest request, HttpResponse response, String name) {
     return getHeader(response, name);
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
@@ -15,18 +15,18 @@ final class ApacheHttpClientNetAttributesGetter
     implements NetClientAttributesGetter<HttpRequest, HttpResponse> {
 
   @Override
-  public String transport(HttpRequest request, @Nullable HttpResponse response) {
+  public String getTransport(HttpRequest request, @Nullable HttpResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(HttpRequest request) {
+  public String getPeerName(HttpRequest request) {
     return request.getAuthority().getHostName();
   }
 
   @Override
-  public Integer peerPort(HttpRequest request) {
+  public Integer getPeerPort(HttpRequest request) {
     return request.getAuthority().getPort();
   }
 }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
@@ -20,23 +20,24 @@ enum ArmeriaHttpClientAttributesGetter
   INSTANCE;
 
   @Override
-  public String method(RequestContext ctx) {
+  public String getMethod(RequestContext ctx) {
     return ctx.method().name();
   }
 
   @Override
-  public String url(RequestContext ctx) {
+  public String getUrl(RequestContext ctx) {
     return request(ctx).uri().toString();
   }
 
   @Override
-  public List<String> requestHeader(RequestContext ctx, String name) {
+  public List<String> getRequestHeader(RequestContext ctx, String name) {
     return request(ctx).headers().getAll(name);
   }
 
   @Override
   @Nullable
-  public Integer statusCode(RequestContext ctx, RequestLog requestLog, @Nullable Throwable error) {
+  public Integer getStatusCode(
+      RequestContext ctx, RequestLog requestLog, @Nullable Throwable error) {
     HttpStatus status = requestLog.responseHeaders().status();
     if (!status.equals(HttpStatus.UNKNOWN)) {
       return status.code();
@@ -45,7 +46,7 @@ enum ArmeriaHttpClientAttributesGetter
   }
 
   @Override
-  public String flavor(RequestContext ctx, @Nullable RequestLog requestLog) {
+  public String getFlavor(RequestContext ctx, @Nullable RequestLog requestLog) {
     SessionProtocol protocol = ctx.sessionProtocol();
     if (protocol.isMultiplex()) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
@@ -55,7 +56,7 @@ enum ArmeriaHttpClientAttributesGetter
   }
 
   @Override
-  public List<String> responseHeader(RequestContext ctx, RequestLog requestLog, String name) {
+  public List<String> getResponseHeader(RequestContext ctx, RequestLog requestLog, String name) {
     return requestLog.responseHeaders().getAll(name);
   }
 

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
@@ -21,29 +21,30 @@ enum ArmeriaHttpServerAttributesGetter
   INSTANCE;
 
   @Override
-  public String method(RequestContext ctx) {
+  public String getMethod(RequestContext ctx) {
     return ctx.method().name();
   }
 
   @Override
-  public String target(RequestContext ctx) {
+  public String getTarget(RequestContext ctx) {
     return request(ctx).path();
   }
 
   @Override
   @Nullable
-  public String scheme(RequestContext ctx) {
+  public String getScheme(RequestContext ctx) {
     return request(ctx).scheme();
   }
 
   @Override
-  public List<String> requestHeader(RequestContext ctx, String name) {
+  public List<String> getRequestHeader(RequestContext ctx, String name) {
     return request(ctx).headers().getAll(name);
   }
 
   @Override
   @Nullable
-  public Integer statusCode(RequestContext ctx, RequestLog requestLog, @Nullable Throwable error) {
+  public Integer getStatusCode(
+      RequestContext ctx, RequestLog requestLog, @Nullable Throwable error) {
     HttpStatus status = requestLog.responseHeaders().status();
     if (!status.equals(HttpStatus.UNKNOWN)) {
       return status.code();
@@ -52,7 +53,7 @@ enum ArmeriaHttpServerAttributesGetter
   }
 
   @Override
-  public String flavor(RequestContext ctx) {
+  public String getFlavor(RequestContext ctx) {
     SessionProtocol protocol = ctx.sessionProtocol();
     if (protocol.isMultiplex()) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
@@ -62,13 +63,13 @@ enum ArmeriaHttpServerAttributesGetter
   }
 
   @Override
-  public List<String> responseHeader(RequestContext ctx, RequestLog requestLog, String name) {
+  public List<String> getResponseHeader(RequestContext ctx, RequestLog requestLog, String name) {
     return requestLog.responseHeaders().getAll(name);
   }
 
   @Override
   @Nullable
-  public String route(RequestContext ctx) {
+  public String getRoute(RequestContext ctx) {
     if (ctx instanceof ServiceRequestContext) {
       return ((ServiceRequestContext) ctx).config().route().patternString();
     }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
@@ -16,19 +16,19 @@ final class ArmeriaNetServerAttributesGetter
     extends InetSocketAddressNetServerAttributesGetter<RequestContext> {
 
   @Override
-  public String transport(RequestContext ctx) {
+  public String getTransport(RequestContext ctx) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(RequestContext ctx) {
+  public String getHostName(RequestContext ctx) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer hostPort(RequestContext ctx) {
+  public Integer getHostPort(RequestContext ctx) {
     return null;
   }
 

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetClientAttributesGetter.java
@@ -22,18 +22,18 @@ public final class ArmeriaNetClientAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<RequestContext, RequestLog> {
 
   @Override
-  public String transport(RequestContext ctx, @Nullable RequestLog requestLog) {
+  public String getTransport(RequestContext ctx, @Nullable RequestLog requestLog) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(RequestContext ctx) {
+  public String getPeerName(RequestContext ctx) {
     return request(ctx).uri().getHost();
   }
 
   @Override
-  public Integer peerPort(RequestContext ctx) {
+  public Integer getPeerPort(RequestContext ctx) {
     return request(ctx).uri().getPort();
   }
 

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesGetter.java
@@ -17,32 +17,32 @@ final class AsyncHttpClientHttpAttributesGetter
     implements HttpClientAttributesGetter<Request, Response> {
 
   @Override
-  public String method(Request request) {
+  public String getMethod(Request request) {
     return request.getMethod();
   }
 
   @Override
-  public String url(Request request) {
+  public String getUrl(Request request) {
     return request.getUri().toUrl();
   }
 
   @Override
-  public List<String> requestHeader(Request request, String name) {
+  public List<String> getRequestHeader(Request request, String name) {
     return request.getHeaders().getOrDefault(name, Collections.emptyList());
   }
 
   @Override
-  public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
+  public Integer getStatusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatusCode();
   }
 
   @Override
-  public String flavor(Request request, @Nullable Response response) {
+  public String getFlavor(Request request, @Nullable Response response) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Override
-  public List<String> responseHeader(Request request, Response response, String name) {
+  public List<String> getResponseHeader(Request request, Response response, String name) {
     return response.getHeaders().getOrDefault(name, Collections.emptyList());
   }
 }

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientNetAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientNetAttributesGetter.java
@@ -15,17 +15,17 @@ final class AsyncHttpClientNetAttributesGetter
     implements NetClientAttributesGetter<Request, Response> {
 
   @Override
-  public String transport(Request request, @Nullable Response response) {
+  public String getTransport(Request request, @Nullable Response response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
-  public String peerName(Request request) {
+  public String getPeerName(Request request) {
     return request.getUri().getHost();
   }
 
   @Override
-  public Integer peerPort(Request request) {
+  public Integer getPeerPort(Request request) {
     return request.getUri().getPort();
   }
 }

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesGetter.java
@@ -15,33 +15,33 @@ final class AsyncHttpClientHttpAttributesGetter
     implements HttpClientAttributesGetter<RequestContext, Response> {
 
   @Override
-  public String method(RequestContext requestContext) {
+  public String getMethod(RequestContext requestContext) {
     return requestContext.getRequest().getMethod();
   }
 
   @Override
-  public String url(RequestContext requestContext) {
+  public String getUrl(RequestContext requestContext) {
     return requestContext.getRequest().getUri().toUrl();
   }
 
   @Override
-  public List<String> requestHeader(RequestContext requestContext, String name) {
+  public List<String> getRequestHeader(RequestContext requestContext, String name) {
     return requestContext.getRequest().getHeaders().getAll(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       RequestContext requestContext, Response response, @Nullable Throwable error) {
     return response.getStatusCode();
   }
 
   @Override
-  public String flavor(RequestContext requestContext, @Nullable Response response) {
+  public String getFlavor(RequestContext requestContext, @Nullable Response response) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       RequestContext requestContext, Response response, String name) {
     return response.getHeaders().getAll(name);
   }

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesGetter.java
@@ -15,18 +15,18 @@ final class AsyncHttpClientNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<RequestContext, Response> {
 
   @Override
-  public String transport(RequestContext request, @Nullable Response response) {
+  public String getTransport(RequestContext request, @Nullable Response response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(RequestContext requestContext) {
+  public String getPeerName(RequestContext requestContext) {
     return requestContext.getRequest().getUri().getHost();
   }
 
   @Override
-  public Integer peerPort(RequestContext requestContext) {
+  public Integer getPeerPort(RequestContext requestContext) {
     return requestContext.getRequest().getUri().getPort();
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkHttpAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkHttpAttributesGetter.java
@@ -18,34 +18,35 @@ import javax.annotation.Nullable;
 class AwsSdkHttpAttributesGetter implements HttpClientAttributesGetter<Request<?>, Response<?>> {
 
   @Override
-  public String url(Request<?> request) {
+  public String getUrl(Request<?> request) {
     return request.getEndpoint().toString();
   }
 
   @Override
   @Nullable
-  public String flavor(Request<?> request, @Nullable Response<?> response) {
+  public String getFlavor(Request<?> request, @Nullable Response<?> response) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Override
-  public String method(Request<?> request) {
+  public String getMethod(Request<?> request) {
     return request.getHttpMethod().name();
   }
 
   @Override
-  public List<String> requestHeader(Request<?> request, String name) {
+  public List<String> getRequestHeader(Request<?> request, String name) {
     String value = request.getHeaders().get(name.equals("user-agent") ? "User-Agent" : name);
     return value == null ? emptyList() : singletonList(value);
   }
 
   @Override
-  public Integer statusCode(Request<?> request, Response<?> response, @Nullable Throwable error) {
+  public Integer getStatusCode(
+      Request<?> request, Response<?> response, @Nullable Throwable error) {
     return response.getHttpResponse().getStatusCode();
   }
 
   @Override
-  public List<String> responseHeader(Request<?> request, Response<?> response, String name) {
+  public List<String> getResponseHeader(Request<?> request, Response<?> response, String name) {
     String value = response.getHttpResponse().getHeaders().get(name);
     return value == null ? emptyList() : singletonList(value);
   }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkNetAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkNetAttributesGetter.java
@@ -14,18 +14,18 @@ import javax.annotation.Nullable;
 class AwsSdkNetAttributesGetter implements NetClientAttributesGetter<Request<?>, Response<?>> {
 
   @Override
-  public String transport(Request<?> request, @Nullable Response<?> response) {
+  public String getTransport(Request<?> request, @Nullable Response<?> response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(Request<?> request) {
+  public String getPeerName(Request<?> request) {
     return request.getEndpoint().getHost();
   }
 
   @Override
-  public Integer peerPort(Request<?> request) {
+  public Integer getPeerPort(Request<?> request) {
     return request.getEndpoint().getPort();
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkRpcAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkRpcAttributesGetter.java
@@ -28,17 +28,17 @@ enum AwsSdkRpcAttributesGetter implements RpcAttributesGetter<Request<?>> {
       };
 
   @Override
-  public String system(Request<?> request) {
+  public String getSystem(Request<?> request) {
     return "aws-api";
   }
 
   @Override
-  public String service(Request<?> request) {
+  public String getService(Request<?> request) {
     return request.getServiceName();
   }
 
   @Override
-  public String method(Request<?> request) {
+  public String getMethod(Request<?> request) {
     return OPERATION_NAME.get(request.getOriginalRequest().getClass());
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkSpanNameExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkSpanNameExtractor.java
@@ -17,8 +17,8 @@ class AwsSdkSpanNameExtractor implements SpanNameExtractor<Request<?>> {
   @Override
   public String extract(Request<?> request) {
     return qualifiedOperation(
-        rpcAttributes.service(request),
-        rpcAttributes.method(request),
+        rpcAttributes.getService(request),
+        rpcAttributes.getMethod(request),
         request.getOriginalRequest().getClass());
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpAttributesGetter.java
@@ -19,7 +19,7 @@ class AwsSdkHttpAttributesGetter
     implements HttpClientAttributesGetter<ExecutionAttributes, SdkHttpResponse> {
 
   @Override
-  public String url(ExecutionAttributes request) {
+  public String getUrl(ExecutionAttributes request) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     return httpRequest.getUri().toString();
@@ -27,19 +27,19 @@ class AwsSdkHttpAttributesGetter
 
   @Override
   @Nullable
-  public String flavor(ExecutionAttributes request, @Nullable SdkHttpResponse response) {
+  public String getFlavor(ExecutionAttributes request, @Nullable SdkHttpResponse response) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Override
-  public String method(ExecutionAttributes request) {
+  public String getMethod(ExecutionAttributes request) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     return httpRequest.method().name();
   }
 
   @Override
-  public List<String> requestHeader(ExecutionAttributes request, String name) {
+  public List<String> getRequestHeader(ExecutionAttributes request, String name) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     List<String> value = httpRequest.headers().get(name);
@@ -47,13 +47,13 @@ class AwsSdkHttpAttributesGetter
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       ExecutionAttributes request, SdkHttpResponse response, @Nullable Throwable error) {
     return response.statusCode();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       ExecutionAttributes request, SdkHttpResponse response, String name) {
     List<String> value = response.headers().get(name);
     return value == null ? emptyList() : value;

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkNetAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkNetAttributesGetter.java
@@ -16,20 +16,20 @@ class AwsSdkNetAttributesGetter
     implements NetClientAttributesGetter<ExecutionAttributes, SdkHttpResponse> {
 
   @Override
-  public String transport(ExecutionAttributes request, @Nullable SdkHttpResponse response) {
+  public String getTransport(ExecutionAttributes request, @Nullable SdkHttpResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(ExecutionAttributes request) {
+  public String getPeerName(ExecutionAttributes request) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     return httpRequest.host();
   }
 
   @Override
-  public Integer peerPort(ExecutionAttributes request) {
+  public Integer getPeerPort(ExecutionAttributes request) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     return httpRequest.port();

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRpcAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkRpcAttributesGetter.java
@@ -13,17 +13,17 @@ enum AwsSdkRpcAttributesGetter implements RpcAttributesGetter<ExecutionAttribute
   INSTANCE;
 
   @Override
-  public String system(ExecutionAttributes request) {
+  public String getSystem(ExecutionAttributes request) {
     return "aws-api";
   }
 
   @Override
-  public String service(ExecutionAttributes request) {
+  public String getService(ExecutionAttributes request) {
     return request.getAttribute(SdkExecutionAttribute.SERVICE_NAME);
   }
 
   @Override
-  public String method(ExecutionAttributes request) {
+  public String getMethod(ExecutionAttributes request) {
     return request.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
@@ -200,7 +200,7 @@ final class TracingExecutionInterceptor implements ExecutionInterceptor {
   // Certain headers in the request like User-Agent are only available after execution.
   private static void onUserAgentHeaderAvailable(Span span, ExecutionAttributes request) {
     List<String> userAgent =
-        AwsSdkInstrumenterFactory.httpAttributesGetter.requestHeader(request, "User-Agent");
+        AwsSdkInstrumenterFactory.httpAttributesGetter.getRequestHeader(request, "User-Agent");
     if (!userAgent.isEmpty()) {
       span.setAttribute(SemanticAttributes.HTTP_USER_AGENT, userAgent.get(0));
     }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetAttributesGetter.java
@@ -15,19 +15,19 @@ final class CassandraNetAttributesGetter
 
   @Override
   @Nullable
-  public String transport(CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
+  public String getTransport(CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(CassandraRequest request) {
+  public String getPeerName(CassandraRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(CassandraRequest request) {
+  public Integer getPeerPort(CassandraRequest request) {
     return null;
   }
 

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSqlAttributesGetter.java
@@ -12,31 +12,31 @@ import javax.annotation.Nullable;
 final class CassandraSqlAttributesGetter implements SqlClientAttributesGetter<CassandraRequest> {
 
   @Override
-  public String system(CassandraRequest request) {
+  public String getSystem(CassandraRequest request) {
     return SemanticAttributes.DbSystemValues.CASSANDRA;
   }
 
   @Override
   @Nullable
-  public String user(CassandraRequest request) {
+  public String getUser(CassandraRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(CassandraRequest request) {
+  public String getName(CassandraRequest request) {
     return request.getSession().getLoggedKeyspace();
   }
 
   @Override
   @Nullable
-  public String connectionString(CassandraRequest request) {
+  public String getConnectionString(CassandraRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String rawStatement(CassandraRequest request) {
+  public String getRawStatement(CassandraRequest request) {
     return request.getStatement();
   }
 }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetAttributesGetter.java
@@ -17,19 +17,19 @@ final class CassandraNetAttributesGetter
 
   @Override
   @Nullable
-  public String transport(CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
+  public String getTransport(CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(CassandraRequest request) {
+  public String getPeerName(CassandraRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(CassandraRequest request) {
+  public Integer getPeerPort(CassandraRequest request) {
     return null;
   }
 

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSqlAttributesGetter.java
@@ -13,31 +13,31 @@ import javax.annotation.Nullable;
 final class CassandraSqlAttributesGetter implements SqlClientAttributesGetter<CassandraRequest> {
 
   @Override
-  public String system(CassandraRequest request) {
+  public String getSystem(CassandraRequest request) {
     return SemanticAttributes.DbSystemValues.CASSANDRA;
   }
 
   @Override
   @Nullable
-  public String user(CassandraRequest request) {
+  public String getUser(CassandraRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(CassandraRequest request) {
+  public String getName(CassandraRequest request) {
     return request.getSession().getKeyspace().map(CqlIdentifier::toString).orElse(null);
   }
 
   @Override
   @Nullable
-  public String connectionString(CassandraRequest request) {
+  public String getConnectionString(CassandraRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String rawStatement(CassandraRequest request) {
+  public String getRawStatement(CassandraRequest request) {
     return request.getStatement();
   }
 }

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetter.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetter.java
@@ -12,37 +12,37 @@ import javax.annotation.Nullable;
 final class CouchbaseAttributesGetter implements DbClientAttributesGetter<CouchbaseRequestInfo> {
 
   @Override
-  public String system(CouchbaseRequestInfo couchbaseRequest) {
+  public String getSystem(CouchbaseRequestInfo couchbaseRequest) {
     return SemanticAttributes.DbSystemValues.COUCHBASE;
   }
 
   @Override
   @Nullable
-  public String user(CouchbaseRequestInfo couchbaseRequest) {
+  public String getUser(CouchbaseRequestInfo couchbaseRequest) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(CouchbaseRequestInfo couchbaseRequest) {
+  public String getName(CouchbaseRequestInfo couchbaseRequest) {
     return couchbaseRequest.bucket();
   }
 
   @Override
   @Nullable
-  public String connectionString(CouchbaseRequestInfo couchbaseRequest) {
+  public String getConnectionString(CouchbaseRequestInfo couchbaseRequest) {
     return null;
   }
 
   @Override
   @Nullable
-  public String statement(CouchbaseRequestInfo couchbaseRequest) {
+  public String getStatement(CouchbaseRequestInfo couchbaseRequest) {
     return couchbaseRequest.statement();
   }
 
   @Override
   @Nullable
-  public String operation(CouchbaseRequestInfo couchbaseRequest) {
+  public String getOperation(CouchbaseRequestInfo couchbaseRequest) {
     return couchbaseRequest.operation();
   }
 }

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseNetAttributesGetter.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseNetAttributesGetter.java
@@ -15,7 +15,7 @@ public class CouchbaseNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<CouchbaseRequestInfo, Void> {
   @Nullable
   @Override
-  public String transport(CouchbaseRequestInfo couchbaseRequest, @Nullable Void unused) {
+  public String getTransport(CouchbaseRequestInfo couchbaseRequest, @Nullable Void unused) {
     return couchbaseRequest.getPeerAddress() != null
         ? SemanticAttributes.NetTransportValues.IP_TCP
         : null;
@@ -23,13 +23,13 @@ public class CouchbaseNetAttributesGetter
 
   @Nullable
   @Override
-  public String peerName(CouchbaseRequestInfo couchbaseRequest) {
+  public String getPeerName(CouchbaseRequestInfo couchbaseRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(CouchbaseRequestInfo couchbaseRequest) {
+  public Integer getPeerPort(CouchbaseRequestInfo couchbaseRequest) {
     return null;
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestAttributesGetter.java
@@ -13,37 +13,37 @@ final class ElasticsearchRestAttributesGetter
     implements DbClientAttributesGetter<ElasticsearchRestRequest> {
 
   @Override
-  public String system(ElasticsearchRestRequest request) {
+  public String getSystem(ElasticsearchRestRequest request) {
     return SemanticAttributes.DbSystemValues.ELASTICSEARCH;
   }
 
   @Override
   @Nullable
-  public String user(ElasticsearchRestRequest request) {
+  public String getUser(ElasticsearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(ElasticsearchRestRequest request) {
+  public String getName(ElasticsearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String connectionString(ElasticsearchRestRequest request) {
+  public String getConnectionString(ElasticsearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String statement(ElasticsearchRestRequest request) {
+  public String getStatement(ElasticsearchRestRequest request) {
     return request.getMethod() + " " + request.getOperation();
   }
 
   @Override
   @Nullable
-  public String operation(ElasticsearchRestRequest request) {
+  public String getOperation(ElasticsearchRestRequest request) {
     return request.getMethod();
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestNetResponseAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestNetResponseAttributesGetter.java
@@ -15,25 +15,25 @@ final class ElasticsearchRestNetResponseAttributesGetter
     implements NetClientAttributesGetter<ElasticsearchRestRequest, Response> {
 
   @Override
-  public String transport(ElasticsearchRestRequest request, Response response) {
+  public String getTransport(ElasticsearchRestRequest request, Response response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(ElasticsearchRestRequest request) {
+  public String getPeerName(ElasticsearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public Integer peerPort(ElasticsearchRestRequest request) {
+  public Integer getPeerPort(ElasticsearchRestRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String sockFamily(
+  public String getSockFamily(
       ElasticsearchRestRequest elasticsearchRestRequest, @Nullable Response response) {
     if (response != null && response.getHost().getAddress() instanceof Inet6Address) {
       return "inet6";
@@ -43,7 +43,7 @@ final class ElasticsearchRestNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String sockPeerAddr(ElasticsearchRestRequest request, @Nullable Response response) {
+  public String getSockPeerAddr(ElasticsearchRestRequest request, @Nullable Response response) {
     if (response != null && response.getHost().getAddress() != null) {
       return response.getHost().getAddress().getHostAddress();
     }

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportNetAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportNetAttributesGetter.java
@@ -15,19 +15,19 @@ public class Elasticsearch6TransportNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<ElasticTransportRequest, ActionResponse> {
   @Override
   @Nullable
-  public String transport(ElasticTransportRequest request, @Nullable ActionResponse response) {
+  public String getTransport(ElasticTransportRequest request, @Nullable ActionResponse response) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(ElasticTransportRequest request) {
+  public String getPeerName(ElasticTransportRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(ElasticTransportRequest request) {
+  public Integer getPeerPort(ElasticTransportRequest request) {
     return null;
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticTransportNetResponseAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticTransportNetResponseAttributesGetter.java
@@ -14,25 +14,26 @@ public class ElasticTransportNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String transport(ElasticTransportRequest request, @Nullable ActionResponse response) {
+  public String getTransport(ElasticTransportRequest request, @Nullable ActionResponse response) {
     return null;
   }
 
   @Override
   @Nullable
-  public String peerName(ElasticTransportRequest request) {
+  public String getPeerName(ElasticTransportRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public Integer peerPort(ElasticTransportRequest request) {
+  public Integer getPeerPort(ElasticTransportRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String sockPeerAddr(ElasticTransportRequest request, @Nullable ActionResponse response) {
+  public String getSockPeerAddr(
+      ElasticTransportRequest request, @Nullable ActionResponse response) {
     if (response != null && response.remoteAddress() != null) {
       return response.remoteAddress().getAddress();
     }
@@ -41,7 +42,8 @@ public class ElasticTransportNetResponseAttributesGetter
 
   @Nullable
   @Override
-  public String sockPeerName(ElasticTransportRequest request, @Nullable ActionResponse response) {
+  public String getSockPeerName(
+      ElasticTransportRequest request, @Nullable ActionResponse response) {
     if (response != null && response.remoteAddress() != null) {
       return response.remoteAddress().getHost();
     }
@@ -50,7 +52,8 @@ public class ElasticTransportNetResponseAttributesGetter
 
   @Nullable
   @Override
-  public Integer sockPeerPort(ElasticTransportRequest request, @Nullable ActionResponse response) {
+  public Integer getSockPeerPort(
+      ElasticTransportRequest request, @Nullable ActionResponse response) {
     if (response != null && response.remoteAddress() != null) {
       return response.remoteAddress().getPort();
     }

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticsearchTransportAttributesGetter.java
@@ -13,36 +13,36 @@ final class ElasticsearchTransportAttributesGetter
     implements DbClientAttributesGetter<ElasticTransportRequest> {
 
   @Override
-  public String system(ElasticTransportRequest s) {
+  public String getSystem(ElasticTransportRequest s) {
     return SemanticAttributes.DbSystemValues.ELASTICSEARCH;
   }
 
   @Override
   @Nullable
-  public String user(ElasticTransportRequest s) {
+  public String getUser(ElasticTransportRequest s) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(ElasticTransportRequest s) {
+  public String getName(ElasticTransportRequest s) {
     return null;
   }
 
   @Override
   @Nullable
-  public String connectionString(ElasticTransportRequest s) {
+  public String getConnectionString(ElasticTransportRequest s) {
     return null;
   }
 
   @Override
   @Nullable
-  public String statement(ElasticTransportRequest s) {
+  public String getStatement(ElasticTransportRequest s) {
     return null;
   }
 
   @Override
-  public String operation(ElasticTransportRequest action) {
+  public String getOperation(ElasticTransportRequest action) {
     return action.getAction().getClass().getSimpleName();
   }
 }

--- a/instrumentation/finatra-2.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/finatra/FinatraCodeAttributesGetter.java
+++ b/instrumentation/finatra-2.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/finatra/FinatraCodeAttributesGetter.java
@@ -11,13 +11,13 @@ import javax.annotation.Nullable;
 public class FinatraCodeAttributesGetter implements CodeAttributesGetter<Class<?>> {
   @Nullable
   @Override
-  public Class<?> codeClass(Class<?> request) {
+  public Class<?> getCodeClass(Class<?> request) {
     return request;
   }
 
   @Nullable
   @Override
-  public String methodName(Class<?> request) {
+  public String getMethodName(Class<?> request) {
     return null;
   }
 }

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeDbAttributesGetter.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/GeodeDbAttributesGetter.java
@@ -17,37 +17,37 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
       SqlStatementSanitizer.create(CommonConfig.get().isStatementSanitizationEnabled());
 
   @Override
-  public String system(GeodeRequest request) {
+  public String getSystem(GeodeRequest request) {
     return SemanticAttributes.DbSystemValues.GEODE;
   }
 
   @Override
   @Nullable
-  public String user(GeodeRequest request) {
+  public String getUser(GeodeRequest request) {
     return null;
   }
 
   @Override
-  public String name(GeodeRequest request) {
+  public String getName(GeodeRequest request) {
     return request.getRegion().getName();
   }
 
   @Override
   @Nullable
-  public String connectionString(GeodeRequest request) {
+  public String getConnectionString(GeodeRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String statement(GeodeRequest request) {
+  public String getStatement(GeodeRequest request) {
     // sanitized statement is cached
     return sanitizer.sanitize(request.getQuery()).getFullStatement();
   }
 
   @Override
   @Nullable
-  public String operation(GeodeRequest request) {
+  public String getOperation(GeodeRequest request) {
     return request.getOperation();
   }
 }

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesGetter.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesGetter.java
@@ -17,33 +17,33 @@ final class GoogleHttpClientHttpAttributesGetter
 
   @Override
   @Nullable
-  public String method(HttpRequest httpRequest) {
+  public String getMethod(HttpRequest httpRequest) {
     return httpRequest.getRequestMethod();
   }
 
   @Override
-  public String url(HttpRequest httpRequest) {
+  public String getUrl(HttpRequest httpRequest) {
     return httpRequest.getUrl().build();
   }
 
   @Override
-  public List<String> requestHeader(HttpRequest httpRequest, String name) {
+  public List<String> getRequestHeader(HttpRequest httpRequest, String name) {
     return httpRequest.getHeaders().getHeaderStringValues(name);
   }
 
   @Override
-  public String flavor(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
+  public String getFlavor(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpRequest httpRequest, HttpResponse httpResponse, @Nullable Throwable error) {
     return httpResponse.getStatusCode();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpRequest httpRequest, HttpResponse httpResponse, String name) {
     return httpResponse.getHeaders().getHeaderStringValues(name);
   }

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientNetAttributesGetter.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientNetAttributesGetter.java
@@ -15,18 +15,18 @@ final class GoogleHttpClientNetAttributesGetter
     implements NetClientAttributesGetter<HttpRequest, HttpResponse> {
 
   @Override
-  public String transport(HttpRequest request, @Nullable HttpResponse response) {
+  public String getTransport(HttpRequest request, @Nullable HttpResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(HttpRequest request) {
+  public String getPeerName(HttpRequest request) {
     return request.getUrl().getHost();
   }
 
   @Override
-  public Integer peerPort(HttpRequest request) {
+  public Integer getPeerPort(HttpRequest request) {
     return request.getUrl().getPort();
   }
 }

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
@@ -18,12 +18,12 @@ final class GrizzlyHttpAttributesGetter
     implements HttpServerAttributesGetter<HttpRequestPacket, HttpResponsePacket> {
 
   @Override
-  public String method(HttpRequestPacket request) {
+  public String getMethod(HttpRequestPacket request) {
     return request.getMethod().getMethodString();
   }
 
   @Override
-  public List<String> requestHeader(HttpRequestPacket request, String name) {
+  public List<String> getRequestHeader(HttpRequestPacket request, String name) {
     return toHeaderList(request.getHeaders().values(name));
   }
 
@@ -37,19 +37,19 @@ final class GrizzlyHttpAttributesGetter
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpRequestPacket request, HttpResponsePacket response, @Nullable Throwable error) {
     return response.getStatus();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpRequestPacket request, HttpResponsePacket response, String name) {
     return toHeaderList(response.getHeaders().values(name));
   }
 
   @Override
-  public String flavor(HttpRequestPacket request) {
+  public String getFlavor(HttpRequestPacket request) {
     String flavor = request.getProtocolString();
     if (flavor.startsWith("HTTP/")) {
       flavor = flavor.substring("HTTP/".length());
@@ -59,7 +59,7 @@ final class GrizzlyHttpAttributesGetter
 
   @Nullable
   @Override
-  public String target(HttpRequestPacket request) {
+  public String getTarget(HttpRequestPacket request) {
     String target = request.getRequestURI();
     String queryString = request.getQueryString();
     if (queryString != null) {
@@ -70,12 +70,12 @@ final class GrizzlyHttpAttributesGetter
 
   @Nullable
   @Override
-  public String route(HttpRequestPacket request) {
+  public String getRoute(HttpRequestPacket request) {
     return null;
   }
 
   @Override
-  public String scheme(HttpRequestPacket request) {
+  public String getScheme(HttpRequestPacket request) {
     return request.isSecure() ? "https" : "http";
   }
 }

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
@@ -16,40 +16,40 @@ import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
 final class GrizzlyNetAttributesGetter implements NetServerAttributesGetter<HttpRequestPacket> {
 
   @Override
-  public String transport(HttpRequestPacket request) {
+  public String getTransport(HttpRequestPacket request) {
     return request.getConnection().getTransport() instanceof TCPNIOTransport ? IP_TCP : IP_UDP;
   }
 
   @Nullable
   @Override
-  public String hostName(HttpRequestPacket request) {
+  public String getHostName(HttpRequestPacket request) {
     return request.getLocalHost();
   }
 
   @Override
-  public Integer hostPort(HttpRequestPacket request) {
+  public Integer getHostPort(HttpRequestPacket request) {
     return request.getServerPort();
   }
 
   @Nullable
   @Override
-  public String sockPeerAddr(HttpRequestPacket request) {
+  public String getSockPeerAddr(HttpRequestPacket request) {
     return request.getRemoteAddress();
   }
 
   @Override
-  public Integer sockPeerPort(HttpRequestPacket request) {
+  public Integer getSockPeerPort(HttpRequestPacket request) {
     return request.getRemotePort();
   }
 
   @Nullable
   @Override
-  public String sockHostAddr(HttpRequestPacket request) {
+  public String getSockHostAddr(HttpRequestPacket request) {
     return request.getLocalAddress();
   }
 
   @Override
-  public Integer sockHostPort(HttpRequestPacket request) {
+  public Integer getSockHostPort(HttpRequestPacket request) {
     return request.getLocalPort();
   }
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRpcAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcRpcAttributesGetter.java
@@ -17,13 +17,13 @@ enum GrpcRpcAttributesGetter implements RpcAttributesGetter<GrpcRequest> {
   INSTANCE;
 
   @Override
-  public String system(GrpcRequest request) {
+  public String getSystem(GrpcRequest request) {
     return "grpc";
   }
 
   @Override
   @Nullable
-  public String service(GrpcRequest request) {
+  public String getService(GrpcRequest request) {
     String fullMethodName = request.getMethod().getFullMethodName();
     int slashIndex = fullMethodName.lastIndexOf('/');
     if (slashIndex == -1) {
@@ -34,7 +34,7 @@ enum GrpcRpcAttributesGetter implements RpcAttributesGetter<GrpcRequest> {
 
   @Override
   @Nullable
-  public String method(GrpcRequest request) {
+  public String getMethod(GrpcRequest request) {
     String fullMethodName = request.getMethod().getFullMethodName();
     int slashIndex = fullMethodName.lastIndexOf('/');
     if (slashIndex == -1) {

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetClientAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetClientAttributesGetter.java
@@ -21,18 +21,18 @@ public final class GrpcNetClientAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<GrpcRequest, Status> {
 
   @Override
-  public String transport(GrpcRequest request, @Nullable Status response) {
+  public String getTransport(GrpcRequest request, @Nullable Status response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(GrpcRequest grpcRequest) {
+  public String getPeerName(GrpcRequest grpcRequest) {
     return grpcRequest.getLogicalHost();
   }
 
   @Override
-  public Integer peerPort(GrpcRequest grpcRequest) {
+  public Integer getPeerPort(GrpcRequest grpcRequest) {
     return grpcRequest.getLogicalPort();
   }
 

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetServerAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetServerAttributesGetter.java
@@ -20,18 +20,18 @@ public final class GrpcNetServerAttributesGetter
     extends InetSocketAddressNetServerAttributesGetter<GrpcRequest> {
 
   @Override
-  public String transport(GrpcRequest request) {
+  public String getTransport(GrpcRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(GrpcRequest grpcRequest) {
+  public String getHostName(GrpcRequest grpcRequest) {
     return grpcRequest.getLogicalHost();
   }
 
   @Override
-  public Integer hostPort(GrpcRequest grpcRequest) {
+  public Integer getHostPort(GrpcRequest grpcRequest) {
     return grpcRequest.getLogicalPort();
   }
 

--- a/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/GwtRpcAttributesGetter.java
+++ b/instrumentation/gwt-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/gwt/GwtRpcAttributesGetter.java
@@ -12,17 +12,17 @@ enum GwtRpcAttributesGetter implements RpcAttributesGetter<Method> {
   INSTANCE;
 
   @Override
-  public String system(Method method) {
+  public String getSystem(Method method) {
     return "gwt";
   }
 
   @Override
-  public String service(Method method) {
+  public String getService(Method method) {
     return method.getDeclaringClass().getName();
   }
 
   @Override
-  public String method(Method method) {
+  public String getMethod(Method method) {
     return method.getName();
   }
 }

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesGetter.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesGetter.java
@@ -18,34 +18,34 @@ class HttpUrlHttpAttributesGetter
     implements HttpClientAttributesGetter<HttpURLConnection, Integer> {
 
   @Override
-  public String method(HttpURLConnection connection) {
+  public String getMethod(HttpURLConnection connection) {
     return connection.getRequestMethod();
   }
 
   @Override
-  public String url(HttpURLConnection connection) {
+  public String getUrl(HttpURLConnection connection) {
     return connection.getURL().toExternalForm();
   }
 
   @Override
-  public List<String> requestHeader(HttpURLConnection connection, String name) {
+  public List<String> getRequestHeader(HttpURLConnection connection, String name) {
     String value = connection.getRequestProperty(name);
     return value == null ? emptyList() : singletonList(value);
   }
 
   @Override
-  public String flavor(HttpURLConnection connection, @Nullable Integer statusCode) {
+  public String getFlavor(HttpURLConnection connection, @Nullable Integer statusCode) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpURLConnection connection, Integer statusCode, @Nullable Throwable error) {
     return statusCode;
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpURLConnection connection, Integer statusCode, String name) {
     String value = connection.getHeaderField(name);
     return value == null ? emptyList() : singletonList(value);

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlNetAttributesGetter.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlNetAttributesGetter.java
@@ -14,17 +14,17 @@ class HttpUrlNetAttributesGetter implements NetClientAttributesGetter<HttpURLCon
 
   @Override
   @Nullable
-  public String transport(HttpURLConnection connection, @Nullable Integer status) {
+  public String getTransport(HttpURLConnection connection, @Nullable Integer status) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
-  public String peerName(HttpURLConnection connection) {
+  public String getPeerName(HttpURLConnection connection) {
     return connection.getURL().getHost();
   }
 
   @Override
-  public Integer peerPort(HttpURLConnection connection) {
+  public Integer getPeerPort(HttpURLConnection connection) {
     return connection.getURL().getPort();
   }
 }

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesGetter.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpAttributesGetter.java
@@ -16,28 +16,28 @@ import javax.annotation.Nullable;
 class JdkHttpAttributesGetter implements HttpClientAttributesGetter<HttpRequest, HttpResponse<?>> {
 
   @Override
-  public String method(HttpRequest httpRequest) {
+  public String getMethod(HttpRequest httpRequest) {
     return httpRequest.method();
   }
 
   @Override
-  public String url(HttpRequest httpRequest) {
+  public String getUrl(HttpRequest httpRequest) {
     return httpRequest.uri().toString();
   }
 
   @Override
-  public List<String> requestHeader(HttpRequest httpRequest, String name) {
+  public List<String> getRequestHeader(HttpRequest httpRequest, String name) {
     return httpRequest.headers().allValues(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpRequest httpRequest, HttpResponse<?> httpResponse, @Nullable Throwable error) {
     return httpResponse.statusCode();
   }
 
   @Override
-  public String flavor(HttpRequest httpRequest, @Nullable HttpResponse<?> httpResponse) {
+  public String getFlavor(HttpRequest httpRequest, @Nullable HttpResponse<?> httpResponse) {
     if (httpResponse != null && httpResponse.version() == Version.HTTP_2) {
       return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
     }
@@ -45,7 +45,7 @@ class JdkHttpAttributesGetter implements HttpClientAttributesGetter<HttpRequest,
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpRequest httpRequest, HttpResponse<?> httpResponse, String name) {
     return httpResponse.headers().allValues(name);
   }

--- a/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesGetter.java
+++ b/instrumentation/java-http-client/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpclient/JdkHttpNetAttributesGetter.java
@@ -15,19 +15,19 @@ public class JdkHttpNetAttributesGetter
     implements NetClientAttributesGetter<HttpRequest, HttpResponse<?>> {
 
   @Override
-  public String transport(HttpRequest httpRequest, @Nullable HttpResponse<?> response) {
+  public String getTransport(HttpRequest httpRequest, @Nullable HttpResponse<?> response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(HttpRequest httpRequest) {
+  public String getPeerName(HttpRequest httpRequest) {
     return httpRequest.uri().getHost();
   }
 
   @Override
   @Nullable
-  public Integer peerPort(HttpRequest httpRequest) {
+  public Integer getPeerPort(HttpRequest httpRequest) {
     return httpRequest.uri().getPort();
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesGetter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesGetter.java
@@ -20,17 +20,17 @@ final class JaxRsClientHttpAttributesGetter
 
   @Override
   @Nullable
-  public String method(ClientRequest httpRequest) {
+  public String getMethod(ClientRequest httpRequest) {
     return httpRequest.getMethod();
   }
 
   @Override
-  public String url(ClientRequest httpRequest) {
+  public String getUrl(ClientRequest httpRequest) {
     return httpRequest.getURI().toString();
   }
 
   @Override
-  public List<String> requestHeader(ClientRequest httpRequest, String name) {
+  public List<String> getRequestHeader(ClientRequest httpRequest, String name) {
     List<Object> rawHeaders = httpRequest.getHeaders().getOrDefault(name, emptyList());
     if (rawHeaders.isEmpty()) {
       return emptyList();
@@ -43,18 +43,18 @@ final class JaxRsClientHttpAttributesGetter
   }
 
   @Override
-  public String flavor(ClientRequest httpRequest, @Nullable ClientResponse httpResponse) {
+  public String getFlavor(ClientRequest httpRequest, @Nullable ClientResponse httpResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       ClientRequest httpRequest, ClientResponse httpResponse, @Nullable Throwable error) {
     return httpResponse.getStatus();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       ClientRequest httpRequest, ClientResponse httpResponse, String name) {
     return httpResponse.getHeaders().getOrDefault(name, emptyList());
   }

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientNetAttributesGetter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientNetAttributesGetter.java
@@ -15,18 +15,18 @@ final class JaxRsClientNetAttributesGetter
     implements NetClientAttributesGetter<ClientRequest, ClientResponse> {
 
   @Override
-  public String transport(ClientRequest request, @Nullable ClientResponse response) {
+  public String getTransport(ClientRequest request, @Nullable ClientResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(ClientRequest request) {
+  public String getPeerName(ClientRequest request) {
     return request.getURI().getHost();
   }
 
   @Override
-  public Integer peerPort(ClientRequest request) {
+  public Integer getPeerPort(ClientRequest request) {
     return request.getURI().getPort();
   }
 }

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxrsCodeAttributesGetter.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxrsCodeAttributesGetter.java
@@ -10,12 +10,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.code.CodeAttributesGett
 public class JaxrsCodeAttributesGetter implements CodeAttributesGetter<HandlerData> {
 
   @Override
-  public Class<?> codeClass(HandlerData handlerData) {
+  public Class<?> getCodeClass(HandlerData handlerData) {
     return handlerData.codeClass();
   }
 
   @Override
-  public String methodName(HandlerData handlerData) {
+  public String getMethodName(HandlerData handlerData) {
     return handlerData.methodName();
   }
 }

--- a/instrumentation/jaxrs/jaxrs-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/JaxrsCodeAttributesGetter.java
+++ b/instrumentation/jaxrs/jaxrs-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/JaxrsCodeAttributesGetter.java
@@ -10,12 +10,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.code.CodeAttributesGett
 public class JaxrsCodeAttributesGetter implements CodeAttributesGetter<HandlerData> {
 
   @Override
-  public Class<?> codeClass(HandlerData handlerData) {
+  public Class<?> getCodeClass(HandlerData handlerData) {
     return handlerData.codeClass();
   }
 
   @Override
-  public String methodName(HandlerData handlerData) {
+  public String getMethodName(HandlerData handlerData) {
     return handlerData.methodName();
   }
 }

--- a/instrumentation/jaxws/jaxws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/common/JaxWsCodeAttributesGetter.java
+++ b/instrumentation/jaxws/jaxws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/common/JaxWsCodeAttributesGetter.java
@@ -10,12 +10,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.code.CodeAttributesGett
 public class JaxWsCodeAttributesGetter implements CodeAttributesGetter<JaxWsRequest> {
 
   @Override
-  public Class<?> codeClass(JaxWsRequest request) {
+  public Class<?> getCodeClass(JaxWsRequest request) {
     return request.codeClass();
   }
 
   @Override
-  public String methodName(JaxWsRequest request) {
+  public String getMethodName(JaxWsRequest request) {
     return request.methodName();
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/DataSourceCodeAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/DataSourceCodeAttributesGetter.java
@@ -11,12 +11,12 @@ import javax.sql.DataSource;
 final class DataSourceCodeAttributesGetter implements CodeAttributesGetter<DataSource> {
 
   @Override
-  public Class<?> codeClass(DataSource dataSource) {
+  public Class<?> getCodeClass(DataSource dataSource) {
     return dataSource.getClass();
   }
 
   @Override
-  public String methodName(DataSource dataSource) {
+  public String getMethodName(DataSource dataSource) {
     return "getConnection";
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -17,32 +17,32 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
 
   @Nullable
   @Override
-  public String system(DbRequest request) {
+  public String getSystem(DbRequest request) {
     return request.getDbInfo().getSystem();
   }
 
   @Nullable
   @Override
-  public String user(DbRequest request) {
+  public String getUser(DbRequest request) {
     return request.getDbInfo().getUser();
   }
 
   @Nullable
   @Override
-  public String name(DbRequest request) {
+  public String getName(DbRequest request) {
     DbInfo dbInfo = request.getDbInfo();
     return dbInfo.getName() == null ? dbInfo.getDb() : dbInfo.getName();
   }
 
   @Nullable
   @Override
-  public String connectionString(DbRequest request) {
+  public String getConnectionString(DbRequest request) {
     return request.getDbInfo().getShortUrl();
   }
 
   @Nullable
   @Override
-  public String rawStatement(DbRequest request) {
+  public String getRawStatement(DbRequest request) {
     return request.getStatement();
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcNetAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcNetAttributesGetter.java
@@ -16,19 +16,19 @@ public final class JdbcNetAttributesGetter implements NetClientAttributesGetter<
 
   @Nullable
   @Override
-  public String transport(DbRequest request, @Nullable Void unused) {
+  public String getTransport(DbRequest request, @Nullable Void unused) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(DbRequest request) {
+  public String getPeerName(DbRequest request) {
     return request.getDbInfo().getHost();
   }
 
   @Nullable
   @Override
-  public Integer peerPort(DbRequest request) {
+  public Integer getPeerPort(DbRequest request) {
     return request.getDbInfo().getPort();
   }
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisDbAttributesGetter.java
@@ -17,33 +17,33 @@ final class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisReq
       RedisCommandSanitizer.create(CommonConfig.get().isStatementSanitizationEnabled());
 
   @Override
-  public String system(JedisRequest request) {
+  public String getSystem(JedisRequest request) {
     return SemanticAttributes.DbSystemValues.REDIS;
   }
 
   @Override
   @Nullable
-  public String user(JedisRequest request) {
+  public String getUser(JedisRequest request) {
     return null;
   }
 
   @Override
-  public String name(JedisRequest request) {
+  public String getName(JedisRequest request) {
     return null;
   }
 
   @Override
-  public String connectionString(JedisRequest request) {
+  public String getConnectionString(JedisRequest request) {
     return null;
   }
 
   @Override
-  public String statement(JedisRequest request) {
+  public String getStatement(JedisRequest request) {
     return sanitizer.sanitize(request.getCommand().name(), request.getArgs());
   }
 
   @Override
-  public String operation(JedisRequest request) {
+  public String getOperation(JedisRequest request) {
     return request.getCommand().name();
   }
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetAttributesGetter.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetAttributesGetter.java
@@ -12,17 +12,17 @@ final class JedisNetAttributesGetter implements NetClientAttributesGetter<JedisR
 
   @Override
   @Nullable
-  public String transport(JedisRequest request, @Nullable Void unused) {
+  public String getTransport(JedisRequest request, @Nullable Void unused) {
     return null;
   }
 
   @Override
-  public String peerName(JedisRequest request) {
+  public String getPeerName(JedisRequest request) {
     return request.getConnection().getHost();
   }
 
   @Override
-  public Integer peerPort(JedisRequest request) {
+  public Integer getPeerPort(JedisRequest request) {
     return request.getConnection().getPort();
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisDbAttributesGetter.java
@@ -12,33 +12,33 @@ import javax.annotation.Nullable;
 final class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisRequest> {
 
   @Override
-  public String system(JedisRequest request) {
+  public String getSystem(JedisRequest request) {
     return SemanticAttributes.DbSystemValues.REDIS;
   }
 
   @Override
   @Nullable
-  public String user(JedisRequest request) {
+  public String getUser(JedisRequest request) {
     return null;
   }
 
   @Override
-  public String name(JedisRequest request) {
+  public String getName(JedisRequest request) {
     return null;
   }
 
   @Override
-  public String connectionString(JedisRequest request) {
+  public String getConnectionString(JedisRequest request) {
     return null;
   }
 
   @Override
-  public String statement(JedisRequest request) {
+  public String getStatement(JedisRequest request) {
     return request.getStatement();
   }
 
   @Override
-  public String operation(JedisRequest request) {
+  public String getOperation(JedisRequest request) {
     return request.getOperation();
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetAttributesGetter.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetAttributesGetter.java
@@ -15,18 +15,18 @@ final class JedisNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<JedisRequest, Void> {
 
   @Override
-  public String transport(JedisRequest jedisRequest, @Nullable Void unused) {
+  public String getTransport(JedisRequest jedisRequest, @Nullable Void unused) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(JedisRequest jedisRequest) {
+  public String getPeerName(JedisRequest jedisRequest) {
     return jedisRequest.getConnection().getHost();
   }
 
   @Override
-  public Integer peerPort(JedisRequest jedisRequest) {
+  public Integer getPeerPort(JedisRequest jedisRequest) {
     return jedisRequest.getConnection().getPort();
   }
 

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisDbAttributesGetter.java
@@ -12,33 +12,33 @@ import javax.annotation.Nullable;
 final class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisRequest> {
 
   @Override
-  public String system(JedisRequest request) {
+  public String getSystem(JedisRequest request) {
     return SemanticAttributes.DbSystemValues.REDIS;
   }
 
   @Override
   @Nullable
-  public String user(JedisRequest request) {
+  public String getUser(JedisRequest request) {
     return null;
   }
 
   @Override
-  public String name(JedisRequest request) {
+  public String getName(JedisRequest request) {
     return null;
   }
 
   @Override
-  public String connectionString(JedisRequest request) {
+  public String getConnectionString(JedisRequest request) {
     return null;
   }
 
   @Override
-  public String statement(JedisRequest request) {
+  public String getStatement(JedisRequest request) {
     return request.getStatement();
   }
 
   @Override
-  public String operation(JedisRequest request) {
+  public String getOperation(JedisRequest request) {
     return request.getOperation();
   }
 }

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisNetAttributesGetter.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisNetAttributesGetter.java
@@ -15,19 +15,19 @@ final class JedisNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<JedisRequest, Void> {
 
   @Override
-  public String transport(JedisRequest jedisRequest, @Nullable Void unused) {
+  public String getTransport(JedisRequest jedisRequest, @Nullable Void unused) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(JedisRequest jedisRequest) {
+  public String getPeerName(JedisRequest jedisRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(JedisRequest jedisRequest) {
+  public Integer getPeerPort(JedisRequest jedisRequest) {
     return null;
   }
 

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
@@ -21,23 +21,23 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
 
   @Override
   @Nullable
-  public String method(Request request) {
+  public String getMethod(Request request) {
     return request.getMethod();
   }
 
   @Override
   @Nullable
-  public String url(Request request) {
+  public String getUrl(Request request) {
     return request.getURI().toString();
   }
 
   @Override
-  public List<String> requestHeader(Request request, String name) {
+  public List<String> getRequestHeader(Request request, String name) {
     return request.getHeaders().getValuesList(name);
   }
 
   @Override
-  public String flavor(Request request, @Nullable Response response) {
+  public String getFlavor(Request request, @Nullable Response response) {
 
     if (response == null) {
       return HTTP_1_1;
@@ -61,12 +61,12 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
   }
 
   @Override
-  public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
+  public Integer getStatusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatus();
   }
 
   @Override
-  public List<String> responseHeader(Request request, Response response, String name) {
+  public List<String> getResponseHeader(Request request, Response response, String name) {
     return response.getHeaders().getValuesList(name);
   }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClientNetAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClientNetAttributesGetter.java
@@ -19,19 +19,19 @@ public class JettyHttpClientNetAttributesGetter
     implements NetClientAttributesGetter<Request, Response> {
 
   @Override
-  public String transport(Request request, @Nullable Response response) {
+  public String getTransport(Request request, @Nullable Response response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(Request request) {
+  public String getPeerName(Request request) {
     return request.getHost();
   }
 
   @Override
   @Nullable
-  public Integer peerPort(Request request) {
+  public Integer getPeerPort(Request request) {
     return request.getPort();
   }
 }

--- a/instrumentation/jms/jms-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageAttributesGetter.java
+++ b/instrumentation/jms/jms-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsMessageAttributesGetter.java
@@ -19,48 +19,48 @@ enum JmsMessageAttributesGetter implements MessagingAttributesGetter<MessageWith
   private static final Logger logger = Logger.getLogger(JmsMessageAttributesGetter.class.getName());
 
   @Override
-  public String system(MessageWithDestination messageWithDestination) {
+  public String getSystem(MessageWithDestination messageWithDestination) {
     return "jms";
   }
 
   @Nullable
   @Override
-  public String destinationKind(MessageWithDestination messageWithDestination) {
+  public String getDestinationKind(MessageWithDestination messageWithDestination) {
     return messageWithDestination.destinationKind();
   }
 
   @Nullable
   @Override
-  public String destination(MessageWithDestination messageWithDestination) {
+  public String getDestination(MessageWithDestination messageWithDestination) {
     return messageWithDestination.destinationName();
   }
 
   @Override
-  public boolean temporaryDestination(MessageWithDestination messageWithDestination) {
+  public boolean isTemporaryDestination(MessageWithDestination messageWithDestination) {
     return messageWithDestination.isTemporaryDestination();
   }
 
   @Nullable
   @Override
-  public String protocol(MessageWithDestination messageWithDestination) {
+  public String getProtocol(MessageWithDestination messageWithDestination) {
     return null;
   }
 
   @Nullable
   @Override
-  public String protocolVersion(MessageWithDestination messageWithDestination) {
+  public String getProtocolVersion(MessageWithDestination messageWithDestination) {
     return null;
   }
 
   @Nullable
   @Override
-  public String url(MessageWithDestination messageWithDestination) {
+  public String getUrl(MessageWithDestination messageWithDestination) {
     return null;
   }
 
   @Nullable
   @Override
-  public String conversationId(MessageWithDestination messageWithDestination) {
+  public String getConversationId(MessageWithDestination messageWithDestination) {
     try {
       return messageWithDestination.message().getJmsCorrelationId();
     } catch (Exception e) {
@@ -71,19 +71,19 @@ enum JmsMessageAttributesGetter implements MessagingAttributesGetter<MessageWith
 
   @Nullable
   @Override
-  public Long messagePayloadSize(MessageWithDestination messageWithDestination) {
+  public Long getMessagePayloadSize(MessageWithDestination messageWithDestination) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadCompressedSize(MessageWithDestination messageWithDestination) {
+  public Long getMessagePayloadCompressedSize(MessageWithDestination messageWithDestination) {
     return null;
   }
 
   @Nullable
   @Override
-  public String messageId(MessageWithDestination messageWithDestination, Void unused) {
+  public String getMessageId(MessageWithDestination messageWithDestination, Void unused) {
     try {
       return messageWithDestination.message().getJmsMessageId();
     } catch (Exception exception) {
@@ -93,7 +93,7 @@ enum JmsMessageAttributesGetter implements MessagingAttributesGetter<MessageWith
   }
 
   @Override
-  public List<String> header(MessageWithDestination messageWithDestination, String name) {
+  public List<String> getMessageHeader(MessageWithDestination messageWithDestination, String name) {
     try {
       String value = messageWithDestination.message().getStringProperty(name);
       if (value != null) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaBatchProcessAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaBatchProcessAttributesGetter.java
@@ -21,18 +21,18 @@ enum KafkaBatchProcessAttributesGetter
   INSTANCE;
 
   @Override
-  public String system(ConsumerRecords<?, ?> records) {
+  public String getSystem(ConsumerRecords<?, ?> records) {
     return "kafka";
   }
 
   @Override
-  public String destinationKind(ConsumerRecords<?, ?> records) {
+  public String getDestinationKind(ConsumerRecords<?, ?> records) {
     return SemanticAttributes.MessagingDestinationKindValues.TOPIC;
   }
 
   @Nullable
   @Override
-  public String destination(ConsumerRecords<?, ?> records) {
+  public String getDestination(ConsumerRecords<?, ?> records) {
     Set<String> topics =
         records.partitions().stream().map(TopicPartition::topic).collect(Collectors.toSet());
     // only return topic when there's exactly one in the batch
@@ -40,54 +40,54 @@ enum KafkaBatchProcessAttributesGetter
   }
 
   @Override
-  public boolean temporaryDestination(ConsumerRecords<?, ?> records) {
+  public boolean isTemporaryDestination(ConsumerRecords<?, ?> records) {
     return false;
   }
 
   @Nullable
   @Override
-  public String protocol(ConsumerRecords<?, ?> records) {
+  public String getProtocol(ConsumerRecords<?, ?> records) {
     return null;
   }
 
   @Nullable
   @Override
-  public String protocolVersion(ConsumerRecords<?, ?> records) {
+  public String getProtocolVersion(ConsumerRecords<?, ?> records) {
     return null;
   }
 
   @Nullable
   @Override
-  public String url(ConsumerRecords<?, ?> records) {
+  public String getUrl(ConsumerRecords<?, ?> records) {
     return null;
   }
 
   @Nullable
   @Override
-  public String conversationId(ConsumerRecords<?, ?> records) {
+  public String getConversationId(ConsumerRecords<?, ?> records) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadSize(ConsumerRecords<?, ?> records) {
+  public Long getMessagePayloadSize(ConsumerRecords<?, ?> records) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadCompressedSize(ConsumerRecords<?, ?> records) {
+  public Long getMessagePayloadCompressedSize(ConsumerRecords<?, ?> records) {
     return null;
   }
 
   @Nullable
   @Override
-  public String messageId(ConsumerRecords<?, ?> records, @Nullable Void unused) {
+  public String getMessageId(ConsumerRecords<?, ?> records, @Nullable Void unused) {
     return null;
   }
 
   @Override
-  public List<String> header(ConsumerRecords<?, ?> records, String name) {
+  public List<String> getMessageHeader(ConsumerRecords<?, ?> records, String name) {
     return StreamSupport.stream(records.spliterator(), false)
         .flatMap(
             consumerRecord ->

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaConsumerAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaConsumerAttributesGetter.java
@@ -23,68 +23,68 @@ public enum KafkaConsumerAttributesGetter
   INSTANCE;
 
   @Override
-  public String system(ConsumerRecord<?, ?> consumerRecord) {
+  public String getSystem(ConsumerRecord<?, ?> consumerRecord) {
     return "kafka";
   }
 
   @Override
-  public String destinationKind(ConsumerRecord<?, ?> consumerRecord) {
+  public String getDestinationKind(ConsumerRecord<?, ?> consumerRecord) {
     return SemanticAttributes.MessagingDestinationKindValues.TOPIC;
   }
 
   @Override
-  public String destination(ConsumerRecord<?, ?> consumerRecord) {
+  public String getDestination(ConsumerRecord<?, ?> consumerRecord) {
     return consumerRecord.topic();
   }
 
   @Override
-  public boolean temporaryDestination(ConsumerRecord<?, ?> consumerRecord) {
+  public boolean isTemporaryDestination(ConsumerRecord<?, ?> consumerRecord) {
     return false;
   }
 
   @Override
   @Nullable
-  public String protocol(ConsumerRecord<?, ?> consumerRecord) {
+  public String getProtocol(ConsumerRecord<?, ?> consumerRecord) {
     return null;
   }
 
   @Override
   @Nullable
-  public String protocolVersion(ConsumerRecord<?, ?> consumerRecord) {
+  public String getProtocolVersion(ConsumerRecord<?, ?> consumerRecord) {
     return null;
   }
 
   @Override
   @Nullable
-  public String url(ConsumerRecord<?, ?> consumerRecord) {
+  public String getUrl(ConsumerRecord<?, ?> consumerRecord) {
     return null;
   }
 
   @Override
   @Nullable
-  public String conversationId(ConsumerRecord<?, ?> consumerRecord) {
+  public String getConversationId(ConsumerRecord<?, ?> consumerRecord) {
     return null;
   }
 
   @Override
-  public Long messagePayloadSize(ConsumerRecord<?, ?> consumerRecord) {
+  public Long getMessagePayloadSize(ConsumerRecord<?, ?> consumerRecord) {
     return (long) consumerRecord.serializedValueSize();
   }
 
   @Override
   @Nullable
-  public Long messagePayloadCompressedSize(ConsumerRecord<?, ?> consumerRecord) {
+  public Long getMessagePayloadCompressedSize(ConsumerRecord<?, ?> consumerRecord) {
     return null;
   }
 
   @Override
   @Nullable
-  public String messageId(ConsumerRecord<?, ?> consumerRecord, @Nullable Void unused) {
+  public String getMessageId(ConsumerRecord<?, ?> consumerRecord, @Nullable Void unused) {
     return null;
   }
 
   @Override
-  public List<String> header(ConsumerRecord<?, ?> consumerRecord, String name) {
+  public List<String> getMessageHeader(ConsumerRecord<?, ?> consumerRecord, String name) {
     return StreamSupport.stream(consumerRecord.headers().headers(name).spliterator(), false)
         .map(header -> new String(header.value(), StandardCharsets.UTF_8))
         .collect(Collectors.toList());

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaProducerAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaProducerAttributesGetter.java
@@ -24,70 +24,70 @@ enum KafkaProducerAttributesGetter
   INSTANCE;
 
   @Override
-  public String system(ProducerRecord<?, ?> producerRecord) {
+  public String getSystem(ProducerRecord<?, ?> producerRecord) {
     return "kafka";
   }
 
   @Override
-  public String destinationKind(ProducerRecord<?, ?> producerRecord) {
+  public String getDestinationKind(ProducerRecord<?, ?> producerRecord) {
     return SemanticAttributes.MessagingDestinationKindValues.TOPIC;
   }
 
   @Override
-  public String destination(ProducerRecord<?, ?> producerRecord) {
+  public String getDestination(ProducerRecord<?, ?> producerRecord) {
     return producerRecord.topic();
   }
 
   @Override
-  public boolean temporaryDestination(ProducerRecord<?, ?> producerRecord) {
+  public boolean isTemporaryDestination(ProducerRecord<?, ?> producerRecord) {
     return false;
   }
 
   @Override
   @Nullable
-  public String protocol(ProducerRecord<?, ?> producerRecord) {
+  public String getProtocol(ProducerRecord<?, ?> producerRecord) {
     return null;
   }
 
   @Override
   @Nullable
-  public String protocolVersion(ProducerRecord<?, ?> producerRecord) {
+  public String getProtocolVersion(ProducerRecord<?, ?> producerRecord) {
     return null;
   }
 
   @Override
   @Nullable
-  public String url(ProducerRecord<?, ?> producerRecord) {
+  public String getUrl(ProducerRecord<?, ?> producerRecord) {
     return null;
   }
 
   @Override
   @Nullable
-  public String conversationId(ProducerRecord<?, ?> producerRecord) {
+  public String getConversationId(ProducerRecord<?, ?> producerRecord) {
     return null;
   }
 
   @Override
   @Nullable
-  public Long messagePayloadSize(ProducerRecord<?, ?> producerRecord) {
+  public Long getMessagePayloadSize(ProducerRecord<?, ?> producerRecord) {
     return null;
   }
 
   @Override
   @Nullable
-  public Long messagePayloadCompressedSize(ProducerRecord<?, ?> producerRecord) {
+  public Long getMessagePayloadCompressedSize(ProducerRecord<?, ?> producerRecord) {
     return null;
   }
 
   @Override
   @Nullable
-  public String messageId(
+  public String getMessageId(
       ProducerRecord<?, ?> producerRecord, @Nullable RecordMetadata recordMetadata) {
     return null;
   }
 
   @Override
-  public List<String> header(ProducerRecord<?, ?> producerRecord, String name) {
+  public List<String> getMessageHeader(ProducerRecord<?, ?> producerRecord, String name) {
     return StreamSupport.stream(producerRecord.headers().headers(name).spliterator(), false)
         .map(header -> new String(header.value(), StandardCharsets.UTF_8))
         .collect(Collectors.toList());

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaReceiveAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaReceiveAttributesGetter.java
@@ -25,18 +25,18 @@ public enum KafkaReceiveAttributesGetter
   INSTANCE;
 
   @Override
-  public String system(ConsumerRecords<?, ?> consumerRecords) {
+  public String getSystem(ConsumerRecords<?, ?> consumerRecords) {
     return "kafka";
   }
 
   @Override
-  public String destinationKind(ConsumerRecords<?, ?> consumerRecords) {
+  public String getDestinationKind(ConsumerRecords<?, ?> consumerRecords) {
     return SemanticAttributes.MessagingDestinationKindValues.TOPIC;
   }
 
   @Override
   @Nullable
-  public String destination(ConsumerRecords<?, ?> consumerRecords) {
+  public String getDestination(ConsumerRecords<?, ?> consumerRecords) {
     Set<String> topics =
         consumerRecords.partitions().stream()
             .map(TopicPartition::topic)
@@ -46,54 +46,54 @@ public enum KafkaReceiveAttributesGetter
   }
 
   @Override
-  public boolean temporaryDestination(ConsumerRecords<?, ?> consumerRecords) {
+  public boolean isTemporaryDestination(ConsumerRecords<?, ?> consumerRecords) {
     return false;
   }
 
   @Override
   @Nullable
-  public String protocol(ConsumerRecords<?, ?> consumerRecords) {
+  public String getProtocol(ConsumerRecords<?, ?> consumerRecords) {
     return null;
   }
 
   @Override
   @Nullable
-  public String protocolVersion(ConsumerRecords<?, ?> consumerRecords) {
+  public String getProtocolVersion(ConsumerRecords<?, ?> consumerRecords) {
     return null;
   }
 
   @Override
   @Nullable
-  public String url(ConsumerRecords<?, ?> consumerRecords) {
+  public String getUrl(ConsumerRecords<?, ?> consumerRecords) {
     return null;
   }
 
   @Override
   @Nullable
-  public String conversationId(ConsumerRecords<?, ?> consumerRecords) {
+  public String getConversationId(ConsumerRecords<?, ?> consumerRecords) {
     return null;
   }
 
   @Override
   @Nullable
-  public Long messagePayloadSize(ConsumerRecords<?, ?> consumerRecords) {
+  public Long getMessagePayloadSize(ConsumerRecords<?, ?> consumerRecords) {
     return null;
   }
 
   @Override
   @Nullable
-  public Long messagePayloadCompressedSize(ConsumerRecords<?, ?> consumerRecords) {
+  public Long getMessagePayloadCompressedSize(ConsumerRecords<?, ?> consumerRecords) {
     return null;
   }
 
   @Override
   @Nullable
-  public String messageId(ConsumerRecords<?, ?> consumerRecords, @Nullable Void unused) {
+  public String getMessageId(ConsumerRecords<?, ?> consumerRecords, @Nullable Void unused) {
     return null;
   }
 
   @Override
-  public List<String> header(ConsumerRecords<?, ?> records, String name) {
+  public List<String> getMessageHeader(ConsumerRecords<?, ?> records, String name) {
     return StreamSupport.stream(records.spliterator(), false)
         .flatMap(
             consumerRecord ->

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
@@ -15,23 +15,23 @@ internal enum class KtorHttpServerAttributesGetter :
   HttpServerAttributesGetter<ApplicationRequest, ApplicationResponse> {
   INSTANCE, ;
 
-  override fun method(request: ApplicationRequest): String {
+  override fun getMethod(request: ApplicationRequest): String {
     return request.httpMethod.value
   }
 
-  override fun requestHeader(request: ApplicationRequest, name: String): List<String> {
+  override fun getRequestHeader(request: ApplicationRequest, name: String): List<String> {
     return request.headers.getAll(name) ?: emptyList()
   }
 
-  override fun statusCode(request: ApplicationRequest, response: ApplicationResponse, error: Throwable?): Int? {
+  override fun getStatusCode(request: ApplicationRequest, response: ApplicationResponse, error: Throwable?): Int? {
     return response.status()?.value
   }
 
-  override fun responseHeader(request: ApplicationRequest, response: ApplicationResponse, name: String): List<String> {
+  override fun getResponseHeader(request: ApplicationRequest, response: ApplicationResponse, name: String): List<String> {
     return response.headers.allValues().getAll(name) ?: emptyList()
   }
 
-  override fun flavor(request: ApplicationRequest): String? {
+  override fun getFlavor(request: ApplicationRequest): String? {
     return when (request.httpVersion) {
       "HTTP/1.1" -> SemanticAttributes.HttpFlavorValues.HTTP_1_1
       "HTTP/2.0" -> SemanticAttributes.HttpFlavorValues.HTTP_2_0
@@ -39,15 +39,15 @@ internal enum class KtorHttpServerAttributesGetter :
     }
   }
 
-  override fun target(request: ApplicationRequest): String {
+  override fun getTarget(request: ApplicationRequest): String {
     return request.uri
   }
 
-  override fun route(request: ApplicationRequest): String? {
+  override fun getRoute(request: ApplicationRequest): String? {
     return null
   }
 
-  override fun scheme(request: ApplicationRequest): String {
+  override fun getScheme(request: ApplicationRequest): String {
     return request.origin.scheme
   }
 }

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorNetServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorNetServerAttributesGetter.kt
@@ -11,11 +11,11 @@ import io.opentelemetry.instrumentation.ktor.isIpAddress
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<ApplicationRequest> {
-  override fun transport(request: ApplicationRequest): String {
+  override fun getTransport(request: ApplicationRequest): String {
     return SemanticAttributes.NetTransportValues.IP_TCP
   }
 
-  override fun sockPeerAddr(request: ApplicationRequest): String? {
+  override fun getSockPeerAddr(request: ApplicationRequest): String? {
     val remote = request.local.remoteHost
     if ("unknown" != remote && isIpAddress(remote)) {
       return remote
@@ -23,11 +23,11 @@ internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<Applica
     return null
   }
 
-  override fun hostName(request: ApplicationRequest): String {
+  override fun getHostName(request: ApplicationRequest): String {
     return request.local.host
   }
 
-  override fun hostPort(request: ApplicationRequest): Int {
+  override fun getHostPort(request: ApplicationRequest): Int {
     return request.local.port
   }
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpServerAttributesGetter.kt
@@ -15,23 +15,23 @@ internal enum class KtorHttpServerAttributesGetter :
   HttpServerAttributesGetter<ApplicationRequest, ApplicationResponse> {
   INSTANCE, ;
 
-  override fun method(request: ApplicationRequest): String {
+  override fun getMethod(request: ApplicationRequest): String {
     return request.httpMethod.value
   }
 
-  override fun requestHeader(request: ApplicationRequest, name: String): List<String> {
+  override fun getRequestHeader(request: ApplicationRequest, name: String): List<String> {
     return request.headers.getAll(name) ?: emptyList()
   }
 
-  override fun statusCode(request: ApplicationRequest, response: ApplicationResponse, error: Throwable?): Int? {
+  override fun getStatusCode(request: ApplicationRequest, response: ApplicationResponse, error: Throwable?): Int? {
     return response.status()?.value
   }
 
-  override fun responseHeader(request: ApplicationRequest, response: ApplicationResponse, name: String): List<String> {
+  override fun getResponseHeader(request: ApplicationRequest, response: ApplicationResponse, name: String): List<String> {
     return response.headers.allValues().getAll(name) ?: emptyList()
   }
 
-  override fun flavor(request: ApplicationRequest): String? {
+  override fun getFlavor(request: ApplicationRequest): String? {
     return when (request.httpVersion) {
       "HTTP/1.1" -> SemanticAttributes.HttpFlavorValues.HTTP_1_1
       "HTTP/2.0" -> SemanticAttributes.HttpFlavorValues.HTTP_2_0
@@ -39,15 +39,15 @@ internal enum class KtorHttpServerAttributesGetter :
     }
   }
 
-  override fun target(request: ApplicationRequest): String {
+  override fun getTarget(request: ApplicationRequest): String {
     return request.uri
   }
 
-  override fun route(request: ApplicationRequest): String? {
+  override fun getRoute(request: ApplicationRequest): String? {
     return null
   }
 
-  override fun scheme(request: ApplicationRequest): String {
+  override fun getScheme(request: ApplicationRequest): String {
     return request.origin.scheme
   }
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorNetServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorNetServerAttributesGetter.kt
@@ -11,11 +11,11 @@ import io.opentelemetry.instrumentation.ktor.isIpAddress
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<ApplicationRequest> {
-  override fun transport(request: ApplicationRequest): String {
+  override fun getTransport(request: ApplicationRequest): String {
     return SemanticAttributes.NetTransportValues.IP_TCP
   }
 
-  override fun sockPeerAddr(request: ApplicationRequest): String? {
+  override fun getSockPeerAddr(request: ApplicationRequest): String? {
     val remote = request.local.remoteHost
     if ("unknown" != remote && isIpAddress(remote)) {
       return remote
@@ -23,11 +23,11 @@ internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<Applica
     return null
   }
 
-  override fun hostName(request: ApplicationRequest): String {
+  override fun getHostName(request: ApplicationRequest): String {
     return request.local.host
   }
 
-  override fun hostPort(request: ApplicationRequest): Int {
+  override fun getHostPort(request: ApplicationRequest): Int {
     return request.local.port
   }
 }

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesGetter.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesGetter.java
@@ -18,33 +18,33 @@ class KubernetesHttpAttributesGetter
     implements HttpClientAttributesGetter<Request, ApiResponse<?>> {
 
   @Override
-  public String method(Request request) {
+  public String getMethod(Request request) {
     return request.method();
   }
 
   @Override
-  public String url(Request request) {
+  public String getUrl(Request request) {
     return request.url().toString();
   }
 
   @Override
-  public List<String> requestHeader(Request request, String name) {
+  public List<String> getRequestHeader(Request request, String name) {
     return request.headers(name);
   }
 
   @Override
-  public String flavor(Request request, @Nullable ApiResponse<?> apiResponse) {
+  public String getFlavor(Request request, @Nullable ApiResponse<?> apiResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       Request request, ApiResponse<?> apiResponse, @Nullable Throwable error) {
     return apiResponse.getStatusCode();
   }
 
   @Override
-  public List<String> responseHeader(Request request, ApiResponse<?> apiResponse, String name) {
+  public List<String> getResponseHeader(Request request, ApiResponse<?> apiResponse, String name) {
     return apiResponse.getHeaders().getOrDefault(name, emptyList());
   }
 }

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesNetAttributesGetter.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesNetAttributesGetter.java
@@ -14,17 +14,17 @@ import okhttp3.Request;
 class KubernetesNetAttributesGetter implements NetClientAttributesGetter<Request, ApiResponse<?>> {
 
   @Override
-  public String transport(Request request, @Nullable ApiResponse<?> response) {
+  public String getTransport(Request request, @Nullable ApiResponse<?> response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
-  public String peerName(Request request) {
+  public String getPeerName(Request request) {
     return request.url().host();
   }
 
   @Override
-  public Integer peerPort(Request request) {
+  public Integer getPeerPort(Request request) {
     return request.url().port();
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetAttributesGetter.java
@@ -13,17 +13,17 @@ final class LettuceConnectNetAttributesGetter implements NetClientAttributesGett
 
   @Override
   @Nullable
-  public String transport(RedisURI redisUri, @Nullable Void unused) {
+  public String getTransport(RedisURI redisUri, @Nullable Void unused) {
     return null;
   }
 
   @Override
-  public String peerName(RedisURI redisUri) {
+  public String getPeerName(RedisURI redisUri) {
     return redisUri.getHost();
   }
 
   @Override
-  public Integer peerPort(RedisURI redisUri) {
+  public Integer getPeerPort(RedisURI redisUri) {
     return redisUri.getPort();
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceDbAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceDbAttributesGetter.java
@@ -13,35 +13,35 @@ import javax.annotation.Nullable;
 final class LettuceDbAttributesGetter implements DbClientAttributesGetter<RedisCommand<?, ?, ?>> {
 
   @Override
-  public String system(RedisCommand<?, ?, ?> request) {
+  public String getSystem(RedisCommand<?, ?, ?> request) {
     return SemanticAttributes.DbSystemValues.REDIS;
   }
 
   @Override
   @Nullable
-  public String user(RedisCommand<?, ?, ?> request) {
+  public String getUser(RedisCommand<?, ?, ?> request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(RedisCommand<?, ?, ?> request) {
+  public String getName(RedisCommand<?, ?, ?> request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String connectionString(RedisCommand<?, ?, ?> request) {
+  public String getConnectionString(RedisCommand<?, ?, ?> request) {
     return null;
   }
 
   @Override
-  public String statement(RedisCommand<?, ?, ?> request) {
+  public String getStatement(RedisCommand<?, ?, ?> request) {
     return null;
   }
 
   @Override
-  public String operation(RedisCommand<?, ?, ?> request) {
+  public String getOperation(RedisCommand<?, ?, ?> request) {
     return request.getType().name();
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetAttributesGetter.java
@@ -13,17 +13,17 @@ final class LettuceConnectNetAttributesGetter implements NetClientAttributesGett
 
   @Override
   @Nullable
-  public String transport(RedisURI redisUri, @Nullable Void unused) {
+  public String getTransport(RedisURI redisUri, @Nullable Void unused) {
     return null;
   }
 
   @Override
-  public String peerName(RedisURI redisUri) {
+  public String getPeerName(RedisURI redisUri) {
     return redisUri.getHost();
   }
 
   @Override
-  public Integer peerPort(RedisURI redisUri) {
+  public Integer getPeerPort(RedisURI redisUri) {
     return redisUri.getPort();
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceDbAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceDbAttributesGetter.java
@@ -21,30 +21,30 @@ final class LettuceDbAttributesGetter implements DbClientAttributesGetter<RedisC
       RedisCommandSanitizer.create(CommonConfig.get().isStatementSanitizationEnabled());
 
   @Override
-  public String system(RedisCommand<?, ?, ?> request) {
+  public String getSystem(RedisCommand<?, ?, ?> request) {
     return SemanticAttributes.DbSystemValues.REDIS;
   }
 
   @Override
   @Nullable
-  public String user(RedisCommand<?, ?, ?> request) {
+  public String getUser(RedisCommand<?, ?, ?> request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(RedisCommand<?, ?, ?> request) {
+  public String getName(RedisCommand<?, ?, ?> request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String connectionString(RedisCommand<?, ?, ?> request) {
+  public String getConnectionString(RedisCommand<?, ?, ?> request) {
     return null;
   }
 
   @Override
-  public String statement(RedisCommand<?, ?, ?> request) {
+  public String getStatement(RedisCommand<?, ?, ?> request) {
     String command = LettuceInstrumentationUtil.getCommandName(request);
     List<String> args =
         request.getArgs() == null
@@ -54,7 +54,7 @@ final class LettuceDbAttributesGetter implements DbClientAttributesGetter<RedisC
   }
 
   @Override
-  public String operation(RedisCommand<?, ?, ?> request) {
+  public String getOperation(RedisCommand<?, ?, ?> request) {
     return request.getType().name();
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceNetAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceNetAttributesGetter.java
@@ -16,19 +16,19 @@ final class LettuceNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<OpenTelemetryEndpoint, Void> {
 
   @Override
-  public String transport(OpenTelemetryEndpoint endpoint, @Nullable Void unused) {
+  public String getTransport(OpenTelemetryEndpoint endpoint, @Nullable Void unused) {
     return IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(OpenTelemetryEndpoint openTelemetryEndpoint) {
+  public String getPeerName(OpenTelemetryEndpoint openTelemetryEndpoint) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(OpenTelemetryEndpoint openTelemetryEndpoint) {
+  public Integer getPeerPort(OpenTelemetryEndpoint openTelemetryEndpoint) {
     return null;
   }
 

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
@@ -14,18 +14,18 @@ public class LibertyDispatcherHttpAttributesGetter
 
   @Override
   @Nullable
-  public String method(LibertyRequest libertyRequest) {
+  public String getMethod(LibertyRequest libertyRequest) {
     return libertyRequest.getMethod();
   }
 
   @Override
-  public List<String> requestHeader(LibertyRequest libertyRequest, String name) {
+  public List<String> getRequestHeader(LibertyRequest libertyRequest, String name) {
     return libertyRequest.getHeaderValues(name);
   }
 
   @Override
   @Nullable
-  public String flavor(LibertyRequest libertyRequest) {
+  public String getFlavor(LibertyRequest libertyRequest) {
     String flavor = libertyRequest.getProtocol();
     if (flavor != null) {
       // remove HTTP/ prefix to comply with semantic conventions
@@ -38,20 +38,20 @@ public class LibertyDispatcherHttpAttributesGetter
 
   @Override
   @Nullable
-  public Integer statusCode(
+  public Integer getStatusCode(
       LibertyRequest libertyRequest, LibertyResponse libertyResponse, @Nullable Throwable error) {
     return libertyResponse.getStatus();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       LibertyRequest libertyRequest, LibertyResponse libertyResponse, String name) {
     return libertyResponse.getHeaderValues(name);
   }
 
   @Override
   @Nullable
-  public String target(LibertyRequest libertyRequest) {
+  public String getTarget(LibertyRequest libertyRequest) {
     String requestUri = libertyRequest.getRequestUri();
     String queryString = libertyRequest.getQueryString();
     if (queryString != null && !queryString.isEmpty()) {
@@ -62,13 +62,13 @@ public class LibertyDispatcherHttpAttributesGetter
 
   @Override
   @Nullable
-  public String scheme(LibertyRequest libertyRequest) {
+  public String getScheme(LibertyRequest libertyRequest) {
     return libertyRequest.getScheme();
   }
 
   @Override
   @Nullable
-  public String route(LibertyRequest libertyRequest) {
+  public String getRoute(LibertyRequest libertyRequest) {
     return null;
   }
 }

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
@@ -13,41 +13,41 @@ public class LibertyDispatcherNetAttributesGetter
     implements NetServerAttributesGetter<LibertyRequest> {
 
   @Override
-  public String transport(LibertyRequest request) {
+  public String getTransport(LibertyRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(LibertyRequest request) {
+  public String getHostName(LibertyRequest request) {
     return request.request().getURLHost();
   }
 
   @Override
-  public Integer hostPort(LibertyRequest request) {
+  public Integer getHostPort(LibertyRequest request) {
     return request.request().getURLPort();
   }
 
   @Override
   @Nullable
-  public String sockPeerAddr(LibertyRequest request) {
+  public String getSockPeerAddr(LibertyRequest request) {
     return request.dispatcher().getRemoteHostAddress();
   }
 
   @Override
-  public Integer sockPeerPort(LibertyRequest request) {
+  public Integer getSockPeerPort(LibertyRequest request) {
     return request.dispatcher().getRemotePort();
   }
 
   @Nullable
   @Override
-  public String sockHostAddr(LibertyRequest request) {
+  public String getSockHostAddr(LibertyRequest request) {
     return request.dispatcher().getLocalHostAddress();
   }
 
   @Nullable
   @Override
-  public Integer sockHostPort(LibertyRequest request) {
+  public Integer getSockHostPort(LibertyRequest request) {
     return request.dispatcher().getLocalPort();
   }
 }

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoDbAttributesGetter.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoDbAttributesGetter.java
@@ -48,25 +48,25 @@ class MongoDbAttributesGetter implements DbClientAttributesGetter<CommandStarted
   }
 
   @Override
-  public String system(CommandStartedEvent event) {
+  public String getSystem(CommandStartedEvent event) {
     return SemanticAttributes.DbSystemValues.MONGODB;
   }
 
   @Override
   @Nullable
-  public String user(CommandStartedEvent event) {
+  public String getUser(CommandStartedEvent event) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(CommandStartedEvent event) {
+  public String getName(CommandStartedEvent event) {
     return event.getDatabaseName();
   }
 
   @Override
   @Nullable
-  public String connectionString(CommandStartedEvent event) {
+  public String getConnectionString(CommandStartedEvent event) {
     ConnectionDescription connectionDescription = event.getConnectionDescription();
     if (connectionDescription != null) {
       ServerAddress sa = connectionDescription.getServerAddress();
@@ -83,13 +83,13 @@ class MongoDbAttributesGetter implements DbClientAttributesGetter<CommandStarted
   }
 
   @Override
-  public String statement(CommandStartedEvent event) {
+  public String getStatement(CommandStartedEvent event) {
     return sanitizeStatement(event.getCommand());
   }
 
   @Override
   @Nullable
-  public String operation(CommandStartedEvent event) {
+  public String getOperation(CommandStartedEvent event) {
     return event.getCommandName();
   }
 

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoNetAttributesGetter.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoNetAttributesGetter.java
@@ -13,13 +13,13 @@ class MongoNetAttributesGetter implements NetClientAttributesGetter<CommandStart
 
   @Override
   @Nullable
-  public String transport(CommandStartedEvent event, @Nullable Void unused) {
+  public String getTransport(CommandStartedEvent event, @Nullable Void unused) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(CommandStartedEvent event) {
+  public String getPeerName(CommandStartedEvent event) {
     if (event.getConnectionDescription() != null
         && event.getConnectionDescription().getServerAddress() != null) {
       return event.getConnectionDescription().getServerAddress().getHost();
@@ -29,7 +29,7 @@ class MongoNetAttributesGetter implements NetClientAttributesGetter<CommandStart
 
   @Nullable
   @Override
-  public Integer peerPort(CommandStartedEvent event) {
+  public Integer getPeerPort(CommandStartedEvent event) {
     if (event.getConnectionDescription() != null
         && event.getConnectionDescription().getServerAddress() != null) {
       return event.getConnectionDescription().getServerAddress().getPort();

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoSpanNameExtractor.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoSpanNameExtractor.java
@@ -22,8 +22,8 @@ class MongoSpanNameExtractor implements SpanNameExtractor<CommandStartedEvent> {
 
   @Override
   public String extract(CommandStartedEvent event) {
-    String operation = dbAttributesGetter.operation(event);
-    String dbName = dbAttributesGetter.name(event);
+    String operation = dbAttributesGetter.getOperation(event);
+    String dbName = dbAttributesGetter.getName(event);
     if (operation == null) {
       return dbName == null ? DEFAULT_SPAN_NAME : dbName;
     }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectHttpAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectHttpAttributesGetter.java
@@ -18,36 +18,37 @@ enum NettyConnectHttpAttributesGetter
 
   @Nullable
   @Override
-  public String url(NettyConnectionRequest nettyConnectionRequest) {
+  public String getUrl(NettyConnectionRequest nettyConnectionRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public String flavor(NettyConnectionRequest nettyConnectionRequest, @Nullable Channel channel) {
+  public String getFlavor(
+      NettyConnectionRequest nettyConnectionRequest, @Nullable Channel channel) {
     return null;
   }
 
   @Nullable
   @Override
-  public String method(NettyConnectionRequest nettyConnectionRequest) {
+  public String getMethod(NettyConnectionRequest nettyConnectionRequest) {
     return null;
   }
 
   @Override
-  public List<String> requestHeader(NettyConnectionRequest nettyConnectionRequest, String name) {
+  public List<String> getRequestHeader(NettyConnectionRequest nettyConnectionRequest, String name) {
     return Collections.emptyList();
   }
 
   @Nullable
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       NettyConnectionRequest nettyConnectionRequest, Channel channel, @Nullable Throwable error) {
     return null;
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       NettyConnectionRequest nettyConnectionRequest, Channel channel, String name) {
     return Collections.emptyList();
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectNetAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectNetAttributesGetter.java
@@ -20,13 +20,13 @@ final class NettyConnectNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<NettyConnectionRequest, Channel> {
 
   @Override
-  public String transport(NettyConnectionRequest request, @Nullable Channel channel) {
+  public String getTransport(NettyConnectionRequest request, @Nullable Channel channel) {
     return channel instanceof DatagramChannel ? IP_UDP : IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(NettyConnectionRequest request) {
+  public String getPeerName(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getHostString();
@@ -36,7 +36,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public Integer peerPort(NettyConnectionRequest request) {
+  public Integer getPeerPort(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getPort();

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientAttributesGetter.java
@@ -20,7 +20,7 @@ final class NettyHttpClientAttributesGetter
 
   @Override
   @Nullable
-  public String url(HttpRequestAndChannel requestAndChannel) {
+  public String getUrl(HttpRequestAndChannel requestAndChannel) {
     try {
       String hostHeader = getHost(requestAndChannel);
       String target = requestAndChannel.request().getUri();
@@ -35,12 +35,13 @@ final class NettyHttpClientAttributesGetter
   }
 
   private String getHost(HttpRequestAndChannel requestAndChannel) {
-    List<String> values = requestHeader(requestAndChannel, "host");
+    List<String> values = getRequestHeader(requestAndChannel, "host");
     return values.isEmpty() ? null : values.get(0);
   }
 
   @Override
-  public String flavor(HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
+  public String getFlavor(
+      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     String flavor = requestAndChannel.request().getProtocolVersion().toString();
     if (flavor.startsWith("HTTP/")) {
       flavor = flavor.substring("HTTP/".length());
@@ -49,23 +50,23 @@ final class NettyHttpClientAttributesGetter
   }
 
   @Override
-  public String method(HttpRequestAndChannel requestAndChannel) {
+  public String getMethod(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.request().getMethod().getName();
   }
 
   @Override
-  public List<String> requestHeader(HttpRequestAndChannel requestAndChannel, String name) {
+  public List<String> getRequestHeader(HttpRequestAndChannel requestAndChannel, String name) {
     return requestAndChannel.request().headers().getAll(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpRequestAndChannel requestAndChannel, HttpResponse response, @Nullable Throwable error) {
     return response.getStatus().getCode();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpRequestAndChannel requestAndChannel, HttpResponse response, String name) {
     return response.headers().getAll(name);
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyNetClientAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyNetClientAttributesGetter.java
@@ -20,20 +20,20 @@ final class NettyNetClientAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<HttpRequestAndChannel, HttpResponse> {
 
   @Override
-  public String transport(
+  public String getTransport(
       HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     return requestAndChannel.channel() instanceof DatagramChannel ? IP_UDP : IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(HttpRequestAndChannel requestAndChannel) {
+  public String getPeerName(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(HttpRequestAndChannel requestAndChannel) {
+  public Integer getPeerPort(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
@@ -5,10 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v3_8.server;
 
-import static io.opentelemetry.javaagent.instrumentation.netty.v3_8.util.HttpSchemeUtil.getScheme;
-
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.netty.v3_8.HttpRequestAndChannel;
+import io.opentelemetry.javaagent.instrumentation.netty.v3_8.util.HttpSchemeUtil;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.jboss.netty.handler.codec.http.HttpResponse;
@@ -17,29 +16,29 @@ final class NettyHttpServerAttributesGetter
     implements HttpServerAttributesGetter<HttpRequestAndChannel, HttpResponse> {
 
   @Override
-  public String method(HttpRequestAndChannel requestAndChannel) {
+  public String getMethod(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.request().getMethod().getName();
   }
 
   @Override
-  public List<String> requestHeader(HttpRequestAndChannel requestAndChannel, String name) {
+  public List<String> getRequestHeader(HttpRequestAndChannel requestAndChannel, String name) {
     return requestAndChannel.request().headers().getAll(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpRequestAndChannel requestAndChannel, HttpResponse response, @Nullable Throwable error) {
     return response.getStatus().getCode();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpRequestAndChannel requestAndChannel, HttpResponse response, String name) {
     return response.headers().getAll(name);
   }
 
   @Override
-  public String flavor(HttpRequestAndChannel requestAndChannel) {
+  public String getFlavor(HttpRequestAndChannel requestAndChannel) {
     String flavor = requestAndChannel.request().getProtocolVersion().toString();
     if (flavor.startsWith("HTTP/")) {
       flavor = flavor.substring("HTTP/".length());
@@ -48,18 +47,18 @@ final class NettyHttpServerAttributesGetter
   }
 
   @Override
-  public String target(HttpRequestAndChannel requestAndChannel) {
+  public String getTarget(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.request().getUri();
   }
 
   @Override
   @Nullable
-  public String route(HttpRequestAndChannel requestAndChannel) {
+  public String getRoute(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Override
-  public String scheme(HttpRequestAndChannel requestAndChannel) {
-    return getScheme(requestAndChannel);
+  public String getScheme(HttpRequestAndChannel requestAndChannel) {
+    return HttpSchemeUtil.getScheme(requestAndChannel);
   }
 }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
@@ -19,19 +19,19 @@ final class NettyNetServerAttributesGetter
     extends InetSocketAddressNetServerAttributesGetter<HttpRequestAndChannel> {
 
   @Override
-  public String transport(HttpRequestAndChannel requestAndChannel) {
+  public String getTransport(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.channel() instanceof DatagramChannel ? IP_UDP : IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(HttpRequestAndChannel requestAndChannel) {
+  public String getHostName(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer hostPort(HttpRequestAndChannel requestAndChannel) {
+  public Integer getHostPort(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectHttpAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectHttpAttributesGetter.java
@@ -18,36 +18,37 @@ enum NettyConnectHttpAttributesGetter
 
   @Nullable
   @Override
-  public String url(NettyConnectionRequest nettyConnectionRequest) {
+  public String getUrl(NettyConnectionRequest nettyConnectionRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public String flavor(NettyConnectionRequest nettyConnectionRequest, @Nullable Channel channel) {
+  public String getFlavor(
+      NettyConnectionRequest nettyConnectionRequest, @Nullable Channel channel) {
     return null;
   }
 
   @Nullable
   @Override
-  public String method(NettyConnectionRequest nettyConnectionRequest) {
+  public String getMethod(NettyConnectionRequest nettyConnectionRequest) {
     return null;
   }
 
   @Override
-  public List<String> requestHeader(NettyConnectionRequest nettyConnectionRequest, String name) {
+  public List<String> getRequestHeader(NettyConnectionRequest nettyConnectionRequest, String name) {
     return Collections.emptyList();
   }
 
   @Nullable
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       NettyConnectionRequest nettyConnectionRequest, Channel channel, @Nullable Throwable error) {
     return null;
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       NettyConnectionRequest nettyConnectionRequest, Channel channel, String name) {
     return Collections.emptyList();
   }

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectNetAttributesGetter.java
@@ -20,13 +20,13 @@ final class NettyConnectNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<NettyConnectionRequest, Channel> {
 
   @Override
-  public String transport(NettyConnectionRequest request, @Nullable Channel channel) {
+  public String getTransport(NettyConnectionRequest request, @Nullable Channel channel) {
     return channel instanceof DatagramChannel ? IP_UDP : IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(NettyConnectionRequest request) {
+  public String getPeerName(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getHostString();
@@ -36,7 +36,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public Integer peerPort(NettyConnectionRequest request) {
+  public Integer getPeerPort(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getPort();

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyHttpClientAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyHttpClientAttributesGetter.java
@@ -20,7 +20,7 @@ final class NettyHttpClientAttributesGetter
 
   @Override
   @Nullable
-  public String url(HttpRequestAndChannel requestAndChannel) {
+  public String getUrl(HttpRequestAndChannel requestAndChannel) {
     try {
       String hostHeader = getHost(requestAndChannel);
       String target = requestAndChannel.request().getUri();
@@ -35,12 +35,13 @@ final class NettyHttpClientAttributesGetter
   }
 
   private String getHost(HttpRequestAndChannel requestAndChannel) {
-    List<String> values = requestHeader(requestAndChannel, "host");
+    List<String> values = getRequestHeader(requestAndChannel, "host");
     return values.isEmpty() ? null : values.get(0);
   }
 
   @Override
-  public String flavor(HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
+  public String getFlavor(
+      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     String flavor = requestAndChannel.request().getProtocolVersion().toString();
     if (flavor.startsWith("HTTP/")) {
       flavor = flavor.substring("HTTP/".length());
@@ -49,23 +50,23 @@ final class NettyHttpClientAttributesGetter
   }
 
   @Override
-  public String method(HttpRequestAndChannel requestAndChannel) {
+  public String getMethod(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.request().getMethod().name();
   }
 
   @Override
-  public List<String> requestHeader(HttpRequestAndChannel requestAndChannel, String name) {
+  public List<String> getRequestHeader(HttpRequestAndChannel requestAndChannel, String name) {
     return requestAndChannel.request().headers().getAll(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpRequestAndChannel requestAndChannel, HttpResponse response, @Nullable Throwable error) {
     return response.getStatus().code();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpRequestAndChannel requestAndChannel, HttpResponse response, String name) {
     return response.headers().getAll(name);
   }

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyNetClientAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyNetClientAttributesGetter.java
@@ -20,20 +20,20 @@ final class NettyNetClientAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<HttpRequestAndChannel, HttpResponse> {
 
   @Override
-  public String transport(
+  public String getTransport(
       HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     return requestAndChannel.channel() instanceof DatagramChannel ? IP_UDP : IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(HttpRequestAndChannel requestAndChannel) {
+  public String getPeerName(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(HttpRequestAndChannel requestAndChannel) {
+  public Integer getPeerPort(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
@@ -17,19 +17,19 @@ final class NettySslNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<NettySslRequest, Void> {
 
   @Override
-  public String transport(NettySslRequest request, @Nullable Void unused) {
+  public String getTransport(NettySslRequest request, @Nullable Void unused) {
     return request.channel() instanceof DatagramChannel ? IP_UDP : IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(NettySslRequest nettySslRequest) {
+  public String getPeerName(NettySslRequest nettySslRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(NettySslRequest nettySslRequest) {
+  public Integer getPeerPort(NettySslRequest nettySslRequest) {
     return null;
   }
 

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyHttpServerAttributesGetter.java
@@ -5,11 +5,10 @@
 
 package io.opentelemetry.instrumentation.netty.v4.common.internal.server;
 
-import static io.opentelemetry.instrumentation.netty.v4.common.internal.HttpSchemeUtil.getScheme;
-
 import io.netty.handler.codec.http.HttpResponse;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesGetter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
+import io.opentelemetry.instrumentation.netty.v4.common.internal.HttpSchemeUtil;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -17,29 +16,29 @@ final class NettyHttpServerAttributesGetter
     implements HttpServerAttributesGetter<HttpRequestAndChannel, HttpResponse> {
 
   @Override
-  public String method(HttpRequestAndChannel requestAndChannel) {
+  public String getMethod(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.request().getMethod().name();
   }
 
   @Override
-  public List<String> requestHeader(HttpRequestAndChannel requestAndChannel, String name) {
+  public List<String> getRequestHeader(HttpRequestAndChannel requestAndChannel, String name) {
     return requestAndChannel.request().headers().getAll(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpRequestAndChannel requestAndChannel, HttpResponse response, @Nullable Throwable error) {
     return response.getStatus().code();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpRequestAndChannel requestAndChannel, HttpResponse response, String name) {
     return response.headers().getAll(name);
   }
 
   @Override
-  public String flavor(HttpRequestAndChannel requestAndChannel) {
+  public String getFlavor(HttpRequestAndChannel requestAndChannel) {
     String flavor = requestAndChannel.request().getProtocolVersion().toString();
     if (flavor.startsWith("HTTP/")) {
       flavor = flavor.substring("HTTP/".length());
@@ -48,18 +47,18 @@ final class NettyHttpServerAttributesGetter
   }
 
   @Override
-  public String target(HttpRequestAndChannel requestAndChannel) {
+  public String getTarget(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.request().getUri();
   }
 
   @Override
   @Nullable
-  public String route(HttpRequestAndChannel requestAndChannel) {
+  public String getRoute(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Override
-  public String scheme(HttpRequestAndChannel requestAndChannel) {
-    return getScheme(requestAndChannel);
+  public String getScheme(HttpRequestAndChannel requestAndChannel) {
+    return HttpSchemeUtil.getScheme(requestAndChannel);
   }
 }

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
@@ -19,19 +19,19 @@ final class NettyNetServerAttributesGetter
     extends InetSocketAddressNetServerAttributesGetter<HttpRequestAndChannel> {
 
   @Override
-  public String transport(HttpRequestAndChannel requestAndChannel) {
+  public String getTransport(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.channel() instanceof DatagramChannel ? IP_UDP : IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(HttpRequestAndChannel requestAndChannel) {
+  public String getHostName(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer hostPort(HttpRequestAndChannel requestAndChannel) {
+  public Integer getHostPort(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesGetter.java
@@ -15,28 +15,28 @@ import javax.annotation.Nullable;
 final class OkHttp2HttpAttributesGetter implements HttpClientAttributesGetter<Request, Response> {
 
   @Override
-  public String method(Request request) {
+  public String getMethod(Request request) {
     return request.method();
   }
 
   @Override
-  public String url(Request request) {
+  public String getUrl(Request request) {
     return request.urlString();
   }
 
   @Override
-  public List<String> requestHeader(Request request, String name) {
+  public List<String> getRequestHeader(Request request, String name) {
     return request.headers(name);
   }
 
   @Override
-  public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
+  public Integer getStatusCode(Request request, Response response, @Nullable Throwable error) {
     return response.code();
   }
 
   @Override
   @Nullable
-  public String flavor(Request request, @Nullable Response response) {
+  public String getFlavor(Request request, @Nullable Response response) {
     if (response == null) {
       return null;
     }
@@ -54,7 +54,7 @@ final class OkHttp2HttpAttributesGetter implements HttpClientAttributesGetter<Re
   }
 
   @Override
-  public List<String> responseHeader(Request request, Response response, String name) {
+  public List<String> getResponseHeader(Request request, Response response, String name) {
     return response.headers(name);
   }
 }

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2NetAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2NetAttributesGetter.java
@@ -15,18 +15,18 @@ public final class OkHttp2NetAttributesGetter
     implements NetClientAttributesGetter<Request, Response> {
 
   @Override
-  public String transport(Request request, @Nullable Response response) {
+  public String getTransport(Request request, @Nullable Response response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(Request request) {
+  public String getPeerName(Request request) {
     return request.url().getHost();
   }
 
   @Override
-  public Integer peerPort(Request request) {
+  public Integer getPeerPort(Request request) {
     return request.url().getPort();
   }
 }

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttpAttributesGetter.java
@@ -16,24 +16,24 @@ enum OkHttpAttributesGetter implements HttpClientAttributesGetter<Request, Respo
   INSTANCE;
 
   @Override
-  public String method(Request request) {
+  public String getMethod(Request request) {
     return request.method();
   }
 
   @Override
-  public String url(Request request) {
+  public String getUrl(Request request) {
     return request.url().toString();
   }
 
   @Override
-  public List<String> requestHeader(Request request, String name) {
+  public List<String> getRequestHeader(Request request, String name) {
     return request.headers(name);
   }
 
   @Override
   @SuppressWarnings("UnnecessaryDefaultInEnumSwitch")
   @Nullable
-  public String flavor(Request request, @Nullable Response response) {
+  public String getFlavor(Request request, @Nullable Response response) {
     if (response == null) {
       return null;
     }
@@ -53,12 +53,12 @@ enum OkHttpAttributesGetter implements HttpClientAttributesGetter<Request, Respo
   }
 
   @Override
-  public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
+  public Integer getStatusCode(Request request, Response response, @Nullable Throwable error) {
     return response.code();
   }
 
   @Override
-  public List<String> responseHeader(Request request, Response response, String name) {
+  public List<String> getResponseHeader(Request request, Response response, String name) {
     return response.headers(name);
   }
 }

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpNetAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpNetAttributesGetter.java
@@ -19,18 +19,18 @@ public final class OkHttpNetAttributesGetter
     implements NetClientAttributesGetter<Request, Response> {
 
   @Override
-  public String transport(Request request, @Nullable Response response) {
+  public String getTransport(Request request, @Nullable Response response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(Request request) {
+  public String getPeerName(Request request) {
     return request.url().host();
   }
 
   @Override
-  public Integer peerPort(Request request) {
+  public Integer getPeerPort(Request request) {
     return request.url().port();
   }
 }

--- a/instrumentation/opensearch/opensearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/OpenSearchRestAttributesGetter.java
+++ b/instrumentation/opensearch/opensearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/OpenSearchRestAttributesGetter.java
@@ -13,37 +13,37 @@ final class OpenSearchRestAttributesGetter
     implements DbClientAttributesGetter<OpenSearchRestRequest> {
 
   @Override
-  public String system(OpenSearchRestRequest request) {
+  public String getSystem(OpenSearchRestRequest request) {
     return SemanticAttributes.DbSystemValues.OPENSEARCH;
   }
 
   @Override
   @Nullable
-  public String user(OpenSearchRestRequest request) {
+  public String getUser(OpenSearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(OpenSearchRestRequest request) {
+  public String getName(OpenSearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String connectionString(OpenSearchRestRequest request) {
+  public String getConnectionString(OpenSearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String statement(OpenSearchRestRequest request) {
+  public String getStatement(OpenSearchRestRequest request) {
     return request.getMethod() + " " + request.getOperation();
   }
 
   @Override
   @Nullable
-  public String operation(OpenSearchRestRequest request) {
+  public String getOperation(OpenSearchRestRequest request) {
     return request.getMethod();
   }
 }

--- a/instrumentation/opensearch/opensearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/OpenSearchRestNetResponseAttributesGetter.java
+++ b/instrumentation/opensearch/opensearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/OpenSearchRestNetResponseAttributesGetter.java
@@ -15,25 +15,25 @@ final class OpenSearchRestNetResponseAttributesGetter
     implements NetClientAttributesGetter<OpenSearchRestRequest, Response> {
 
   @Override
-  public String transport(OpenSearchRestRequest request, Response response) {
+  public String getTransport(OpenSearchRestRequest request, Response response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(OpenSearchRestRequest request) {
+  public String getPeerName(OpenSearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public Integer peerPort(OpenSearchRestRequest request) {
+  public Integer getPeerPort(OpenSearchRestRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String sockFamily(
+  public String getSockFamily(
       OpenSearchRestRequest elasticsearchRestRequest, @Nullable Response response) {
     if (response != null && response.getHost().getAddress() instanceof Inet6Address) {
       return "inet6";
@@ -43,7 +43,7 @@ final class OpenSearchRestNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String sockPeerAddr(OpenSearchRestRequest request, @Nullable Response response) {
+  public String getSockPeerAddr(OpenSearchRestRequest request, @Nullable Response response) {
     if (response != null && response.getHost().getAddress() != null) {
       return response.getHost().getAddress().getHostAddress();
     }

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/MethodCodeAttributesGetter.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/MethodCodeAttributesGetter.java
@@ -12,12 +12,12 @@ enum MethodCodeAttributesGetter implements CodeAttributesGetter<Method> {
   INSTANCE;
 
   @Override
-  public Class<?> codeClass(Method method) {
+  public Class<?> getCodeClass(Method method) {
     return method.getDeclaringClass();
   }
 
   @Override
-  public String methodName(Method method) {
+  public String getMethodName(Method method) {
     return method.getName();
   }
 }

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/MethodRequestCodeAttributesGetter.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/MethodRequestCodeAttributesGetter.java
@@ -11,12 +11,12 @@ enum MethodRequestCodeAttributesGetter implements CodeAttributesGetter<MethodReq
   INSTANCE;
 
   @Override
-  public Class<?> codeClass(MethodRequest methodRequest) {
+  public Class<?> getCodeClass(MethodRequest methodRequest) {
     return methodRequest.method().getDeclaringClass();
   }
 
   @Override
-  public String methodName(MethodRequest methodRequest) {
+  public String getMethodName(MethodRequest methodRequest) {
     return methodRequest.method().getName();
   }
 }

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/MethodCodeAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/MethodCodeAttributesGetter.java
@@ -12,12 +12,12 @@ enum MethodCodeAttributesGetter implements CodeAttributesGetter<Method> {
   INSTANCE;
 
   @Override
-  public Class<?> codeClass(Method method) {
+  public Class<?> getCodeClass(Method method) {
     return method.getDeclaringClass();
   }
 
   @Override
-  public String methodName(Method method) {
+  public String getMethodName(Method method) {
     return method.getName();
   }
 }

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/MethodRequestCodeAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/MethodRequestCodeAttributesGetter.java
@@ -11,12 +11,12 @@ enum MethodRequestCodeAttributesGetter implements CodeAttributesGetter<MethodReq
   INSTANCE;
 
   @Override
-  public Class<?> codeClass(MethodRequest methodRequest) {
+  public Class<?> getCodeClass(MethodRequest methodRequest) {
     return methodRequest.method().getDeclaringClass();
   }
 
   @Override
-  public String methodName(MethodRequest methodRequest) {
+  public String getMethodName(MethodRequest methodRequest) {
     return methodRequest.method().getName();
   }
 }

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
@@ -18,47 +18,47 @@ enum MockHttpServerAttributesGetter implements HttpServerAttributesGetter<String
 
   @Nullable
   @Override
-  public String method(String s) {
+  public String getMethod(String s) {
     return null;
   }
 
   @Override
-  public List<String> requestHeader(String s, String name) {
+  public List<String> getRequestHeader(String s, String name) {
     return emptyList();
   }
 
   @Nullable
   @Override
-  public Integer statusCode(String s, Void unused, @Nullable Throwable error) {
+  public Integer getStatusCode(String s, Void unused, @Nullable Throwable error) {
     return null;
   }
 
   @Override
-  public List<String> responseHeader(String s, Void unused, String name) {
+  public List<String> getResponseHeader(String s, Void unused, String name) {
     return emptyList();
   }
 
   @Nullable
   @Override
-  public String flavor(String s) {
+  public String getFlavor(String s) {
     return null;
   }
 
   @Nullable
   @Override
-  public String target(String s) {
+  public String getTarget(String s) {
     return null;
   }
 
   @Nullable
   @Override
-  public String route(String s) {
+  public String getRoute(String s) {
     return null;
   }
 
   @Nullable
   @Override
-  public String scheme(String s) {
+  public String getScheme(String s) {
     return null;
   }
 }

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockNetServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockNetServerAttributesGetter.java
@@ -14,19 +14,19 @@ enum MockNetServerAttributesGetter implements NetServerAttributesGetter<String> 
 
   @Nullable
   @Override
-  public String transport(String s) {
+  public String getTransport(String s) {
     return null;
   }
 
   @Nullable
   @Override
-  public String hostName(String s) {
+  public String getHostName(String s) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer hostPort(String s) {
+  public Integer getHostPort(String s) {
     return null;
   }
 }

--- a/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesGetter.java
+++ b/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesGetter.java
@@ -16,32 +16,32 @@ final class PlayWsClientHttpAttributesGetter
     implements HttpClientAttributesGetter<Request, Response> {
 
   @Override
-  public String method(Request request) {
+  public String getMethod(Request request) {
     return request.getMethod();
   }
 
   @Override
-  public String url(Request request) {
+  public String getUrl(Request request) {
     return request.getUri().toUrl();
   }
 
   @Override
-  public List<String> requestHeader(Request request, String name) {
+  public List<String> getRequestHeader(Request request, String name) {
     return request.getHeaders().getAll(name);
   }
 
   @Override
-  public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
+  public Integer getStatusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatusCode();
   }
 
   @Override
-  public String flavor(Request request, @Nullable Response response) {
+  public String getFlavor(Request request, @Nullable Response response) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Override
-  public List<String> responseHeader(Request request, Response response, String name) {
+  public List<String> getResponseHeader(Request request, Response response, String name) {
     return response.getHeaders().getAll(name);
   }
 }

--- a/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientNetAttributesGetter.java
+++ b/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientNetAttributesGetter.java
@@ -16,18 +16,18 @@ final class PlayWsClientNetAttributesGetter
     extends InetSocketAddressNetClientAttributesGetter<Request, Response> {
 
   @Override
-  public String transport(Request request, @Nullable Response response) {
+  public String getTransport(Request request, @Nullable Response response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(Request request) {
+  public String getPeerName(Request request) {
     return request.getUri().getHost();
   }
 
   @Override
-  public Integer peerPort(Request request) {
+  public Integer getPeerPort(Request request) {
     return request.getUri().getPort();
   }
 

--- a/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzCodeAttributesGetter.java
+++ b/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzCodeAttributesGetter.java
@@ -11,12 +11,12 @@ import org.quartz.JobExecutionContext;
 public class QuartzCodeAttributesGetter implements CodeAttributesGetter<JobExecutionContext> {
 
   @Override
-  public Class<?> codeClass(JobExecutionContext jobExecutionContext) {
+  public Class<?> getCodeClass(JobExecutionContext jobExecutionContext) {
     return jobExecutionContext.getJobDetail().getJobClass();
   }
 
   @Override
-  public String methodName(JobExecutionContext jobExecutionContext) {
+  public String getMethodName(JobExecutionContext jobExecutionContext) {
     return "execute";
   }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelAttributesGetter.java
@@ -15,70 +15,70 @@ enum RabbitChannelAttributesGetter implements MessagingAttributesGetter<ChannelA
   INSTANCE;
 
   @Override
-  public String system(ChannelAndMethod channelAndMethod) {
+  public String getSystem(ChannelAndMethod channelAndMethod) {
     return "rabbitmq";
   }
 
   @Override
-  public String destinationKind(ChannelAndMethod channelAndMethod) {
+  public String getDestinationKind(ChannelAndMethod channelAndMethod) {
     return SemanticAttributes.MessagingDestinationKindValues.QUEUE;
   }
 
   @Nullable
   @Override
-  public String destination(ChannelAndMethod channelAndMethod) {
+  public String getDestination(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Override
-  public boolean temporaryDestination(ChannelAndMethod channelAndMethod) {
+  public boolean isTemporaryDestination(ChannelAndMethod channelAndMethod) {
     return false;
   }
 
   @Nullable
   @Override
-  public String protocol(ChannelAndMethod channelAndMethod) {
+  public String getProtocol(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public String protocolVersion(ChannelAndMethod channelAndMethod) {
+  public String getProtocolVersion(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public String url(ChannelAndMethod channelAndMethod) {
+  public String getUrl(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public String conversationId(ChannelAndMethod channelAndMethod) {
+  public String getConversationId(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadSize(ChannelAndMethod channelAndMethod) {
+  public Long getMessagePayloadSize(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadCompressedSize(ChannelAndMethod channelAndMethod) {
+  public Long getMessagePayloadCompressedSize(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public String messageId(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+  public String getMessageId(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
     return null;
   }
 
   @Override
-  public List<String> header(ChannelAndMethod channelAndMethod, String name) {
+  public List<String> getMessageHeader(ChannelAndMethod channelAndMethod, String name) {
     if (channelAndMethod.getHeaders() != null) {
       Object value = channelAndMethod.getHeaders().get(name);
       if (value != null) {

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelNetAttributesGetter.java
@@ -14,36 +14,36 @@ public class RabbitChannelNetAttributesGetter
 
   @Nullable
   @Override
-  public String transport(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+  public String getTransport(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(ChannelAndMethod channelAndMethod) {
+  public String getPeerName(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(ChannelAndMethod channelAndMethod) {
+  public Integer getPeerPort(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public String sockPeerAddr(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+  public String getSockPeerAddr(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
     return channelAndMethod.getChannel().getConnection().getAddress().getHostAddress();
   }
 
   @Override
-  public Integer sockPeerPort(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+  public Integer getSockPeerPort(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
     return channelAndMethod.getChannel().getConnection().getPort();
   }
 
   @Nullable
   @Override
-  public String sockFamily(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+  public String getSockFamily(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
     if (channelAndMethod.getChannel().getConnection().getAddress() instanceof Inet6Address) {
       return "inet6";
     }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitDeliveryAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitDeliveryAttributesGetter.java
@@ -15,18 +15,18 @@ enum RabbitDeliveryAttributesGetter implements MessagingAttributesGetter<Deliver
   INSTANCE;
 
   @Override
-  public String system(DeliveryRequest request) {
+  public String getSystem(DeliveryRequest request) {
     return "rabbitmq";
   }
 
   @Override
-  public String destinationKind(DeliveryRequest request) {
+  public String getDestinationKind(DeliveryRequest request) {
     return SemanticAttributes.MessagingDestinationKindValues.QUEUE;
   }
 
   @Nullable
   @Override
-  public String destination(DeliveryRequest request) {
+  public String getDestination(DeliveryRequest request) {
     if (request.getEnvelope() != null) {
       return normalizeExchangeName(request.getEnvelope().getExchange());
     } else {
@@ -39,37 +39,37 @@ enum RabbitDeliveryAttributesGetter implements MessagingAttributesGetter<Deliver
   }
 
   @Override
-  public boolean temporaryDestination(DeliveryRequest request) {
+  public boolean isTemporaryDestination(DeliveryRequest request) {
     return false;
   }
 
   @Nullable
   @Override
-  public String protocol(DeliveryRequest request) {
+  public String getProtocol(DeliveryRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String protocolVersion(DeliveryRequest request) {
+  public String getProtocolVersion(DeliveryRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String url(DeliveryRequest request) {
+  public String getUrl(DeliveryRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String conversationId(DeliveryRequest request) {
+  public String getConversationId(DeliveryRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadSize(DeliveryRequest request) {
+  public Long getMessagePayloadSize(DeliveryRequest request) {
     if (request.getBody() != null) {
       return (long) request.getBody().length;
     }
@@ -78,18 +78,18 @@ enum RabbitDeliveryAttributesGetter implements MessagingAttributesGetter<Deliver
 
   @Nullable
   @Override
-  public Long messagePayloadCompressedSize(DeliveryRequest request) {
+  public Long getMessagePayloadCompressedSize(DeliveryRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String messageId(DeliveryRequest request, @Nullable Void unused) {
+  public String getMessageId(DeliveryRequest request, @Nullable Void unused) {
     return null;
   }
 
   @Override
-  public List<String> header(DeliveryRequest request, String name) {
+  public List<String> getMessageHeader(DeliveryRequest request, String name) {
     Object value = request.getProperties().getHeaders().get(name);
     if (value != null) {
       return Collections.singletonList(value.toString());

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitReceiveAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitReceiveAttributesGetter.java
@@ -17,18 +17,18 @@ enum RabbitReceiveAttributesGetter
   INSTANCE;
 
   @Override
-  public String system(ReceiveRequest request) {
+  public String getSystem(ReceiveRequest request) {
     return "rabbitmq";
   }
 
   @Override
-  public String destinationKind(ReceiveRequest request) {
+  public String getDestinationKind(ReceiveRequest request) {
     return SemanticAttributes.MessagingDestinationKindValues.QUEUE;
   }
 
   @Nullable
   @Override
-  public String destination(ReceiveRequest request) {
+  public String getDestination(ReceiveRequest request) {
     if (request.getResponse() != null) {
       return normalizeExchangeName(request.getResponse().getEnvelope().getExchange());
     } else {
@@ -41,54 +41,54 @@ enum RabbitReceiveAttributesGetter
   }
 
   @Override
-  public boolean temporaryDestination(ReceiveRequest request) {
+  public boolean isTemporaryDestination(ReceiveRequest request) {
     return false;
   }
 
   @Nullable
   @Override
-  public String protocol(ReceiveRequest request) {
+  public String getProtocol(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String protocolVersion(ReceiveRequest request) {
+  public String getProtocolVersion(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String url(ReceiveRequest request) {
+  public String getUrl(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String conversationId(ReceiveRequest request) {
+  public String getConversationId(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadSize(ReceiveRequest request) {
+  public Long getMessagePayloadSize(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadCompressedSize(ReceiveRequest request) {
+  public Long getMessagePayloadCompressedSize(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String messageId(ReceiveRequest request, @Nullable GetResponse response) {
+  public String getMessageId(ReceiveRequest request, @Nullable GetResponse response) {
     return null;
   }
 
   @Override
-  public List<String> header(ReceiveRequest request, String name) {
+  public List<String> getMessageHeader(ReceiveRequest request, String name) {
     GetResponse response = request.getResponse();
     if (response != null) {
       Object value = request.getResponse().getProps().getHeaders().get(name);

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitReceiveNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitReceiveNetAttributesGetter.java
@@ -15,37 +15,37 @@ public class RabbitReceiveNetAttributesGetter
 
   @Nullable
   @Override
-  public String transport(ReceiveRequest request, @Nullable GetResponse response) {
+  public String getTransport(ReceiveRequest request, @Nullable GetResponse response) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(ReceiveRequest request) {
+  public String getPeerName(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(ReceiveRequest request) {
+  public Integer getPeerPort(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String sockPeerAddr(ReceiveRequest request, @Nullable GetResponse response) {
+  public String getSockPeerAddr(ReceiveRequest request, @Nullable GetResponse response) {
     return request.getConnection().getAddress().getHostAddress();
   }
 
   @Nullable
   @Override
-  public Integer sockPeerPort(ReceiveRequest request, @Nullable GetResponse response) {
+  public Integer getSockPeerPort(ReceiveRequest request, @Nullable GetResponse response) {
     return request.getConnection().getPort();
   }
 
   @Nullable
   @Override
-  public String sockFamily(ReceiveRequest request, @Nullable GetResponse response) {
+  public String getSockFamily(ReceiveRequest request, @Nullable GetResponse response) {
     if (request.getConnection().getAddress() instanceof Inet6Address) {
       return "inet6";
     }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpAttributesGetter.java
@@ -18,26 +18,26 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   INSTANCE;
 
   @Override
-  public String method(Request request) {
+  public String getMethod(Request request) {
     return request.getMethod().getName();
   }
 
   @Override
-  public String target(Request request) {
+  public String getTarget(Request request) {
     // Uri is the path + query string, not a full URL
     return request.getUri();
   }
 
   @Override
   @Nullable
-  public String route(Request request) {
+  public String getRoute(Request request) {
     // Ratpack route not available at the beginning of request.
     return null;
   }
 
   @Override
   @Nullable
-  public String scheme(Request request) {
+  public String getScheme(Request request) {
     Context ratpackContext = request.get(Context.class);
     if (ratpackContext == null) {
       return null;
@@ -50,13 +50,13 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   }
 
   @Override
-  public List<String> requestHeader(Request request, String name) {
+  public List<String> getRequestHeader(Request request, String name) {
     return request.getHeaders().getAll(name);
   }
 
   @Override
   @Nullable
-  public String flavor(Request request) {
+  public String getFlavor(Request request) {
     switch (request.getProtocol()) {
       case "HTTP/1.0":
         return SemanticAttributes.HttpFlavorValues.HTTP_1_0;
@@ -71,12 +71,12 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   }
 
   @Override
-  public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
+  public Integer getStatusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatus().getCode();
   }
 
   @Override
-  public List<String> responseHeader(Request request, Response response, String name) {
+  public List<String> getResponseHeader(Request request, Response response, String name) {
     return response.getHeaders().getAll(name);
   }
 }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpClientAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/RatpackHttpClientAttributesGetter.java
@@ -18,34 +18,34 @@ enum RatpackHttpClientAttributesGetter
 
   @Nullable
   @Override
-  public String url(RequestSpec requestSpec) {
+  public String getUrl(RequestSpec requestSpec) {
     return requestSpec.getUri().toString();
   }
 
   @Override
-  public String flavor(RequestSpec requestSpec, @Nullable HttpResponse httpResponse) {
+  public String getFlavor(RequestSpec requestSpec, @Nullable HttpResponse httpResponse) {
     return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
   }
 
   @Nullable
   @Override
-  public String method(RequestSpec requestSpec) {
+  public String getMethod(RequestSpec requestSpec) {
     return requestSpec.getMethod().getName();
   }
 
   @Override
-  public List<String> requestHeader(RequestSpec requestSpec, String name) {
+  public List<String> getRequestHeader(RequestSpec requestSpec, String name) {
     return requestSpec.getHeaders().getAll(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       RequestSpec requestSpec, HttpResponse httpResponse, @Nullable Throwable error) {
     return httpResponse.getStatusCode();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       RequestSpec requestSpec, HttpResponse httpResponse, String name) {
     return httpResponse.getHeaders().getAll(name);
   }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/internal/RatpackNetClientAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/internal/RatpackNetClientAttributesGetter.java
@@ -19,18 +19,18 @@ public final class RatpackNetClientAttributesGetter
     implements NetClientAttributesGetter<RequestSpec, HttpResponse> {
 
   @Override
-  public String transport(RequestSpec request, @Nullable HttpResponse response) {
+  public String getTransport(RequestSpec request, @Nullable HttpResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(RequestSpec request) {
+  public String getPeerName(RequestSpec request) {
     return request.getUri().getHost();
   }
 
   @Override
-  public Integer peerPort(RequestSpec request) {
+  public Integer getPeerPort(RequestSpec request) {
     return request.getUri().getPort();
   }
 }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/internal/RatpackNetServerAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/internal/RatpackNetServerAttributesGetter.java
@@ -18,20 +18,20 @@ import ratpack.server.PublicAddress;
  */
 public final class RatpackNetServerAttributesGetter implements NetServerAttributesGetter<Request> {
   @Override
-  public String transport(Request request) {
+  public String getTransport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(Request request) {
+  public String getHostName(Request request) {
     PublicAddress publicAddress = getPublicAddress(request);
     return publicAddress == null ? null : publicAddress.get().getHost();
   }
 
   @Nullable
   @Override
-  public Integer hostPort(Request request) {
+  public Integer getHostPort(Request request) {
     PublicAddress publicAddress = getPublicAddress(request);
     return publicAddress == null ? null : publicAddress.get().getPort();
   }
@@ -45,7 +45,7 @@ public final class RatpackNetServerAttributesGetter implements NetServerAttribut
   }
 
   @Override
-  public Integer sockPeerPort(Request request) {
+  public Integer getSockPeerPort(Request request) {
     return request.getRemoteAddress().getPort();
   }
 }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
@@ -17,7 +17,7 @@ final class ReactorNettyHttpClientAttributesGetter
     implements HttpClientAttributesGetter<HttpClientConfig, HttpClientResponse> {
 
   @Override
-  public String url(HttpClientConfig request) {
+  public String getUrl(HttpClientConfig request) {
     String uri = request.uri();
     if (isAbsolute(uri)) {
       return uri;
@@ -59,7 +59,7 @@ final class ReactorNettyHttpClientAttributesGetter
 
   @Nullable
   @Override
-  public String flavor(HttpClientConfig request, @Nullable HttpClientResponse response) {
+  public String getFlavor(HttpClientConfig request, @Nullable HttpClientResponse response) {
     if (response != null) {
       String flavor = response.version().text();
       if (flavor.startsWith("HTTP/")) {
@@ -71,23 +71,23 @@ final class ReactorNettyHttpClientAttributesGetter
   }
 
   @Override
-  public String method(HttpClientConfig request) {
+  public String getMethod(HttpClientConfig request) {
     return request.method().name();
   }
 
   @Override
-  public List<String> requestHeader(HttpClientConfig request, String name) {
+  public List<String> getRequestHeader(HttpClientConfig request, String name) {
     return request.headers().getAll(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpClientConfig request, HttpClientResponse response, @Nullable Throwable error) {
     return response.status().code();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpClientConfig request, HttpClientResponse response, String name) {
     return response.responseHeaders().getAll(name);
   }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyNetClientAttributesGetter.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyNetClientAttributesGetter.java
@@ -18,19 +18,19 @@ final class ReactorNettyNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String transport(HttpClientConfig request, @Nullable HttpClientResponse response) {
+  public String getTransport(HttpClientConfig request, @Nullable HttpClientResponse response) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(HttpClientConfig request) {
+  public String getPeerName(HttpClientConfig request) {
     return getHost(request);
   }
 
   @Nullable
   @Override
-  public Integer peerPort(HttpClientConfig request) {
+  public Integer getPeerPort(HttpClientConfig request) {
     return getPort(request);
   }
 

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaAttributesGetter.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/RediscalaAttributesGetter.java
@@ -14,36 +14,36 @@ import redis.RedisCommand;
 final class RediscalaAttributesGetter implements DbClientAttributesGetter<RedisCommand<?, ?>> {
 
   @Override
-  public String system(RedisCommand<?, ?> redisCommand) {
+  public String getSystem(RedisCommand<?, ?> redisCommand) {
     return SemanticAttributes.DbSystemValues.REDIS;
   }
 
   @Override
   @Nullable
-  public String user(RedisCommand<?, ?> redisCommand) {
+  public String getUser(RedisCommand<?, ?> redisCommand) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(RedisCommand<?, ?> redisCommand) {
+  public String getName(RedisCommand<?, ?> redisCommand) {
     return null;
   }
 
   @Override
   @Nullable
-  public String connectionString(RedisCommand<?, ?> redisCommand) {
+  public String getConnectionString(RedisCommand<?, ?> redisCommand) {
     return null;
   }
 
   @Override
   @Nullable
-  public String statement(RedisCommand<?, ?> redisCommand) {
+  public String getStatement(RedisCommand<?, ?> redisCommand) {
     return null;
   }
 
   @Override
-  public String operation(RedisCommand<?, ?> redisCommand) {
+  public String getOperation(RedisCommand<?, ?> redisCommand) {
     return redisCommand.getClass().getSimpleName().toUpperCase(Locale.ROOT);
   }
 }

--- a/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonDbAttributesGetter.java
+++ b/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonDbAttributesGetter.java
@@ -12,35 +12,35 @@ import javax.annotation.Nullable;
 final class RedissonDbAttributesGetter implements DbClientAttributesGetter<RedissonRequest> {
 
   @Override
-  public String system(RedissonRequest request) {
+  public String getSystem(RedissonRequest request) {
     return SemanticAttributes.DbSystemValues.REDIS;
   }
 
   @Nullable
   @Override
-  public String user(RedissonRequest request) {
+  public String getUser(RedissonRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String name(RedissonRequest request) {
+  public String getName(RedissonRequest request) {
     return null;
   }
 
   @Override
-  public String connectionString(RedissonRequest request) {
+  public String getConnectionString(RedissonRequest request) {
     return null;
   }
 
   @Override
-  public String statement(RedissonRequest request) {
+  public String getStatement(RedissonRequest request) {
     return request.getStatement();
   }
 
   @Nullable
   @Override
-  public String operation(RedissonRequest request) {
+  public String getOperation(RedissonRequest request) {
     return request.getOperation();
   }
 }

--- a/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonNetAttributesGetter.java
+++ b/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonNetAttributesGetter.java
@@ -14,19 +14,19 @@ final class RedissonNetAttributesGetter
 
   @Nullable
   @Override
-  public String transport(RedissonRequest request, @Nullable Void unused) {
+  public String getTransport(RedissonRequest request, @Nullable Void unused) {
     return null;
   }
 
   @Nullable
   @Override
-  public String peerName(RedissonRequest redissonRequest) {
+  public String getPeerName(RedissonRequest redissonRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer peerPort(RedissonRequest redissonRequest) {
+  public Integer getPeerPort(RedissonRequest redissonRequest) {
     return null;
   }
 

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletHttpAttributesGetter.java
@@ -24,13 +24,13 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   INSTANCE;
 
   @Override
-  public String method(Request request) {
+  public String getMethod(Request request) {
     return request.getMethod().toString();
   }
 
   @Override
   @Nullable
-  public String target(Request request) {
+  public String getTarget(Request request) {
     Reference ref = request.getOriginalRef();
     String path = ref.getPath();
     return ref.hasQuery() ? path + "?" + ref.getQuery() : path;
@@ -38,18 +38,18 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
 
   @Override
   @Nullable
-  public String route(Request request) {
+  public String getRoute(Request request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String scheme(Request request) {
+  public String getScheme(Request request) {
     return request.getOriginalRef().getScheme();
   }
 
   @Override
-  public List<String> requestHeader(Request request, String name) {
+  public List<String> getRequestHeader(Request request, String name) {
     Form headers = getHeaders(request);
     if (headers == null) {
       return Collections.emptyList();
@@ -59,7 +59,7 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
 
   @Override
   @Nullable
-  public String flavor(Request request) {
+  public String getFlavor(Request request) {
     String version = (String) request.getAttributes().get("org.restlet.http.version");
     switch (version) {
       case "HTTP/1.0":
@@ -75,12 +75,12 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   }
 
   @Override
-  public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
+  public Integer getStatusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatus().getCode();
   }
 
   @Override
-  public List<String> responseHeader(Request request, Response response, String name) {
+  public List<String> getResponseHeader(Request request, Response response, String name) {
     Form headers = getHeaders(response);
     if (headers == null) {
       return Collections.emptyList();

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletNetAttributesGetter.java
@@ -15,38 +15,38 @@ import org.restlet.data.Request;
 final class RestletNetAttributesGetter implements NetServerAttributesGetter<Request> {
 
   @Override
-  public String transport(Request request) {
+  public String getTransport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(Request request) {
+  public String getHostName(Request request) {
     HttpCall call = httpCall(request);
     return call == null ? null : call.getHostDomain();
   }
 
   @Nullable
   @Override
-  public Integer hostPort(Request request) {
+  public Integer getHostPort(Request request) {
     HttpCall call = httpCall(request);
     return call == null ? null : call.getServerPort();
   }
 
   @Override
   @Nullable
-  public String sockPeerAddr(Request request) {
+  public String getSockPeerAddr(Request request) {
     return request.getClientInfo().getAddress();
   }
 
   @Override
-  public Integer sockPeerPort(Request request) {
+  public Integer getSockPeerPort(Request request) {
     return request.getClientInfo().getPort();
   }
 
   @Nullable
   @Override
-  public String sockHostAddr(Request request) {
+  public String getSockHostAddr(Request request) {
     HttpCall call = httpCall(request);
     return call == null ? null : call.getServerAddress();
   }

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
@@ -26,13 +26,13 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
   INSTANCE;
 
   @Override
-  public String method(Request request) {
+  public String getMethod(Request request) {
     return request.getMethod().toString();
   }
 
   @Override
   @Nullable
-  public String target(Request request) {
+  public String getTarget(Request request) {
     Reference ref = request.getOriginalRef();
     String path = ref.getPath();
     return ref.hasQuery() ? path + "?" + ref.getQuery() : path;
@@ -40,18 +40,18 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public String route(Request request) {
+  public String getRoute(Request request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String scheme(Request request) {
+  public String getScheme(Request request) {
     return request.getOriginalRef().getScheme();
   }
 
   @Override
-  public List<String> requestHeader(Request request, String name) {
+  public List<String> getRequestHeader(Request request, String name) {
     Series<?> headers = getHeaders(request);
     if (headers == null) {
       return Collections.emptyList();
@@ -61,7 +61,7 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public String flavor(Request request) {
+  public String getFlavor(Request request) {
     switch (request.getProtocol().toString()) {
       case "HTTP/1.0":
         return SemanticAttributes.HttpFlavorValues.HTTP_1_0;
@@ -76,12 +76,12 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
   }
 
   @Override
-  public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
+  public Integer getStatusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatus().getCode();
   }
 
   @Override
-  public List<String> responseHeader(Request request, Response response, String name) {
+  public List<String> getResponseHeader(Request request, Response response, String name) {
     Series<?> headers = getHeaders(response);
     if (headers == null) {
       return Collections.emptyList();

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletNetAttributesGetter.java
@@ -79,13 +79,13 @@ public final class RestletNetAttributesGetter implements NetServerAttributesGett
   }
 
   @Override
-  public String transport(Request request) {
+  public String getTransport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(Request request) {
+  public String getHostName(Request request) {
     if (GET_HOST_DOMAIN == null) {
       return null;
     }
@@ -102,7 +102,7 @@ public final class RestletNetAttributesGetter implements NetServerAttributesGett
 
   @Nullable
   @Override
-  public Integer hostPort(Request request) {
+  public Integer getHostPort(Request request) {
     if (GET_SERVER_PORT == null) {
       return null;
     }
@@ -119,18 +119,18 @@ public final class RestletNetAttributesGetter implements NetServerAttributesGett
 
   @Override
   @Nullable
-  public String sockPeerAddr(Request request) {
+  public String getSockPeerAddr(Request request) {
     return request.getClientInfo().getAddress();
   }
 
   @Override
-  public Integer sockPeerPort(Request request) {
+  public Integer getSockPeerPort(Request request) {
     return request.getClientInfo().getPort();
   }
 
   @Nullable
   @Override
-  public String sockHostAddr(Request request) {
+  public String getSockHostAddr(Request request) {
     if (GET_SERVER_ADDRESS == null) {
       return null;
     }

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientAttributesGetter.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/client/RmiClientAttributesGetter.java
@@ -12,17 +12,17 @@ enum RmiClientAttributesGetter implements RpcAttributesGetter<Method> {
   INSTANCE;
 
   @Override
-  public String system(Method method) {
+  public String getSystem(Method method) {
     return "java_rmi";
   }
 
   @Override
-  public String service(Method method) {
+  public String getService(Method method) {
     return method.getDeclaringClass().getName();
   }
 
   @Override
-  public String method(Method method) {
+  public String getMethod(Method method) {
     return method.getName();
   }
 }

--- a/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerAttributesGetter.java
+++ b/instrumentation/rmi/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rmi/server/RmiServerAttributesGetter.java
@@ -12,17 +12,17 @@ enum RmiServerAttributesGetter implements RpcAttributesGetter<ClassAndMethod> {
   INSTANCE;
 
   @Override
-  public String system(ClassAndMethod classAndMethod) {
+  public String getSystem(ClassAndMethod classAndMethod) {
     return "java_rmi";
   }
 
   @Override
-  public String service(ClassAndMethod classAndMethod) {
+  public String getService(ClassAndMethod classAndMethod) {
     return classAndMethod.declaringClass().getName();
   }
 
   @Override
-  public String method(ClassAndMethod classAndMethod) {
+  public String getMethod(ClassAndMethod classAndMethod) {
     return classAndMethod.methodName();
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerAttributeGetter.java
@@ -16,70 +16,70 @@ enum RocketMqConsumerAttributeGetter implements MessagingAttributesGetter<Messag
   INSTANCE;
 
   @Override
-  public String system(MessageExt request) {
+  public String getSystem(MessageExt request) {
     return "rocketmq";
   }
 
   @Override
-  public String destinationKind(MessageExt request) {
+  public String getDestinationKind(MessageExt request) {
     return SemanticAttributes.MessagingDestinationKindValues.TOPIC;
   }
 
   @Override
-  public String destination(MessageExt request) {
+  public String getDestination(MessageExt request) {
     return request.getTopic();
   }
 
   @Override
-  public boolean temporaryDestination(MessageExt request) {
+  public boolean isTemporaryDestination(MessageExt request) {
     return false;
   }
 
   @Nullable
   @Override
-  public String protocol(MessageExt request) {
+  public String getProtocol(MessageExt request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String protocolVersion(MessageExt request) {
+  public String getProtocolVersion(MessageExt request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String url(MessageExt request) {
+  public String getUrl(MessageExt request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String conversationId(MessageExt request) {
+  public String getConversationId(MessageExt request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadSize(MessageExt request) {
+  public Long getMessagePayloadSize(MessageExt request) {
     byte[] body = request.getBody();
     return body == null ? null : (long) body.length;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadCompressedSize(MessageExt request) {
+  public Long getMessagePayloadCompressedSize(MessageExt request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String messageId(MessageExt request, @Nullable Void unused) {
+  public String getMessageId(MessageExt request, @Nullable Void unused) {
     return request.getMsgId();
   }
 
   @Override
-  public List<String> header(MessageExt request, String name) {
+  public List<String> getMessageHeader(MessageExt request, String name) {
     String value = request.getProperties().get(name);
     if (value != null) {
       return Collections.singletonList(value);

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqProducerAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqProducerAttributeGetter.java
@@ -19,72 +19,72 @@ enum RocketMqProducerAttributeGetter
   INSTANCE;
 
   @Override
-  public String system(SendMessageContext sendMessageContext) {
+  public String getSystem(SendMessageContext sendMessageContext) {
     return "rocketmq";
   }
 
   @Override
-  public String destinationKind(SendMessageContext sendMessageContext) {
+  public String getDestinationKind(SendMessageContext sendMessageContext) {
     return SemanticAttributes.MessagingDestinationKindValues.TOPIC;
   }
 
   @Nullable
   @Override
-  public String destination(SendMessageContext sendMessageContext) {
+  public String getDestination(SendMessageContext sendMessageContext) {
     Message message = sendMessageContext.getMessage();
     return message == null ? null : message.getTopic();
   }
 
   @Override
-  public boolean temporaryDestination(SendMessageContext sendMessageContext) {
+  public boolean isTemporaryDestination(SendMessageContext sendMessageContext) {
     return false;
   }
 
   @Nullable
   @Override
-  public String protocol(SendMessageContext sendMessageContext) {
+  public String getProtocol(SendMessageContext sendMessageContext) {
     return null;
   }
 
   @Nullable
   @Override
-  public String protocolVersion(SendMessageContext sendMessageContext) {
+  public String getProtocolVersion(SendMessageContext sendMessageContext) {
     return null;
   }
 
   @Nullable
   @Override
-  public String url(SendMessageContext sendMessageContext) {
+  public String getUrl(SendMessageContext sendMessageContext) {
     return null;
   }
 
   @Nullable
   @Override
-  public String conversationId(SendMessageContext sendMessageContext) {
+  public String getConversationId(SendMessageContext sendMessageContext) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadSize(SendMessageContext sendMessageContext) {
+  public Long getMessagePayloadSize(SendMessageContext sendMessageContext) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadCompressedSize(SendMessageContext sendMessageContext) {
+  public Long getMessagePayloadCompressedSize(SendMessageContext sendMessageContext) {
     return null;
   }
 
   @Nullable
   @Override
-  public String messageId(SendMessageContext request, @Nullable Void unused) {
+  public String getMessageId(SendMessageContext request, @Nullable Void unused) {
     SendResult sendResult = request.getSendResult();
     return sendResult == null ? null : sendResult.getMsgId();
   }
 
   @Override
-  public List<String> header(SendMessageContext request, String name) {
+  public List<String> getMessageHeader(SendMessageContext request, String name) {
     String value = request.getMessage().getProperties().get(name);
     if (value != null) {
       return Collections.singletonList(value);

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerProcessAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerProcessAttributeGetter.java
@@ -19,71 +19,71 @@ enum RocketMqConsumerProcessAttributeGetter
 
   @Nullable
   @Override
-  public String system(MessageView messageView) {
+  public String getSystem(MessageView messageView) {
     return "rocketmq";
   }
 
   @Nullable
   @Override
-  public String destinationKind(MessageView messageView) {
+  public String getDestinationKind(MessageView messageView) {
     return SemanticAttributes.MessagingDestinationKindValues.TOPIC;
   }
 
   @Nullable
   @Override
-  public String destination(MessageView messageView) {
+  public String getDestination(MessageView messageView) {
     return messageView.getTopic();
   }
 
   @Override
-  public boolean temporaryDestination(MessageView messageView) {
+  public boolean isTemporaryDestination(MessageView messageView) {
     return false;
   }
 
   @Nullable
   @Override
-  public String protocol(MessageView messageView) {
+  public String getProtocol(MessageView messageView) {
     return null;
   }
 
   @Nullable
   @Override
-  public String protocolVersion(MessageView messageView) {
+  public String getProtocolVersion(MessageView messageView) {
     return null;
   }
 
   @Nullable
   @Override
-  public String url(MessageView messageView) {
+  public String getUrl(MessageView messageView) {
     return null;
   }
 
   @Nullable
   @Override
-  public String conversationId(MessageView messageView) {
+  public String getConversationId(MessageView messageView) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadSize(MessageView messageView) {
+  public Long getMessagePayloadSize(MessageView messageView) {
     return (long) messageView.getBody().remaining();
   }
 
   @Nullable
   @Override
-  public Long messagePayloadCompressedSize(MessageView messageView) {
+  public Long getMessagePayloadCompressedSize(MessageView messageView) {
     return null;
   }
 
   @Nullable
   @Override
-  public String messageId(MessageView messageView, @Nullable ConsumeResult unused) {
+  public String getMessageId(MessageView messageView, @Nullable ConsumeResult unused) {
     return messageView.getMessageId().toString();
   }
 
   @Override
-  public List<String> header(MessageView messageView, String name) {
+  public List<String> getMessageHeader(MessageView messageView, String name) {
     String value = messageView.getProperties().get(name);
     if (value != null) {
       return Collections.singletonList(value);

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerReceiveAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerReceiveAttributeGetter.java
@@ -18,66 +18,66 @@ enum RocketMqConsumerReceiveAttributeGetter
 
   @Nullable
   @Override
-  public String system(ReceiveMessageRequest request) {
+  public String getSystem(ReceiveMessageRequest request) {
     return "rocketmq";
   }
 
   @Nullable
   @Override
-  public String destinationKind(ReceiveMessageRequest request) {
+  public String getDestinationKind(ReceiveMessageRequest request) {
     return SemanticAttributes.MessagingDestinationKindValues.TOPIC;
   }
 
   @Nullable
   @Override
-  public String destination(ReceiveMessageRequest request) {
+  public String getDestination(ReceiveMessageRequest request) {
     return request.getMessageQueue().getTopic().getName();
   }
 
   @Override
-  public boolean temporaryDestination(ReceiveMessageRequest request) {
+  public boolean isTemporaryDestination(ReceiveMessageRequest request) {
     return false;
   }
 
   @Nullable
   @Override
-  public String protocol(ReceiveMessageRequest request) {
+  public String getProtocol(ReceiveMessageRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String protocolVersion(ReceiveMessageRequest request) {
+  public String getProtocolVersion(ReceiveMessageRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String url(ReceiveMessageRequest request) {
+  public String getUrl(ReceiveMessageRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String conversationId(ReceiveMessageRequest request) {
+  public String getConversationId(ReceiveMessageRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadSize(ReceiveMessageRequest request) {
+  public Long getMessagePayloadSize(ReceiveMessageRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadCompressedSize(ReceiveMessageRequest request) {
+  public Long getMessagePayloadCompressedSize(ReceiveMessageRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String messageId(ReceiveMessageRequest request, @Nullable List<MessageView> unused) {
+  public String getMessageId(ReceiveMessageRequest request, @Nullable List<MessageView> unused) {
     return null;
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqProducerAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqProducerAttributeGetter.java
@@ -19,71 +19,71 @@ enum RocketMqProducerAttributeGetter
 
   @Nullable
   @Override
-  public String system(PublishingMessageImpl message) {
+  public String getSystem(PublishingMessageImpl message) {
     return "rocketmq";
   }
 
   @Nullable
   @Override
-  public String destinationKind(PublishingMessageImpl message) {
+  public String getDestinationKind(PublishingMessageImpl message) {
     return SemanticAttributes.MessagingDestinationKindValues.TOPIC;
   }
 
   @Nullable
   @Override
-  public String destination(PublishingMessageImpl message) {
+  public String getDestination(PublishingMessageImpl message) {
     return message.getTopic();
   }
 
   @Override
-  public boolean temporaryDestination(PublishingMessageImpl message) {
+  public boolean isTemporaryDestination(PublishingMessageImpl message) {
     return false;
   }
 
   @Nullable
   @Override
-  public String protocol(PublishingMessageImpl message) {
+  public String getProtocol(PublishingMessageImpl message) {
     return null;
   }
 
   @Nullable
   @Override
-  public String protocolVersion(PublishingMessageImpl message) {
+  public String getProtocolVersion(PublishingMessageImpl message) {
     return null;
   }
 
   @Nullable
   @Override
-  public String url(PublishingMessageImpl message) {
+  public String getUrl(PublishingMessageImpl message) {
     return null;
   }
 
   @Nullable
   @Override
-  public String conversationId(PublishingMessageImpl message) {
+  public String getConversationId(PublishingMessageImpl message) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long messagePayloadSize(PublishingMessageImpl message) {
+  public Long getMessagePayloadSize(PublishingMessageImpl message) {
     return (long) message.getBody().remaining();
   }
 
   @Nullable
   @Override
-  public Long messagePayloadCompressedSize(PublishingMessageImpl message) {
+  public Long getMessagePayloadCompressedSize(PublishingMessageImpl message) {
     return null;
   }
 
   @Nullable
   @Override
-  public String messageId(PublishingMessageImpl message, @Nullable SendReceiptImpl sendReceipt) {
+  public String getMessageId(PublishingMessageImpl message, @Nullable SendReceiptImpl sendReceipt) {
     return message.getMessageId().toString();
   }
 
   @Override
-  public List<String> header(PublishingMessageImpl message, String name) {
+  public List<String> getMessageHeader(PublishingMessageImpl message, String name) {
     String value = message.getProperties().get(name);
     if (value != null) {
       return Collections.singletonList(value);

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2HttpAttributesGetter.java
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2HttpAttributesGetter.java
@@ -23,7 +23,7 @@ public class Servlet2HttpAttributesGetter
 
   @Override
   @Nullable
-  public Integer statusCode(
+  public Integer getStatusCode(
       ServletRequestContext<HttpServletRequest> requestContext,
       ServletResponseContext<HttpServletResponse> responseContext,
       @Nullable Throwable error) {

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
@@ -21,13 +21,13 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
 
   @Override
   @Nullable
-  public String method(ServletRequestContext<REQUEST> requestContext) {
+  public String getMethod(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestMethod(requestContext.request());
   }
 
   @Override
   @Nullable
-  public String target(ServletRequestContext<REQUEST> requestContext) {
+  public String getTarget(ServletRequestContext<REQUEST> requestContext) {
     REQUEST request = requestContext.request();
     String target = accessor.getRequestUri(request);
     String queryString = accessor.getRequestQueryString(request);
@@ -39,18 +39,18 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
 
   @Override
   @Nullable
-  public String scheme(ServletRequestContext<REQUEST> requestContext) {
+  public String getScheme(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestScheme(requestContext.request());
   }
 
   @Override
-  public List<String> requestHeader(ServletRequestContext<REQUEST> requestContext, String name) {
+  public List<String> getRequestHeader(ServletRequestContext<REQUEST> requestContext, String name) {
     return accessor.getRequestHeaderValues(requestContext.request(), name);
   }
 
   @Override
   @Nullable
-  public String flavor(ServletRequestContext<REQUEST> requestContext) {
+  public String getFlavor(ServletRequestContext<REQUEST> requestContext) {
     String flavor = accessor.getRequestProtocol(requestContext.request());
     if (flavor != null) {
       // remove HTTP/ prefix to comply with semantic conventions
@@ -63,7 +63,7 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
 
   @Override
   @Nullable
-  public Integer statusCode(
+  public Integer getStatusCode(
       ServletRequestContext<REQUEST> requestContext,
       ServletResponseContext<RESPONSE> responseContext,
       @Nullable Throwable error) {
@@ -87,7 +87,7 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       ServletRequestContext<REQUEST> requestContext,
       ServletResponseContext<RESPONSE> responseContext,
       String name) {
@@ -96,7 +96,7 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
 
   @Override
   @Nullable
-  public String route(ServletRequestContext<REQUEST> requestContext) {
+  public String getRoute(ServletRequestContext<REQUEST> requestContext) {
     return null;
   }
 }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesGetter.java
@@ -20,43 +20,43 @@ public class ServletNetAttributesGetter<REQUEST, RESPONSE>
 
   @Override
   @Nullable
-  public String transport(ServletRequestContext<REQUEST> requestContext) {
+  public String getTransport(ServletRequestContext<REQUEST> requestContext) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(ServletRequestContext<REQUEST> requestContext) {
+  public String getHostName(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestServerName(requestContext.request());
   }
 
   @Nullable
   @Override
-  public Integer hostPort(ServletRequestContext<REQUEST> requestContext) {
+  public Integer getHostPort(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestServerPort(requestContext.request());
   }
 
   @Override
   @Nullable
-  public String sockPeerAddr(ServletRequestContext<REQUEST> requestContext) {
+  public String getSockPeerAddr(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestRemoteAddr(requestContext.request());
   }
 
   @Override
   @Nullable
-  public Integer sockPeerPort(ServletRequestContext<REQUEST> requestContext) {
+  public Integer getSockPeerPort(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestRemotePort(requestContext.request());
   }
 
   @Nullable
   @Override
-  public String sockHostAddr(ServletRequestContext<REQUEST> requestContext) {
+  public String getSockHostAddr(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestLocalAddr(requestContext.request());
   }
 
   @Nullable
   @Override
-  public Integer sockHostPort(ServletRequestContext<REQUEST> requestContext) {
+  public Integer getSockHostPort(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestLocalPort(requestContext.request());
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/JointPointCodeAttributesExtractor.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/aspects/JointPointCodeAttributesExtractor.java
@@ -11,12 +11,12 @@ enum JointPointCodeAttributesExtractor implements CodeAttributesGetter<JoinPoint
   INSTANCE;
 
   @Override
-  public Class<?> codeClass(JoinPointRequest joinPointRequest) {
+  public Class<?> getCodeClass(JoinPointRequest joinPointRequest) {
     return joinPointRequest.method().getDeclaringClass();
   }
 
   @Override
-  public String methodName(JoinPointRequest joinPointRequest) {
+  public String getMethodName(JoinPointRequest joinPointRequest) {
     return joinPointRequest.method().getName();
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringMessagingAttributesGetter.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringMessagingAttributesGetter.java
@@ -17,71 +17,71 @@ enum SpringMessagingAttributesGetter
 
   @Override
   @Nullable
-  public String system(MessageWithChannel messageWithChannel) {
+  public String getSystem(MessageWithChannel messageWithChannel) {
     return null;
   }
 
   @Override
   @Nullable
-  public String destinationKind(MessageWithChannel messageWithChannel) {
+  public String getDestinationKind(MessageWithChannel messageWithChannel) {
     return null;
   }
 
   @Override
   @Nullable
-  public String destination(MessageWithChannel messageWithChannel) {
+  public String getDestination(MessageWithChannel messageWithChannel) {
     return null;
   }
 
   @Override
-  public boolean temporaryDestination(MessageWithChannel messageWithChannel) {
+  public boolean isTemporaryDestination(MessageWithChannel messageWithChannel) {
     return false;
   }
 
   @Override
   @Nullable
-  public String protocol(MessageWithChannel messageWithChannel) {
+  public String getProtocol(MessageWithChannel messageWithChannel) {
     return null;
   }
 
   @Override
   @Nullable
-  public String protocolVersion(MessageWithChannel messageWithChannel) {
+  public String getProtocolVersion(MessageWithChannel messageWithChannel) {
     return null;
   }
 
   @Override
   @Nullable
-  public String url(MessageWithChannel messageWithChannel) {
+  public String getUrl(MessageWithChannel messageWithChannel) {
     return null;
   }
 
   @Override
   @Nullable
-  public String conversationId(MessageWithChannel messageWithChannel) {
+  public String getConversationId(MessageWithChannel messageWithChannel) {
     return null;
   }
 
   @Override
   @Nullable
-  public Long messagePayloadSize(MessageWithChannel messageWithChannel) {
+  public Long getMessagePayloadSize(MessageWithChannel messageWithChannel) {
     return null;
   }
 
   @Override
   @Nullable
-  public Long messagePayloadCompressedSize(MessageWithChannel messageWithChannel) {
+  public Long getMessagePayloadCompressedSize(MessageWithChannel messageWithChannel) {
     return null;
   }
 
   @Override
   @Nullable
-  public String messageId(MessageWithChannel messageWithChannel, @Nullable Void unused) {
+  public String getMessageId(MessageWithChannel messageWithChannel, @Nullable Void unused) {
     return null;
   }
 
   @Override
-  public List<String> header(MessageWithChannel request, String name) {
+  public List<String> getMessageHeader(MessageWithChannel request, String name) {
     Object value = request.getMessage().getHeaders().get(name);
     if (value != null) {
       return Collections.singletonList(value.toString());

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMessageAttributesGetter.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMessageAttributesGetter.java
@@ -15,69 +15,69 @@ enum SpringRabbitMessageAttributesGetter implements MessagingAttributesGetter<Me
   INSTANCE;
 
   @Override
-  public String system(Message message) {
+  public String getSystem(Message message) {
     return "rabbitmq";
   }
 
   @Override
-  public String destinationKind(Message message) {
+  public String getDestinationKind(Message message) {
     return "queue";
   }
 
   @Override
   @Nullable
-  public String destination(Message message) {
+  public String getDestination(Message message) {
     return message.getMessageProperties().getReceivedRoutingKey();
   }
 
   @Override
-  public boolean temporaryDestination(Message message) {
+  public boolean isTemporaryDestination(Message message) {
     return false;
   }
 
   @Override
   @Nullable
-  public String protocol(Message message) {
+  public String getProtocol(Message message) {
     return null;
   }
 
   @Override
   @Nullable
-  public String protocolVersion(Message message) {
+  public String getProtocolVersion(Message message) {
     return null;
   }
 
   @Override
   @Nullable
-  public String url(Message message) {
+  public String getUrl(Message message) {
     return null;
   }
 
   @Override
   @Nullable
-  public String conversationId(Message message) {
+  public String getConversationId(Message message) {
     return null;
   }
 
   @Override
-  public Long messagePayloadSize(Message message) {
+  public Long getMessagePayloadSize(Message message) {
     return message.getMessageProperties().getContentLength();
   }
 
   @Override
   @Nullable
-  public Long messagePayloadCompressedSize(Message message) {
+  public Long getMessagePayloadCompressedSize(Message message) {
     return null;
   }
 
   @Override
   @Nullable
-  public String messageId(Message message, @Nullable Void unused) {
+  public String getMessageId(Message message, @Nullable Void unused) {
     return message.getMessageProperties().getMessageId();
   }
 
   @Override
-  public List<String> header(Message message, String name) {
+  public List<String> getMessageHeader(Message message, String name) {
     Object value = message.getMessageProperties().getHeaders().get(name);
     if (value != null) {
       return Collections.singletonList(value.toString());

--- a/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/client/ClientAttributesGetter.java
+++ b/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/client/ClientAttributesGetter.java
@@ -12,17 +12,17 @@ public enum ClientAttributesGetter implements RpcAttributesGetter<Method> {
   INSTANCE;
 
   @Override
-  public String system(Method method) {
+  public String getSystem(Method method) {
     return "spring_rmi";
   }
 
   @Override
-  public String service(Method method) {
+  public String getService(Method method) {
     return method.getDeclaringClass().getName();
   }
 
   @Override
-  public String method(Method method) {
+  public String getMethod(Method method) {
     return method.getName();
   }
 }

--- a/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/server/ServerAttributesGetter.java
+++ b/instrumentation/spring/spring-rmi-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rmi/v4_0/server/ServerAttributesGetter.java
@@ -12,17 +12,17 @@ public enum ServerAttributesGetter implements RpcAttributesGetter<ClassAndMethod
   INSTANCE;
 
   @Override
-  public String system(ClassAndMethod classAndMethod) {
+  public String getSystem(ClassAndMethod classAndMethod) {
     return "spring_rmi";
   }
 
   @Override
-  public String service(ClassAndMethod classAndMethod) {
+  public String getService(ClassAndMethod classAndMethod) {
     return classAndMethod.declaringClass().getName();
   }
 
   @Override
-  public String method(ClassAndMethod classAndMethod) {
+  public String getMethod(ClassAndMethod classAndMethod) {
     return classAndMethod.methodName();
   }
 }

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/SpringSchedulingCodeAttributesGetter.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/SpringSchedulingCodeAttributesGetter.java
@@ -11,7 +11,7 @@ import org.springframework.scheduling.support.ScheduledMethodRunnable;
 public class SpringSchedulingCodeAttributesGetter implements CodeAttributesGetter<Runnable> {
 
   @Override
-  public Class<?> codeClass(Runnable runnable) {
+  public Class<?> getCodeClass(Runnable runnable) {
     if (runnable instanceof ScheduledMethodRunnable) {
       ScheduledMethodRunnable scheduledMethodRunnable = (ScheduledMethodRunnable) runnable;
       return scheduledMethodRunnable.getMethod().getDeclaringClass();
@@ -21,7 +21,7 @@ public class SpringSchedulingCodeAttributesGetter implements CodeAttributesGette
   }
 
   @Override
-  public String methodName(Runnable runnable) {
+  public String getMethodName(Runnable runnable) {
     if (runnable instanceof ScheduledMethodRunnable) {
       ScheduledMethodRunnable scheduledMethodRunnable = (ScheduledMethodRunnable) runnable;
       return scheduledMethodRunnable.getMethod().getName();

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebHttpAttributesGetter.java
@@ -21,24 +21,25 @@ enum SpringWebHttpAttributesGetter
   INSTANCE;
 
   @Override
-  public String method(HttpRequest httpRequest) {
+  public String getMethod(HttpRequest httpRequest) {
     return httpRequest.getMethod().name();
   }
 
   @Override
   @Nullable
-  public String url(HttpRequest httpRequest) {
+  public String getUrl(HttpRequest httpRequest) {
     return httpRequest.getURI().toString();
   }
 
   @Override
-  public List<String> requestHeader(HttpRequest httpRequest, String name) {
+  public List<String> getRequestHeader(HttpRequest httpRequest, String name) {
     return httpRequest.getHeaders().getOrDefault(name, emptyList());
   }
 
   @Override
   @Nullable
-  public String flavor(HttpRequest httpRequest, @Nullable ClientHttpResponse clientHttpResponse) {
+  public String getFlavor(
+      HttpRequest httpRequest, @Nullable ClientHttpResponse clientHttpResponse) {
     return null;
   }
 
@@ -82,7 +83,7 @@ enum SpringWebHttpAttributesGetter
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpRequest httpRequest, ClientHttpResponse clientHttpResponse, @Nullable Throwable error) {
 
     if (GET_STATUS_CODE == null || STATUS_CODE_VALUE == null) {
@@ -98,7 +99,7 @@ enum SpringWebHttpAttributesGetter
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpRequest httpRequest, ClientHttpResponse clientHttpResponse, String name) {
     return clientHttpResponse.getHeaders().getOrDefault(name, emptyList());
   }

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebNetAttributesGetter.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebNetAttributesGetter.java
@@ -15,18 +15,18 @@ final class SpringWebNetAttributesGetter
     implements NetClientAttributesGetter<HttpRequest, ClientHttpResponse> {
 
   @Override
-  public String transport(HttpRequest httpRequest, @Nullable ClientHttpResponse response) {
+  public String getTransport(HttpRequest httpRequest, @Nullable ClientHttpResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Override
   @Nullable
-  public String peerName(HttpRequest httpRequest) {
+  public String getPeerName(HttpRequest httpRequest) {
     return httpRequest.getURI().getHost();
   }
 
   @Override
-  public Integer peerPort(HttpRequest httpRequest) {
+  public Integer getPeerPort(HttpRequest httpRequest) {
     return httpRequest.getURI().getPort();
   }
 }

--- a/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/HandlerCodeAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/HandlerCodeAttributesGetter.java
@@ -11,13 +11,13 @@ import javax.annotation.Nullable;
 public class HandlerCodeAttributesGetter implements CodeAttributesGetter<Object> {
   @Nullable
   @Override
-  public Class<?> codeClass(Object handler) {
+  public Class<?> getCodeClass(Object handler) {
     return handler.getClass();
   }
 
   @Nullable
   @Override
-  public String methodName(Object handler) {
+  public String getMethodName(Object handler) {
     return "handle";
   }
 }

--- a/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_0/client/SpringWebfluxHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_0/client/SpringWebfluxHttpAttributesGetter.java
@@ -18,35 +18,36 @@ enum SpringWebfluxHttpAttributesGetter
   INSTANCE;
 
   @Override
-  public String url(ClientRequest request) {
+  public String getUrl(ClientRequest request) {
     return request.url().toString();
   }
 
   @Nullable
   @Override
-  public String flavor(ClientRequest request, @Nullable ClientResponse response) {
+  public String getFlavor(ClientRequest request, @Nullable ClientResponse response) {
     return null;
   }
 
   @Override
-  public String method(ClientRequest request) {
+  public String getMethod(ClientRequest request) {
     return request.method().name();
   }
 
   @Override
-  public List<String> requestHeader(ClientRequest request, String name) {
+  public List<String> getRequestHeader(ClientRequest request, String name) {
     return request.headers().getOrDefault(name, emptyList());
   }
 
   @Override
   @Nullable
-  public Integer statusCode(
+  public Integer getStatusCode(
       ClientRequest request, ClientResponse response, @Nullable Throwable error) {
     return StatusCodes.get(response);
   }
 
   @Override
-  public List<String> responseHeader(ClientRequest request, ClientResponse response, String name) {
+  public List<String> getResponseHeader(
+      ClientRequest request, ClientResponse response, String name) {
     return response.headers().header(name);
   }
 }

--- a/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_0/client/internal/SpringWebfluxNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux-5.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_0/client/internal/SpringWebfluxNetAttributesGetter.java
@@ -19,18 +19,18 @@ public final class SpringWebfluxNetAttributesGetter
     implements NetClientAttributesGetter<ClientRequest, ClientResponse> {
 
   @Override
-  public String transport(ClientRequest request, @Nullable ClientResponse response) {
+  public String getTransport(ClientRequest request, @Nullable ClientResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(ClientRequest request) {
+  public String getPeerName(ClientRequest request) {
     return request.url().getHost();
   }
 
   @Override
-  public Integer peerPort(ClientRequest request) {
+  public Integer getPeerPort(ClientRequest request) {
     return request.url().getPort();
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
@@ -21,19 +21,19 @@ enum SpringWebMvcHttpAttributesGetter
 
   @Override
   @Nullable
-  public String method(HttpServletRequest request) {
+  public String getMethod(HttpServletRequest request) {
     return request.getMethod();
   }
 
   @Override
-  public List<String> requestHeader(HttpServletRequest request, String name) {
+  public List<String> getRequestHeader(HttpServletRequest request, String name) {
     Enumeration<String> headers = request.getHeaders(name);
     return headers == null ? Collections.emptyList() : Collections.list(headers);
   }
 
   @Override
   @Nullable
-  public String flavor(HttpServletRequest request) {
+  public String getFlavor(HttpServletRequest request) {
     String flavor = request.getProtocol();
     if (flavor == null) {
       return null;
@@ -45,7 +45,7 @@ enum SpringWebMvcHttpAttributesGetter
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpServletRequest request, HttpServletResponse response, @Nullable Throwable error) {
 
     int statusCode;
@@ -64,7 +64,7 @@ enum SpringWebMvcHttpAttributesGetter
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpServletRequest request, HttpServletResponse response, String name) {
     Collection<String> headers = response.getHeaders(name);
     if (headers == null) {
@@ -78,7 +78,7 @@ enum SpringWebMvcHttpAttributesGetter
 
   @Override
   @Nullable
-  public String target(HttpServletRequest request) {
+  public String getTarget(HttpServletRequest request) {
     String target = request.getRequestURI();
     String queryString = request.getQueryString();
     if (queryString != null) {
@@ -89,13 +89,13 @@ enum SpringWebMvcHttpAttributesGetter
 
   @Override
   @Nullable
-  public String route(HttpServletRequest request) {
+  public String getRoute(HttpServletRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String scheme(HttpServletRequest request) {
+  public String getScheme(HttpServletRequest request) {
     return request.getScheme();
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcNetAttributesGetter.java
@@ -14,40 +14,40 @@ enum SpringWebMvcNetAttributesGetter implements NetServerAttributesGetter<HttpSe
   INSTANCE;
 
   @Override
-  public String transport(HttpServletRequest request) {
+  public String getTransport(HttpServletRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(HttpServletRequest request) {
+  public String getHostName(HttpServletRequest request) {
     return request.getServerName();
   }
 
   @Override
-  public Integer hostPort(HttpServletRequest request) {
+  public Integer getHostPort(HttpServletRequest request) {
     return request.getServerPort();
   }
 
   @Override
   @Nullable
-  public String sockPeerAddr(HttpServletRequest request) {
+  public String getSockPeerAddr(HttpServletRequest request) {
     return request.getRemoteAddr();
   }
 
   @Override
-  public Integer sockPeerPort(HttpServletRequest request) {
+  public Integer getSockPeerPort(HttpServletRequest request) {
     return request.getRemotePort();
   }
 
   @Nullable
   @Override
-  public String sockHostAddr(HttpServletRequest request) {
+  public String getSockHostAddr(HttpServletRequest request) {
     return request.getLocalAddr();
   }
 
   @Override
-  public Integer sockHostPort(HttpServletRequest request) {
+  public Integer getSockHostPort(HttpServletRequest request) {
     return request.getLocalPort();
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcHttpAttributesGetter.java
@@ -21,19 +21,19 @@ enum SpringWebMvcHttpAttributesGetter
 
   @Override
   @Nullable
-  public String method(HttpServletRequest request) {
+  public String getMethod(HttpServletRequest request) {
     return request.getMethod();
   }
 
   @Override
-  public List<String> requestHeader(HttpServletRequest request, String name) {
+  public List<String> getRequestHeader(HttpServletRequest request, String name) {
     Enumeration<String> headers = request.getHeaders(name);
     return headers == null ? Collections.emptyList() : Collections.list(headers);
   }
 
   @Override
   @Nullable
-  public String flavor(HttpServletRequest request) {
+  public String getFlavor(HttpServletRequest request) {
     String flavor = request.getProtocol();
     if (flavor == null) {
       return null;
@@ -45,7 +45,7 @@ enum SpringWebMvcHttpAttributesGetter
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpServletRequest request, HttpServletResponse response, @Nullable Throwable error) {
 
     int statusCode;
@@ -64,7 +64,7 @@ enum SpringWebMvcHttpAttributesGetter
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpServletRequest request, HttpServletResponse response, String name) {
     Collection<String> headers = response.getHeaders(name);
     if (headers == null) {
@@ -78,7 +78,7 @@ enum SpringWebMvcHttpAttributesGetter
 
   @Override
   @Nullable
-  public String target(HttpServletRequest request) {
+  public String getTarget(HttpServletRequest request) {
     String target = request.getRequestURI();
     String queryString = request.getQueryString();
     if (queryString != null) {
@@ -89,13 +89,13 @@ enum SpringWebMvcHttpAttributesGetter
 
   @Override
   @Nullable
-  public String route(HttpServletRequest request) {
+  public String getRoute(HttpServletRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String scheme(HttpServletRequest request) {
+  public String getScheme(HttpServletRequest request) {
     return request.getScheme();
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcNetAttributesGetter.java
@@ -14,40 +14,40 @@ enum SpringWebMvcNetAttributesGetter implements NetServerAttributesGetter<HttpSe
   INSTANCE;
 
   @Override
-  public String transport(HttpServletRequest request) {
+  public String getTransport(HttpServletRequest request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(HttpServletRequest request) {
+  public String getHostName(HttpServletRequest request) {
     return request.getServerName();
   }
 
   @Override
-  public Integer hostPort(HttpServletRequest request) {
+  public Integer getHostPort(HttpServletRequest request) {
     return request.getServerPort();
   }
 
   @Override
   @Nullable
-  public String sockPeerAddr(HttpServletRequest request) {
+  public String getSockPeerAddr(HttpServletRequest request) {
     return request.getRemoteAddr();
   }
 
   @Override
-  public Integer sockPeerPort(HttpServletRequest request) {
+  public Integer getSockPeerPort(HttpServletRequest request) {
     return request.getRemotePort();
   }
 
   @Nullable
   @Override
-  public String sockHostAddr(HttpServletRequest request) {
+  public String getSockHostAddr(HttpServletRequest request) {
     return request.getLocalAddr();
   }
 
   @Override
-  public Integer sockHostPort(HttpServletRequest request) {
+  public Integer getSockHostPort(HttpServletRequest request) {
     return request.getLocalPort();
   }
 }

--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/v2_0/SpringWsCodeAttributesGetter.java
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/v2_0/SpringWsCodeAttributesGetter.java
@@ -10,12 +10,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.code.CodeAttributesGett
 public class SpringWsCodeAttributesGetter implements CodeAttributesGetter<SpringWsRequest> {
 
   @Override
-  public Class<?> codeClass(SpringWsRequest request) {
+  public Class<?> getCodeClass(SpringWsRequest request) {
     return request.getCodeClass();
   }
 
   @Override
-  public String methodName(SpringWsRequest request) {
+  public String getMethodName(SpringWsRequest request) {
     return request.getMethodName();
   }
 }

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SpymemcachedAttributesGetter.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/SpymemcachedAttributesGetter.java
@@ -11,37 +11,37 @@ import javax.annotation.Nullable;
 public class SpymemcachedAttributesGetter implements DbClientAttributesGetter<SpymemcachedRequest> {
 
   @Override
-  public String system(SpymemcachedRequest spymemcachedRequest) {
+  public String getSystem(SpymemcachedRequest spymemcachedRequest) {
     return "memcached";
   }
 
   @Override
   @Nullable
-  public String user(SpymemcachedRequest spymemcachedRequest) {
+  public String getUser(SpymemcachedRequest spymemcachedRequest) {
     return null;
   }
 
   @Override
   @Nullable
-  public String name(SpymemcachedRequest spymemcachedRequest) {
+  public String getName(SpymemcachedRequest spymemcachedRequest) {
     return null;
   }
 
   @Override
   @Nullable
-  public String connectionString(SpymemcachedRequest spymemcachedRequest) {
+  public String getConnectionString(SpymemcachedRequest spymemcachedRequest) {
     return null;
   }
 
   @Override
   @Nullable
-  public String statement(SpymemcachedRequest spymemcachedRequest) {
+  public String getStatement(SpymemcachedRequest spymemcachedRequest) {
     return null;
   }
 
   @Override
   @Nullable
-  public String operation(SpymemcachedRequest spymemcachedRequest) {
+  public String getOperation(SpymemcachedRequest spymemcachedRequest) {
     return spymemcachedRequest.dbOperation();
   }
 }

--- a/instrumentation/struts-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/struts2/StrutsCodeAttributesGetter.java
+++ b/instrumentation/struts-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/struts2/StrutsCodeAttributesGetter.java
@@ -11,12 +11,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.code.CodeAttributesGett
 public class StrutsCodeAttributesGetter implements CodeAttributesGetter<ActionInvocation> {
 
   @Override
-  public Class<?> codeClass(ActionInvocation actionInvocation) {
+  public Class<?> getCodeClass(ActionInvocation actionInvocation) {
     return actionInvocation.getAction().getClass();
   }
 
   @Override
-  public String methodName(ActionInvocation actionInvocation) {
+  public String getMethodName(ActionInvocation actionInvocation) {
     return actionInvocation.getProxy().getMethod();
   }
 }

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
@@ -18,13 +18,13 @@ import org.apache.tomcat.util.buf.MessageBytes;
 public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Request, Response> {
 
   @Override
-  public String method(Request request) {
+  public String getMethod(Request request) {
     return messageBytesToString(request.method());
   }
 
   @Override
   @Nullable
-  public String target(Request request) {
+  public String getTarget(Request request) {
     String target = messageBytesToString(request.requestURI());
     String queryString = messageBytesToString(request.queryString());
     if (queryString != null) {
@@ -35,19 +35,19 @@ public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public String scheme(Request request) {
+  public String getScheme(Request request) {
     MessageBytes schemeMessageBytes = request.scheme();
     return schemeMessageBytes.isNull() ? "http" : messageBytesToString(schemeMessageBytes);
   }
 
   @Override
-  public List<String> requestHeader(Request request, String name) {
+  public List<String> getRequestHeader(Request request, String name) {
     return Collections.list(request.getMimeHeaders().values(name));
   }
 
   @Override
   @Nullable
-  public String flavor(Request request) {
+  public String getFlavor(Request request) {
     String flavor = messageBytesToString(request.protocol());
     if (flavor != null) {
       // remove HTTP/ prefix to comply with semantic conventions
@@ -60,18 +60,18 @@ public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public Integer statusCode(Request request, Response response, @Nullable Throwable error) {
+  public Integer getStatusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatus();
   }
 
   @Override
-  public List<String> responseHeader(Request request, Response response, String name) {
+  public List<String> getResponseHeader(Request request, Response response, String name) {
     return Collections.list(response.getMimeHeaders().values(name));
   }
 
   @Override
   @Nullable
-  public String route(Request request) {
+  public String getRoute(Request request) {
     return null;
   }
 }

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesGetter.java
@@ -17,45 +17,45 @@ public class TomcatNetAttributesGetter implements NetServerAttributesGetter<Requ
 
   @Override
   @Nullable
-  public String transport(Request request) {
+  public String getTransport(Request request) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(Request request) {
+  public String getHostName(Request request) {
     return messageBytesToString(request.serverName());
   }
 
   @Override
-  public Integer hostPort(Request request) {
+  public Integer getHostPort(Request request) {
     return request.getServerPort();
   }
 
   @Override
   @Nullable
-  public String sockPeerAddr(Request request) {
+  public String getSockPeerAddr(Request request) {
     request.action(ActionCode.REQ_HOST_ADDR_ATTRIBUTE, request);
     return messageBytesToString(request.remoteAddr());
   }
 
   @Override
   @Nullable
-  public Integer sockPeerPort(Request request) {
+  public Integer getSockPeerPort(Request request) {
     request.action(ActionCode.REQ_REMOTEPORT_ATTRIBUTE, request);
     return request.getRemotePort();
   }
 
   @Nullable
   @Override
-  public String sockHostAddr(Request request) {
+  public String getSockHostAddr(Request request) {
     request.action(ActionCode.REQ_LOCAL_ADDR_ATTRIBUTE, request);
     return messageBytesToString(request.localAddr());
   }
 
   @Nullable
   @Override
-  public Integer sockHostPort(Request request) {
+  public Integer getSockHostPort(Request request) {
     request.action(ActionCode.REQ_LOCALPORT_ATTRIBUTE, request);
     return request.getLocalPort();
   }

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
@@ -16,18 +16,18 @@ public class UndertowHttpAttributesGetter
     implements HttpServerAttributesGetter<HttpServerExchange, HttpServerExchange> {
 
   @Override
-  public String method(HttpServerExchange exchange) {
+  public String getMethod(HttpServerExchange exchange) {
     return exchange.getRequestMethod().toString();
   }
 
   @Override
-  public List<String> requestHeader(HttpServerExchange exchange, String name) {
+  public List<String> getRequestHeader(HttpServerExchange exchange, String name) {
     HeaderValues values = exchange.getRequestHeaders().get(name);
     return values == null ? Collections.emptyList() : values;
   }
 
   @Override
-  public String flavor(HttpServerExchange exchange) {
+  public String getFlavor(HttpServerExchange exchange) {
     String flavor = exchange.getProtocol().toString();
     // remove HTTP/ prefix to comply with semantic conventions
     if (flavor.startsWith("HTTP/")) {
@@ -37,13 +37,13 @@ public class UndertowHttpAttributesGetter
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpServerExchange exchange, HttpServerExchange unused, @Nullable Throwable error) {
     return exchange.getStatusCode();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpServerExchange exchange, HttpServerExchange unused, String name) {
     HeaderValues values = exchange.getResponseHeaders().get(name);
     return values == null ? Collections.emptyList() : values;
@@ -51,7 +51,7 @@ public class UndertowHttpAttributesGetter
 
   @Override
   @Nullable
-  public String target(HttpServerExchange exchange) {
+  public String getTarget(HttpServerExchange exchange) {
     String requestPath = exchange.getRequestPath();
     String queryString = exchange.getQueryString();
     if (requestPath != null && queryString != null && !queryString.isEmpty()) {
@@ -62,13 +62,13 @@ public class UndertowHttpAttributesGetter
 
   @Override
   @Nullable
-  public String scheme(HttpServerExchange exchange) {
+  public String getScheme(HttpServerExchange exchange) {
     return exchange.getRequestScheme();
   }
 
   @Override
   @Nullable
-  public String route(HttpServerExchange exchange) {
+  public String getRoute(HttpServerExchange exchange) {
     return null;
   }
 }

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
@@ -15,19 +15,19 @@ public class UndertowNetAttributesGetter
     extends InetSocketAddressNetServerAttributesGetter<HttpServerExchange> {
 
   @Override
-  public String transport(HttpServerExchange exchange) {
+  public String getTransport(HttpServerExchange exchange) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String hostName(HttpServerExchange exchange) {
+  public String getHostName(HttpServerExchange exchange) {
     return exchange.getHostName();
   }
 
   @Nullable
   @Override
-  public Integer hostPort(HttpServerExchange exchange) {
+  public Integer getHostPort(HttpServerExchange exchange) {
     return exchange.getHostPort();
   }
 

--- a/instrumentation/vaadin-14.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vaadin/ClientCallableCodeAttributesGetter.java
+++ b/instrumentation/vaadin-14.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vaadin/ClientCallableCodeAttributesGetter.java
@@ -11,12 +11,12 @@ public class ClientCallableCodeAttributesGetter
     implements CodeAttributesGetter<VaadinClientCallableRequest> {
 
   @Override
-  public Class<?> codeClass(VaadinClientCallableRequest request) {
+  public Class<?> getCodeClass(VaadinClientCallableRequest request) {
     return request.getComponentClass();
   }
 
   @Override
-  public String methodName(VaadinClientCallableRequest request) {
+  public String getMethodName(VaadinClientCallableRequest request) {
     return request.getMethodName();
   }
 }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3HttpAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3HttpAttributesGetter.java
@@ -15,7 +15,7 @@ final class Vertx3HttpAttributesGetter extends AbstractVertxHttpAttributesGetter
       VirtualField.find(HttpClientRequest.class, VertxRequestInfo.class);
 
   @Override
-  public String url(HttpClientRequest request) {
+  public String getUrl(HttpClientRequest request) {
     String uri = request.uri();
     // Uri should be relative, but it is possible to misuse vert.x api and pass an absolute uri
     // where relative is expected.
@@ -44,7 +44,7 @@ final class Vertx3HttpAttributesGetter extends AbstractVertxHttpAttributesGetter
   }
 
   @Override
-  public String method(HttpClientRequest request) {
+  public String getMethod(HttpClientRequest request) {
     return request.method().name();
   }
 }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3NetAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3NetAttributesGetter.java
@@ -17,24 +17,24 @@ enum Vertx3NetAttributesGetter
   INSTANCE;
 
   @Override
-  public String transport(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getTransport(HttpClientRequest request, @Nullable HttpClientResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(HttpClientRequest request) {
+  public String getPeerName(HttpClientRequest request) {
     return null;
   }
 
   @Override
-  public Integer peerPort(HttpClientRequest request) {
+  public Integer getPeerPort(HttpClientRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String sockPeerName(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getSockPeerName(HttpClientRequest request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }
@@ -44,7 +44,7 @@ enum Vertx3NetAttributesGetter
 
   @Nullable
   @Override
-  public Integer sockPeerPort(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public Integer getSockPeerPort(HttpClientRequest request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4HttpAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4HttpAttributesGetter.java
@@ -15,7 +15,7 @@ import javax.annotation.Nullable;
 final class Vertx4HttpAttributesGetter extends AbstractVertxHttpAttributesGetter {
 
   @Override
-  public String url(HttpClientRequest request) {
+  public String getUrl(HttpClientRequest request) {
     String uri = request.getURI();
     if (!isAbsolute(uri)) {
       uri = request.absoluteURI();
@@ -28,13 +28,13 @@ final class Vertx4HttpAttributesGetter extends AbstractVertxHttpAttributesGetter
   }
 
   @Override
-  public String method(HttpClientRequest request) {
+  public String getMethod(HttpClientRequest request) {
     return request.getMethod().name();
   }
 
   @Nullable
   @Override
-  public String flavor(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getFlavor(HttpClientRequest request, @Nullable HttpClientResponse response) {
     HttpVersion version = request.version();
     if (version == null) {
       return null;

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4NetAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4NetAttributesGetter.java
@@ -16,24 +16,24 @@ final class Vertx4NetAttributesGetter
     implements NetClientAttributesGetter<HttpClientRequest, HttpClientResponse> {
 
   @Override
-  public String transport(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getTransport(HttpClientRequest request, @Nullable HttpClientResponse response) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
   }
 
   @Nullable
   @Override
-  public String peerName(HttpClientRequest request) {
+  public String getPeerName(HttpClientRequest request) {
     return request.getHost();
   }
 
   @Override
-  public Integer peerPort(HttpClientRequest request) {
+  public Integer getPeerPort(HttpClientRequest request) {
     return request.getPort();
   }
 
   @Nullable
   @Override
-  public String sockPeerAddr(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getSockPeerAddr(HttpClientRequest request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }
@@ -43,7 +43,7 @@ final class Vertx4NetAttributesGetter
 
   @Nullable
   @Override
-  public String sockPeerName(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getSockPeerName(HttpClientRequest request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }
@@ -53,7 +53,7 @@ final class Vertx4NetAttributesGetter
 
   @Nullable
   @Override
-  public Integer sockPeerPort(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public Integer getSockPeerPort(HttpClientRequest request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/client/AbstractVertxHttpAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/client/AbstractVertxHttpAttributesGetter.java
@@ -16,23 +16,23 @@ public abstract class AbstractVertxHttpAttributesGetter
 
   @Nullable
   @Override
-  public String flavor(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getFlavor(HttpClientRequest request, @Nullable HttpClientResponse response) {
     return null;
   }
 
   @Override
-  public List<String> requestHeader(HttpClientRequest request, String name) {
+  public List<String> getRequestHeader(HttpClientRequest request, String name) {
     return request.headers().getAll(name);
   }
 
   @Override
-  public Integer statusCode(
+  public Integer getStatusCode(
       HttpClientRequest request, HttpClientResponse response, @Nullable Throwable error) {
     return response.statusCode();
   }
 
   @Override
-  public List<String> responseHeader(
+  public List<String> getResponseHeader(
       HttpClientRequest request, HttpClientResponse response, String name) {
     return response.headers().getAll(name);
   }


### PR DESCRIPTION
Resolves #6562

This PR only contains renames; the actual content is in the `*Getter` interfaces, the rest of changes is just IntelliJ doing its job.