### PR TITLE
Make the OpenTelemetry Logback appender work with GraalVM native images

### DIFF
--- a/instrumentation-api/src/main/resources/META-INF/native-image/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api/native-image.properties
+++ b/instrumentation-api/src/main/resources/META-INF/native-image/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api/native-image.properties
@@ -1,0 +1,2 @@
+Args=\
+  --initialize-at-build-time=io.opentelemetry.instrumentation.api.internal.cache.concurrentlinkedhashmap.ConcurrentLinkedHashMap

--- a/instrumentation/logback/logback-appender-1.0/library/src/main/resources/META-INF/native-image/io.opentelemetry.instrumentation/opentelemetry-jdbc/native-image.properties
+++ b/instrumentation/logback/logback-appender-1.0/library/src/main/resources/META-INF/native-image/io.opentelemetry.instrumentation/opentelemetry-jdbc/native-image.properties
@@ -1,0 +1,2 @@
+Args=\
+  --initialize-at-build-time=io.opentelemetry.instrumentation.logback.appender.v1_0.internal.LoggingEventMapper


### PR DESCRIPTION
I have tried the [OpenTelemetry Logback appender](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/logback/logback-appender-1.0/library) with GraalVM native images. The GraalVM configurations of this PR are required to make it work.

It's my first GraalVM-related PR in this repo. In future works, adding automatic tests with GraalVM on some [programmatic instrumentation libraries](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md#libraries--frameworks) may be interesting.