### PR TITLE
Parallelize tests across multiple GitHub Actions jobs

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -133,6 +133,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    name: test${{ matrix.test-partition }} (${{ matrix.test-java-version }}, ${{ matrix.vm }})
     strategy:
       matrix:
         test-java-version:

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -143,6 +143,11 @@ jobs:
         vm:
           - hotspot
           - openj9
+        test-partition:
+          - 0
+          - 1
+          - 2
+          - 3
         exclude:
           - test-java-version: 19
             vm: openj9
@@ -189,6 +194,7 @@ jobs:
             -PtestJavaVM=${{ matrix.vm }}
             -Porg.gradle.java.installations.paths=${{ steps.setup-test-java.outputs.path }}
             -Porg.gradle.java.installations.auto-download=false
+            -PtestPartition=${{ matrix.test-partition }}
             ${{ inputs.no-build-cache && ' --no-build-cache' || '' }}
           # only push cache for one matrix option since github action cache space is limited
           cache-read-only: ${{ inputs.cache-read-only || matrix.test-java-version != 11 || matrix.vm != 'hotspot' }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,3 +32,18 @@ nexusPublishing {
 }
 
 description = "OpenTelemetry instrumentations for Java"
+
+// total of 4 partitions (see modulo 4 below)
+var testPartition = (project.findProperty("testPartition") as String?)?.toInt()
+if (testPartition != null) {
+  var testPartitionCounter = 0
+  subprojects {
+    // relying on predictable ordering of subprojects
+    // (see https://docs.gradle.org/current/dsl/org.gradle.api.Project.html#N14CB4)
+    // since we are splitting these tasks across different github action jobs
+    val enabled = testPartitionCounter++ % 4 == testPartition
+    tasks.withType<Test>().configureEach {
+      this.enabled = enabled
+    }
+  }
+}


### PR DESCRIPTION
The build takes ~2 hours when there are changes to core modules that force re-running of all tests.

Ran into the long test times (again) in #7632.

This also affects release times since the version bump PR build takes 2 hours to run, and then another 2 hours to run release (or wait 2 hours for CI build to run and update gradle cache).