### PR TITLE
Fix spring boot 3 webmvc autoconfiguration

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
@@ -20,15 +20,16 @@ dependencies {
   implementation(project(":instrumentation:spring:spring-web:spring-web-3.1:library"))
   implementation(project(":instrumentation:spring:spring-webmvc:spring-webmvc-5.3:library"))
   implementation(project(":instrumentation:spring:spring-webmvc:spring-webmvc-6.0:library"))
+  compileOnly("javax.servlet:javax.servlet-api:3.1.0")
   compileOnly("jakarta.servlet:jakarta.servlet-api:5.0.0")
   implementation(project(":instrumentation:spring:spring-webflux:spring-webflux-5.3:library"))
   implementation(project(":instrumentation:micrometer:micrometer-1.5:library"))
 
-  compileOnly("org.springframework.kafka:spring-kafka:2.9.0")
-  compileOnly("org.springframework.boot:spring-boot-starter-actuator:$springBootVersion")
-  compileOnly("org.springframework.boot:spring-boot-starter-aop:$springBootVersion")
-  compileOnly("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
-  compileOnly("org.springframework.boot:spring-boot-starter-webflux:$springBootVersion")
+  library("org.springframework.kafka:spring-kafka:2.9.0")
+  library("org.springframework.boot:spring-boot-starter-actuator:$springBootVersion")
+  library("org.springframework.boot:spring-boot-starter-aop:$springBootVersion")
+  library("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
+  library("org.springframework.boot:spring-boot-starter-webflux:$springBootVersion")
 
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry:opentelemetry-extension-annotations")
@@ -44,15 +45,12 @@ dependencies {
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service-annotations")
 
-  testImplementation("org.springframework.kafka:spring-kafka:2.9.0")
-  testImplementation("org.springframework.boot:spring-boot-starter-actuator:$springBootVersion")
-  testImplementation("org.springframework.boot:spring-boot-starter-aop:$springBootVersion")
-  testImplementation("org.springframework.boot:spring-boot-starter-webflux:$springBootVersion")
-  testImplementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
-  testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
+  testLibrary("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
     exclude("org.junit.vintage", "junit-vintage-engine")
   }
   testImplementation("org.testcontainers:kafka")
+  testImplementation("javax.servlet:javax.servlet-api:3.1.0")
+  testImplementation("jakarta.servlet:jakarta.servlet-api:5.0.0")
 
   testImplementation(project(":testing-common"))
   testImplementation("io.opentelemetry:opentelemetry-sdk")
@@ -69,11 +67,22 @@ dependencies {
   testImplementation(project(":instrumentation-annotations"))
 }
 
+val latestDepTest = findProperty("testLatestDeps") as Boolean
+
+// spring 6 (spring boot 3) requires java 17
+if (latestDepTest) {
+  otelJava {
+    minJavaVersionSupported.set(JavaVersion.VERSION_17)
+  }
+}
+
 tasks.compileTestJava {
   options.compilerArgs.add("-parameters")
 }
 
 tasks.withType<Test>().configureEach {
+  systemProperty("testLatestDeps", latestDepTest)
+
   // required on jdk17
   jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -11,4 +11,4 @@ io.opentelemetry.instrumentation.spring.autoconfigure.kafka.KafkaInstrumentation
 io.opentelemetry.instrumentation.spring.autoconfigure.metrics.MicrometerShimAutoConfiguration
 io.opentelemetry.instrumentation.spring.autoconfigure.propagators.PropagationAutoConfiguration
 io.opentelemetry.instrumentation.spring.autoconfigure.resources.OtelResourceAutoConfiguration
-io.opentelemetry.instrumentation.spring.autoconfigure.webmvc.WebMvcFilterAutoConfiguration
+io.opentelemetry.instrumentation.spring.autoconfigure.webmvc.WebMvcFilterAutoConfigurationSpring6

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/kafka/KafkaIntegrationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/kafka/KafkaIntegrationTest.java
@@ -81,7 +81,9 @@ class KafkaIntegrationTest {
     contextRunner.run(KafkaIntegrationTest::runShouldInstrumentProducerAndConsumer);
   }
 
-  @SuppressWarnings("unchecked")
+  // In kafka 2 ops.send is deprecated. We are using it to avoid reflection because kafka 3 also has
+  // ops.send, although with different return type.
+  @SuppressWarnings({"unchecked", "deprecation"})
   private static void runShouldInstrumentProducerAndConsumer(
       ConfigurableApplicationContext applicationContext) {
     KafkaTemplate<String, String> kafkaTemplate = applicationContext.getBean(KafkaTemplate.class);
@@ -91,7 +93,7 @@ class KafkaIntegrationTest {
         () -> {
           kafkaTemplate.executeInTransaction(
               ops -> {
-                ops.usingCompletableFuture().send("testTopic", "10", "testSpan");
+                ops.send("testTopic", "10", "testSpan");
                 return 0;
               });
         });

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfigurationSpring6Test.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfigurationSpring6Test.java
@@ -22,7 +22,8 @@ class WebMvcFilterAutoConfigurationSpring6Test {
       new ApplicationContextRunner()
           .withConfiguration(
               AutoConfigurations.of(
-                  OpenTelemetryAutoConfiguration.class, WebMvcFilterAutoConfigurationSpring6.class));
+                  OpenTelemetryAutoConfiguration.class,
+                  WebMvcFilterAutoConfigurationSpring6.class));
 
   @BeforeAll
   static void setUp() {

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfigurationSpring6Test.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/webmvc/WebMvcFilterAutoConfigurationSpring6Test.java
@@ -6,27 +6,27 @@
 package io.opentelemetry.instrumentation.spring.autoconfigure.webmvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration;
-import javax.servlet.Filter;
+import jakarta.servlet.Filter;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
-/** Spring Boot auto configuration test for {@link WebMvcFilterAutoConfiguration}. */
-class WebMvcFilterAutoConfigurationTest {
+/** Spring Boot auto configuration test for {@link WebMvcFilterAutoConfigurationSpring6}. */
+class WebMvcFilterAutoConfigurationSpring6Test {
   private final ApplicationContextRunner contextRunner =
       new ApplicationContextRunner()
           .withConfiguration(
               AutoConfigurations.of(
-                  OpenTelemetryAutoConfiguration.class, WebMvcFilterAutoConfiguration.class));
+                  OpenTelemetryAutoConfiguration.class, WebMvcFilterAutoConfigurationSpring6.class));
 
   @BeforeAll
   static void setUp() {
-    assumeFalse(Boolean.getBoolean("testLatestDeps"));
+    assumeTrue(Boolean.getBoolean("testLatestDeps"));
   }
 
   @Test


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8028#issuecomment-1466496896
spring boot 3 uses `jakarta.servlet` so we need to use `WebMvcFilterAutoConfigurationSpring6 ` instead of `WebMvcFilterAutoConfiguration`