### PR TITLE
Attempt to work around flaky reactor rabbitmq test

### DIFF
--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/ReactorRabbitMqTest.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/ReactorRabbitMqTest.groovy
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.Connection
+import com.rabbitmq.client.ShutdownSignalException
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -12,12 +15,25 @@ import reactor.rabbitmq.SenderOptions
 
 class ReactorRabbitMqTest extends AgentInstrumentationSpecification implements WithRabbitMqTrait {
 
+  // Open connection outside of the test method to ensure that connection can be successfully
+  // established inside the test method without producing extra spans for connection recovery
+  Connection conn = connectionFactory.newConnection()
+  Channel channel = conn.createChannel()
+
   def setupSpec() {
     startRabbit()
   }
 
   def cleanupSpec() {
     stopRabbit()
+  }
+
+  def cleanup() {
+    try {
+      channel.close()
+      conn.close()
+    } catch (ShutdownSignalException ignored) {
+    }
   }
 
   def "should not fail declaring exchange"() {


### PR DESCRIPTION
https://ge.opentelemetry.io/s/tik4gdzpiygbo/tests/:instrumentation:rabbitmq-2.7:javaagent:test/ReactorRabbitMqTest/should%20not%20fail%20declaring%20exchange?top-execution=1
Occasionally `ReactorRabbitMqTest` fails because there are more spans than expected. It seems like opening the connection inside the test occasionally does some kind of connection recovery that produces spans. The  non reactor version of the test doesn't have this problem. Hopefully opening the connection outside of the test method, the same way as the non reactor version does, helps to make establishing the connection inside the test smoother.