### PR TITLE
Reduce memory usage for ClassLoaderHasClassesNamedMatcher

### DIFF
--- a/gradle-plugins/src/main/kotlin/io/opentelemetry/javaagent/muzzle/matcher/MuzzleGradlePluginUtil.kt
+++ b/gradle-plugins/src/main/kotlin/io/opentelemetry/javaagent/muzzle/matcher/MuzzleGradlePluginUtil.kt
@@ -59,9 +59,6 @@ class MuzzleGradlePluginUtil {
 
       // We cannot reference Mismatch class directly here, because we are loaded from a different
       // class loader.
-
-      // We cannot reference Mismatch class directly here, because we are loaded from a different
-      // class loader.
       val allMismatches = matcherClass
         .getMethod("matchesAll", ClassLoader::class.java, Boolean::class.javaPrimitiveType, Set::class.java)
         .invoke(null, userClassLoader, assertPass, excludedInstrumentationNames)

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/ClassLoaderMatcherCacheHolder.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/ClassLoaderMatcherCacheHolder.java
@@ -22,11 +22,11 @@ import java.util.List;
 public final class ClassLoaderMatcherCacheHolder {
 
   @GuardedBy("allCaches")
-  private static final List<Cache<ClassLoader, Boolean>> allCaches = new ArrayList<>();
+  private static final List<Cache<ClassLoader, ?>> allCaches = new ArrayList<>();
 
   private ClassLoaderMatcherCacheHolder() {}
 
-  public static void addCache(Cache<ClassLoader, Boolean> cache) {
+  public static void addCache(Cache<ClassLoader, ?> cache) {
     synchronized (allCaches) {
       allCaches.add(cache);
     }
@@ -34,7 +34,7 @@ public final class ClassLoaderMatcherCacheHolder {
 
   public static void invalidateAllCachesForClassLoader(ClassLoader loader) {
     synchronized (allCaches) {
-      for (Cache<ClassLoader, Boolean> cache : allCaches) {
+      for (Cache<ClassLoader, ?> cache : allCaches) {
         cache.remove(loader);
       }
     }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/ClassLoaderHasClassesNamedMatcher.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/matcher/ClassLoaderHasClassesNamedMatcher.java
@@ -8,20 +8,24 @@ package io.opentelemetry.javaagent.extension.matcher;
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import io.opentelemetry.javaagent.bootstrap.internal.ClassLoaderMatcherCacheHolder;
 import io.opentelemetry.javaagent.bootstrap.internal.InClassLoaderMatcher;
+import java.util.BitSet;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.bytebuddy.matcher.ElementMatcher;
 
 class ClassLoaderHasClassesNamedMatcher extends ElementMatcher.Junction.AbstractBase<ClassLoader> {
-
-  private final Cache<ClassLoader, Boolean> cache = Cache.weak();
+  private static final AtomicInteger counter = new AtomicInteger();
 
   private final String[] resources;
+  private final int index = counter.getAndIncrement();
 
   ClassLoaderHasClassesNamedMatcher(String... classNames) {
     resources = classNames;
     for (int i = 0; i < resources.length; i++) {
       resources[i] = resources[i].replace(".", "/") + ".class";
     }
-    ClassLoaderMatcherCacheHolder.addCache(cache);
+    Manager.INSTANCE.add(this);
   }
 
   @Override
@@ -30,10 +34,10 @@ class ClassLoaderHasClassesNamedMatcher extends ElementMatcher.Junction.Abstract
       // Can't match the bootstrap class loader.
       return false;
     }
-    return cache.computeIfAbsent(cl, this::hasResources);
+    return Manager.INSTANCE.match(this, cl);
   }
 
-  private boolean hasResources(ClassLoader cl) {
+  private static boolean hasResources(ClassLoader cl, String... resources) {
     boolean priorValue = InClassLoaderMatcher.getAndSet(true);
     try {
       for (String resource : resources) {
@@ -45,5 +49,42 @@ class ClassLoaderHasClassesNamedMatcher extends ElementMatcher.Junction.Abstract
       InClassLoaderMatcher.set(priorValue);
     }
     return true;
+  }
+
+  private static class Manager {
+    private static final BitSet EMPTY = new BitSet(0);
+    static final Manager INSTANCE = new Manager();
+    private final List<ClassLoaderHasClassesNamedMatcher> matchers = new CopyOnWriteArrayList<>();
+    private final Cache<ClassLoader, BitSet> enabled = Cache.weak();
+    private volatile boolean matchCalled = false;
+
+    Manager() {
+      ClassLoaderMatcherCacheHolder.addCache(enabled);
+    }
+
+    void add(ClassLoaderHasClassesNamedMatcher matcher) {
+      if (matchCalled) {
+        throw new IllegalStateException("All matchers should be create before match is called");
+      }
+      matchers.add(matcher);
+    }
+
+    boolean match(ClassLoaderHasClassesNamedMatcher matcher, ClassLoader cl) {
+      matchCalled = true;
+      BitSet set = enabled.get(cl);
+      if (set == null) {
+        set = new BitSet(counter.get());
+        for (ClassLoaderHasClassesNamedMatcher m : matchers) {
+          if (hasResources(cl, m.resources)) {
+            set.set(m.index);
+          }
+        }
+        enabled.put(cl, set.isEmpty() ? EMPTY : set);
+        enabled.put(cl, set);
+      } else if (set.isEmpty()) {
+        return false;
+      }
+      return set.get(matcher.index);
+    }
   }
 }


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7698
This is an attempt to reduce memory usage for `ClassLoaderHasClassesNamedMatcher`. Instead of having each matcher keep a `Map<ClassLoader, Boolean>` we can have one `Map<ClassLoader, BitSet>` where each matcher uses one bit in the `BitSet`. Alternatively `Map<ClassLoader, Set<ClassLoaderHasClassesNamedMatcher>>` where set contains matchers that match for given class loader would also work well because these matchers usually don't match so we can expect to have only a few elements in the set.