### PR TITLE
Grpc client instrumentation net.sock.peer.addr

### DIFF
--- a/instrumentation/grpc-1.6/javaagent/build.gradle.kts
+++ b/instrumentation/grpc-1.6/javaagent/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 
 tasks {
   test {
+    systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
     // The agent context debug mechanism isn't compatible with the bridge approach which may add a
     // gRPC context to the root.
     jvmArgs("-Dotel.javaagent.experimental.thread-propagation-debugger.enabled=false")

--- a/instrumentation/grpc-1.6/library/build.gradle.kts
+++ b/instrumentation/grpc-1.6/library/build.gradle.kts
@@ -15,3 +15,9 @@ dependencies {
 
   testImplementation(project(":instrumentation:grpc-1.6:testing"))
 }
+
+tasks {
+  test {
+    systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
+  }
+}

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/TracingClientInterceptor.java
@@ -152,6 +152,7 @@ final class TracingClientInterceptor implements ClientInterceptor {
 
       @Override
       public void onClose(Status status, Metadata trailers) {
+        request.setPeerSocketAddress(getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
         instrumenter.end(context, request, status, status.getCause());
         try (Scope ignored = parentContext.makeCurrent()) {
           delegate().onClose(status, trailers);
@@ -161,7 +162,6 @@ final class TracingClientInterceptor implements ClientInterceptor {
       @Override
       public void onReady() {
         try (Scope ignored = context.makeCurrent()) {
-          request.setPeerSocketAddress(getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR));
           delegate().onReady();
         }
       }

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcStreamingTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6;
 
+import static io.opentelemetry.instrumentation.grpc.v1_6.AbstractGrpcTest.addExtraClientAttributes;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -175,17 +176,19 @@ public abstract class AbstractGrpcStreamingTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(
-                                equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
-                                equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "Conversation"),
-                                equalTo(
-                                    SemanticAttributes.NET_TRANSPORT,
-                                    SemanticAttributes.NetTransportValues.IP_TCP),
-                                equalTo(
-                                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                                    (long) Status.Code.OK.value()),
-                                equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
-                                equalTo(SemanticAttributes.NET_PEER_PORT, (long) server.getPort()))
+                                addExtraClientAttributes(
+                                    equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
+                                    equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
+                                    equalTo(SemanticAttributes.RPC_METHOD, "Conversation"),
+                                    equalTo(
+                                        SemanticAttributes.NET_TRANSPORT,
+                                        SemanticAttributes.NetTransportValues.IP_TCP),
+                                    equalTo(
+                                        SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                                        (long) Status.Code.OK.value()),
+                                    equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
+                                    equalTo(
+                                        SemanticAttributes.NET_PEER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(events.toArray(new Consumer[0])),
                     span ->
                         span.hasName("example.Greeter/Conversation")

--- a/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
+++ b/instrumentation/grpc-1.6/testing/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/AbstractGrpcTest.java
@@ -46,9 +46,12 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.util.ThrowingRunnable;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
@@ -129,17 +132,19 @@ public abstract class AbstractGrpcTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
-                                equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
-                                equalTo(
-                                    SemanticAttributes.NET_TRANSPORT,
-                                    SemanticAttributes.NetTransportValues.IP_TCP),
-                                equalTo(
-                                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                                    (long) Status.Code.OK.value()),
-                                equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
-                                equalTo(SemanticAttributes.NET_PEER_PORT, (long) server.getPort()))
+                                addExtraClientAttributes(
+                                    equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
+                                    equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
+                                    equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
+                                    equalTo(
+                                        SemanticAttributes.NET_TRANSPORT,
+                                        SemanticAttributes.NetTransportValues.IP_TCP),
+                                    equalTo(
+                                        SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                                        (long) Status.Code.OK.value()),
+                                    equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
+                                    equalTo(
+                                        SemanticAttributes.NET_PEER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -317,17 +322,19 @@ public abstract class AbstractGrpcTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
-                                equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
-                                equalTo(
-                                    SemanticAttributes.NET_TRANSPORT,
-                                    SemanticAttributes.NetTransportValues.IP_TCP),
-                                equalTo(
-                                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                                    (long) Status.Code.OK.value()),
-                                equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
-                                equalTo(SemanticAttributes.NET_PEER_PORT, (long) server.getPort()))
+                                addExtraClientAttributes(
+                                    equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
+                                    equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
+                                    equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
+                                    equalTo(
+                                        SemanticAttributes.NET_TRANSPORT,
+                                        SemanticAttributes.NetTransportValues.IP_TCP),
+                                    equalTo(
+                                        SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                                        (long) Status.Code.OK.value()),
+                                    equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
+                                    equalTo(
+                                        SemanticAttributes.NET_PEER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -516,17 +523,19 @@ public abstract class AbstractGrpcTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
-                                equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
-                                equalTo(
-                                    SemanticAttributes.NET_TRANSPORT,
-                                    SemanticAttributes.NetTransportValues.IP_TCP),
-                                equalTo(
-                                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                                    (long) Status.Code.OK.value()),
-                                equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
-                                equalTo(SemanticAttributes.NET_PEER_PORT, (long) server.getPort()))
+                                addExtraClientAttributes(
+                                    equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
+                                    equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
+                                    equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
+                                    equalTo(
+                                        SemanticAttributes.NET_TRANSPORT,
+                                        SemanticAttributes.NetTransportValues.IP_TCP),
+                                    equalTo(
+                                        SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                                        (long) Status.Code.OK.value()),
+                                    equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
+                                    equalTo(
+                                        SemanticAttributes.NET_PEER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -689,17 +698,19 @@ public abstract class AbstractGrpcTest {
                             .hasNoParent()
                             .hasStatus(StatusData.error())
                             .hasAttributesSatisfyingExactly(
-                                equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
-                                equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
-                                equalTo(
-                                    SemanticAttributes.NET_TRANSPORT,
-                                    SemanticAttributes.NetTransportValues.IP_TCP),
-                                equalTo(
-                                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                                    (long) status.getCode().value()),
-                                equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
-                                equalTo(SemanticAttributes.NET_PEER_PORT, (long) server.getPort()))
+                                addExtraClientAttributes(
+                                    equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
+                                    equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
+                                    equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
+                                    equalTo(
+                                        SemanticAttributes.NET_TRANSPORT,
+                                        SemanticAttributes.NetTransportValues.IP_TCP),
+                                    equalTo(
+                                        SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                                        (long) status.getCode().value()),
+                                    equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
+                                    equalTo(
+                                        SemanticAttributes.NET_PEER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -851,17 +862,19 @@ public abstract class AbstractGrpcTest {
                             .hasNoParent()
                             .hasStatus(StatusData.error())
                             .hasAttributesSatisfyingExactly(
-                                equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
-                                equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
-                                equalTo(
-                                    SemanticAttributes.NET_TRANSPORT,
-                                    SemanticAttributes.NetTransportValues.IP_TCP),
-                                equalTo(
-                                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                                    (long) Status.UNKNOWN.getCode().value()),
-                                equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
-                                equalTo(SemanticAttributes.NET_PEER_PORT, (long) server.getPort()))
+                                addExtraClientAttributes(
+                                    equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
+                                    equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
+                                    equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
+                                    equalTo(
+                                        SemanticAttributes.NET_TRANSPORT,
+                                        SemanticAttributes.NetTransportValues.IP_TCP),
+                                    equalTo(
+                                        SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                                        (long) Status.UNKNOWN.getCode().value()),
+                                    equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
+                                    equalTo(
+                                        SemanticAttributes.NET_PEER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1104,17 +1117,19 @@ public abstract class AbstractGrpcTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
-                                equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
-                                equalTo(
-                                    SemanticAttributes.NET_TRANSPORT,
-                                    SemanticAttributes.NetTransportValues.IP_TCP),
-                                equalTo(
-                                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                                    (long) Status.Code.OK.value()),
-                                equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
-                                equalTo(SemanticAttributes.NET_PEER_PORT, (long) server.getPort()))
+                                addExtraClientAttributes(
+                                    equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
+                                    equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
+                                    equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
+                                    equalTo(
+                                        SemanticAttributes.NET_TRANSPORT,
+                                        SemanticAttributes.NetTransportValues.IP_TCP),
+                                    equalTo(
+                                        SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                                        (long) Status.Code.OK.value()),
+                                    equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
+                                    equalTo(
+                                        SemanticAttributes.NET_PEER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1246,17 +1261,19 @@ public abstract class AbstractGrpcTest {
                             .hasParent(trace.getSpan(0))
                             .hasStatus(StatusData.error())
                             .hasAttributesSatisfyingExactly(
-                                equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
-                                equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "SayMultipleHello"),
-                                equalTo(
-                                    SemanticAttributes.NET_TRANSPORT,
-                                    SemanticAttributes.NetTransportValues.IP_TCP),
-                                equalTo(
-                                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                                    (long) Status.Code.CANCELLED.value()),
-                                equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
-                                equalTo(SemanticAttributes.NET_PEER_PORT, (long) server.getPort()))
+                                addExtraClientAttributes(
+                                    equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
+                                    equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
+                                    equalTo(SemanticAttributes.RPC_METHOD, "SayMultipleHello"),
+                                    equalTo(
+                                        SemanticAttributes.NET_TRANSPORT,
+                                        SemanticAttributes.NetTransportValues.IP_TCP),
+                                    equalTo(
+                                        SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                                        (long) Status.Code.CANCELLED.value()),
+                                    equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
+                                    equalTo(
+                                        SemanticAttributes.NET_PEER_PORT, (long) server.getPort())))
                             .hasEventsSatisfying(
                                 events -> {
                                   assertThat(events).hasSize(3);
@@ -1385,19 +1402,21 @@ public abstract class AbstractGrpcTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(
-                                equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
-                                equalTo(
-                                    SemanticAttributes.RPC_SERVICE,
-                                    "grpc.reflection.v1alpha.ServerReflection"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "ServerReflectionInfo"),
-                                equalTo(
-                                    SemanticAttributes.NET_TRANSPORT,
-                                    SemanticAttributes.NetTransportValues.IP_TCP),
-                                equalTo(
-                                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                                    (long) Status.Code.OK.value()),
-                                equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
-                                equalTo(SemanticAttributes.NET_PEER_PORT, (long) server.getPort()))
+                                addExtraClientAttributes(
+                                    equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
+                                    equalTo(
+                                        SemanticAttributes.RPC_SERVICE,
+                                        "grpc.reflection.v1alpha.ServerReflection"),
+                                    equalTo(SemanticAttributes.RPC_METHOD, "ServerReflectionInfo"),
+                                    equalTo(
+                                        SemanticAttributes.NET_TRANSPORT,
+                                        SemanticAttributes.NetTransportValues.IP_TCP),
+                                    equalTo(
+                                        SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                                        (long) Status.Code.OK.value()),
+                                    equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
+                                    equalTo(
+                                        SemanticAttributes.NET_PEER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1516,17 +1535,19 @@ public abstract class AbstractGrpcTest {
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
-                                equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
-                                equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
-                                equalTo(
-                                    SemanticAttributes.NET_TRANSPORT,
-                                    SemanticAttributes.NetTransportValues.IP_TCP),
-                                equalTo(
-                                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                                    (long) Status.Code.OK.value()),
-                                equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
-                                equalTo(SemanticAttributes.NET_PEER_PORT, (long) server.getPort()))
+                                addExtraClientAttributes(
+                                    equalTo(SemanticAttributes.RPC_SYSTEM, "grpc"),
+                                    equalTo(SemanticAttributes.RPC_SERVICE, "example.Greeter"),
+                                    equalTo(SemanticAttributes.RPC_METHOD, "SayHello"),
+                                    equalTo(
+                                        SemanticAttributes.NET_TRANSPORT,
+                                        SemanticAttributes.NetTransportValues.IP_TCP),
+                                    equalTo(
+                                        SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                                        (long) Status.Code.OK.value()),
+                                    equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
+                                    equalTo(
+                                        SemanticAttributes.NET_PEER_PORT, (long) server.getPort())))
                             .hasEventsSatisfyingExactly(
                                 event ->
                                     event
@@ -1764,5 +1785,14 @@ public abstract class AbstractGrpcTest {
     } catch (NoSuchMethodException unused) {
       channelBuilder.getClass().getMethod("usePlaintext").invoke(channelBuilder);
     }
+  }
+
+  static List<AttributeAssertion> addExtraClientAttributes(AttributeAssertion... assertions) {
+    List<AttributeAssertion> result = new ArrayList<>();
+    result.addAll(Arrays.asList(assertions));
+    if (Boolean.getBoolean("testLatestDeps")) {
+      result.add(equalTo(SemanticAttributes.NET_SOCK_PEER_ADDR, "127.0.0.1"));
+    }
+    return result;
   }
 }


### PR DESCRIPTION
Currently grpc client instrumentation unreliably fills `net.sock.peer.addr` which makes tests flaky https://ge.opentelemetry.io/s/nni57d5zryafk/tests/:instrumentation:grpc-1.6:javaagent:test/io.opentelemetry.javaagent.instrumentation.grpc.v1_6.GrpcStreamingTest/conversation(int,%20int)%5B8%5D?expanded-stacktrace=WyIwIl0&top-execution=1 This pr moves capturing `net.sock.peer.addr` to a later point where it seems to work reliably.