### PR TITLE
Fix Un-sampled spanContext created in OpenCensus-Shim is lost when agent is enabled (issues/8148)

### DIFF
--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/Bridging.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/trace/Bridging.java
@@ -73,6 +73,8 @@ public class Bridging {
       return io.opentelemetry.api.trace.Span.getInvalid();
     } else if (applicationSpan instanceof ApplicationSpan) {
       return ((ApplicationSpan) applicationSpan).getAgentSpan();
+    } else if (applicationSpan instanceof io.opentelemetry.api.trace.Span) {
+      return (io.opentelemetry.api.trace.Span) applicationSpan;
     } else {
       return null;
     }


### PR DESCRIPTION
This is to fix Issue #8148. 

For particular issue, when SPAN is not sampled by OC sampler, it will not be wrapped in the applicationSpan, in that case the origin logic will return null.  In that case, all the children spans will be orphan spans. 

This diff is a work around to full back to check if the type is `Span`, if so, just return the same object with casting. 
