### PR TITLE
Limit junit-pioneer to 1.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,9 @@ updates:
       - dependency-name: "org.mockito:*"
         # mockito 5 requires Java 11
         versions: [ "[5,)" ]
+      - dependency-name: "org.junit-pioneer:junit-pioneer"
+        # junit-pioneer 2.x requires Java 11
+        versions: [ "[1,)" ]
     rebase-strategy: "disabled"
     schedule:
       interval: "daily"


### PR DESCRIPTION
junit-pioneer 2.0 requires Java 11