### PR TITLE
Tests need to reset GlobalEventEmitterProvider

### DIFF
--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/OpenTelemetryInstallerTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/OpenTelemetryInstallerTest.groovy
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.tooling
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.events.GlobalEventEmitterProvider
 import io.opentelemetry.api.logs.GlobalLoggerProvider
 import spock.lang.Specification
 
@@ -15,11 +16,13 @@ class OpenTelemetryInstallerTest extends Specification {
   void setup() {
     GlobalOpenTelemetry.resetForTest()
     GlobalLoggerProvider.resetForTest()
+    GlobalEventEmitterProvider.resetForTest()
   }
 
   void cleanup() {
     GlobalOpenTelemetry.resetForTest()
     GlobalLoggerProvider.resetForTest()
+    GlobalEventEmitterProvider.resetForTest()
   }
 
   def "should initialize GlobalOpenTelemetry"() {

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFileLoaderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigurationFileLoaderTest.java
@@ -10,6 +10,7 @@ import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.events.GlobalEventEmitterProvider;
 import io.opentelemetry.api.logs.GlobalLoggerProvider;
 import io.opentelemetry.javaagent.tooling.OpenTelemetryInstaller;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
@@ -33,6 +34,7 @@ class ConfigurationFileLoaderTest {
   static void cleanUp() {
     GlobalOpenTelemetry.resetForTest();
     GlobalLoggerProvider.resetForTest();
+    GlobalEventEmitterProvider.resetForTest();
   }
 
   // regression for https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6696


### PR DESCRIPTION
After sdk update we have new flaky tests
https://ge.opentelemetry.io/s/qozoj3c4zxmge/tests/:javaagent-tooling:test/io.opentelemetry.javaagent.test.HelperInjectionTest/helpers%20injected%20on%20bootstrap%20classloader?top-execution=1
https://ge.opentelemetry.io/s/qozoj3c4zxmge/tests/:javaagent-tooling:test/io.opentelemetry.javaagent.tooling.OpenTelemetryInstallerTest/should%20initialize%20GlobalOpenTelemetry?top-execution=1