### PR TITLE
Improve compatibility with SecurityManager

### DIFF
--- a/docs/advanced-configuration-options.md
+++ b/docs/advanced-configuration-options.md
@@ -17,3 +17,14 @@ which could have unknown side-effects.
 | System property                | Environment variable           | Purpose                                                                                           |
 |--------------------------------|--------------------------------|---------------------------------------------------------------------------------------------------|
 | otel.javaagent.exclude-classes | OTEL_JAVAAGENT_EXCLUDE_CLASSES | Suppresses all instrumentation for specific classes, format is "my.package.MyClass,my.package2.*" |
+
+## Running application with security manager
+
+This option can be used to let agent run with all privileges without being affected by security policy restricting some operations.
+
+| System property                                              | Environment variable                                         | Purpose                               |
+|--------------------------------------------------------------|--------------------------------------------------------------|---------------------------------------|
+| otel.javaagent.experimental.security-manager-support.enabled | OTEL_JAVAAGENT_EXPERIMENTAL_SECURITY_MANAGER_SUPPORT_ENABLED | Grant all privileges to agent code[1] |
+
+[1] Disclaimer: agent can provide application means for escaping security manager sandbox. Do not use
+this option if your application relies on security manager to run untrusted code.

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -11,8 +11,9 @@ import io.opentelemetry.javaagent.bootstrap.JavaagentFileHolder;
 import java.io.File;
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
+import java.net.JarURLConnection;
 import java.net.URISyntaxException;
