### PR TITLE
End netty client span before callbacks

### DIFF
--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/HttpClientResponseTracingHandler.java
@@ -50,6 +50,13 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       requestAttr.remove();
     }
 
+    if (msg instanceof FullHttpResponse) {
+      instrumenter().end(context, request, (HttpResponse) msg, null);
+    } else if (msg instanceof LastHttpContent) {
+      HttpResponse response = ctx.channel().attr(AttributeKeys.CLIENT_RESPONSE).getAndRemove();
+      instrumenter().end(context, request, response, null);
+    }
+
     // We want the callback in the scope of the parent, not the client span
     if (parentContext != null) {
       try (Scope ignored = parentContext.makeCurrent()) {
@@ -57,13 +64,6 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       }
     } else {
       ctx.fireChannelRead(msg);
-    }
-
-    if (msg instanceof FullHttpResponse) {
-      instrumenter().end(context, request, (HttpResponse) msg, null);
-    } else if (msg instanceof LastHttpContent) {
-      HttpResponse response = ctx.channel().attr(AttributeKeys.CLIENT_RESPONSE).getAndRemove();
-      instrumenter().end(context, request, response, null);
     }
   }
 }

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientResponseTracingHandler.java
@@ -66,6 +66,12 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       requestAttr.set(null);
     }
 
+    if (msg instanceof FullHttpResponse) {
+      instrumenter.end(context, request, (HttpResponse) msg, null);
+    } else if (msg instanceof LastHttpContent) {
+      instrumenter.end(context, request, ctx.channel().attr(HTTP_RESPONSE).getAndSet(null), null);
+    }
+
     // We want the callback in the scope of the parent, not the client span
     if (parentContext != null) {
       try (Scope ignored = parentContext.makeCurrent()) {
@@ -73,12 +79,6 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       }
     } else {
       ctx.fireChannelRead(msg);
-    }
-
-    if (msg instanceof FullHttpResponse) {
-      instrumenter.end(context, request, (HttpResponse) msg, null);
-    } else if (msg instanceof LastHttpContent) {
-      instrumenter.end(context, request, ctx.channel().attr(HTTP_RESPONSE).getAndSet(null), null);
     }
   }
 }


### PR DESCRIPTION
netty 3.8 already ends client span before callbacks:

https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/b17f20c08e9def0cc2d342e7acd313dd7e52d677/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/HttpClientResponseTracingHandler.java#L33-L46