### PR TITLE
Preserve span order

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TelemetryDataUtil.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/TelemetryDataUtil.java
@@ -14,7 +14,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -37,7 +37,9 @@ public final class TelemetryDataUtil {
   public static List<List<SpanData>> groupTraces(List<SpanData> spans) {
     List<List<SpanData>> traces =
         new ArrayList<>(
-            spans.stream().collect(Collectors.groupingBy(SpanData::getTraceId)).values());
+            spans.stream()
+                .collect(Collectors.groupingBy(SpanData::getTraceId, LinkedHashMap::new, toList()))
+                .values());
     sortTraces(traces);
     for (int i = 0; i < traces.size(); i++) {
       List<SpanData> trace = traces.get(i);
@@ -107,7 +109,7 @@ public final class TelemetryDataUtil {
   @SuppressWarnings("UnstableApiUsage")
   private static List<SpanData> sort(List<SpanData> trace) {
 
-    Map<String, Node> lookup = new HashMap<>();
+    Map<String, Node> lookup = new LinkedHashMap<>();
     for (SpanData span : trace) {
       lookup.put(span.getSpanId(), new Node(span));
     }

--- a/testing-common/src/test/java/io/opentelemetry/instrumentation/testing/util/TelemetryDataUtilTest.java
+++ b/testing-common/src/test/java/io/opentelemetry/instrumentation/testing/util/TelemetryDataUtilTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.testing.util;
+
+import static io.opentelemetry.sdk.testing.assertj.TracesAssert.assertThat;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.testing.assertj.TraceAssert;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+public class TelemetryDataUtilTest {
+
+  @Test
+  void testTraceOrderPreserved() {
+    List<SpanData> spans = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      spans.add(
+          TestSpanData.builder()
+              .setName("trace" + i)
+              .setSpanContext(
+                  SpanContext.create(
+                      TraceId.fromLongs(0, i),
+                      SpanId.fromLong(i),
+                      TraceFlags.getDefault(),
+                      TraceState.getDefault()))
+              .setKind(SpanKind.CLIENT)
+              .setStatus(StatusData.unset())
+              .setHasEnded(true)
+              .setStartEpochNanos(1678338770194000000L)
+              .setEndEpochNanos(1678338770196419884L)
+              .build());
+    }
+
+    List<Consumer<TraceAssert>> asserts = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      String spanName = "trace" + i;
+      asserts.add(trace -> trace.hasSpansSatisfyingExactly(span -> span.hasName(spanName)));
+    }
+
+    List<List<SpanData>> result = TelemetryDataUtil.groupTraces(spans);
+    assertThat(result).hasTracesSatisfyingExactly(asserts);
+  }
+
+  @Test
+  void testSpanOrderPreserved() {
+    List<SpanData> spans = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      spans.add(
+          TestSpanData.builder()
+              .setName("span" + i)
+              .setSpanContext(
+                  SpanContext.create(
+                      TraceId.fromLongs(0, 1),
+                      SpanId.fromLong(i),
+                      TraceFlags.getDefault(),
+                      TraceState.getDefault()))
+              .setKind(SpanKind.CLIENT)
+              .setStatus(StatusData.unset())
+              .setHasEnded(true)
+              .setStartEpochNanos(1678338770194000000L)
+              .setEndEpochNanos(1678338770196419884L)
+              .build());
+    }
+
+    List<Consumer<SpanDataAssert>> asserts = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      String spanName = "span" + i;
+      asserts.add(span -> span.hasName(spanName));
+    }
+
+    List<List<SpanData>> result = TelemetryDataUtil.groupTraces(spans);
+    assertThat(result).hasTracesSatisfyingExactly(trace -> trace.hasSpansSatisfyingExactly(asserts));
+  }
+}

--- a/testing-common/src/test/java/io/opentelemetry/instrumentation/testing/util/TelemetryDataUtilTest.java
+++ b/testing-common/src/test/java/io/opentelemetry/instrumentation/testing/util/TelemetryDataUtilTest.java
@@ -84,6 +84,7 @@ public class TelemetryDataUtilTest {
     }
 
     List<List<SpanData>> result = TelemetryDataUtil.groupTraces(spans);
-    assertThat(result).hasTracesSatisfyingExactly(trace -> trace.hasSpansSatisfyingExactly(asserts));
+    assertThat(result)
+        .hasTracesSatisfyingExactly(trace -> trace.hasSpansSatisfyingExactly(asserts));
   }
 }


### PR DESCRIPTION
On jdk8 tests occasionally fail when spans starting on the same millisecond get reordered. As we eventually sort the spans by start time we can't get the initial oder back when the start time is the same for these spans. Hopefully preserving the initial order reduces such flakiness.