### PR TITLE
Verify that server span ends after child spans in java tests

### DIFF
--- a/instrumentation/ktor/ktor-1.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerTest.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerTest.kt
@@ -134,5 +134,8 @@ class KtorHttpServerTest : AbstractHttpServerTest<ApplicationEngine>() {
         else -> expectedHttpRoute(it)
       }
     }
+    // ktor does not have a controller lifecycle so the server span ends immediately when the
+    // response is sent, which is before the controller span finishes.
+    options.setVerifyServerSpanEndTime(false)
   }
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorHttpServerTest.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorHttpServerTest.kt
@@ -134,5 +134,9 @@ class KtorHttpServerTest : AbstractHttpServerTest<ApplicationEngine>() {
         else -> expectedHttpRoute(it)
       }
     }
+
+    // ktor does not have a controller lifecycle so the server span ends immediately when the
+    // response is sent, which is before the controller span finishes.
+    options.setVerifyServerSpanEndTime(false)
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import org.assertj.core.api.AssertAccess;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -466,6 +467,17 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
             }
 
             trace.hasSpansSatisfyingExactly(spanAssertions);
+
+            if (options.verifyServerSpanEndTime) {
+              List<SpanData> spanData = AssertAccess.getActual(trace);
+              if (spanData.size() > 1) {
+                SpanData rootSpan = spanData.get(0);
+                for (int j = 1; j < spanData.size(); j++) {
+                  assertThat(rootSpan.getEndEpochNanos())
+                      .isGreaterThanOrEqualTo(spanData.get(j).getEndEpochNanos());
+                }
+              }
+            }
           });
     }
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerTestOptions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerTestOptions.java
@@ -51,6 +51,7 @@ public final class HttpServerTestOptions {
   boolean testPathParam = false;
   boolean testCaptureHttpHeaders = true;
   boolean testCaptureRequestParameters = false;
+  boolean verifyServerSpanEndTime = true;
 
   HttpServerTestOptions() {}
 
@@ -171,6 +172,12 @@ public final class HttpServerTestOptions {
   public HttpServerTestOptions setTestCaptureRequestParameters(
       boolean testCaptureRequestParameters) {
     this.testCaptureRequestParameters = testCaptureRequestParameters;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public HttpServerTestOptions setVerifyServerSpanEndTime(boolean verifyServerSpanEndTime) {
+    this.verifyServerSpanEndTime = verifyServerSpanEndTime;
     return this;
   }
 

--- a/testing-common/src/main/java/org/assertj/core/api/AssertAccess.java
+++ b/testing-common/src/main/java/org/assertj/core/api/AssertAccess.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.assertj.core.api;
+
+public final class AssertAccess {
+  private AssertAccess() {}
+
+  public static <ACTUAL> ACTUAL getActual(AbstractAssert<?, ACTUAL> abstractAssert) {
+    return abstractAssert.actual;
+  }
+}


### PR DESCRIPTION
Currently server span end time verification is only implemented for groovy tests. 