### PR TITLE
Add `removeJarVersionNumbers` build setting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,14 @@ and then you can find the java agent artifact at
 
 `javaagent/build/libs/opentelemetry-javaagent-<version>.jar`.
 
+To simplify local development, you can remove the version number from the build product. This allows
+the file name to stay consistent across versions. To do so, add the following to
+`~/.gradle/gradle.properties`.
+
+```properties
+removeJarVersionNumbers=true
+```
+
 ## IntelliJ setup and troubleshooting
 
 See [IntelliJ setup and troubleshooting](docs/contributing/intellij-setup-and-troubleshooting.md)

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -216,7 +216,7 @@ tasks {
     dependsOn(shadowJar, baseJavaagentJar)
   }
 
-  if ((findProperty("removeJarVersionNumbers") ?: "false").toString().toBoolean()) {
+  if (findProperty("removeJarVersionNumbers") == "true") {
     withType<AbstractArchiveTask>().configureEach {
       archiveVersion.set("")
     }

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -216,6 +216,12 @@ tasks {
     dependsOn(shadowJar, baseJavaagentJar)
   }
 
+  if ((findProperty("removeJarVersionNumbers") ?: "false").toString().toBoolean()) {
+    withType<AbstractArchiveTask>().configureEach {
+      archiveVersion.set("")
+    }
+  }
+
   withType<Test>().configureEach {
     dependsOn(shadowJar)
 


### PR DESCRIPTION
This is handy to enable consistent local version numbers rather than updating file paths each release.

Add the following to enable locally `~/.gradle/gradle.properties`

```
removeJarVersionNumbers=true
```