### PR TITLE
Fix gradle warning

### DIFF
--- a/gradle-plugins/settings.gradle.kts
+++ b/gradle-plugins/settings.gradle.kts
@@ -4,3 +4,7 @@ pluginManagement {
     id("io.github.gradle-nexus.publish-plugin") version "1.2.0"
   }
 }
+
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ pluginManagement {
 plugins {
   id("com.gradle.enterprise") version "3.12.2"
   id("com.gradle.common-custom-user-data-gradle-plugin") version "1.8.2"
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
> Java toolchain auto-provisioning enabled, but no java toolchain repositories declared by the build. Will rely on the built-in repository. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. In order to declare a repository for java toolchains, you must edit your settings script and add one via the toolchainManagement block. See https://docs.gradle.org/7.6.1/userguide/toolchains.html#sec:provisioning for more details.

The sample at linked page mentions `repository("adoptium")` which looks like what we would like to use, but apparently this is just a sample how configuration might look like, `AdoptiumResolver` doesn't really exist. The one that exists is https://github.com/gradle/foojay-toolchains