### PR TITLE
Update contributing doc for instrumentationModule

### DIFF
--- a/docs/contributing/writing-instrumentation-module.md
+++ b/docs/contributing/writing-instrumentation-module.md
@@ -73,7 +73,7 @@ public boolean isHelperClass(String className) {
 
 For more information on package conventions, see the [muzzle docs](muzzle.md#compile-time-reference-collection).
 
-### Inject additional resources using the `helperResourceNames()` method
+### Inject additional resources using the `registerHelperResources(HelperResourceBuilder)` method
 
 Some libraries may expose SPI interfaces that you can easily implement to provide
 telemetry-gathering capabilities. The OpenTelemetry javaagent is able to inject `ServiceLoader`
@@ -81,8 +81,8 @@ service provider files, but it needs to be told which ones:
 
 ```java
 @Override
-public List<String> helperResourceNames() {
-  return singletonList("META-INF/services/org.my.library.SpiClass");
+public void registerHelperResources(HelperResourceBuilder helperResourceBuilder) {
+    helperResourceBuilder.register("META-INF/services/org.my.library.SpiClass");
 }
 ```
 


### PR DESCRIPTION
As `helperResourceNames()` method is replaced by `registerHelperResources(HelperResourceBuilder)` method, replacing it to use `registerHelperResources(HelperResourceBuilder)` in [writing-instrumentation-module.md](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/contributing/writing-instrumentation-module.md#inject-additional-resources-using-the-helperresourcenames-method)
