### PR TITLE
Http attributes: only set content_length when it's >0

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpCommonAttributesExtractor.java
@@ -63,8 +63,10 @@ abstract class HttpCommonAttributesExtractor<
       @Nullable RESPONSE response,
       @Nullable Throwable error) {
 
-    internalSet(
-        attributes, SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, requestContentLength(request));
+    Long requestLength = requestContentLength(request);
+    if (requestLength != null && requestLength > 0) {
+      internalSet(attributes, SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, requestLength);
+    }
 
     if (response != null) {
       Integer statusCode = getter.getStatusCode(request, response, error);
@@ -72,10 +74,10 @@ abstract class HttpCommonAttributesExtractor<
         internalSet(attributes, SemanticAttributes.HTTP_STATUS_CODE, (long) statusCode);
       }
 
-      internalSet(
-          attributes,
-          SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,
-          responseContentLength(request, response));
+      Long responseLength = responseContentLength(request, response);
+      if (responseLength != null && responseLength > 0) {
+        internalSet(attributes, SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, responseLength);
+      }
 
       for (String name : capturedResponseHeaders) {
         List<String> values = getter.getResponseHeader(request, response, name);

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -57,7 +57,8 @@ class HttpClientAttributesExtractorTest {
     @Override
     public Integer getStatusCode(
         Map<String, String> request, Map<String, String> response, @Nullable Throwable error) {
-      return Integer.parseInt(response.get("statusCode"));
+      String statusCode = response.get("statusCode");
+      return statusCode == null ? null : Integer.parseInt(statusCode);
     }
 
     @Override
@@ -291,6 +292,25 @@ class HttpClientAttributesExtractorTest {
     AttributesBuilder attributes = Attributes.builder();
     extractor.onStart(attributes, Context.root(), request);
     extractor.onEnd(attributes, Context.root(), request, null, null);
+    assertThat(attributes.build()).isEmpty();
+  }
+
+  @Test
+  void emptyBodies() {
+    Map<String, String> request = new HashMap<>();
+    request.put("header.content-length", "0");
+
+    Map<String, String> response = new HashMap<>();
+    response.put("header.content-length", "-1");
+
+    AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+        HttpClientAttributesExtractor.builder(
+                new TestHttpClientAttributesGetter(), new TestNetClientAttributesGetter())
+            .build();
+
+    AttributesBuilder attributes = Attributes.builder();
+    extractor.onStart(attributes, Context.root(), request);
+    extractor.onEnd(attributes, Context.root(), request, response, null);
     assertThat(attributes.build()).isEmpty();
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -110,7 +110,7 @@ class Aws0ClientTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_METHOD" "$method"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" {it == null || it instanceof Long}
             "$SemanticAttributes.NET_PEER_PORT" server.httpPort()
             "$SemanticAttributes.NET_PEER_NAME" "127.0.0.1"
             "$SemanticAttributes.RPC_SYSTEM" "aws-api"

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractAws1ClientTest.groovy
@@ -109,7 +109,7 @@ abstract class AbstractAws1ClientTest extends InstrumentationSpecification {
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
+            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
             "$SemanticAttributes.NET_PEER_PORT" server.httpPort()
             "$SemanticAttributes.NET_PEER_NAME" "127.0.0.1"
             "$SemanticAttributes.RPC_SYSTEM" "aws-api"


### PR DESCRIPTION
Fixes an issue encountered in #8111