### PR TITLE
Codeql detects zipslip vulnerability

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -91,11 +91,10 @@ public class ExtensionClassLoader extends URLClassLoader {
           File tempFile = new File(tempDirectory, name.substring(prefix.length()));
           // reject extensions that would be extracted outside of temp directory
           // https://security.snyk.io/research/zip-slip-vulnerability
-          if (name.indexOf("..") != -1
-              && !tempFile
-                  .getCanonicalFile()
-                  .toPath()
-                  .startsWith(tempDirectory.getCanonicalFile().toPath())) {
+          if (!tempFile
+              .getCanonicalFile()
+              .toPath()
+              .startsWith(tempDirectory.getCanonicalFile().toPath())) {
             throw new IllegalStateException("Invalid extension " + name);
           }
           if (tempFile.createNewFile()) {


### PR DESCRIPTION
I think that the only way zipslip could happen is when name contains `..` but codeql isn't able to cope with that. Removing the `..` check gets rid of the code scanning alert.