### PR TITLE
Optional redefinition stragegy for working with another APM javaagent

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -133,7 +133,7 @@ public class AgentInstaller {
             // disableClassFormatChanges sets type strategy to TypeStrategy.Default.REDEFINE_FROZEN
             // we'll wrap it with our own strategy
             .with(new SafeTypeStrategy(AgentBuilder.TypeStrategy.Default.REDEFINE_FROZEN))
-            .with(AgentBuilder.RedefinitionStrategy.REDEFINITION)
+            .with(AgentConfig.redefinitionStrategy(sdkConfig))
             .with(new RedefinitionDiscoveryStrategy())
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
             .with(AgentTooling.poolStrategy())

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -148,7 +148,7 @@ public class AgentInstaller {
     if (AgentConfig.isDebugModeEnabled(sdkConfig)) {
       agentBuilder =
           agentBuilder
-              .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+              .with(AgentConfig.redefinitionStrategy(sdkConfig))
               .with(new RedefinitionDiscoveryStrategy())
               .with(new RedefinitionLoggingListener())
               .with(new TransformLoggingListener());

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -133,7 +133,7 @@ public class AgentInstaller {
             // disableClassFormatChanges sets type strategy to TypeStrategy.Default.REDEFINE_FROZEN
             // we'll wrap it with our own strategy
             .with(new SafeTypeStrategy(AgentBuilder.TypeStrategy.Default.REDEFINE_FROZEN))
-            .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+            .with(AgentBuilder.RedefinitionStrategy.REDEFINITION)
             .with(new RedefinitionDiscoveryStrategy())
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
             .with(AgentTooling.poolStrategy())

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
@@ -38,7 +38,8 @@ public final class AgentConfig {
     try {
       return AgentBuilder.RedefinitionStrategy.valueOf(strategy.toUpperCase());
     } catch (IllegalArgumentException e) {
-      throw new ConfigurationException("Unrecognized value for otel.redefinition.strategy: " + strategy, e);
+      throw new ConfigurationException(
+          "Unrecognized value for otel.redefinition.strategy: " + strategy, e);
     }
   }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.tooling.config;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import net.bytebuddy.agent.builder.AgentBuilder;
+import java.util.Locale;
 
 public final class AgentConfig {
 
@@ -36,7 +37,7 @@ public final class AgentConfig {
   public static AgentBuilder.RedefinitionStrategy redefinitionStrategy(ConfigProperties config) {
     String strategy = config.getString("otel.redefinition.strategy", "retransformation");
     try {
-      return AgentBuilder.RedefinitionStrategy.valueOf(strategy.toUpperCase());
+      return AgentBuilder.RedefinitionStrategy.valueOf(strategy.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new ConfigurationException(
           "Unrecognized value for otel.redefinition.strategy: " + strategy, e);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.tooling.config;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import net.bytebuddy.agent.builder.AgentBuilder;
 
 public final class AgentConfig {
 
@@ -29,6 +30,11 @@ public final class AgentConfig {
 
   public static boolean isDebugModeEnabled(ConfigProperties config) {
     return config.getBoolean("otel.javaagent.debug", false);
+  }
+
+  public static AgentBuilder.RedefinitionStrategy redefinitionStrategy(ConfigProperties config) {
+    String strategy = config.getString("otel.redefinition.strategy", "retransformation");
+    return AgentBuilder.RedefinitionStrategy.valueOf(strategy.toUpperCase());
   }
 
   private AgentConfig() {}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.tooling.config;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import net.bytebuddy.agent.builder.AgentBuilder;
 
 public final class AgentConfig {
@@ -34,7 +35,11 @@ public final class AgentConfig {
 
   public static AgentBuilder.RedefinitionStrategy redefinitionStrategy(ConfigProperties config) {
     String strategy = config.getString("otel.redefinition.strategy", "retransformation");
-    return AgentBuilder.RedefinitionStrategy.valueOf(strategy.toUpperCase());
+    try {
+      return AgentBuilder.RedefinitionStrategy.valueOf(strategy.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new ConfigurationException("Unrecognized value for otel.redefinition.strategy: " + strategy, e);
+    }
   }
 
   private AgentConfig() {}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
@@ -15,6 +15,7 @@ import io.opentelemetry.javaagent.tooling.EmptyConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.TreeSet;
 import java.util.stream.Stream;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -72,7 +73,7 @@ class AgentConfigTest {
     // miss typo
     when(config.getString("otel.redefinition.strategy", "retransformation"))
         .thenReturn("somethingElse");
-    assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(ConfigurationException.class, () -> {
       AgentConfig.redefinitionStrategy(config);
     });
   }

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
@@ -13,9 +13,9 @@ import static org.mockito.Mockito.when;
 
 import io.opentelemetry.javaagent.tooling.EmptyConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import java.util.TreeSet;
 import java.util.stream.Stream;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -67,15 +67,16 @@ class AgentConfigTest {
     when(config.getString("otel.redefinition.strategy", "retransformation"))
         .thenReturn("redefinition");
     assertEquals(
-        AgentBuilder.RedefinitionStrategy.REDEFINITION,
-        AgentConfig.redefinitionStrategy(config));
+        AgentBuilder.RedefinitionStrategy.REDEFINITION, AgentConfig.redefinitionStrategy(config));
 
     // miss typo
     when(config.getString("otel.redefinition.strategy", "retransformation"))
         .thenReturn("somethingElse");
-    assertThrows(ConfigurationException.class, () -> {
-      AgentConfig.redefinitionStrategy(config);
-    });
+    assertThrows(
+        ConfigurationException.class,
+        () -> {
+          AgentConfig.redefinitionStrategy(config);
+        });
   }
 
   private static class InstrumentationEnabledParams implements ArgumentsProvider {


### PR DESCRIPTION
I'm doing maintanance javaagent of APM product.
Recently, We have scheduled accpet OpenTelemetry data from various agent of them.
So I tried install our javaagent with otel javaagent.
It's purpose that fill not enough funtionality of each of them.

My javaagent add interface to HttpServletRequest and HttpServletResponse loading them to free class reference when use their method as like `getParameter()`
But When otel javaagent installed sametimes interface added by my agent was gone.
That's look like return to origin shape.
I'm tried to found root cause and workaround then I found below issue.
#7594 

A reason is otel javaagent using ByteBuddy redeifne strategy is `RETRANSFORM`
It's works that instrument byte code after finish class loading.
So redefined class ignored after doing retransform.

Surely, ByteBuddy has three redefinition strategy. (NONE, RETRANSFORM, REDEFINITION)
When I set REDEFINITION strategy to AgentInstaller, otel agent and my agent working well together.
But I'm not sure how affect to opentelemetry agent entire range soI added agent option can adjust redefinition strategy.
We can expect user who want to use multiple agent setting this option.  


