### PR TITLE
Fix kotlin coroutine context propagation

### DIFF
--- a/instrumentation/kotlinx-coroutines/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/KotlinCoroutinesInstrumentation.java
+++ b/instrumentation/kotlinx-coroutines/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/KotlinCoroutinesInstrumentation.java
@@ -25,6 +25,7 @@ public class KotlinCoroutinesInstrumentation implements TypeInstrumentation {
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
         named("newCoroutineContext")
+            .and(takesArgument(0, named("kotlinx.coroutines.CoroutineScope")))
             .and(takesArgument(1, named("kotlin.coroutines.CoroutineContext"))),
         this.getClass().getName() + "$ContextAdvice");
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7837
`org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1` adds a second `newCoroutineContext` that we shouldn't instrument. When we instrument it the order of [`KotlinContextElement`](https://github.com/open-telemetry/opentelemetry-java/blob/main/extensions/kotlin/src/main/java/io/opentelemetry/extension/kotlin/KotlinContextElement.java) and user added `ThreadContextElement` gets reversed. If user added `ThreadContextElement` changes opentelemetry context then these changes will get overwritten by `KotlinContextElement`.