### PR TITLE
Skip openj9 in PR build

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -9,6 +9,9 @@ on:
       no-build-cache:
         type: boolean
         required: false
+      skip-openj9-tests:
+        type: boolean
+        required: false
       skip-windows-smoke-tests:
         type: boolean
         required: false
@@ -144,6 +147,7 @@ jobs:
           - hotspot
           - openj9
         exclude:
+          - vm: ${{ inputs.skip-openj9-tests && 'openj9' || '' }}
           - test-java-version: 19
             vm: openj9
       fail-fast: false

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -11,7 +11,8 @@ jobs:
   common:
     uses: ./.github/workflows/build-common.yml
     with:
-      # windows smoke tests are slower, and it's rare for only the windows smoke tests to break
+      # it's rare for only the openj9 tests or the windows smoke tests to break
+      skip-openj9-tests: false
       skip-windows-smoke-tests: false
       cache-read-only: true
 


### PR DESCRIPTION
to help offset new parallelization in #7639