### PR TITLE
Fix vaadin 14 test failures

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -35,11 +35,6 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
       - name: Spotless
         uses: gradle/gradle-build-action@v2
         env:
@@ -178,6 +173,11 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       # vaadin tests use pnpm
       - name: Cache pnpm modules

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -35,6 +35,11 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Spotless
         uses: gradle/gradle-build-action@v2
         env:

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -174,6 +174,7 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      # vaadin 14 tests fail with node 18
       - name: Set up Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/reusable-test-latest-deps.yml
+++ b/.github/workflows/reusable-test-latest-deps.yml
@@ -37,6 +37,7 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      # vaadin 14 tests fail with node 18
       - name: Set up Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/reusable-test-latest-deps.yml
+++ b/.github/workflows/reusable-test-latest-deps.yml
@@ -37,6 +37,11 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       # vaadin tests use pnpm
       - name: Cache pnpm modules
         uses: actions/cache@v3

--- a/instrumentation/vaadin-14.2/testing/src/main/resources/application.properties
+++ b/instrumentation/vaadin-14.2/testing/src/main/resources/application.properties
@@ -2,4 +2,4 @@
 vaadin.whitelisted-packages=test/vaadin
 vaadin.devmode.liveReload.enabled=false
 vaadin.pnpm.enable=true
-vaadin.devmode.webpack.options=--host 127.0.0.1 -d --inline=false
+vaadin.devmode.webpack.options=--host 0.0.0.0 -d --inline=false

--- a/instrumentation/vaadin-14.2/testing/src/main/resources/application.properties
+++ b/instrumentation/vaadin-14.2/testing/src/main/resources/application.properties
@@ -2,4 +2,4 @@
 vaadin.whitelisted-packages=test/vaadin
 vaadin.devmode.liveReload.enabled=false
 vaadin.pnpm.enable=true
-vaadin.devmode.webpack.options=--host 0.0.0.0 -d --inline=false
+vaadin.devmode.webpack.options=--host 127.0.0.1 -d --inline=false


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7859
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7855
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7854
Apparently default node version was change to 18 for github actions. I wasn't able to reproduce the failure, nor find anything in the test output that would help to pinpoint the exact cause of the failure. Changing the node version to 16 seems to get vaadin 14 tests passing again.