### PR TITLE
Add application name to spring boot smoke test app

### DIFF
--- a/smoke-tests/images/spring-boot/build.gradle.kts
+++ b/smoke-tests/images/spring-boot/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   id("otel.java-conventions")
 
   id("com.google.cloud.tools.jib")
+  id("org.springframework.boot") version "2.6.6"
 }
 
 dependencies {
@@ -16,6 +17,14 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-web")
 }
 
+configurations.runtimeClasspath {
+  resolutionStrategy {
+    // requires old logback (and therefore also old slf4j)
+    force("ch.qos.logback:logback-classic:1.2.11")
+    force("org.slf4j:slf4j-api:1.7.36")
+  }
+}
+
 val targetJDK = project.findProperty("targetJDK") ?: "11"
 
 val tag = findProperty("tag")
@@ -25,4 +34,15 @@ jib {
   from.image = "openjdk:$targetJDK"
   to.image = "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-spring-boot:jdk$targetJDK-$tag"
   container.ports = listOf("8080")
+}
+
+tasks {
+  val springBootJar by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+  }
+
+  artifacts {
+    add("springBootJar", bootJar)
+  }
 }

--- a/smoke-tests/images/spring-boot/src/main/resources/application.properties
+++ b/smoke-tests/images/spring-boot/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.application.name=otel-spring-test-app
+
 logging.level.root=WARN
 logging.level.io.opentelemetry=INFO
 logging.pattern.console=%-5level [%t] %C{1.}: %msg trace_id=%X{trace_id}%n


### PR DESCRIPTION
Add application name to spring boot smoke test app so that it could be used for testing spring boot service name auto detection. Also fixes logging dependencies.