### PR TITLE
Fix flaky jfr metrics test

### DIFF
--- a/instrumentation/runtime-telemetry-jfr/library/build.gradle.kts
+++ b/instrumentation/runtime-telemetry-jfr/library/build.gradle.kts
@@ -32,6 +32,7 @@ tasks {
     }
     include("**/*PsGcMemoryMetricTest.*")
     jvmArgs("-XX:+UseParallelGC")
+    jvmArgs("-Xmx128m")
   }
 
   val testSerial by registering(Test::class) {

--- a/instrumentation/runtime-telemetry-jfr/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/PsGcMemoryMetricTest.java
+++ b/instrumentation/runtime-telemetry-jfr/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/PsGcMemoryMetricTest.java
@@ -76,12 +76,24 @@ class PsGcMemoryMetricTest {
         .anyMatch(p -> p.getAttributes().equals(ATTR_PS_OLD_GEN));
   }
 
+  private static void causeGc() {
+    String s = "1234567890";
+    try {
+      while (true) {
+        s = s + s;
+      }
+    } catch (OutOfMemoryError outOfMemoryError) {
+      // ignore
+    }
+  }
+
   @Test
-  void shouldHaveGcDurationMetrics() throws InterruptedException {
+  void shouldHaveGcDurationMetrics() {
     // TODO: Need a reliable way to test old and young gen GC in isolation.
     // Generate some JFR events
-    Thread.sleep(100);
-    System.gc();
+    // using System.gc() here doesn't reliably get us the GC events we need
+    causeGc();
+
     Attributes minorGcAttributes =
         Attributes.of(ATTR_GC, "PS Scavenge", ATTR_ACTION, END_OF_MINOR_GC);
     Attributes majorGcAttributes =


### PR DESCRIPTION
https://ge.opentelemetry.io/s/svewzdm7cppaa/tests/:instrumentation:runtime-telemetry-jfr:library:testPS/io.opentelemetry.instrumentation.runtimetelemetryjfr.PsGcMemoryMetricTest/shouldHaveGcDurationMetrics()?top-execution=1