### PR TITLE
Remove unneeded dependsOn

### DIFF
--- a/instrumentation/jsf/jsf-myfaces-1.2/javaagent/build.gradle.kts
+++ b/instrumentation/jsf/jsf-myfaces-1.2/javaagent/build.gradle.kts
@@ -12,13 +12,6 @@ muzzle {
   }
 }
 
-tasks {
-  test {
-    dependsOn("myfaces12Test")
-    dependsOn("myfaces2Test")
-  }
-}
-
 dependencies {
   compileOnly("org.apache.myfaces.core:myfaces-api:1.2.12")
   compileOnly("javax.el:el-api:1.0")


### PR DESCRIPTION
Should have been removed with test sets to test suites migration. There already is
```
tasks {
  check {
    dependsOn(testing.suites)
  }
}
```