### PR TITLE
Fix flaky dubbo tests

### DIFF
--- a/instrumentation/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.groovy
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.groovy
@@ -24,6 +24,8 @@ import spock.lang.Unroll
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboTestUtil.newDubboBootstrap
+import static io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboTestUtil.newFrameworkModel
 
 @Unroll
 abstract class AbstractDubboTest extends InstrumentationSpecification {
@@ -58,7 +60,8 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
     def port = PortUtils.findOpenPort()
     protocolConfig.setPort(port)
 
-    DubboBootstrap bootstrap = DubboBootstrap.newInstance()
+    def frameworkModel = newFrameworkModel()
+    DubboBootstrap bootstrap = newDubboBootstrap(frameworkModel)
     bootstrap.application(new ApplicationConfig("dubbo-test-provider"))
       .service(configureServer())
       .protocol(protocolConfig)
@@ -68,7 +71,7 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
     consumerProtocolConfig.setRegister(false)
 
     def reference = configureClient(port)
-    DubboBootstrap consumerBootstrap = DubboBootstrap.newInstance()
+    DubboBootstrap consumerBootstrap = newDubboBootstrap(frameworkModel)
     consumerBootstrap.application(new ApplicationConfig("dubbo-demo-api-consumer"))
       .reference(reference)
       .protocol(consumerProtocolConfig)
@@ -122,6 +125,7 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
     cleanup:
     bootstrap.destroy()
     consumerBootstrap.destroy()
+    frameworkModel?.destroy()
   }
 
   def "test apache dubbo test #dubbo"() {
@@ -129,7 +133,8 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
     def port = PortUtils.findOpenPort()
     protocolConfig.setPort(port)
 
-    DubboBootstrap bootstrap = DubboBootstrap.newInstance()
+    def frameworkModel = newFrameworkModel()
+    DubboBootstrap bootstrap = newDubboBootstrap(frameworkModel)
     bootstrap.application(new ApplicationConfig("dubbo-test-async-provider"))
       .service(configureServer())
       .protocol(protocolConfig)
@@ -139,7 +144,7 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
     consumerProtocolConfig.setRegister(false)
 
     def reference = configureClient(port)
-    DubboBootstrap consumerBootstrap = DubboBootstrap.newInstance()
+    DubboBootstrap consumerBootstrap = newDubboBootstrap(frameworkModel)
     consumerBootstrap.application(new ApplicationConfig("dubbo-demo-async-api-consumer"))
       .reference(reference)
       .protocol(consumerProtocolConfig)
@@ -193,5 +198,6 @@ abstract class AbstractDubboTest extends InstrumentationSpecification {
     cleanup:
     bootstrap.destroy()
     consumerBootstrap.destroy()
+    frameworkModel?.destroy()
   }
 }

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTraceChainTest.groovy
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTraceChainTest.groovy
@@ -25,6 +25,8 @@ import spock.lang.Unroll
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.SERVER
+import static io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboTestUtil.newDubboBootstrap
+import static io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboTestUtil.newFrameworkModel
 
 @Unroll
 abstract class AbstractDubboTraceChainTest extends InstrumentationSpecification {
@@ -76,7 +78,8 @@ abstract class AbstractDubboTraceChainTest extends InstrumentationSpecification 
     def protocolConfig = new ProtocolConfig()
     protocolConfig.setPort(port)
 
-    DubboBootstrap bootstrap = DubboBootstrap.newInstance()
+    def frameworkModel = newFrameworkModel()
+    DubboBootstrap bootstrap = newDubboBootstrap(frameworkModel)
     bootstrap.application(new ApplicationConfig("dubbo-test-provider"))
       .service(configureServer())
       .protocol(protocolConfig)
@@ -86,7 +89,7 @@ abstract class AbstractDubboTraceChainTest extends InstrumentationSpecification 
     middleProtocolConfig.setPort(middlePort)
 
     def reference = configureClient(port)
-    DubboBootstrap middleBootstrap = DubboBootstrap.newInstance()
+    DubboBootstrap middleBootstrap = newDubboBootstrap(frameworkModel)
     middleBootstrap.application(new ApplicationConfig("dubbo-demo-middle"))
       .reference(reference)
       .service(configureMiddleServer(reference))
@@ -98,7 +101,7 @@ abstract class AbstractDubboTraceChainTest extends InstrumentationSpecification 
     consumerProtocolConfig.setRegister(false)
 
     def middleReference = configureMiddleClient(middlePort)
-    DubboBootstrap consumerBootstrap = DubboBootstrap.newInstance()
+    DubboBootstrap consumerBootstrap = newDubboBootstrap(frameworkModel)
     consumerBootstrap.application(new ApplicationConfig("dubbo-demo-api-consumer"))
       .reference(middleReference)
       .protocol(consumerProtocolConfig)

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTestUtil.groovy
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/groovy/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTestUtil.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.apachedubbo.v2_7
+
+import org.apache.dubbo.config.bootstrap.DubboBootstrap
+
+class DubboTestUtil {
+  static newFrameworkModel() {
+    try {
+      // only present in latest dep
+      return Class.forName("org.apache.dubbo.rpc.model.FrameworkModel").newInstance()
+    } catch (ClassNotFoundException exception) {
+      return null
+    }
+  }
+
+  static DubboBootstrap newDubboBootstrap(Object frameworkModel) {
+    if (frameworkModel == null) {
+      return DubboBootstrap.newInstance()
+    }
+    return DubboBootstrap.newInstance(frameworkModel)
+  }
+}


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboTraceChainTest&tests.sortField=FLAKY&tests.test=test%20that%20context%20is%20propagated%20correctly%20in%20chained%20dubbo%20calls&tests.unstableOnly=true
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboTest&tests.sortField=FLAKY&tests.unstableOnly=true
Something has changed in later versions of dubbo that causes failures when more than one test is run.