### PR TITLE
Dubbo: don't create spans for calls inside the same jvm

### DIFF
--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/TracingFilter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/TracingFilter.java
@@ -35,7 +35,7 @@ final class TracingFilter implements Filter {
     }
 
     RpcContext rpcContext = RpcContext.getContext();
-    if (rpcContext.getUrl() == null) {
+    if (rpcContext.getUrl() == null || "injvm".equals(rpcContext.getUrl().getProtocol())) {
       return invoker.invoke(invocation);
     }
 


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7520
Invoking a dubbo service, like in https://github.com/zewade/opentelemetry-dubbo-demo/blob/d7e2417ae787808dbfb43747d586b91a1b29ecec/demo-business-provider/src/main/java/cn/zewade/business/controller/BusinessController.java#L20, creates a client span (and a server span on the receiving end). If the caller and service are on the jvm this call doesn't go through remoting and will be handled with regular java calls. Now when the initially called service calls another service, like in https://github.com/zewade/opentelemetry-dubbo-demo/blob/main/demo-business-provider/src/main/java/cn/zewade/business/dubbo/BusinessDubboServiceImpl.java#L25, that second call will also attempt to create a client span. This second client span will be suppressed which will also suppress context propagation.