### PR TITLE
Check that extracting extension jar doesn't escape designated directory

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -83,11 +83,20 @@ public class ExtensionClassLoader extends URLClassLoader {
       File tempDirectory = null;
       while (entryEnumeration.hasMoreElements()) {
         JarEntry jarEntry = entryEnumeration.nextElement();
+        String name = jarEntry.getName();
 
-        if (jarEntry.getName().startsWith(prefix) && !jarEntry.isDirectory()) {
+        if (name.startsWith(prefix) && !jarEntry.isDirectory()) {
           tempDirectory = ensureTempDirectoryExists(tempDirectory);
 
-          File tempFile = new File(tempDirectory, jarEntry.getName().substring(prefix.length()));
+          File tempFile = new File(tempDirectory, name.substring(prefix.length()));
+          // reject extensions that would be extracted outside of temp directory
+          if (name.indexOf("..") != -1
+              && !tempFile
+                  .getCanonicalFile()
+                  .toPath()
+                  .startsWith(tempDirectory.getCanonicalFile().toPath())) {
+            throw new IllegalStateException("Invalid extension " + name);
+          }
           if (tempFile.createNewFile()) {
             tempFile.deleteOnExit();
             extractFile(jarFile, jarEntry, tempFile);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -90,6 +90,7 @@ public class ExtensionClassLoader extends URLClassLoader {
 
           File tempFile = new File(tempDirectory, name.substring(prefix.length()));
           // reject extensions that would be extracted outside of temp directory
+          // https://security.snyk.io/research/zip-slip-vulnerability
           if (name.indexOf("..") != -1
               && !tempFile
                   .getCanonicalFile()


### PR DESCRIPTION
Mostly to appease code scanners.