### PR TITLE
Disable automatic connection recovery in reactor rabbit test

### DIFF
--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/ReactorRabbitMqTest.groovy
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/groovy/ReactorRabbitMqTest.groovy
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import com.rabbitmq.client.Channel
-import com.rabbitmq.client.Connection
-import com.rabbitmq.client.ShutdownSignalException
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -15,25 +12,13 @@ import reactor.rabbitmq.SenderOptions
 
 class ReactorRabbitMqTest extends AgentInstrumentationSpecification implements WithRabbitMqTrait {
 
-  // Open connection outside of the test method to ensure that connection can be successfully
-  // established inside the test method without producing extra spans for connection recovery
-  Connection conn = connectionFactory.newConnection()
-  Channel channel = conn.createChannel()
-
   def setupSpec() {
     startRabbit()
+    connectionFactory.setAutomaticRecoveryEnabled(false)
   }
 
   def cleanupSpec() {
     stopRabbit()
-  }
-
-  def cleanup() {
-    try {
-      channel.close()
-      conn.close()
-    } catch (ShutdownSignalException ignored) {
-    }
   }
 
   def "should not fail declaring exchange"() {


### PR DESCRIPTION
As https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8232 didn't help agains flaky test let's try disabling automatic connection recovery.