### PR TITLE
Fix the shardingsphere display the error tag #8109

### DIFF
--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcIgnoredTypesConfigurer.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcIgnoredTypesConfigurer.java
@@ -17,5 +17,7 @@ public class JdbcIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
   public void configure(IgnoredTypesBuilder builder, ConfigProperties config) {
     // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/5946
     builder.ignoreClass("org.jboss.jca.adapters.jdbc.");
+    // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8109
+    builder.ignoreClass("org.apache.shardingsphere.shardingjdbc.jdbc.core.statement.");
   }
 }


### PR DESCRIPTION
Adding shardingsphere related classes to the `JdbcIgnoredTypesConfigurer` allows the actual execution of the statement to be captured