### PR TITLE
Fix flaky google http client async test

### DIFF
--- a/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientAsyncTest.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientAsyncTest.java
@@ -7,11 +7,21 @@ package io.opentelemetry.javaagent.instrumentation.googlehttpclient;
 
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterAll;
 
 class GoogleHttpClientAsyncTest extends AbstractGoogleHttpClientTest {
 
+  private final ExecutorService executor = Executors.newFixedThreadPool(4);
+
+  @AfterAll
+  void tearDown() {
+    executor.shutdown();
+  }
+
   @Override
   protected HttpResponse sendRequest(HttpRequest request) throws Exception {
-    return request.executeAsync().get();
+    return request.executeAsync(executor).get();
   }
 }


### PR DESCRIPTION
https://ge.opentelemetry.io/s/gnwekqhhf3ut6/tests/:instrumentation:google-http-client-1.19:javaagent:test/io.opentelemetry.javaagent.instrumentation.googlehttpclient.GoogleHttpClientAsyncTest/highConcurrency()?page=eyJvdXRwdXQiOnsiMCI6Mn19&top-execution=1
The problem is that the google http client method we use is implemented like
```
  public Future<HttpResponse> executeAsync() {
    return executeAsync(Executors.newSingleThreadExecutor());
  }
```
as explained in https://bugs.openjdk.org/browse/JDK-8145304 when `newSingleThreadExecutor` is used in such a way it is possible that this executor is shut down before it actually manages to execute anything.