### PR TITLE
Make AggregationTemporality configurable for OtlpInMemoryMetricExporter

### DIFF
--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryMetricExporter.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryMetricExporter.java
@@ -19,6 +19,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Logger;
@@ -39,7 +40,8 @@ class OtlpInMemoryMetricExporter implements MetricExporter {
     if (temporalityProperty == null) {
       aggregationTemporality = AggregationTemporality.DELTA;
     } else {
-      aggregationTemporality = AggregationTemporality.valueOf(temporalityProperty.toUpperCase());
+      aggregationTemporality =
+          AggregationTemporality.valueOf(temporalityProperty.toUpperCase(Locale.ROOT));
     }
     logger.log(CONFIG, "Setting aggregation temporality to {0}", aggregationTemporality.toString());
     return aggregationTemporality;

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryMetricExporter.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryMetricExporter.java
@@ -29,18 +29,20 @@ class OtlpInMemoryMetricExporter implements MetricExporter {
 
   private final Queue<byte[]> collectedRequests = new ConcurrentLinkedQueue<>();
 
-  private final AggregationTemporality aggregationTemporality;
+  private static final AggregationTemporality aggregationTemporality = initAggregationTemporality();
 
-  OtlpInMemoryMetricExporter() {
+  private static AggregationTemporality initAggregationTemporality() {
     // this configuration setting is for external users
     // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7902
     String temporalityProperty = System.getProperty("otel.javaagent.testing.exporter.temporality");
+    AggregationTemporality aggregationTemporality;
     if (temporalityProperty == null) {
       aggregationTemporality = AggregationTemporality.DELTA;
     } else {
       aggregationTemporality = AggregationTemporality.valueOf(temporalityProperty.toUpperCase());
     }
     logger.log(CONFIG, "Setting aggregation temporality to {0}", aggregationTemporality.toString());
+    return aggregationTemporality;
   }
 
   List<byte[]> getCollectedExportRequests() {

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryMetricExporter.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/exporter/OtlpInMemoryMetricExporter.java
@@ -32,6 +32,8 @@ class OtlpInMemoryMetricExporter implements MetricExporter {
   private final AggregationTemporality aggregationTemporality;
 
   OtlpInMemoryMetricExporter() {
+    // this configuration setting is for external users
+    // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7902
     String temporalityProperty = System.getProperty("otel.javaagent.testing.exporter.temporality");
     if (temporalityProperty == null) {
       aggregationTemporality = AggregationTemporality.DELTA;


### PR DESCRIPTION
References https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7902.

Not sure if system property name is the most appropriate or if any tests are required for these changes.