### PR TITLE
Hide smoke test spring boot test app from dependabot

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -127,7 +127,7 @@ include(":smoke-tests:images:quarkus")
 include(":smoke-tests:images:servlet")
 hideFromDependabot(":smoke-tests:images:servlet:servlet-3.0")
 hideFromDependabot(":smoke-tests:images:servlet:servlet-5.0")
-include(":smoke-tests:images:spring-boot")
+hideFromDependabot(":smoke-tests:images:spring-boot")
 
 hideFromDependabot("instrumentation:akka:akka-actor-2.3:javaagent")
 hideFromDependabot(":instrumentation:akka:akka-actor-fork-join-2.5:javaagent")


### PR DESCRIPTION
We want to keep that app using spring boot 2 so dependabot trying to update to spring boot 3 isn't useful.