### PR TITLE
Fix up a few kotlin build warnings

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-testing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-testing.gradle.kts
@@ -154,7 +154,7 @@ plugins.withId("maven-publish") {
 }
 
 configurations.configureEach {
-  if (name.toLowerCase().endsWith("testruntimeclasspath")) {
+  if (name.endsWith("testruntimeclasspath", ignoreCase = true)) {
     // Added by agent, don't let Gradle bring it in when running tests.
     exclude("io.opentelemetry.javaagent", "opentelemetry-javaagent-bootstrap")
   }

--- a/conventions/src/main/kotlin/otel.javaagent-testing.gradle.kts
+++ b/conventions/src/main/kotlin/otel.javaagent-testing.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 }
 
 configurations.configureEach {
-  if (name.toLowerCase().endsWith("testruntimeclasspath")) {
+  if (name.endsWith("testruntimeclasspath", ignoreCase = true)) {
     // Added by agent, don't let Gradle bring it in when running tests.
     exclude(module = "javaagent-bootstrap")
   }

--- a/conventions/src/main/kotlin/otel.nullaway-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.nullaway-conventions.gradle.kts
@@ -18,7 +18,7 @@ nullaway {
 
 tasks {
   withType<JavaCompile>().configureEach {
-    if (!name.toLowerCase().contains("test")) {
+    if (!name.contains("test", ignoreCase = true)) {
       options.errorprone.nullaway {
         severity.set(CheckSeverity.ERROR)
       }

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-generation.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-generation.gradle.kts
@@ -50,7 +50,7 @@ val languageTasks = LANGUAGES.map { language ->
     return@map null
   }
   val compileTask = tasks.named(compileTaskName)
-  createLanguageTask(compileTask, "byteBuddy${language.capitalize()}")
+  createLanguageTask(compileTask, "byteBuddy${language.replaceFirstChar(Char::titlecase)}")
 }.filterNotNull()
 
 tasks {

--- a/gradle-plugins/src/main/kotlin/io/opentelemetry/javaagent/muzzle/AcceptableVersions.kt
+++ b/gradle-plugins/src/main/kotlin/io/opentelemetry/javaagent/muzzle/AcceptableVersions.kt
@@ -16,7 +16,7 @@ class AcceptableVersions(private val skipVersions: Collection<String>) :
     if (version == null) {
       return false
     }
-    val versionString = version.toString().toLowerCase(Locale.ROOT)
+    val versionString = version.toString().lowercase(Locale.ROOT)
     if (skipVersions.contains(versionString)) {
       return false
     }

--- a/gradle-plugins/src/main/kotlin/io/opentelemetry/javaagent/muzzle/MuzzleDirective.kt
+++ b/gradle-plugins/src/main/kotlin/io/opentelemetry/javaagent/muzzle/MuzzleDirective.kt
@@ -78,7 +78,7 @@ abstract class MuzzleDirective {
 
   internal val normalizedSkipVersions: Set<String>
     get() = skipVersions.getOrElse(setOf()).stream()
-      .map(String::toLowerCase)
+      .map(String::lowercase)
       .collect(Collectors.toSet())
 
   override fun toString(): String {


### PR DESCRIPTION
I noticed some kotlin deprecation warnings in the build output, so I thought I would try and fix them up.