### PR TITLE
Ignore janino classloader

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -119,8 +119,8 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
             "org.springframework.context.support.ContextTypeMatchClassLoader$ContextOverridingClassLoader")
         .ignoreClassLoader("sun.misc.Launcher$ExtClassLoader")
         .ignoreClassLoader("org.openjdk.nashorn.internal.runtime.ScriptLoader")
-        .ignoreClassLoader("org.codehaus.janino.ByteArrayClassLoader");
-        .ignoreClassLoader("org.eclipse.persistence.internal.jaxb.JaxbClassLoader");
+        .ignoreClassLoader("org.codehaus.janino.ByteArrayClassLoader")
+        .ignoreClassLoader("org.eclipse.persistence.internal.jaxb.JaxbClassLoader")
         .ignoreClassLoader(AgentClassLoader.class.getName())
         .ignoreClassLoader(ExtensionClassLoader.class.getName());
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -119,6 +119,8 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
             "org.springframework.context.support.ContextTypeMatchClassLoader$ContextOverridingClassLoader")
         .ignoreClassLoader("sun.misc.Launcher$ExtClassLoader")
         .ignoreClassLoader("org.openjdk.nashorn.internal.runtime.ScriptLoader")
+        .ignoreClassLoader("org.codehaus.janino.ByteArrayClassLoader");
+        .ignoreClassLoader("org.eclipse.persistence.internal.jaxb.JaxbClassLoader");
         .ignoreClassLoader(AgentClassLoader.class.getName())
         .ignoreClassLoader(ExtensionClassLoader.class.getName());
 


### PR DESCRIPTION
Fixes #7670

These obscure classloaders should be ignored completely, they process in-line class creation and should not branch out to interactions that are useful in distributed tracing. These two are responsible for outages recently in many of our applications due to driving up memory usage from WeakKey caching. In some cases, janino processing has ran wild and stimulated over 5.7mil WeakKey objects accounting for close to 200MB of heap.