### PR TITLE
Add agent option for adjust ByteBuddy redefinition strategy

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -133,7 +133,7 @@ public class AgentInstaller {
             // disableClassFormatChanges sets type strategy to TypeStrategy.Default.REDEFINE_FROZEN
             // we'll wrap it with our own strategy
             .with(new SafeTypeStrategy(AgentBuilder.TypeStrategy.Default.REDEFINE_FROZEN))
-            .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+            .with(AgentConfig.redefinitionStrategy(sdkConfig))
             .with(new RedefinitionDiscoveryStrategy())
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
             .with(AgentTooling.poolStrategy())
@@ -148,7 +148,7 @@ public class AgentInstaller {
     if (AgentConfig.isDebugModeEnabled(sdkConfig)) {
       agentBuilder =
           agentBuilder
-              .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+              .with(AgentConfig.redefinitionStrategy(sdkConfig))
               .with(new RedefinitionDiscoveryStrategy())
               .with(new RedefinitionLoggingListener())
               .with(new TransformLoggingListener());

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
@@ -35,12 +35,17 @@ public final class AgentConfig {
   }
 
   public static AgentBuilder.RedefinitionStrategy redefinitionStrategy(ConfigProperties config) {
-    String strategy = config.getString("otel.redefinition.strategy", "retransformation");
+    String strategyKey = config.getString("otel.redefinition.strategy", "retransformation").toUpperCase(
+        Locale.ROOT);
     try {
-      return AgentBuilder.RedefinitionStrategy.valueOf(strategy.toUpperCase(Locale.ROOT));
+      AgentBuilder.RedefinitionStrategy strategy = AgentBuilder.RedefinitionStrategy.valueOf(strategyKey);
+      if (strategy == AgentBuilder.RedefinitionStrategy.DISABLED) {
+        throw new ConfigurationException("disabled strategy is not allowed. Set either retransformation or redefinition");
+      }
+      return strategy;
     } catch (IllegalArgumentException e) {
       throw new ConfigurationException(
-          "Unrecognized value for otel.redefinition.strategy: " + strategy, e);
+          "Unrecognized value for otel.redefinition.strategy: " + strategyKey, e);
     }
   }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
@@ -35,12 +35,14 @@ public final class AgentConfig {
   }
 
   public static AgentBuilder.RedefinitionStrategy redefinitionStrategy(ConfigProperties config) {
-    String strategyKey = config.getString("otel.redefinition.strategy", "retransformation").toUpperCase(
-        Locale.ROOT);
+    String strategyKey =
+        config.getString("otel.redefinition.strategy", "retransformation").toUpperCase(Locale.ROOT);
     try {
-      AgentBuilder.RedefinitionStrategy strategy = AgentBuilder.RedefinitionStrategy.valueOf(strategyKey);
+      AgentBuilder.RedefinitionStrategy strategy =
+          AgentBuilder.RedefinitionStrategy.valueOf(strategyKey);
       if (strategy == AgentBuilder.RedefinitionStrategy.DISABLED) {
-        throw new ConfigurationException("disabled strategy is not allowed. Set either retransformation or redefinition");
+        throw new ConfigurationException(
+            "disabled strategy is not allowed. Set either retransformation or redefinition");
       }
       return strategy;
     } catch (IllegalArgumentException e) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/AgentConfig.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.javaagent.tooling.config;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import java.util.Locale;
+import net.bytebuddy.agent.builder.AgentBuilder;
 
 public final class AgentConfig {
 
@@ -29,6 +32,16 @@ public final class AgentConfig {
 
   public static boolean isDebugModeEnabled(ConfigProperties config) {
     return config.getBoolean("otel.javaagent.debug", false);
+  }
+
+  public static AgentBuilder.RedefinitionStrategy redefinitionStrategy(ConfigProperties config) {
+    String strategy = config.getString("otel.redefinition.strategy", "retransformation");
+    try {
+      return AgentBuilder.RedefinitionStrategy.valueOf(strategy.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new ConfigurationException(
+          "Unrecognized value for otel.redefinition.strategy: " + strategy, e);
+    }
   }
 
   private AgentConfig() {}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
@@ -72,16 +72,11 @@ class AgentConfigTest {
     // miss typo
     when(config.getString("otel.redefinition.strategy", "retransformation"))
         .thenReturn("somethingElse");
-    assertThrows(
-        ConfigurationException.class,
-        () -> AgentConfig.redefinitionStrategy(config));
+    assertThrows(ConfigurationException.class, () -> AgentConfig.redefinitionStrategy(config));
 
     // passing value is disabled
-    when(config.getString("otel.redefinition.strategy", "retransformation"))
-        .thenReturn("disabled");
-    assertThrows(
-        ConfigurationException.class,
-        () -> AgentConfig.redefinitionStrategy(config));
+    when(config.getString("otel.redefinition.strategy", "retransformation")).thenReturn("disabled");
+    assertThrows(ConfigurationException.class, () -> AgentConfig.redefinitionStrategy(config));
   }
 
   private static class InstrumentationEnabledParams implements ArgumentsProvider {

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
@@ -7,12 +7,17 @@ package io.opentelemetry.javaagent.tooling.config;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.javaagent.tooling.EmptyConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import java.util.TreeSet;
 import java.util.stream.Stream;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -40,6 +45,38 @@ class AgentConfigTest {
         expected,
         AgentConfig.isInstrumentationEnabled(
             config, new TreeSet<>(asList("first", "second")), defaultEnabled));
+  }
+
+  @Test
+  void testInstrumentationStrategy() {
+    // default
+    assertEquals(
+        AgentBuilder.RedefinitionStrategy.RETRANSFORMATION,
+        AgentConfig.redefinitionStrategy(EmptyConfigProperties.INSTANCE));
+
+    ConfigProperties config = mock(ConfigProperties.class);
+
+    // explicit default
+    when(config.getString("otel.redefinition.strategy", "retransformation"))
+        .thenReturn("retransformation");
+    assertEquals(
+        AgentBuilder.RedefinitionStrategy.RETRANSFORMATION,
+        AgentConfig.redefinitionStrategy(config));
+
+    // explicit redefinition
+    when(config.getString("otel.redefinition.strategy", "retransformation"))
+        .thenReturn("redefinition");
+    assertEquals(
+        AgentBuilder.RedefinitionStrategy.REDEFINITION, AgentConfig.redefinitionStrategy(config));
+
+    // miss typo
+    when(config.getString("otel.redefinition.strategy", "retransformation"))
+        .thenReturn("somethingElse");
+    assertThrows(
+        ConfigurationException.class,
+        () -> {
+          AgentConfig.redefinitionStrategy(config);
+        });
   }
 
   private static class InstrumentationEnabledParams implements ArgumentsProvider {

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/AgentConfigTest.java
@@ -74,9 +74,14 @@ class AgentConfigTest {
         .thenReturn("somethingElse");
     assertThrows(
         ConfigurationException.class,
-        () -> {
-          AgentConfig.redefinitionStrategy(config);
-        });
+        () -> AgentConfig.redefinitionStrategy(config));
+
+    // passing value is disabled
+    when(config.getString("otel.redefinition.strategy", "retransformation"))
+        .thenReturn("disabled");
+    assertThrows(
+        ConfigurationException.class,
+        () -> AgentConfig.redefinitionStrategy(config));
   }
 
   private static class InstrumentationEnabledParams implements ArgumentsProvider {


### PR DESCRIPTION
@laurit I make pr again due to missing cla commit from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7835

I'm doing maintanance javaagent of APM product.
Recently, We have scheduled accpet OpenTelemetry data from various agent of them.
So I tried install our javaagent with otel javaagent.
It's purpose that fill not enough funtionality of each of them.

My javaagent add interface to HttpServletRequest and HttpServletResponse loading them to free class reference when use their method as like getParameter()
But When otel javaagent installed sametimes interface added by my agent was gone.
That's look like return to origin shape.
I'm tried to found root cause and workaround then I found below issue.
https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7594

A reason is otel javaagent using ByteBuddy redeifne strategy is RETRANSFORM
It's works that instrument byte code after finish class loading.
So redefined class ignored after doing retransform.

Surely, ByteBuddy has three redefinition strategy. (NONE, RETRANSFORM, REDEFINITION)
When I set REDEFINITION strategy to AgentInstaller, otel agent and my agent working well together.
But I'm not sure how affect to opentelemetry agent entire range soI added agent option can adjust redefinition strategy.
We can expect user who want to use multiple agent setting this option.
