### PR TITLE
Reactor 3.5 draft for testing

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -71,7 +71,7 @@ tasks.withType<JavaCompile>().configureEach {
           "-Xlint:-options",
 
           // Fail build on any warning
-          "-Werror"
+          // "-Werror"
         )
       )
     }

--- a/instrumentation/reactor/reactor-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-3.1/javaagent/build.gradle.kts
@@ -20,7 +20,7 @@ tasks.withType<Test>().configureEach {
 
 dependencies {
   implementation(project(":instrumentation:reactor:reactor-3.1:library"))
-  library("io.projectreactor:reactor-core:3.1.0.RELEASE")
+  library("io.projectreactor:reactor-core:3.5.0")
 
   implementation(project(":instrumentation:opentelemetry-api:opentelemetry-api-1.0:javaagent"))
 
@@ -30,14 +30,11 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:opentelemetry-extension-annotations-1.0:javaagent"))
 
-  testLibrary("io.projectreactor:reactor-test:3.1.0.RELEASE")
+  testLibrary("io.projectreactor:reactor-test:3.5.0")
   testImplementation(project(":instrumentation-annotations-support-testing"))
   testImplementation(project(":instrumentation:reactor:reactor-3.1:testing"))
   testImplementation(project(":instrumentation-annotations"))
   testImplementation("io.opentelemetry:opentelemetry-extension-annotations")
-
-  latestDepTestLibrary("io.projectreactor:reactor-core:3.4.+")
-  latestDepTestLibrary("io.projectreactor:reactor-test:3.4.+")
 }
 
 testing {
@@ -46,7 +43,7 @@ testing {
       dependencies {
         implementation(project(":instrumentation:reactor:reactor-3.1:library"))
         implementation(project(":instrumentation-annotations"))
-        implementation("io.projectreactor:reactor-test:3.1.0.RELEASE")
+        implementation("io.projectreactor:reactor-test:3.5.0")
       }
     }
   }

--- a/instrumentation/reactor/reactor-3.1/library/build.gradle.kts
+++ b/instrumentation/reactor/reactor-3.1/library/build.gradle.kts
@@ -3,12 +3,9 @@ plugins {
 }
 
 dependencies {
-  library("io.projectreactor:reactor-core:3.1.0.RELEASE")
+  library("io.projectreactor:reactor-core:3.5.0")
   implementation(project(":instrumentation-annotations-support"))
-  testLibrary("io.projectreactor:reactor-test:3.1.0.RELEASE")
+  testLibrary("io.projectreactor:reactor-test:3.5.0")
 
   testImplementation(project(":instrumentation:reactor:reactor-3.1:testing"))
-
-  latestDepTestLibrary("io.projectreactor:reactor-core:3.4.+")
-  latestDepTestLibrary("io.projectreactor:reactor-test:3.4.+")
 }


### PR DESCRIPTION
After #7538, the only test that's failing against 3.5.0/3.5.1 is `nestedNonBlocking`.