### PR TITLE
Add HttpServerResponseCustomizer support for Netty

### DIFF
--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpResponseMutator.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpResponseMutator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.netty.v3_8.server;
+
+import io.opentelemetry.javaagent.bootstrap.http.HttpServerResponseMutator;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+
+public enum NettyHttpResponseMutator implements HttpServerResponseMutator<HttpResponse> {
+  INSTANCE;
+
+  NettyHttpResponseMutator() {}
+
+  @Override
+  public void appendHeader(HttpResponse response, String name, String value) {
+    response.headers().add(name, value);
+  }
+}

--- a/instrumentation/netty/netty-3.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/Netty38ServerTest.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/Netty38ServerTest.java
@@ -89,6 +89,7 @@ class Netty38ServerTest extends AbstractHttpServerTest<ServerBootstrap> {
         });
 
     options.setExpectedException(new IllegalArgumentException(ServerEndpoint.EXCEPTION.getBody()));
+    options.setHasResponseCustomizer(serverEndpoint -> true);
   }
 
   private static ChannelPipeline channelPipeline() {

--- a/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/NettyHttpResponseMutator.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/server/NettyHttpResponseMutator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.netty.v4_0.server;
+
+import io.netty.handler.codec.http.HttpResponse;
+import io.opentelemetry.javaagent.bootstrap.http.HttpServerResponseMutator;
+
+public enum NettyHttpResponseMutator implements HttpServerResponseMutator<HttpResponse> {
+  INSTANCE;
+
+  NettyHttpResponseMutator() {}
+
+  @Override
+  public void appendHeader(HttpResponse response, String name, String value) {
+    response.headers().add(name, value);
+  }
+}

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/Netty40ServerTest.groovy
@@ -27,6 +27,7 @@ import io.netty.util.CharsetUtil
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
+import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
@@ -46,6 +47,11 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 class Netty40ServerTest extends HttpServerTest<EventLoopGroup> implements AgentTestTrait {
 
   static final LoggingHandler LOGGING_HANDLER = new LoggingHandler(SERVER_LOGGER.name, LogLevel.DEBUG)
+
+  @Override
+  boolean hasResponseCustomizer(ServerEndpoint endpoint) {
+    true
+  }
 
   @Override
   EventLoopGroup startServer(int port) {

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
@@ -105,11 +105,17 @@ public class NettyChannelPipelineInstrumentation
       ChannelHandler ourHandler = null;
       // Server pipeline handlers
       if (handler instanceof HttpServerCodec) {
-        ourHandler = new HttpServerTracingHandler(NettyServerSingletons.instrumenter());
+        ourHandler =
+            new HttpServerTracingHandler(
+                NettyServerSingletons.instrumenter(),
+                NettyHttpServerResponseBeforeCommitHandler.INSTANCE);
       } else if (handler instanceof HttpRequestDecoder) {
         ourHandler = new HttpServerRequestTracingHandler(NettyServerSingletons.instrumenter());
       } else if (handler instanceof HttpResponseEncoder) {
-        ourHandler = new HttpServerResponseTracingHandler(NettyServerSingletons.instrumenter());
+        ourHandler =
+            new HttpServerResponseTracingHandler(
+                NettyServerSingletons.instrumenter(),
+                NettyHttpServerResponseBeforeCommitHandler.INSTANCE);
         // Client pipeline handlers
       } else if (handler instanceof HttpClientCodec) {
         ourHandler = new HttpClientTracingHandler(NettyClientSingletons.instrumenter());

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyHttpServerResponseBeforeCommitHandler.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyHttpServerResponseBeforeCommitHandler.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
+
+import io.netty.handler.codec.http.HttpResponse;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.netty.v4_1.internal.server.HttpServerResponseBeforeCommitHandler;
+import io.opentelemetry.javaagent.bootstrap.http.HttpServerResponseCustomizerHolder;
+
+public enum NettyHttpServerResponseBeforeCommitHandler
+    implements HttpServerResponseBeforeCommitHandler {
+  INSTANCE;
+
+  @Override
+  public void handle(Context context, HttpResponse response) {
+    HttpServerResponseCustomizerHolder.getCustomizer()
+        .customize(context, response, NettyHttpServerResponseMutator.INSTANCE);
+  }
+}

--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyHttpServerResponseMutator.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/NettyHttpServerResponseMutator.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
+
+import io.netty.handler.codec.http.HttpResponse;
+import io.opentelemetry.javaagent.bootstrap.http.HttpServerResponseMutator;
+
+public enum NettyHttpServerResponseMutator implements HttpServerResponseMutator<HttpResponse> {
+  INSTANCE;
+
+  @Override
+  public void appendHeader(HttpResponse response, String name, String value) {
+    response.headers().add(name, value);
+  }
+}

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ServerTest.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ServerTest.java
@@ -9,12 +9,19 @@ import io.netty.channel.ChannelPipeline;
 import io.opentelemetry.instrumentation.netty.v4_1.AbstractNetty41ServerTest;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class Netty41ServerTest extends AbstractNetty41ServerTest {
 
   @RegisterExtension
   static final InstrumentationExtension testing = HttpServerInstrumentationExtension.forAgent();
+
+  @Override
+  protected void configure(HttpServerTestOptions options) {
+    super.configure(options);
+    options.setHasResponseCustomizer(serverEndpoint -> true);
+  }
 
   @Override
   protected void configurePipeline(ChannelPipeline channelPipeline) {}

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyServerTelemetry.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/NettyServerTelemetry.java
@@ -13,6 +13,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.server.HttpServerRequestTracingHandler;
+import io.opentelemetry.instrumentation.netty.v4_1.internal.server.HttpServerResponseBeforeCommitHandler;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.server.HttpServerResponseTracingHandler;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.server.HttpServerTracingHandler;
 
@@ -51,7 +52,8 @@ public final class NettyServerTelemetry {
    * responses. Must be paired with {@link #createRequestHandler()}.
    */
   public ChannelOutboundHandlerAdapter createResponseHandler() {
-    return new HttpServerResponseTracingHandler(instrumenter);
+    return new HttpServerResponseTracingHandler(
+        instrumenter, HttpServerResponseBeforeCommitHandler.Noop.INSTANCE);
   }
 
   /**
@@ -61,6 +63,7 @@ public final class NettyServerTelemetry {
   public CombinedChannelDuplexHandler<
           ? extends ChannelInboundHandlerAdapter, ? extends ChannelOutboundHandlerAdapter>
       createCombinedHandler() {
-    return new HttpServerTracingHandler(instrumenter);
+    return new HttpServerTracingHandler(
+        instrumenter, HttpServerResponseBeforeCommitHandler.Noop.INSTANCE);
   }
 }

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerResponseBeforeCommitHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerResponseBeforeCommitHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.netty.v4_1.internal.server;
+
+import io.netty.handler.codec.http.HttpResponse;
+import io.opentelemetry.context.Context;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public interface HttpServerResponseBeforeCommitHandler {
+  void handle(Context context, HttpResponse response);
+
+  /**
+   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+   * any time.
+   */
+  enum Noop implements HttpServerResponseBeforeCommitHandler {
+    INSTANCE;
+
+    @Override
+    public void handle(Context context, HttpResponse response) {}
+  }
+}

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerTracingHandler.java
@@ -18,9 +18,11 @@ public class HttpServerTracingHandler
     extends CombinedChannelDuplexHandler<
         HttpServerRequestTracingHandler, HttpServerResponseTracingHandler> {
 
-  public HttpServerTracingHandler(Instrumenter<HttpRequestAndChannel, HttpResponse> instrumenter) {
+  public HttpServerTracingHandler(
+      Instrumenter<HttpRequestAndChannel, HttpResponse> instrumenter,
+      HttpServerResponseBeforeCommitHandler responseBeforeCommitHandler) {
     super(
         new HttpServerRequestTracingHandler(instrumenter),
-        new HttpServerResponseTracingHandler(instrumenter));
+        new HttpServerResponseTracingHandler(instrumenter, responseBeforeCommitHandler));
   }
 }


### PR DESCRIPTION
Add `HttpServerResponseCustomizer` support for Netty 3.8, 4.0 and 4.1 instrumentations and enable testing for it in their respective `HttpServerTest` tests.