### PR TITLE
Ensure kafka configuration remains serializable

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaSingletons.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/KafkaSingletons.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.kafka.internal.KafkaInstrumenterFactory;
 import io.opentelemetry.instrumentation.kafka.internal.OpenTelemetryMetricsReporter;
+import io.opentelemetry.instrumentation.kafka.internal.OpenTelemetrySupplier;
 import io.opentelemetry.javaagent.bootstrap.internal.DeprecatedConfigProperties;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
@@ -75,7 +76,8 @@ public final class KafkaSingletons {
         OpenTelemetryMetricsReporter.class.getName(),
         (class1, class2) -> class1 + "," + class2);
     config.put(
-        OpenTelemetryMetricsReporter.CONFIG_KEY_OPENTELEMETRY_INSTANCE, GlobalOpenTelemetry.get());
+        OpenTelemetryMetricsReporter.CONFIG_KEY_OPENTELEMETRY_SUPPLIER,
+        new OpenTelemetrySupplier(GlobalOpenTelemetry.get()));
     config.put(
         OpenTelemetryMetricsReporter.CONFIG_KEY_OPENTELEMETRY_INSTRUMENTATION_NAME,
         INSTRUMENTATION_NAME);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/KafkaTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/KafkaTelemetry.java
@@ -18,6 +18,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.kafka.internal.KafkaConsumerRecordGetter;
 import io.opentelemetry.instrumentation.kafka.internal.KafkaHeadersSetter;
 import io.opentelemetry.instrumentation.kafka.internal.OpenTelemetryMetricsReporter;
+import io.opentelemetry.instrumentation.kafka.internal.OpenTelemetrySupplier;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.util.Collections;
@@ -162,7 +163,9 @@ public final class KafkaTelemetry {
     config.put(
         CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
         OpenTelemetryMetricsReporter.class.getName());
-    config.put(OpenTelemetryMetricsReporter.CONFIG_KEY_OPENTELEMETRY_INSTANCE, openTelemetry);
+    config.put(
+        OpenTelemetryMetricsReporter.CONFIG_KEY_OPENTELEMETRY_SUPPLIER,
+        new OpenTelemetrySupplier(openTelemetry));
     config.put(
         OpenTelemetryMetricsReporter.CONFIG_KEY_OPENTELEMETRY_INSTRUMENTATION_NAME,
         KafkaTelemetryBuilder.INSTRUMENTATION_NAME);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/OpenTelemetryMetricsReporter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/OpenTelemetryMetricsReporter.java
@@ -35,7 +35,7 @@ import org.apache.kafka.common.metrics.MetricsReporter;
  */
 public final class OpenTelemetryMetricsReporter implements MetricsReporter {
 
-  public static final String CONFIG_KEY_OPENTELEMETRY_INSTANCE = "opentelemetry.instance";
+  public static final String CONFIG_KEY_OPENTELEMETRY_SUPPLIER = "opentelemetry.supplier";
   public static final String CONFIG_KEY_OPENTELEMETRY_INSTRUMENTATION_NAME =
       "opentelemetry.instrumentation_name";
 
@@ -150,8 +150,9 @@ public final class OpenTelemetryMetricsReporter implements MetricsReporter {
 
   @Override
   public void configure(Map<String, ?> configs) {
-    OpenTelemetry openTelemetry =
-        getProperty(configs, CONFIG_KEY_OPENTELEMETRY_INSTANCE, OpenTelemetry.class);
+    OpenTelemetrySupplier openTelemetrySupplier =
+        getProperty(configs, CONFIG_KEY_OPENTELEMETRY_SUPPLIER, OpenTelemetrySupplier.class);
+    OpenTelemetry openTelemetry = openTelemetrySupplier.get();
     String instrumentationName =
         getProperty(configs, CONFIG_KEY_OPENTELEMETRY_INSTRUMENTATION_NAME, String.class);
     String instrumentationVersion =

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/OpenTelemetrySupplier.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/OpenTelemetrySupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.kafka.internal;
+
+import io.opentelemetry.api.OpenTelemetry;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ *
+ * https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7597
+ * Wrapper for OpenTelemetry that can be injected into kafka configuration without breaking
+ * serialization.
+ */
+public final class OpenTelemetrySupplier implements Supplier<OpenTelemetry>, Serializable {
+  private static final long serialVersionUID = 1L;
+  private final transient OpenTelemetry openTelemetry;
+
+  public OpenTelemetrySupplier(OpenTelemetry openTelemetry) {
+    Objects.requireNonNull(openTelemetry);
+    this.openTelemetry = openTelemetry;
+  }
+
+  @Override
+  public OpenTelemetry get() {
+    return openTelemetry;
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/OpenTelemetrySupplier.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/OpenTelemetrySupplier.java
@@ -11,12 +11,11 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
- *
- * https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7597
  * Wrapper for OpenTelemetry that can be injected into kafka configuration without breaking
- * serialization.
+ * serialization. https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7597
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 public final class OpenTelemetrySupplier implements Supplier<OpenTelemetry>, Serializable {
   private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7597
I wasn't able to reproduce this. Figuring out how to run beam, flink and kafka together feels like too much effort. Without reproducing it is too hard to tell why the configuration is serialized, but my hunch is that it is enough to ensure that the configuration can be serialized.