### PR TITLE
Update websphere smoke test images

### DIFF
--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -61,9 +61,7 @@ val targets = mapOf(
     ImageTarget(listOf("9.0.0-M7"), listOf("openj9"), listOf("8", "11", "17", "18"), war = "servlet-5.0"),
   ),
   "websphere" to listOf(
-    // TODO (trask) this is a recent change, check back in a while and see if it's been fixed
-    // 8.5.5.20 only has linux/ppc64le image
-    ImageTarget(listOf("8.5.5.19", "9.0.5.9"), listOf("openj9"), listOf("8"), windows = false),
+    ImageTarget(listOf("8.5.5.22", "9.0.5.14"), listOf("openj9"), listOf("8"), windows = false),
   ),
   "wildfly" to listOf(
     ImageTarget(listOf("13.0.0.Final"), listOf("hotspot", "openj9"), listOf("8")),


### PR DESCRIPTION
See output of https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/4247069738/jobs/7384671536
For websphere 8.5 the scripts that deploy the test application and change the default port didn't run successfully. Upgrading the version in the hope that this produces a working image.