### PR TITLE
Second attempt at fixing serializing kafka configuration

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafka/internal/OpenTelemetryMetricsReporterTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafka/internal/OpenTelemetryMetricsReporterTest.java
@@ -140,6 +140,7 @@ class OpenTelemetryMetricsReporterTest extends AbstractOpenTelemetryMetricsRepor
     try (ObjectOutputStream outputStream = new ObjectOutputStream(byteOutputStream)) {
       outputStream.writeObject(map);
     }
+
     class CustomObjectInputStream extends ObjectInputStream {
       CustomObjectInputStream(InputStream inputStream) throws IOException {
         super(inputStream);
@@ -149,11 +150,13 @@ class OpenTelemetryMetricsReporterTest extends AbstractOpenTelemetryMetricsRepor
       protected Class<?> resolveClass(ObjectStreamClass desc)
           throws IOException, ClassNotFoundException {
         if (desc.getName().startsWith("io.opentelemetry.")) {
-          throw new IllegalStateException("Serial form contains opentelemetry class " + desc.getName());
+          throw new IllegalStateException(
+              "Serial form contains opentelemetry class " + desc.getName());
         }
         return super.resolveClass(desc);
       }
     }
+
     try (ObjectInputStream inputStream =
         new CustomObjectInputStream(new ByteArrayInputStream(byteOutputStream.toByteArray()))) {
       Map<String, Object> result = (Map<String, Object>) inputStream.readObject();

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/OpenTelemetrySupplier.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/OpenTelemetrySupplier.java
@@ -30,4 +30,9 @@ public final class OpenTelemetrySupplier implements Supplier<OpenTelemetry>, Ser
   public OpenTelemetry get() {
     return openTelemetry;
   }
+
+  private Object writeReplace() {
+    // serialize this object to null
+    return null;
+  }
 }


### PR DESCRIPTION
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7597
Without reproducing the issue it is hard to tell whether this will help. Another issue that could arise is that we add our metrics class in `metric.reporters` property which will probably break if this configuration is used to build consumer or producer after deserializing as our classes don't seem to be available there.  If this fails we'll need to ask the issue reporter for instructions how to reproduce and find a different strategy for fixing this.