### PR TITLE
Return interface instead of concrete implementation in instrumentatio…

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractor.java
@@ -22,7 +22,7 @@ public final class CodeAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {
 
   /** Creates the code attributes extractor. */
-  public static <REQUEST, RESPONSE> CodeAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       CodeAttributesGetter<REQUEST> getter) {
     return new CodeAttributesExtractor<>(getter);
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientAttributesExtractor.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorU
 
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 /**
@@ -24,7 +25,7 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
         REQUEST, RESPONSE, DbClientAttributesGetter<REQUEST>> {
 
   /** Creates the database client attributes extractor with default configuration. */
-  public static <REQUEST, RESPONSE> DbClientAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       DbClientAttributesGetter<REQUEST> getter) {
     return new DbClientAttributesExtractor<>(getter);
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesExtractor.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.db.SqlStatementInfo;
 import io.opentelemetry.instrumentation.api.db.SqlStatementSanitizer;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 /**
@@ -29,7 +30,7 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
         REQUEST, RESPONSE, SqlClientAttributesGetter<REQUEST>> {
 
   /** Creates the SQL client attributes extractor with default configuration. */
-  public static <REQUEST, RESPONSE> SqlClientAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       SqlClientAttributesGetter<REQUEST> getter) {
     return SqlClientAttributesExtractor.<REQUEST, RESPONSE>builder(getter).build();
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesExtractorBuilder.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesExtractorBuilder.java
@@ -10,6 +10,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.db.SqlStatementSanitizer;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 /** A builder of {@link SqlClientAttributesExtractor}. */
@@ -54,7 +55,7 @@ public final class SqlClientAttributesExtractorBuilder<REQUEST, RESPONSE> {
    * Returns a new {@link SqlClientAttributesExtractor} with the settings of this {@link
    * SqlClientAttributesExtractorBuilder}.
    */
-  public SqlClientAttributesExtractor<REQUEST, RESPONSE> build() {
+  public AttributesExtractor<REQUEST, RESPONSE> build() {
     return new SqlClientAttributesExtractor<>(
         getter, dbTableAttribute, SqlStatementSanitizer.create(statementSanitizationEnabled));
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorU
 
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InternalNetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
@@ -37,13 +38,13 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
    * @deprecated Use {@link #create(HttpClientAttributesGetter, NetClientAttributesGetter)} instead.
    */
   @Deprecated
-  public static <REQUEST, RESPONSE> HttpClientAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       HttpClientAttributesGetter<REQUEST, RESPONSE> getter) {
     return builder(getter).build();
   }
 
   /** Creates the HTTP client attributes extractor with default configuration. */
-  public static <REQUEST, RESPONSE> HttpClientAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       HttpClientAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter,
       NetClientAttributesGetter<REQUEST, RESPONSE> netAttributesGetter) {
     return builder(httpAttributesGetter, netAttributesGetter).build();

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBuilder.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBuilder.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.api.instrumenter.http;
 import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import java.util.List;
 
@@ -67,7 +68,7 @@ public final class HttpClientAttributesExtractorBuilder<REQUEST, RESPONSE> {
    * Returns a new {@link HttpClientAttributesExtractor} with the settings of this {@link
    * HttpClientAttributesExtractorBuilder}.
    */
-  public HttpClientAttributesExtractor<REQUEST, RESPONSE> build() {
+  public AttributesExtractor<REQUEST, RESPONSE> build() {
     return new HttpClientAttributesExtractor<>(
         httpAttributesGetter, netAttributesGetter, capturedRequestHeaders, capturedResponseHeaders);
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorU
 
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InternalNetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
@@ -37,7 +38,7 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
     implements SpanKeyProvider {
 
   /** Creates the HTTP server attributes extractor with default configuration. */
-  public static <REQUEST, RESPONSE> HttpServerAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       HttpServerAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter,
       NetServerAttributesGetter<REQUEST> netAttributesGetter) {
     return builder(httpAttributesGetter, netAttributesGetter).build();

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBuilder.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBuilder.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.api.instrumenter.http;
 import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import java.util.List;
 
@@ -67,7 +68,7 @@ public final class HttpServerAttributesExtractorBuilder<REQUEST, RESPONSE> {
    * Returns a new {@link HttpServerAttributesExtractor} with the settings of this {@link
    * HttpServerAttributesExtractorBuilder}.
    */
-  public HttpServerAttributesExtractor<REQUEST, RESPONSE> build() {
+  public AttributesExtractor<REQUEST, RESPONSE> build() {
     return new HttpServerAttributesExtractor<>(
         httpAttributesGetter, netAttributesGetter, capturedRequestHeaders, capturedResponseHeaders);
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractor.java
@@ -37,7 +37,7 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
    * Creates the messaging attributes extractor for the given {@link MessageOperation operation}
    * with default configuration.
    */
-  public static <REQUEST, RESPONSE> MessagingAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
     return builder(getter, operation).build();
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractorBuilder.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractorBuilder.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.api.instrumenter.messaging;
 import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.List;
 
 /** A builder of {@link MessagingAttributesExtractor}. */
@@ -43,7 +44,7 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
    * Returns a new {@link MessagingAttributesExtractor} with the settings of this {@link
    * MessagingAttributesExtractorBuilder}.
    */
-  public MessagingAttributesExtractor<REQUEST, RESPONSE> build() {
+  public AttributesExtractor<REQUEST, RESPONSE> build() {
     return new MessagingAttributesExtractor<>(getter, operation, capturedHeaders);
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingSpanNameExtractor.java
@@ -32,7 +32,6 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
     this.operation = operation;
   }
 
-  @SuppressWarnings("deprecation") // operationName
   @Override
   public String extract(REQUEST request) {
     String destinationName =

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
@@ -26,7 +26,7 @@ public final class NetClientAttributesExtractor<REQUEST, RESPONSE>
 
   private final InternalNetClientAttributesExtractor<REQUEST, RESPONSE> internalExtractor;
 
-  public static <REQUEST, RESPONSE> NetClientAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       NetClientAttributesGetter<REQUEST, RESPONSE> getter) {
     return new NetClientAttributesExtractor<>(getter);
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
@@ -23,7 +23,7 @@ public final class NetServerAttributesExtractor<REQUEST, RESPONSE>
 
   private final InternalNetServerAttributesExtractor<REQUEST> internalExtractor;
 
-  public static <REQUEST, RESPONSE> NetServerAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       NetServerAttributesGetter<REQUEST> getter) {
     return new NetServerAttributesExtractor<>(getter);
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractor.java
@@ -35,7 +35,7 @@ public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
    * Returns a new {@link PeerServiceAttributesExtractor} that will use the passed {@code
    * netAttributesExtractor} instance to determine the value of the {@code peer.service} attribute.
    */
-  public static <REQUEST, RESPONSE> PeerServiceAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       NetClientAttributesGetter<REQUEST, RESPONSE> attributesGetter,
       Map<String, String> peerServiceMapping) {
     return new PeerServiceAttributesExtractor<>(attributesGetter, peerServiceMapping);

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcClientAttributesExtractor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.rpc;
 
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
 
@@ -20,7 +21,7 @@ public final class RpcClientAttributesExtractor<REQUEST, RESPONSE>
     extends RpcCommonAttributesExtractor<REQUEST, RESPONSE> implements SpanKeyProvider {
 
   /** Creates the RPC client attributes extractor. */
-  public static <REQUEST, RESPONSE> RpcClientAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       RpcAttributesGetter<REQUEST> getter) {
     return new RpcClientAttributesExtractor<>(getter);
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerAttributesExtractor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.rpc;
 
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
 
@@ -20,7 +21,7 @@ public final class RpcServerAttributesExtractor<REQUEST, RESPONSE>
     extends RpcCommonAttributesExtractor<REQUEST, RESPONSE> implements SpanKeyProvider {
 
   /** Creates the RPC server attributes extractor. */
-  public static <REQUEST, RESPONSE> RpcServerAttributesExtractor<REQUEST, RESPONSE> create(
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       RpcAttributesGetter<REQUEST> getter) {
     return new RpcServerAttributesExtractor<>(getter);
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/code/CodeAttributesExtractorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.entry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,7 +46,7 @@ class CodeAttributesExtractorTest {
 
     Context context = Context.root();
 
-    CodeAttributesExtractor<Map<String, String>, Void> underTest =
+    AttributesExtractor<Map<String, String>, Void> underTest =
         CodeAttributesExtractor.create(new TestAttributesGetter());
 
     // when
@@ -67,7 +68,7 @@ class CodeAttributesExtractorTest {
   @Test
   void shouldExtractNoAttributesIfNoneAreAvailable() {
     // given
-    CodeAttributesExtractor<Map<String, String>, Void> underTest =
+    AttributesExtractor<Map<String, String>, Void> underTest =
         CodeAttributesExtractor.create(new TestAttributesGetter());
 
     // when

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/DbClientAttributesExtractorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.entry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.Collections;
 import java.util.HashMap;
@@ -64,7 +65,7 @@ class DbClientAttributesExtractorTest {
 
     Context context = Context.root();
 
-    DbClientAttributesExtractor<Map<String, String>, Void> underTest =
+    AttributesExtractor<Map<String, String>, Void> underTest =
         DbClientAttributesExtractor.create(new TestAttributesGetter());
 
     // when
@@ -90,7 +91,7 @@ class DbClientAttributesExtractorTest {
   @Test
   void shouldExtractNoAttributesIfNoneAreAvailable() {
     // given
-    DbClientAttributesExtractor<Map<String, String>, Void> underTest =
+    AttributesExtractor<Map<String, String>, Void> underTest =
         DbClientAttributesExtractor.create(new TestAttributesGetter());
 
     // when

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/db/SqlClientAttributesExtractorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.entry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,7 +61,7 @@ class SqlClientAttributesExtractorTest {
 
     Context context = Context.root();
 
-    SqlClientAttributesExtractor<Map<String, String>, Void> underTest =
+    AttributesExtractor<Map<String, String>, Void> underTest =
         SqlClientAttributesExtractor.create(new TestAttributesGetter());
 
     // when
@@ -92,7 +93,7 @@ class SqlClientAttributesExtractorTest {
 
     Context context = Context.root();
 
-    SqlClientAttributesExtractor<Map<String, String>, Void> underTest =
+    AttributesExtractor<Map<String, String>, Void> underTest =
         SqlClientAttributesExtractor.create(new TestAttributesGetter());
 
     // when
@@ -114,7 +115,7 @@ class SqlClientAttributesExtractorTest {
 
     Context context = Context.root();
 
-    SqlClientAttributesExtractor<Map<String, String>, Void> underTest =
+    AttributesExtractor<Map<String, String>, Void> underTest =
         SqlClientAttributesExtractor.<Map<String, String>, Void>builder(new TestAttributesGetter())
             .setTableAttribute(SemanticAttributes.DB_CASSANDRA_TABLE)
             .build();
@@ -134,7 +135,7 @@ class SqlClientAttributesExtractorTest {
   @Test
   void shouldExtractNoAttributesIfNoneAreAvailable() {
     // when
-    SqlClientAttributesExtractor<Map<String, String>, Void> underTest =
+    AttributesExtractor<Map<String, String>, Void> underTest =
         SqlClientAttributesExtractor.create(new TestAttributesGetter());
 
     // when

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -17,6 +17,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
@@ -113,7 +114,7 @@ class HttpClientAttributesExtractorTest {
     response.put("header.custom-response-header", "654,321");
     response.put("transport", IP_TCP);
 
-    HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+    AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.builder(
                 new TestHttpClientAttributesGetter(), new TestNetClientAttributesGetter())
             .setCapturedRequestHeaders(singletonList("Custom-Request-Header"))
@@ -153,7 +154,7 @@ class HttpClientAttributesExtractorTest {
     Map<String, String> request = new HashMap<>();
     request.put("url", url);
 
-    HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+    AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.builder(
                 new TestHttpClientAttributesGetter(), new TestNetClientAttributesGetter())
             .build();
@@ -189,7 +190,7 @@ class HttpClientAttributesExtractorTest {
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "0");
 
-    HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+    AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.builder(
                 new TestHttpClientAttributesGetter(), new TestNetClientAttributesGetter())
             .setCapturedRequestHeaders(emptyList())
@@ -209,7 +210,7 @@ class HttpClientAttributesExtractorTest {
     Map<String, String> request = new HashMap<>();
     request.put("header.host", "thehost:777");
 
-    HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+    AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.create(
             new TestHttpClientAttributesGetter(), new TestNetClientAttributesGetter());
 
@@ -229,7 +230,7 @@ class HttpClientAttributesExtractorTest {
     request.put("peerName", "thehost");
     request.put("peerPort", "777");
 
-    HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+    AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.create(
             new TestHttpClientAttributesGetter(), new TestNetClientAttributesGetter());
 
@@ -249,7 +250,7 @@ class HttpClientAttributesExtractorTest {
     request.put("url", url);
     request.put("peerPort", String.valueOf(peerPort));
 
-    HttpClientAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+    AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.builder(
                 new TestHttpClientAttributesGetter(), new TestNetClientAttributesGetter())
             .build();

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
@@ -176,7 +177,7 @@ class HttpServerAttributesExtractorTest {
     Map<String, Object> request = new HashMap<>();
     request.put("header.x-forwarded-for", "1.1.1.1");
 
-    HttpServerAttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
+    AttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
         HttpServerAttributesExtractor.builder(
                 new TestHttpServerAttributesGetter(), new TestNetServerAttributesGetter())
             .setCapturedRequestHeaders(emptyList())
@@ -198,7 +199,7 @@ class HttpServerAttributesExtractorTest {
     Map<String, Object> request = new HashMap<>();
     request.put("header.x-forwarded-proto", "https");
 
-    HttpServerAttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
+    AttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
         HttpServerAttributesExtractor.builder(
                 new TestHttpServerAttributesGetter(), new TestNetServerAttributesGetter())
             .setCapturedRequestHeaders(emptyList())
@@ -218,7 +219,7 @@ class HttpServerAttributesExtractorTest {
     Map<String, Object> request = new HashMap<>();
     request.put("header.host", "thehost:777");
 
-    HttpServerAttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
+    AttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
         HttpServerAttributesExtractor.builder(
                 new TestHttpServerAttributesGetter(), new TestNetServerAttributesGetter())
             .setCapturedRequestHeaders(emptyList())
@@ -240,7 +241,7 @@ class HttpServerAttributesExtractorTest {
     request.put("hostName", "thehost");
     request.put("hostPort", 777);
 
-    HttpServerAttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
+    AttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
         HttpServerAttributesExtractor.builder(
                 new TestHttpServerAttributesGetter(), new TestNetServerAttributesGetter())
             .setCapturedRequestHeaders(emptyList())
@@ -262,7 +263,7 @@ class HttpServerAttributesExtractorTest {
     request.put("scheme", scheme);
     request.put("hostPort", hostPort);
 
-    HttpServerAttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
+    AttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
         HttpServerAttributesExtractor.builder(
                 new TestHttpServerAttributesGetter(), new TestNetServerAttributesGetter())
             .setCapturedRequestHeaders(emptyList())

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/messaging/MessagingAttributesExtractorTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,7 +51,7 @@ class MessagingAttributesExtractorTest {
     request.put("payloadSize", "100");
     request.put("payloadCompressedSize", "10");
 
-    MessagingAttributesExtractor<Map<String, String>, String> underTest =
+    AttributesExtractor<Map<String, String>, String> underTest =
         MessagingAttributesExtractor.create(TestGetter.INSTANCE, operation);
 
     Context context = Context.root();
@@ -97,7 +98,7 @@ class MessagingAttributesExtractorTest {
   @Test
   void shouldExtractNoAttributesIfNoneAreAvailable() {
     // given
-    MessagingAttributesExtractor<Map<String, String>, String> underTest =
+    AttributesExtractor<Map<String, String>, String> underTest =
         MessagingAttributesExtractor.create(TestGetter.INSTANCE, MessageOperation.SEND);
 
     Context context = Context.root();

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetterTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetterTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.entry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
@@ -47,7 +48,7 @@ class InetSocketAddressNetClientAttributesGetterTest {
               return response;
             }
           };
-  private final NetClientAttributesExtractor<InetSocketAddress, InetSocketAddress> extractor =
+  private final AttributesExtractor<InetSocketAddress, InetSocketAddress> extractor =
       NetClientAttributesExtractor.create(getter);
 
   @Test

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.entry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
@@ -51,7 +52,7 @@ class InetSocketAddressNetServerAttributesGetterTest {
           return request.host;
         }
       };
-  private final NetServerAttributesExtractor<Addresses, Addresses> extractor =
+  private final AttributesExtractor<Addresses, Addresses> extractor =
       NetServerAttributesExtractor.create(getter);
 
   @Test

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.entry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
 import java.util.Map;
@@ -74,7 +75,7 @@ class NetServerAttributesExtractorTest {
     }
   }
 
-  NetServerAttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+  AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
       NetServerAttributesExtractor.create(new TestNetServerAttributesGetter());
 
   @Test

--- a/instrumentation/jms/jms-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/JmsInstrumenterFactory.java
@@ -9,6 +9,7 @@ import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
@@ -84,8 +85,8 @@ public final class JmsInstrumenterFactory {
         .buildConsumerInstrumenter(MessagePropertyGetter.INSTANCE);
   }
 
-  private MessagingAttributesExtractor<MessageWithDestination, Void>
-      createMessagingAttributesExtractor(MessageOperation operation) {
+  private AttributesExtractor<MessageWithDestination, Void> createMessagingAttributesExtractor(
+      MessageOperation operation) {
     return MessagingAttributesExtractor.builder(JmsMessageAttributesGetter.INSTANCE, operation)
         .setCapturedHeaders(capturedHeaders)
         .build();

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
@@ -171,7 +171,7 @@ public final class KafkaInstrumenterFactory {
   }
 
   private static <REQUEST, RESPONSE>
-      MessagingAttributesExtractor<REQUEST, RESPONSE> buildMessagingAttributesExtractor(
+      AttributesExtractor<REQUEST, RESPONSE> buildMessagingAttributesExtractor(
           MessagingAttributesGetter<REQUEST, RESPONSE> getter,
           MessageOperation operation,
           List<String> capturedHeaders) {

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -24,6 +24,7 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.db.RedisCommandSanitizer;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DbSystemValues;
@@ -36,9 +37,8 @@ import javax.annotation.Nullable;
 
 final class OpenTelemetryTracing implements Tracing {
 
-  private static final NetClientAttributesExtractor<OpenTelemetryEndpoint, Void>
-      netAttributesExtractor =
-          NetClientAttributesExtractor.create(new LettuceNetAttributesGetter());
+  private static final AttributesExtractor<OpenTelemetryEndpoint, Void> netAttributesExtractor =
+      NetClientAttributesExtractor.create(new LettuceNetAttributesGetter());
   private final TracerProvider tracerProvider;
 
   OpenTelemetryTracing(io.opentelemetry.api.trace.Tracer tracer, RedisCommandSanitizer sanitizer) {

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoInstrumenterFactory.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoInstrumenterFactory.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.mongo.v3_1;
 
 import com.mongodb.event.CommandStartedEvent;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
@@ -17,8 +18,8 @@ class MongoInstrumenterFactory {
 
   private static final MongoAttributesExtractor attributesExtractor =
       new MongoAttributesExtractor();
-  private static final NetClientAttributesExtractor<CommandStartedEvent, Void>
-      netAttributesExtractor = NetClientAttributesExtractor.create(new MongoNetAttributesGetter());
+  private static final AttributesExtractor<CommandStartedEvent, Void> netAttributesExtractor =
+      NetClientAttributesExtractor.create(new MongoNetAttributesGetter());
 
   static Instrumenter<CommandStartedEvent, Void> createInstrumenter(
       OpenTelemetry openTelemetry,

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitSingletons.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitSingletons.java
@@ -104,7 +104,7 @@ public final class RabbitSingletons {
         .buildConsumerInstrumenter(DeliveryRequestGetter.INSTANCE);
   }
 
-  private static <T, V> MessagingAttributesExtractor<T, V> buildMessagingAttributesExtractor(
+  private static <T, V> AttributesExtractor<T, V> buildMessagingAttributesExtractor(
       MessagingAttributesGetter<T, V> getter, MessageOperation operation) {
     return MessagingAttributesExtractor.builder(getter, operation)
         .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletInstrumenterFactory.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletInstrumenterFactory.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.restlet.v2_0.internal;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
@@ -26,7 +25,7 @@ public final class RestletInstrumenterFactory {
 
   public static Instrumenter<Request, Response> newServerInstrumenter(
       OpenTelemetry openTelemetry,
-      HttpServerAttributesExtractor<Request, Response> httpServerAttributesExtractor,
+      AttributesExtractor<Request, Response> httpServerAttributesExtractor,
       List<AttributesExtractor<Request, Response>> additionalExtractors) {
 
     RestletHttpAttributesGetter httpAttributesGetter = RestletHttpAttributesGetter.INSTANCE;

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSA
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_SYSTEM;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
@@ -123,7 +124,7 @@ class RocketMqInstrumenterFactory {
     }
   }
 
-  private static <T> MessagingAttributesExtractor<T, Void> buildMessagingAttributesExtractor(
+  private static <T> AttributesExtractor<T, Void> buildMessagingAttributesExtractor(
       MessagingAttributesGetter<T, Void> getter,
       MessageOperation operation,
       List<String> capturedHeaders) {

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
@@ -53,7 +53,7 @@ final class RocketMqInstrumenterFactory {
     RocketMqConsumerReceiveAttributeGetter getter = RocketMqConsumerReceiveAttributeGetter.INSTANCE;
     MessageOperation operation = MessageOperation.RECEIVE;
 
-    MessagingAttributesExtractor<ReceiveMessageRequest, List<MessageView>> attributesExtractor =
+    AttributesExtractor<ReceiveMessageRequest, List<MessageView>> attributesExtractor =
         buildMessagingAttributesExtractor(getter, operation, capturedHeaders);
 
     InstrumenterBuilder<ReceiveMessageRequest, List<MessageView>> instrumenterBuilder =
@@ -74,7 +74,7 @@ final class RocketMqInstrumenterFactory {
     RocketMqConsumerProcessAttributeGetter getter = RocketMqConsumerProcessAttributeGetter.INSTANCE;
     MessageOperation operation = MessageOperation.PROCESS;
 
-    MessagingAttributesExtractor<MessageView, ConsumeResult> attributesExtractor =
+    AttributesExtractor<MessageView, ConsumeResult> attributesExtractor =
         buildMessagingAttributesExtractor(getter, operation, capturedHeaders);
 
     InstrumenterBuilder<MessageView, ConsumeResult> instrumenterBuilder =
@@ -101,7 +101,7 @@ final class RocketMqInstrumenterFactory {
     return instrumenterBuilder.buildConsumerInstrumenter(MessageMapGetter.INSTANCE);
   }
 
-  private static <T, R> MessagingAttributesExtractor<T, R> buildMessagingAttributesExtractor(
+  private static <T, R> AttributesExtractor<T, R> buildMessagingAttributesExtractor(
       MessagingAttributesGetter<T, R> getter,
       MessageOperation operation,
       List<String> capturedHeaders) {

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
@@ -111,11 +111,10 @@ public final class SpringIntegrationTelemetryBuilder {
         producerSpanEnabled);
   }
 
-  private static MessagingAttributesExtractor<MessageWithChannel, Void>
-      buildMessagingAttributesExtractor(
-          MessagingAttributesGetter<MessageWithChannel, Void> getter,
-          MessageOperation operation,
-          List<String> capturedHeaders) {
+  private static AttributesExtractor<MessageWithChannel, Void> buildMessagingAttributesExtractor(
+      MessagingAttributesGetter<MessageWithChannel, Void> getter,
+      MessageOperation operation,
+      List<String> capturedHeaders) {
     return MessagingAttributesExtractor.builder(getter, operation)
         .setCapturedHeaders(capturedHeaders)
         .build();


### PR DESCRIPTION
…n-api-semconv

We're already doing that for `SpanNameExtractor`, `OperationMetrics`, `ContextCustomizer`, etc., so I figured we should do the same for `AttributesExtractor` implementation. Also, none of the implementations have any additional public surface - aside from the builder/factory method users can just simply use the interface everywhere.