### PR TITLE
Remove info logging from JfrTelemetry

### DIFF
--- a/instrumentation/runtime-telemetry-jfr/library/src/main/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/JfrTelemetry.java
+++ b/instrumentation/runtime-telemetry-jfr/library/src/main/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/JfrTelemetry.java
@@ -31,7 +31,6 @@ public final class JfrTelemetry implements Closeable {
     this.openTelemetry = openTelemetry;
     this.recordedEventHandlers = HandlerRegistry.getHandlers(openTelemetry, featurePredicate);
     try {
-      logger.log(Level.INFO, "Starting JfrTelemetry");
       recordingStream = new RecordingStream();
       recordedEventHandlers.forEach(
           handler -> {
@@ -92,11 +91,7 @@ public final class JfrTelemetry implements Closeable {
       logger.log(Level.WARNING, "JfrTelemetry is already closed");
       return;
     }
-    logger.log(Level.INFO, "Closing JfrTelemetry");
     recordingStream.close();
-    recordedEventHandlers.forEach(
-        handler -> {
-          handler.close();
-        });
+    recordedEventHandlers.forEach(RecordedEventHandler::close);
   }
 }

--- a/instrumentation/runtime-telemetry-jfr/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/JfrTelemetryTest.java
+++ b/instrumentation/runtime-telemetry-jfr/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/JfrTelemetryTest.java
@@ -41,9 +41,6 @@ class JfrTelemetryTest {
   @Test
   void create_Default() {
     try (JfrTelemetry unused = JfrTelemetry.create(sdk)) {
-      assertThat(logs.getEvents()).hasSize(1);
-      logs.assertContains("Starting JfrTelemetry");
-
       assertThat(reader.collectAllMetrics())
           .isNotEmpty()
           .allSatisfy(
@@ -58,9 +55,6 @@ class JfrTelemetryTest {
   @Test
   void create_AllDisabled() {
     try (JfrTelemetry unused = JfrTelemetry.builder(sdk).disableAllFeatures().build()) {
-      assertThat(logs.getEvents()).hasSize(1);
-      logs.assertContains("Starting JfrTelemetry");
-
       assertThat(reader.collectAllMetrics()).isEmpty();
     }
   }
@@ -85,7 +79,6 @@ class JfrTelemetryTest {
       assertThat(reader.collectAllMetrics()).isNotEmpty();
 
       jfrTelemetry.close();
-      logs.assertContains("Closing JfrTelemetry");
       logs.assertDoesNotContain("JfrTelemetry is already closed");
       assertThat(recordingStreamClosed.get()).isTrue();
       assertThat(reader.collectAllMetrics()).isEmpty();


### PR DESCRIPTION
`INFO` level logs are printed to stdout, we don't want these there. As these don't seem to be too useful I removed them instead of reducing the log level.