### PR TITLE
Improve compatibility with other agents

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -138,6 +138,7 @@ public class AgentInstaller {
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
             .with(AgentTooling.poolStrategy())
             .with(new ClassLoadListener())
+            .with(AgentTooling.transformListener())
             .with(AgentTooling.locationStrategy());
     if (JavaModule.isSupported()) {
       agentBuilder = agentBuilder.with(new ExposeAgentBootstrapListener(inst));

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategy.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategy.java
@@ -275,6 +275,15 @@ public class AgentCachingPoolStrategy implements AgentBuilder.PoolStrategy {
       if (OBJECT_NAME.equals(className)) {
         return OBJECT_RESOLUTION;
       }
+      // Skip cache for the type that is currently being transformed.
+      // If class has been transformed by another agent or by class loader it is possible that the
+      // cached TypeDescription isn't the same as the one built from the actual bytes that are
+      // being defined. For example if another agent adds an interface to the class then returning
+      // the cached description that does not have that interface would result in bytebuddy removing
+      // that interface.
+      if (AgentTooling.isTransforming(loaderRef.get(), className)) {
+        return null;
+      }
 
       TypePool.Resolution existingResolution =
           sharedResolutionCache.get(new TypeCacheKey(loaderHash, loaderRef, className));

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategy.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentCachingPoolStrategy.java
@@ -281,7 +281,7 @@ public class AgentCachingPoolStrategy implements AgentBuilder.PoolStrategy {
       // being defined. For example if another agent adds an interface to the class then returning
       // the cached description that does not have that interface would result in bytebuddy removing
       // that interface.
-      if (AgentTooling.isTransforming(loaderRef.get(), className)) {
+      if (AgentTooling.isTransforming(loaderRef != null ? loaderRef.get() : null, className)) {
         return null;
       }
 

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentTooling.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/AgentTooling.java
@@ -58,10 +58,6 @@ public final class AgentTooling {
         && currentTransform.classLoader == classLoader;
   }
 
-  public static void completeLoadClass() {
-    CURRENT_TRANSFORM.remove();
-  }
-
   private static class ClassTransformListener extends AgentBuilder.Listener.Adapter {
     @Override
     public void onDiscovery(


### PR DESCRIPTION
Fixes the issue described in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7887
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7594
We should not use cached `TypeDescription` for currently transformed class as the cached description will not be the same as newly created one if the class bytes were transformed. For example if another agent adds an interface to the class then returning the cached description that does not have that interface would result in bytebuddy removing that interface, see https://github.com/raphw/byte-buddy/blob/665a090c733c37339788cc5a1c441bd47fb77ef0/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/scaffold/TypeWriter.java#L5012