### PR TITLE
Improve type resolution cache for classes in java package

### DIFF
--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategy.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategy.java
@@ -168,6 +168,7 @@ public class AgentCachingPoolStrategy implements AgentBuilder.PoolStrategy {
    */
   private static final class TypeCacheKey {
     private final int loaderHash;
+    @Nullable
     private final WeakReference<ClassLoader> loaderRef;
     private final String className;
 
@@ -206,6 +207,8 @@ public class AgentCachingPoolStrategy implements AgentBuilder.PoolStrategy {
       // Also covers the bootstrap null loaderRef case
       if (loaderRef == other.loaderRef) {
         return true;
+      } else if (loaderRef == null || other.loaderRef == null) {
+        return false;
       }
 
       // need to perform a deeper loader check -- requires calling Reference.get

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategy.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategy.java
@@ -168,8 +168,7 @@ public class AgentCachingPoolStrategy implements AgentBuilder.PoolStrategy {
    */
   private static final class TypeCacheKey {
     private final int loaderHash;
-    @Nullable
-    private final WeakReference<ClassLoader> loaderRef;
+    @Nullable private final WeakReference<ClassLoader> loaderRef;
     private final String className;
 
     private final int hashCode;


### PR DESCRIPTION
Classes in `java.` package can only be loaded by boot loader. As the class loader that we currently use in cache key for these classes isn't always the boot loader we can end up with multiple entries for the same class.