### PR TITLE
Update squash merge commit message

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -6,7 +6,7 @@ settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-conf
 
 ## General > Pull Requests
 
-* Allow squash merging > Default to pull request title and description
+* Allow squash merging > Default to pull request title
 
 * Allow auto-merge
 


### PR DESCRIPTION
We tend to put questions and random thoughts into PR descriptions (as opposed to, well, description of the changes).

And then there's the enormous dependabot PR descriptions.