### PR TITLE
Fix flaky spring rabbit test

### DIFF
--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
@@ -4,7 +4,6 @@
  */
 
 import com.rabbitmq.client.ConnectionFactory
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.testing.GlobalTraceUtil
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
@@ -4,6 +4,7 @@
  */
 
 import com.rabbitmq.client.ConnectionFactory
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.instrumentation.testing.GlobalTraceUtil
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -91,6 +92,10 @@ class ContextPropagationTest extends AgentInstrumentationSpecification {
     then:
     assertTraces(2) {
       trace(0, 5) {
+        spans.subList(2, 4).sort {
+          def destination = it.attributes.get(SemanticAttributes.MESSAGING_DESTINATION_NAME)
+          return destination == "<default>" ? 0 : 1
+        }
         span(0) {
           name "parent"
         }


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.relativeStartTime=P28D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=ContextPropagationTest&tests.sortField=FLAKY&tests.test=should%20propagate%20context%20to%20consumer%2C%20test%20headers:%20true&tests.unstableOnly=true
On jdk8 we can have 2 spans starting on the same millisecond.