### PR TITLE
Rename logback mdc library package name

### DIFF
--- a/instrumentation/logback/logback-mdc-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/mdc/v1_0/LoggingEventInstrumentation.java
+++ b/instrumentation/logback/logback-mdc-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/logback/mdc/v1_0/LoggingEventInstrumentation.java
@@ -20,7 +20,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
-import io.opentelemetry.instrumentation.logback.v1_0.internal.UnionMap;
+import io.opentelemetry.instrumentation.logback.mdc.v1_0.internal.UnionMap;
 import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;

--- a/instrumentation/logback/logback-mdc-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/logback/v1_0/LogbackTest.groovy
+++ b/instrumentation/logback/logback-mdc-1.0/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/logback/v1_0/LogbackTest.groovy
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.logback.v1_0
 
-import io.opentelemetry.instrumentation.logback.v1_0.AbstractLogbackTest
+import io.opentelemetry.instrumentation.logback.mdc.v1_0.AbstractLogbackTest
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 
 class LogbackTest extends AbstractLogbackTest implements AgentTestTrait {

--- a/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/LoggingEventWrapper.java
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/LoggingEventWrapper.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.logback.v1_0;
+package io.opentelemetry.instrumentation.logback.mdc.v1_0;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;

--- a/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/OpenTelemetryAppender.java
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/OpenTelemetryAppender.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.logback.v1_0;
+package io.opentelemetry.instrumentation.logback.mdc.v1_0;
 
 import static io.opentelemetry.instrumentation.api.log.LoggingContextConstants.SPAN_ID;
 import static io.opentelemetry.instrumentation.api.log.LoggingContextConstants.TRACE_FLAGS;
@@ -16,7 +16,7 @@ import ch.qos.logback.core.spi.AppenderAttachable;
 import ch.qos.logback.core.spi.AppenderAttachableImpl;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.instrumentation.logback.v1_0.internal.UnionMap;
+import io.opentelemetry.instrumentation.logback.mdc.v1_0.internal.UnionMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;

--- a/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/UnionMap.java
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/UnionMap.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.logback.v1_0.internal;
+package io.opentelemetry.instrumentation.logback.mdc.v1_0.internal;
 
 import java.util.AbstractMap;
 import java.util.AbstractSet;

--- a/instrumentation/logback/logback-mdc-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/logback/mdc/v1_0/LogbackTest.groovy
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/logback/mdc/v1_0/LogbackTest.groovy
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.logback.v1_0
+package io.opentelemetry.instrumentation.logback.mdc.v1_0
 
 import io.opentelemetry.instrumentation.test.LibraryTestTrait
 

--- a/instrumentation/logback/logback-mdc-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/UnionMapTest.groovy
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/test/groovy/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/UnionMapTest.groovy
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.logback.v1_0.internal
+package io.opentelemetry.instrumentation.logback.mdc.v1_0.internal
 
 import spock.lang.Specification
 

--- a/instrumentation/logback/logback-mdc-1.0/library/src/test/resources/logback.xml
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/test/resources/logback.xml
@@ -18,7 +18,8 @@
 <configuration>
   <appender name="LIST" class="ch.qos.logback.core.read.ListAppender"/>
 
-  <appender name="OTEL" class="io.opentelemetry.instrumentation.logback.v1_0.OpenTelemetryAppender">
+  <appender name="OTEL"
+    class="io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender">
     <appender-ref ref="LIST"/>
   </appender>
 

--- a/instrumentation/logback/logback-mdc-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/logback/mdc/v1_0/AbstractLogbackTest.groovy
+++ b/instrumentation/logback/logback-mdc-1.0/testing/src/main/groovy/io/opentelemetry/instrumentation/logback/mdc/v1_0/AbstractLogbackTest.groovy
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.logback.v1_0
+package io.opentelemetry.instrumentation.logback.mdc.v1_0
 
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender


### PR DESCRIPTION
(should help with this issue:)

> Firstly in https://github.com/ff-sdesai/distributed-tracing-spring/blob/main/spring-cloud-sleuth-otel-slf4j/src/main/resources/logback.xml#L13 you are using `io.opentelemetry.instrumentation.logback.v1_0.OpenTelemetryAppender` this is the appender for mdc instrumentation. For exporting logs you'll need `io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender`.