-import java.security.CodeSource;
+import java.net.URL;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
@@ -64,24 +65,30 @@ public final class OpenTelemetryAgent {
 
   private static synchronized File installBootstrapJar(Instrumentation inst)
       throws IOException, URISyntaxException {
-
-    CodeSource codeSource = OpenTelemetryAgent.class.getProtectionDomain().getCodeSource();
-
-    if (codeSource == null) {
-      throw new IllegalStateException("could not get agent jar location");
+    // we are not using OpenTelemetryAgent.class.getProtectionDomain().getCodeSource() to get agent
+    // location because getProtectionDomain does a permission check with security manager
+    URL url =
+        OpenTelemetryAgent.class
+            .getClassLoader()
+            .getResource(OpenTelemetryAgent.class.getName().replace('.', '/') + ".class");
+    if (url == null || !"jar".equals(url.getProtocol())) {
+      throw new IllegalStateException("could not get agent jar location from url " + url);
     }
-
-    File javaagentFile = new File(codeSource.getLocation().toURI());
+    String resourcePath = url.toURI().getSchemeSpecificPart();
+    int protocolSeparatorIndex = resourcePath.indexOf(":");
+    int resourceSeparatorIndex = resourcePath.indexOf("!/");
+    if (protocolSeparatorIndex == -1 || resourceSeparatorIndex == -1) {
+      throw new IllegalStateException("could not get agent location from url " + url);
+    }
+    String agentPath = resourcePath.substring(protocolSeparatorIndex + 1, resourceSeparatorIndex);
+    File javaagentFile = new File(agentPath);
 
     if (!javaagentFile.isFile()) {
       throw new IllegalStateException(
           "agent jar location doesn't appear to be a file: " + javaagentFile.getAbsolutePath());
     }
 
-    // passing verify false for vendors who sign the agent jar, because jar file signature
-    // verification is very slow before the JIT compiler starts up, which on Java 8 is not until
-    // after premain execution completes
-    JarFile agentJar = new JarFile(javaagentFile, false);
+    JarFile agentJar = ((JarURLConnection) url.openConnection()).getJarFile();
     verifyJarManifestMainClassIsThis(javaagentFile, agentJar);
     inst.appendToBootstrapClassLoaderSearch(agentJar);
     return javaagentFile;

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentClassLoader.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentClassLoader.java
@@ -69,8 +69,9 @@ public class AgentClassLoader extends URLClassLoader {
   private final boolean isSecurityManagerSupportEnabled;
   private final Manifest manifest;
 
-  public AgentClassLoader(File javaagentFile, String internalJarFileName) {
-    this(javaagentFile, internalJarFileName, false);
+  // Used by tests
+  public AgentClassLoader(File javaagentFile) {
+    this(javaagentFile, "", false);
   }
 
   /**

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentClassLoader.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentClassLoader.java
@@ -105,8 +105,6 @@ public class AgentClassLoader extends URLClassLoader {
       jarBase =
           new URL("x-internal-jar", null, 0, "/", new AgentClassLoaderUrlStreamHandler(jarFile));
       codeSource = new CodeSource(javaagentFile.toURI().toURL(), (Certificate[]) null);
-      Permissions permissions = new Permissions();
-      permissions.add(new AllPermission());
       manifest = jarFile.getManifest();
     } catch (IOException e) {
       throw new IllegalStateException("Unable to open agent jar", e);

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentClassLoader.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentClassLoader.java
@@ -69,6 +69,10 @@ public class AgentClassLoader extends URLClassLoader {
   private final boolean isSecurityManagerSupportEnabled;
   private final Manifest manifest;
 
+  public AgentClassLoader(File javaagentFile, String internalJarFileName) {
+    this(javaagentFile, internalJarFileName, false);
+  }
+
   /**
    * Construct a new AgentClassLoader.
    *

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
@@ -66,7 +66,7 @@ public final class AgentInitializer {
   }
 
   private static boolean isSecurityManagerSupportEnabled() {
-    return getBoolean("otel.javaagent.experimental.security-manager.enabled", false);
+    return getBoolean("otel.javaagent.experimental.security-manager-support.enabled", false);
   }
 
   private static boolean getBoolean(String property, boolean defaultValue) {
@@ -173,8 +173,9 @@ public final class AgentInitializer {
     Class<?> starterClass =
         agentClassLoader.loadClass("io.opentelemetry.javaagent.tooling.AgentStarterImpl");
     Constructor<?> constructor =
-        starterClass.getDeclaredConstructor(Instrumentation.class, File.class);
-    return (AgentStarter) constructor.newInstance(instrumentation, javaagentFile);
+        starterClass.getDeclaredConstructor(Instrumentation.class, File.class, boolean.class);
+    return (AgentStarter)
+        constructor.newInstance(instrumentation, javaagentFile, isSecurityManagerSupportEnabled);
   }
 
   private AgentInitializer() {}

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/AgentInitializer.java
@@ -51,7 +51,6 @@ public final class AgentInitializer {
         });
   }
 
-  @SuppressWarnings("removal")
   private static void execute(PrivilegedExceptionAction<Void> action) throws Exception {
     if (System.getSecurityManager() != null && AccessControllerInvoker.canInvoke()) {
       AccessControllerInvoker.invoke(action);

--- a/javaagent-bootstrap/src/test/groovy/io/opentelemetry/javaagent/bootstrap/AgentClassLoaderTest.groovy
+++ b/javaagent-bootstrap/src/test/groovy/io/opentelemetry/javaagent/bootstrap/AgentClassLoaderTest.groovy
@@ -19,7 +19,7 @@ class AgentClassLoaderTest extends Specification {
     def className2 = 'some/class/Name2'
     // any jar would do, use opentelemety sdk
     URL testJarLocation = JavaVersionSpecific.getProtectionDomain().getCodeSource().getLocation()
-    AgentClassLoader loader = new AgentClassLoader(new File(testJarLocation.toURI()), "")
+    AgentClassLoader loader = new AgentClassLoader(new File(testJarLocation.toURI()))
     Phaser threadHoldLockPhase = new Phaser(2)
     Phaser acquireLockFromMainThreadPhase = new Phaser(2)
 
@@ -58,7 +58,7 @@ class AgentClassLoaderTest extends Specification {
     boolean jdk8 = "1.8" == System.getProperty("java.specification.version")
     // sdk is a multi release jar
     URL multiReleaseJar = JavaVersionSpecific.getProtectionDomain().getCodeSource().getLocation()
-    AgentClassLoader loader = new AgentClassLoader(new File(multiReleaseJar.toURI()), "") {
+    AgentClassLoader loader = new AgentClassLoader(new File(multiReleaseJar.toURI())) {
       @Override
       protected String getClassSuffix() {
         return ""

--- a/javaagent-tooling/javaagent-tooling-java9/src/test/groovy/UnsafeTest.groovy
+++ b/javaagent-tooling/javaagent-tooling-java9/src/test/groovy/UnsafeTest.groovy
@@ -14,7 +14,7 @@ class UnsafeTest extends Specification {
     setup:
     ByteBuddyAgent.install()
     URL testJarLocation = AgentClassLoader.getProtectionDomain().getCodeSource().getLocation()
-    AgentClassLoader loader = new AgentClassLoader(new File(testJarLocation.toURI()), "")
+    AgentClassLoader loader = new AgentClassLoader(new File(testJarLocation.toURI()))
     UnsafeInitializer.initialize(ByteBuddyAgent.getInstrumentation(), loader, false)
 
     expect:

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
@@ -30,11 +30,16 @@ import org.objectweb.asm.Type;
 public class AgentStarterImpl implements AgentStarter {
   private final Instrumentation instrumentation;
   private final File javaagentFile;
+  private final boolean isSecurityManagerSupportEnabled;
   private ClassLoader extensionClassLoader;
 
-  public AgentStarterImpl(Instrumentation instrumentation, File javaagentFile) {
+  public AgentStarterImpl(
+      Instrumentation instrumentation,
+      File javaagentFile,
+      boolean isSecurityManagerSupportEnabled) {
     this.instrumentation = instrumentation;
     this.javaagentFile = javaagentFile;
+    this.isSecurityManagerSupportEnabled = isSecurityManagerSupportEnabled;
   }
 
   @Override
@@ -62,7 +67,7 @@ public class AgentStarterImpl implements AgentStarter {
 
   @Override
   public void start() {
-    extensionClassLoader = createExtensionClassLoader(getClass().getClassLoader(), javaagentFile);
+    extensionClassLoader = createExtensionClassLoader(getClass().getClassLoader());
 
     String loggerImplementationName = ConfigPropertiesUtil.getString("otel.javaagent.logging");
     // default to the built-in stderr slf4j-simple logger
@@ -119,9 +124,9 @@ public class AgentStarterImpl implements AgentStarter {
     return extensionClassLoader;
   }
 
-  private static ClassLoader createExtensionClassLoader(
-      ClassLoader agentClassLoader, File javaagentFile) {
-    return ExtensionClassLoader.getInstance(agentClassLoader, javaagentFile);
+  private ClassLoader createExtensionClassLoader(ClassLoader agentClassLoader) {
+    return ExtensionClassLoader.getInstance(
+        agentClassLoader, javaagentFile, isSecurityManagerSupportEnabled);
   }
 
   private static class LaunchHelperClassFileTransformer implements ClassFileTransformer {

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -39,7 +39,6 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassInjector;
-import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.utility.JavaModule;
 
 /**
@@ -58,6 +57,7 @@ public class HelperInjector implements Transformer {
 
   private static final TransformSafeLogger logger =
       TransformSafeLogger.getLogger(HelperInjector.class);
+
   private static final ProtectionDomain PROTECTION_DOMAIN =
       HelperInjector.class.getProtectionDomain();
 
@@ -315,8 +315,7 @@ public class HelperInjector implements Transformer {
     }
 
     if (ClassInjector.UsingUnsafe.isAvailable()) {
-      return new ClassInjector.UsingUnsafe(ClassLoadingStrategy.BOOTSTRAP_LOADER, PROTECTION_DOMAIN)
-          .injectRaw(classnameToBytes);
+      return ClassInjector.UsingUnsafe.ofBootLoader().injectRaw(classnameToBytes);
     }
 
     // Mar 2020: Since we're proactively cleaning up tempDirs, we cannot share dirs per thread.

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -390,7 +390,8 @@ public class HelperInjector implements Transformer {
 
     Class<?> inject(ClassLoader classLoader, String className) {
       // if security manager is present byte buddy calls
-      // checkPermission(new ReflectPermission("suppressAccessChecks"))
+      // checkPermission(new ReflectPermission("suppressAccessChecks")) so we must call class
+      // injection with AccessController.doPrivileged when security manager is enabled
       Map<String, Class<?>> result =
           execute(
               () ->

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -15,9 +15,6 @@ import io.opentelemetry.javaagent.tooling.muzzle.HelperResource;
 import java.io.File;
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.net.URL;
 import java.nio.file.Files;
 import java.security.PrivilegedAction;
@@ -403,41 +400,12 @@ public class HelperInjector implements Transformer {
     }
   }
 
+  @SuppressWarnings({"deprecation", "removal"}) // AccessController is deprecated
   private static <T> T execute(PrivilegedAction<T> action) {
-    if (System.getSecurityManager() != null && AccessControllerInvoker.canInvoke()) {
-      return AccessControllerInvoker.invoke(action);
+    if (System.getSecurityManager() != null) {
+      return java.security.AccessController.doPrivileged(action);
     } else {
       return action.run();
-    }
-  }
-
-  // using java.security.AccessController directly causes build to fail due to warnings about
-  // using a terminally deprecated class
-  private static class AccessControllerInvoker {
-    private static final MethodHandle doPrivilegedMethodHandle = getDoPrivilegedMethodHandle();
-
-    private static MethodHandle getDoPrivilegedMethodHandle() {
-      try {
-        Class<?> clazz = Class.forName("java.security.AccessController");
-        return MethodHandles.lookup()
-            .findStatic(
-                clazz, "doPrivileged", MethodType.methodType(Object.class, PrivilegedAction.class));
-      } catch (Exception exception) {
-        return null;
-      }
-    }
-
-    static boolean canInvoke() {
-      return doPrivilegedMethodHandle != null;
-    }
-
-    @SuppressWarnings("unchecked")
-    static <T> T invoke(PrivilegedAction<T> action) {
-      try {
-        return (T) doPrivilegedMethodHandle.invoke(action);
-      } catch (Throwable exception) {
-        throw new IllegalStateException(exception);
-      }
     }
   }
 }

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SecurityManagerSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SecurityManagerSmokeTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.smoketest
+
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import spock.lang.IgnoreIf
+import spock.lang.Unroll
+
+import static io.opentelemetry.smoketest.TestContainerManager.useWindowsContainers
+
+@IgnoreIf({ useWindowsContainers() })
+class SecurityManagerSmokeTest extends SmokeTest {
+
+  protected String getTargetImage(String jdk) {
+    "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-security-manager:jdk$jdk-20230323.4502979551"
+  }
+
+  @Unroll
+  def "security manager smoke test on JDK #jdk"(int jdk) {
+    setup:
+    startTarget(jdk)
+
+    expect:
+    Collection<ExportTraceServiceRequest> traces = waitForTraces()
+    countSpansByName(traces, 'test') == 1
+
+    cleanup:
+    stopTarget()
+
+    where:
+    jdk << [8, 11, 17, 19]
+  }
+}

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SecurityManagerSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SecurityManagerSmokeTest.groovy
@@ -14,8 +14,14 @@ import static io.opentelemetry.smoketest.TestContainerManager.useWindowsContaine
 @IgnoreIf({ useWindowsContainers() })
 class SecurityManagerSmokeTest extends SmokeTest {
 
+  @Override
   protected String getTargetImage(String jdk) {
     "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-security-manager:jdk$jdk-20230323.4502979551"
+  }
+
+  @Override
+  protected Map<String, String> getExtraEnv() {
+    return Collections.singletonMap("OTEL_JAVAAGENT_EXPERIMENTAL_SECURITY_MANAGER_ENABLED", "true")
   }
 
   @Unroll

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SecurityManagerSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/SecurityManagerSmokeTest.groovy
@@ -21,7 +21,7 @@ class SecurityManagerSmokeTest extends SmokeTest {
 
   @Override
   protected Map<String, String> getExtraEnv() {
-    return Collections.singletonMap("OTEL_JAVAAGENT_EXPERIMENTAL_SECURITY_MANAGER_ENABLED", "true")
+    return Collections.singletonMap("OTEL_JAVAAGENT_EXPERIMENTAL_SECURITY_MANAGER_SUPPORT_ENABLED", "true")
   }
 
   @Unroll


### PR DESCRIPTION
This pr gives classes defined in agent and extension class loaders all permissions. Injected helper classes are also defined with all permissions. Agent startup is altered so that we won't call methods that require permission before we are able to get those permissions.
This pr does not attempt to address issues where agent code could allow user code to circumvent security manager e.g. https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/InstrumentationHolder.java gives access to `Instrumentation` that could be used to redefine classes and remove security checks. Also this pr does not address failed permission checks that could arise from user code calling agent code. When user code, that does not have privileges, calls agent code, that has the privileges, and agent code performs a sensitive operation then permission check would fail because it is performed for all calling classes, including the user classes. To fix this agent code should uses `AccessController.doPrivileged` which basically means that, hey I have done all the checks, run this call with my privileges and ignore the privileges of my callers.