### PR TITLE
Alternative fix for flaky jfr telemetry test

### DIFF
--- a/instrumentation/runtime-telemetry-jfr/library/build.gradle.kts
+++ b/instrumentation/runtime-telemetry-jfr/library/build.gradle.kts
@@ -32,7 +32,6 @@ tasks {
     }
     include("**/*PsGcMemoryMetricTest.*")
     jvmArgs("-XX:+UseParallelGC")
-    jvmArgs("-Xmx128m")
   }
 
   val testSerial by registering(Test::class) {

--- a/instrumentation/runtime-telemetry-jfr/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/JfrExtension.java
+++ b/instrumentation/runtime-telemetry-jfr/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/JfrExtension.java
@@ -14,6 +14,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.assertj.MetricAssert;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -33,7 +34,7 @@ public class JfrExtension implements BeforeEachCallback, AfterEachCallback {
   }
 
   @Override
-  public void beforeEach(ExtensionContext context) {
+  public void beforeEach(ExtensionContext context) throws InterruptedException {
     try {
       Class.forName("jdk.jfr.consumer.RecordingStream");
     } catch (ClassNotFoundException exception) {
@@ -46,6 +47,7 @@ public class JfrExtension implements BeforeEachCallback, AfterEachCallback {
     JfrTelemetryBuilder builder = JfrTelemetry.builder(sdk);
     builderConsumer.accept(builder);
     jfrTelemetry = builder.build();
+    jfrTelemetry.getStartUpLatch().await(30, TimeUnit.SECONDS);
   }
 
   @Override

--- a/instrumentation/runtime-telemetry-jfr/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/PsGcMemoryMetricTest.java
+++ b/instrumentation/runtime-telemetry-jfr/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/PsGcMemoryMetricTest.java
@@ -76,23 +76,11 @@ class PsGcMemoryMetricTest {
         .anyMatch(p -> p.getAttributes().equals(ATTR_PS_OLD_GEN));
   }
 
-  private static void causeGc() {
-    String s = "1234567890";
-    try {
-      while (true) {
-        s = s + s;
-      }
-    } catch (OutOfMemoryError outOfMemoryError) {
-      // ignore
-    }
-  }
-
   @Test
   void shouldHaveGcDurationMetrics() {
     // TODO: Need a reliable way to test old and young gen GC in isolation.
     // Generate some JFR events
-    // using System.gc() here doesn't reliably get us the GC events we need
-    causeGc();
+    System.gc();
 
     Attributes minorGcAttributes =
         Attributes.of(ATTR_GC, "PS Scavenge", ATTR_ACTION, END_OF_MINOR_GC);

--- a/instrumentation/runtime-telemetry-jfr/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/SerialGcMemoryMetricTest.java
+++ b/instrumentation/runtime-telemetry-jfr/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetryjfr/SerialGcMemoryMetricTest.java
@@ -30,10 +30,9 @@ class SerialGcMemoryMetricTest {
   }
 
   @Test
-  void shouldHaveGcDurationMetrics() throws InterruptedException {
+  void shouldHaveGcDurationMetrics() {
     // TODO: Need a reliable way to test old and young gen GC in isolation.
     // Generate some JFR events
-    Thread.sleep(100);
     System.gc();
     Attributes minorGcAttributes = Attributes.of(ATTR_GC, "Copy", ATTR_ACTION, END_OF_MINOR_GC);
     Attributes majorGcAttributes =


### PR DESCRIPTION
Reverts https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8183
Perhaps the problem is that the gc happens before reading jfr events is started.