### PR TITLE
Switch from http.flavor to net.protocol.* in HTTP server instrumentat…

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -90,7 +90,6 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
     super.onStart(attributes, parentContext, request);
 
-    internalSet(attributes, SemanticAttributes.HTTP_FLAVOR, getter.getFlavor(request));
     String forwardedProto = forwardedProto(request);
     String value = forwardedProto != null ? forwardedProto : getter.getScheme(request);
     internalSet(attributes, SemanticAttributes.HTTP_SCHEME, value);

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import javax.annotation.Nullable;
 
 /**
@@ -19,8 +20,17 @@ public interface HttpServerAttributesGetter<REQUEST, RESPONSE>
 
   // Attributes that always exist in a request
 
+  /**
+   * Extracts the {@code http.flavor} span attribute.
+   *
+   * @deprecated Use {@link NetServerAttributesGetter#getProtocolName(Object)} and {@link
+   *     NetServerAttributesGetter#getProtocolVersion(Object)} instead.
+   */
+  @Deprecated
   @Nullable
-  String getFlavor(REQUEST request);
+  default String getFlavor(REQUEST request) {
+    return null;
+  }
 
   @Nullable
   String getTarget(REQUEST request);

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsView.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsView.java
@@ -30,7 +30,6 @@ final class TemporaryMetricsView {
     Set<AttributeKey> view = new HashSet<>();
     view.add(SemanticAttributes.HTTP_METHOD);
     view.add(SemanticAttributes.HTTP_STATUS_CODE); // Optional
-    view.add(SemanticAttributes.HTTP_FLAVOR); // Optional
     view.add(NetAttributes.NET_PROTOCOL_NAME); // Optional
     view.add(NetAttributes.NET_PROTOCOL_VERSION); // Optional
     return view;
@@ -67,7 +66,6 @@ final class TemporaryMetricsView {
     Set<AttributeKey> view = new HashSet<>();
     view.add(SemanticAttributes.HTTP_METHOD);
     view.add(SemanticAttributes.HTTP_SCHEME);
-    view.add(SemanticAttributes.HTTP_FLAVOR);
     view.add(SemanticAttributes.NET_HOST_NAME);
     view.add(SemanticAttributes.NET_HOST_PORT);
     return view;

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetServerAttributesExtractor.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorU
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.Locale;
 import java.util.function.BiPredicate;
 
 /**
@@ -34,7 +35,11 @@ public final class InternalNetServerAttributesExtractor<REQUEST> {
   public void onStart(AttributesBuilder attributes, REQUEST request) {
 
     internalSet(attributes, SemanticAttributes.NET_TRANSPORT, getter.getTransport(request));
-    internalSet(attributes, NetAttributes.NET_PROTOCOL_NAME, getter.getProtocolName(request));
+    String protocolName = getter.getProtocolName(request);
+    if (protocolName != null) {
+      internalSet(
+          attributes, NetAttributes.NET_PROTOCOL_NAME, protocolName.toLowerCase(Locale.ROOT));
+    }
     internalSet(attributes, NetAttributes.NET_PROTOCOL_VERSION, getter.getProtocolVersion(request));
 
     boolean setSockFamily = false;

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsTest.java
@@ -15,6 +15,7 @@ import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -44,10 +45,10 @@ class HttpClientMetricsTest {
 
     Attributes responseAttributes =
         Attributes.builder()
-            .put("http.flavor", "2.0")
             .put("http.status_code", 200)
             .put("http.response_content_length", 200)
-            .put("net.sock.family", "inet")
+            .put(NetAttributes.NET_PROTOCOL_NAME, "http")
+            .put(NetAttributes.NET_PROTOCOL_VERSION, "2.0")
             .put("net.sock.peer.addr", "1.2.3.4")
             .put("net.sock.peer.name", "somehost20")
             .put("net.sock.peer.port", 8080)
@@ -88,7 +89,8 @@ class HttpClientMetricsTest {
                                         .hasAttributesSatisfying(
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_NAME, "http"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
                                             equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_PEER_PORT, 1234),
                                             equalTo(
@@ -111,7 +113,8 @@ class HttpClientMetricsTest {
                                         .hasAttributesSatisfying(
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_NAME, "http"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
                                             equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_PEER_PORT, 1234),
                                             equalTo(
@@ -134,7 +137,8 @@ class HttpClientMetricsTest {
                                         .hasAttributesSatisfying(
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_NAME, "http"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
                                             equalTo(SemanticAttributes.NET_PEER_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_PEER_PORT, 1234),
                                             equalTo(

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -18,6 +18,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
 import java.util.List;
@@ -71,11 +72,6 @@ class HttpServerAttributesExtractorTest {
     }
 
     @Override
-    public String getFlavor(Map<String, Object> request) {
-      return (String) request.get("flavor");
-    }
-
-    @Override
     public List<String> getResponseHeader(
         Map<String, Object> request, Map<String, Object> response, String name) {
       String values = (String) response.get("header." + name);
@@ -89,6 +85,18 @@ class HttpServerAttributesExtractorTest {
     @Override
     public String getTransport(Map<String, Object> request) {
       return (String) request.get("transport");
+    }
+
+    @Nullable
+    @Override
+    public String getProtocolName(Map<String, Object> request) {
+      return (String) request.get("protocolName");
+    }
+
+    @Nullable
+    @Override
+    public String getProtocolVersion(Map<String, Object> request) {
+      return (String) request.get("protocolVersion");
     }
 
     @Nullable
@@ -112,12 +120,13 @@ class HttpServerAttributesExtractorTest {
     request.put("target", "/repositories/1");
     request.put("scheme", "http");
     request.put("header.content-length", "10");
-    request.put("flavor", "http/2");
     request.put("route", "/repositories/{id}");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.host", "github.com");
     request.put("header.forwarded", "for=1.1.1.1;proto=https");
     request.put("header.custom-request-header", "123,456");
+    request.put("protocolName", "http");
+    request.put("protocolVersion", "2.0");
 
     Map<String, Object> response = new HashMap<>();
     response.put("statusCode", "202");
@@ -139,7 +148,8 @@ class HttpServerAttributesExtractorTest {
     assertThat(attributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_HOST_NAME, "github.com"),
-            entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
+            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
             entry(SemanticAttributes.HTTP_TARGET, "/repositories/1"),
@@ -154,6 +164,8 @@ class HttpServerAttributesExtractorTest {
     assertThat(attributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_HOST_NAME, "github.com"),
+            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
             entry(SemanticAttributes.HTTP_TARGET, "/repositories/1"),
@@ -164,7 +176,6 @@ class HttpServerAttributesExtractorTest {
             entry(
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")),
-            entry(SemanticAttributes.HTTP_FLAVOR, "http/2"),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
             entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
             entry(

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.api.instrumenter.http;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_2_0;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
 
 import io.opentelemetry.api.common.Attributes;
@@ -17,6 +16,7 @@ import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -36,10 +36,11 @@ class HttpServerMetricsTest {
     Attributes requestAttributes =
         Attributes.builder()
             .put("http.method", "GET")
-            .put("http.flavor", HTTP_2_0)
             .put("http.target", "/")
             .put("http.scheme", "https")
             .put("net.transport", IP_TCP)
+            .put(NetAttributes.NET_PROTOCOL_NAME, "http")
+            .put(NetAttributes.NET_PROTOCOL_VERSION, "2.0")
             .put("net.host.name", "localhost")
             .put("net.host.port", 1234)
             .put("net.sock.family", "inet")
@@ -89,7 +90,6 @@ class HttpServerMetricsTest {
                                         .hasAttributesSatisfying(
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, HTTP_2_0),
                                             equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_HOST_PORT, 1234L))
                                         .hasExemplarsSatisfying(
@@ -115,7 +115,6 @@ class HttpServerMetricsTest {
                                         .hasAttributesSatisfying(
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, HTTP_2_0),
                                             equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_HOST_PORT, 1234L))
                                         .hasExemplarsSatisfying(
@@ -140,7 +139,6 @@ class HttpServerMetricsTest {
                                         .hasAttributesSatisfying(
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, HTTP_2_0),
                                             equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_HOST_PORT, 1234L))
                                         .hasExemplarsSatisfying(
@@ -161,7 +159,8 @@ class HttpServerMetricsTest {
                                         .hasAttributesSatisfying(
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_NAME, "http"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
                                             equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
                                             equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_HOST_PORT, 1234))
@@ -183,7 +182,8 @@ class HttpServerMetricsTest {
                                         .hasAttributesSatisfying(
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_NAME, "http"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
                                             equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
                                             equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_HOST_PORT, 1234))
@@ -205,7 +205,8 @@ class HttpServerMetricsTest {
                                         .hasAttributesSatisfying(
                                             equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                             equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
-                                            equalTo(SemanticAttributes.HTTP_FLAVOR, "2.0"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_NAME, "http"),
+                                            equalTo(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
                                             equalTo(SemanticAttributes.HTTP_SCHEME, "https"),
                                             equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"),
                                             equalTo(SemanticAttributes.NET_HOST_PORT, 1234))

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsViewTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsViewTest.java
@@ -9,11 +9,11 @@ import static io.opentelemetry.instrumentation.api.instrumenter.http.TemporaryMe
 import static io.opentelemetry.instrumentation.api.instrumenter.http.TemporaryMetricsView.applyClientDurationAndSizeView;
 import static io.opentelemetry.instrumentation.api.instrumenter.http.TemporaryMetricsView.applyServerDurationAndSizeView;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HttpFlavorValues.HTTP_1_1;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.junit.jupiter.api.Test;
 
@@ -34,8 +34,9 @@ class TemporaryMetricsViewTest {
     Attributes endAttributes =
         Attributes.builder()
             .put(SemanticAttributes.HTTP_STATUS_CODE, 500)
-            .put(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1)
             .put(SemanticAttributes.NET_TRANSPORT, IP_TCP)
+            .put(NetAttributes.NET_PROTOCOL_NAME, "http")
+            .put(NetAttributes.NET_PROTOCOL_VERSION, "1.1")
             .put(SemanticAttributes.NET_PEER_NAME, "somehost2")
             .put(SemanticAttributes.NET_PEER_PORT, 443)
             .put(SemanticAttributes.NET_SOCK_FAMILY, "inet")
@@ -48,7 +49,8 @@ class TemporaryMetricsViewTest {
         .containsOnly(
             entry(SemanticAttributes.HTTP_METHOD, "GET"),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 500L),
-            entry(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1),
+            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"),
             entry(SemanticAttributes.NET_PEER_NAME, "somehost2"),
             entry(SemanticAttributes.NET_PEER_PORT, 443L),
             entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1.2.3.4"));
@@ -62,10 +64,11 @@ class TemporaryMetricsViewTest {
             .put(
                 SemanticAttributes.HTTP_URL,
                 "https://somehost/high/cardinality/12345?jsessionId=121454")
-            .put(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1)
             .put(SemanticAttributes.HTTP_TARGET, "/high/cardinality/12345?jsessionId=121454")
             .put(SemanticAttributes.HTTP_SCHEME, "https")
             .put(SemanticAttributes.NET_TRANSPORT, IP_TCP)
+            .put(NetAttributes.NET_PROTOCOL_NAME, "http")
+            .put(NetAttributes.NET_PROTOCOL_VERSION, "1.1")
             .put(SemanticAttributes.NET_HOST_NAME, "somehost")
             .put(SemanticAttributes.NET_HOST_PORT, 443)
             .put(SemanticAttributes.NET_SOCK_FAMILY, "inet")
@@ -87,8 +90,9 @@ class TemporaryMetricsViewTest {
         .containsOnly(
             entry(SemanticAttributes.HTTP_METHOD, "GET"),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 500L),
-            entry(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
+            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"),
             entry(SemanticAttributes.NET_HOST_NAME, "somehost"),
             entry(SemanticAttributes.NET_HOST_PORT, 443L),
             entry(SemanticAttributes.HTTP_ROUTE, "/somehost/high/{name}/{id}"));
@@ -102,10 +106,11 @@ class TemporaryMetricsViewTest {
             .put(
                 SemanticAttributes.HTTP_URL,
                 "https://somehost/high/cardinality/12345?jsessionId=121454")
-            .put(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1)
             .put(SemanticAttributes.HTTP_TARGET, "/high/cardinality/12345?jsessionId=121454")
             .put(SemanticAttributes.HTTP_SCHEME, "https")
             .put(SemanticAttributes.NET_TRANSPORT, IP_TCP)
+            .put(NetAttributes.NET_PROTOCOL_NAME, "http")
+            .put(NetAttributes.NET_PROTOCOL_VERSION, "1.1")
             .put(SemanticAttributes.NET_HOST_NAME, "somehost")
             .put(SemanticAttributes.NET_HOST_PORT, 443)
             .put(SemanticAttributes.NET_SOCK_FAMILY, "inet")
@@ -119,7 +124,6 @@ class TemporaryMetricsViewTest {
         .containsOnly(
             entry(SemanticAttributes.HTTP_METHOD, "GET"),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
-            entry(SemanticAttributes.HTTP_FLAVOR, HTTP_1_1),
             entry(SemanticAttributes.NET_HOST_NAME, "somehost"),
             entry(SemanticAttributes.NET_HOST_PORT, 443L));
   }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpUtil.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpUtil.java
@@ -32,12 +32,20 @@ public class AkkaHttpUtil {
         .orElse(Collections.emptyList());
   }
 
-  public static String httpVersion(HttpRequest httpRequest) {
-    String protocol = httpRequest.protocol().value();
+  public static String protocolName(HttpRequest request) {
+    String protocol = request.protocol().value();
     if (protocol.startsWith("HTTP/")) {
-      protocol = protocol.substring("HTTP/".length());
+      return "http";
     }
-    return protocol;
+    return null;
+  }
+
+  public static String protocolVersion(HttpRequest request) {
+    String protocol = request.protocol().value();
+    if (protocol.startsWith("HTTP/")) {
+      return protocol.substring("HTTP/".length());
+    }
+    return null;
   }
 
   private AkkaHttpUtil() {}

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpNetAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpNetAttributesGetter.java
@@ -22,13 +22,13 @@ class AkkaHttpNetAttributesGetter implements NetClientAttributesGetter<HttpReque
   @Nullable
   @Override
   public String getProtocolName(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
-    return "http";
+    return AkkaHttpUtil.protocolName(httpRequest);
   }
 
   @Nullable
   @Override
   public String getProtocolVersion(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
-    return AkkaHttpUtil.httpVersion(httpRequest);
+    return AkkaHttpUtil.protocolVersion(httpRequest);
   }
 
   @Override

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
@@ -39,11 +39,6 @@ class AkkaHttpServerAttributesGetter
   }
 
   @Override
-  public String getFlavor(HttpRequest request) {
-    return AkkaHttpUtil.httpVersion(request);
-  }
-
-  @Override
   public String getTarget(HttpRequest request) {
     String target = request.uri().path().toString();
     Option<String> queryString = request.uri().rawQueryString();

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaNetServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaNetServerAttributesGetter.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
 
 import akka.http.scaladsl.model.HttpRequest;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
+import io.opentelemetry.javaagent.instrumentation.akkahttp.AkkaHttpUtil;
 import javax.annotation.Nullable;
 
 // TODO (trask) capture net attributes?
@@ -14,19 +15,31 @@ class AkkaNetServerAttributesGetter implements NetServerAttributesGetter<HttpReq
 
   @Nullable
   @Override
-  public String getTransport(HttpRequest httpRequest) {
+  public String getTransport(HttpRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String getHostName(HttpRequest httpRequest) {
+  public String getProtocolName(HttpRequest request) {
+    return AkkaHttpUtil.protocolName(request);
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(HttpRequest request) {
+    return AkkaHttpUtil.protocolVersion(request);
+  }
+
+  @Nullable
+  @Override
+  public String getHostName(HttpRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(HttpRequest httpRequest) {
+  public Integer getHostPort(HttpRequest request) {
     return null;
   }
 }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
@@ -8,11 +8,9 @@ package io.opentelemetry.instrumentation.armeria.v1_3;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesGetter;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -50,16 +48,6 @@ enum ArmeriaHttpServerAttributesGetter
       return status.code();
     }
     return null;
-  }
-
-  @Override
-  public String getFlavor(RequestContext ctx) {
-    SessionProtocol protocol = ctx.sessionProtocol();
-    if (protocol.isMultiplex()) {
-      return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
-    } else {
-      return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
-    }
   }
 
   @Override

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.SessionProtocol;
 import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.InetSocketAddress;
@@ -18,6 +19,17 @@ final class ArmeriaNetServerAttributesGetter
   @Override
   public String getTransport(RequestContext ctx) {
     return SemanticAttributes.NetTransportValues.IP_TCP;
+  }
+
+  @Override
+  public String getProtocolName(RequestContext ctx) {
+    return "http";
+  }
+
+  @Override
+  public String getProtocolVersion(RequestContext ctx) {
+    SessionProtocol protocol = ctx.sessionProtocol();
+    return protocol.isMultiplex() ? "2.0" : "1.1";
   }
 
   @Nullable

--- a/instrumentation/camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.groovy
+++ b/instrumentation/camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/RestCamelTest.groovy
@@ -90,10 +90,11 @@ class RestCamelTest extends AgentInstrumentationSpecification implements RetryOn
             "$SemanticAttributes.HTTP_TARGET" "/api/firstModule/unit/unitOne"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_USER_AGENT" String
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_ROUTE" "/api/{module}/unit/{unitId}"
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"

--- a/instrumentation/camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
+++ b/instrumentation/camel-2.20/javaagent/src/test/groovy/io/opentelemetry/javaagent/instrumentation/apachecamel/TwoServicesWithDirectClientCamelTest.groovy
@@ -126,10 +126,11 @@ class TwoServicesWithDirectClientCamelTest extends AgentInstrumentationSpecifica
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_TARGET" "/serviceTwo"
             "$SemanticAttributes.HTTP_USER_AGENT" "Jakarta Commons-HttpClient/3.1"
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" Long
             "$SemanticAttributes.HTTP_ROUTE" "/serviceTwo"
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "127.0.0.1"
             "$SemanticAttributes.NET_HOST_PORT" portTwo
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
@@ -48,15 +48,6 @@ final class GrizzlyHttpAttributesGetter
     return toHeaderList(response.getHeaders().values(name));
   }
 
-  @Override
-  public String getFlavor(HttpRequestPacket request) {
-    String flavor = request.getProtocolString();
-    if (flavor.startsWith("HTTP/")) {
-      flavor = flavor.substring("HTTP/".length());
-    }
-    return flavor;
-  }
-
   @Nullable
   @Override
   public String getTarget(HttpRequestPacket request) {

--- a/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
+++ b/instrumentation/grizzly-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
@@ -22,6 +22,26 @@ final class GrizzlyNetAttributesGetter implements NetServerAttributesGetter<Http
 
   @Nullable
   @Override
+  public String getProtocolName(HttpRequestPacket request) {
+    String protocol = request.getProtocolString();
+    if (protocol.startsWith("HTTP/")) {
+      return "http";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(HttpRequestPacket request) {
+    String protocol = request.getProtocolString();
+    if (protocol.startsWith("HTTP/")) {
+      return protocol.substring("HTTP/".length());
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
   public String getHostName(HttpRequestPacket request) {
     return request.getLocalHost();
   }

--- a/instrumentation/jaxrs/jaxrs-common/testing/src/main/groovy/AbstractJaxRsHttpServerTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-common/testing/src/main/groovy/AbstractJaxRsHttpServerTest.groovy
@@ -280,6 +280,8 @@ abstract class AbstractJaxRsHttpServerTest<S> extends HttpServerTest<S> implemen
         spanId spanID
       }
       attributes {
+        "net.protocol.name" "http"
+        "net.protocol.version" "1.1"
         "$SemanticAttributes.NET_HOST_NAME" fullUrl.host
         "$SemanticAttributes.NET_HOST_PORT" fullUrl.port
         "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -289,7 +291,6 @@ abstract class AbstractJaxRsHttpServerTest<S> extends HttpServerTest<S> implemen
         "$SemanticAttributes.HTTP_TARGET" fullUrl.getPath() + (fullUrl.getQuery() != null ? "?" + fullUrl.getQuery() : "")
         "$SemanticAttributes.HTTP_METHOD" method
         "$SemanticAttributes.HTTP_STATUS_CODE" statusCode
-        "$SemanticAttributes.HTTP_FLAVOR" "1.1"
         "$SemanticAttributes.HTTP_USER_AGENT" TEST_USER_AGENT
         "$SemanticAttributes.HTTP_CLIENT_IP" TEST_CLIENT_IP
         "$SemanticAttributes.NET_TRANSPORT" IP_TCP

--- a/instrumentation/jsf/jsf-jakarta-common/testing/src/main/groovy/BaseJsfTest.groovy
+++ b/instrumentation/jsf/jsf-jakarta-common/testing/src/main/groovy/BaseJsfTest.groovy
@@ -87,6 +87,8 @@ abstract class BaseJsfTest extends AgentInstrumentationSpecification implements 
           hasNoParent()
           attributes {
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -96,7 +98,6 @@ abstract class BaseJsfTest extends AgentInstrumentationSpecification implements 
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_TARGET" "/jetty-context/" + path
             "$SemanticAttributes.HTTP_USER_AGENT" TEST_USER_AGENT
-            "$SemanticAttributes.HTTP_FLAVOR" SemanticAttributes.HttpFlavorValues.HTTP_1_1
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_ROUTE" "/jetty-context/" + route
             "$SemanticAttributes.HTTP_CLIENT_IP" { it == null || it == TEST_CLIENT_IP }

--- a/instrumentation/jsf/jsf-javax-common/testing/src/main/groovy/BaseJsfTest.groovy
+++ b/instrumentation/jsf/jsf-javax-common/testing/src/main/groovy/BaseJsfTest.groovy
@@ -98,6 +98,8 @@ abstract class BaseJsfTest extends AgentInstrumentationSpecification implements 
           hasNoParent()
           attributes {
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -107,7 +109,6 @@ abstract class BaseJsfTest extends AgentInstrumentationSpecification implements 
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_TARGET" "/jetty-context/" + path
             "$SemanticAttributes.HTTP_USER_AGENT" TEST_USER_AGENT
-            "$SemanticAttributes.HTTP_FLAVOR" SemanticAttributes.HttpFlavorValues.HTTP_1_1
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_ROUTE" "/jetty-context/" + route
             "$SemanticAttributes.HTTP_CLIENT_IP" { it == null || it == TEST_CLIENT_IP }

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationBasicTests.groovy
@@ -94,11 +94,12 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -153,10 +154,11 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" "$route?$queryString"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -207,11 +209,12 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "POST"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" Long
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -271,10 +274,11 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 500
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -339,10 +343,11 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -388,10 +393,11 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -469,10 +475,11 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 500
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -519,10 +526,11 @@ class JspInstrumentationBasicTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" "/$jspWebappContext/$staticFile"
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"

--- a/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/javaagent/src/test/groovy/JspInstrumentationForwardTests.groovy
@@ -92,10 +92,11 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -162,10 +163,11 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -211,10 +213,11 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -308,10 +311,11 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -391,10 +395,11 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 500
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -453,10 +458,11 @@ class JspInstrumentationForwardTests extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_TARGET" route
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 404
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" route
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" "localhost"
             "$SemanticAttributes.NET_HOST_PORT" port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
@@ -9,7 +9,6 @@ import io.ktor.features.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesGetter
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 internal enum class KtorHttpServerAttributesGetter :
   HttpServerAttributesGetter<ApplicationRequest, ApplicationResponse> {
@@ -29,14 +28,6 @@ internal enum class KtorHttpServerAttributesGetter :
 
   override fun getResponseHeader(request: ApplicationRequest, response: ApplicationResponse, name: String): List<String> {
     return response.headers.allValues().getAll(name) ?: emptyList()
-  }
-
-  override fun getFlavor(request: ApplicationRequest): String? {
-    return when (request.httpVersion) {
-      "HTTP/1.1" -> SemanticAttributes.HttpFlavorValues.HTTP_1_1
-      "HTTP/2.0" -> SemanticAttributes.HttpFlavorValues.HTTP_2_0
-      else -> null
-    }
   }
 
   override fun getTarget(request: ApplicationRequest): String {

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorNetServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorNetServerAttributesGetter.kt
@@ -15,6 +15,12 @@ internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<Applica
     return SemanticAttributes.NetTransportValues.IP_TCP
   }
 
+  override fun getProtocolName(request: ApplicationRequest): String? =
+    if (request.httpVersion.startsWith("HTTP/")) "http" else null
+
+  override fun getProtocolVersion(request: ApplicationRequest): String? =
+    if (request.httpVersion.startsWith("HTTP/")) request.httpVersion.substring("HTTP/".length) else null
+
   override fun getSockPeerAddr(request: ApplicationRequest): String? {
     val remote = request.local.remoteHost
     if ("unknown" != remote && isIpAddress(remote)) {

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorHttpServerAttributesGetter.kt
@@ -9,7 +9,6 @@ import io.ktor.server.plugins.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesGetter
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
 
 internal enum class KtorHttpServerAttributesGetter :
   HttpServerAttributesGetter<ApplicationRequest, ApplicationResponse> {
@@ -29,14 +28,6 @@ internal enum class KtorHttpServerAttributesGetter :
 
   override fun getResponseHeader(request: ApplicationRequest, response: ApplicationResponse, name: String): List<String> {
     return response.headers.allValues().getAll(name) ?: emptyList()
-  }
-
-  override fun getFlavor(request: ApplicationRequest): String? {
-    return when (request.httpVersion) {
-      "HTTP/1.1" -> SemanticAttributes.HttpFlavorValues.HTTP_1_1
-      "HTTP/2.0" -> SemanticAttributes.HttpFlavorValues.HTTP_2_0
-      else -> null
-    }
   }
 
   override fun getTarget(request: ApplicationRequest): String {

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorNetServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorNetServerAttributesGetter.kt
@@ -15,13 +15,11 @@ internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<Applica
     return SemanticAttributes.NetTransportValues.IP_TCP
   }
 
-  override fun getSockPeerAddr(request: ApplicationRequest): String? {
-    val remote = request.local.remoteHost
-    if ("unknown" != remote && isIpAddress(remote)) {
-      return remote
-    }
-    return null
-  }
+  override fun getProtocolName(request: ApplicationRequest): String? =
+    if (request.httpVersion.startsWith("HTTP/")) "http" else null
+
+  override fun getProtocolVersion(request: ApplicationRequest): String? =
+    if (request.httpVersion.startsWith("HTTP/")) request.httpVersion.substring("HTTP/".length) else null
 
   override fun getHostName(request: ApplicationRequest): String {
     return request.local.host
@@ -29,5 +27,13 @@ internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<Applica
 
   override fun getHostPort(request: ApplicationRequest): Int {
     return request.local.port
+  }
+
+  override fun getSockPeerAddr(request: ApplicationRequest): String? {
+    val remote = request.local.remoteHost
+    if ("unknown" != remote && isIpAddress(remote)) {
+      return remote
+    }
+    return null
   }
 }

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
@@ -25,19 +25,6 @@ public class LibertyDispatcherHttpAttributesGetter
 
   @Override
   @Nullable
-  public String getFlavor(LibertyRequest libertyRequest) {
-    String flavor = libertyRequest.getProtocol();
-    if (flavor != null) {
-      // remove HTTP/ prefix to comply with semantic conventions
-      if (flavor.startsWith("HTTP/")) {
-        flavor = flavor.substring("HTTP/".length());
-      }
-    }
-    return flavor;
-  }
-
-  @Override
-  @Nullable
   public Integer getStatusCode(
       LibertyRequest libertyRequest, LibertyResponse libertyResponse, @Nullable Throwable error) {
     return libertyResponse.getStatus();

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
@@ -19,6 +19,26 @@ public class LibertyDispatcherNetAttributesGetter
 
   @Nullable
   @Override
+  public String getProtocolName(LibertyRequest request) {
+    String protocol = request.getProtocol();
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return "http";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(LibertyRequest request) {
+    String protocol = request.getProtocol();
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return protocol.substring("HTTP/".length());
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
   public String getHostName(LibertyRequest request) {
     return request.request().getURLHost();
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
@@ -38,15 +38,6 @@ final class NettyHttpServerAttributesGetter
   }
 
   @Override
-  public String getFlavor(HttpRequestAndChannel requestAndChannel) {
-    String flavor = requestAndChannel.request().getProtocolVersion().toString();
-    if (flavor.startsWith("HTTP/")) {
-      flavor = flavor.substring("HTTP/".length());
-    }
-    return flavor;
-  }
-
-  @Override
   public String getTarget(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.request().getUri();
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
@@ -14,6 +14,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 import org.jboss.netty.channel.socket.DatagramChannel;
+import org.jboss.netty.handler.codec.http.HttpVersion;
 
 final class NettyNetServerAttributesGetter
     extends InetSocketAddressNetServerAttributesGetter<HttpRequestAndChannel> {
@@ -21,6 +22,17 @@ final class NettyNetServerAttributesGetter
   @Override
   public String getTransport(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.channel() instanceof DatagramChannel ? IP_UDP : IP_TCP;
+  }
+
+  @Override
+  public String getProtocolName(HttpRequestAndChannel requestAndChannel) {
+    return requestAndChannel.request().getProtocolVersion().getProtocolName();
+  }
+
+  @Override
+  public String getProtocolVersion(HttpRequestAndChannel requestAndChannel) {
+    HttpVersion version = requestAndChannel.request().getProtocolVersion();
+    return version.getMajorVersion() + "." + version.getMinorVersion();
   }
 
   @Nullable

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyHttpServerAttributesGetter.java
@@ -38,15 +38,6 @@ final class NettyHttpServerAttributesGetter
   }
 
   @Override
-  public String getFlavor(HttpRequestAndChannel requestAndChannel) {
-    String flavor = requestAndChannel.request().getProtocolVersion().toString();
-    if (flavor.startsWith("HTTP/")) {
-      flavor = flavor.substring("HTTP/".length());
-    }
-    return flavor;
-  }
-
-  @Override
   public String getTarget(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.request().getUri();
   }

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTr
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_UDP;
 
 import io.netty.channel.socket.DatagramChannel;
+import io.netty.handler.codec.http.HttpVersion;
 import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import java.net.InetSocketAddress;
@@ -21,6 +22,17 @@ final class NettyNetServerAttributesGetter
   @Override
   public String getTransport(HttpRequestAndChannel requestAndChannel) {
     return requestAndChannel.channel() instanceof DatagramChannel ? IP_UDP : IP_TCP;
+  }
+
+  @Override
+  public String getProtocolName(HttpRequestAndChannel requestAndChannel) {
+    return requestAndChannel.request().getProtocolVersion().protocolName();
+  }
+
+  @Override
+  public String getProtocolVersion(HttpRequestAndChannel requestAndChannel) {
+    HttpVersion version = requestAndChannel.request().getProtocolVersion();
+    return version.majorVersion() + "." + version.minorVersion();
   }
 
   @Nullable

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
@@ -39,12 +39,6 @@ enum MockHttpServerAttributesGetter implements HttpServerAttributesGetter<String
 
   @Nullable
   @Override
-  public String getFlavor(String s) {
-    return null;
-  }
-
-  @Nullable
-  @Override
   public String getTarget(String s) {
     return null;
   }

--- a/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
+++ b/instrumentation/ratpack/ratpack-1.4/testing/src/main/groovy/io/opentelemetry/instrumentation/ratpack/server/AbstractRatpackRoutesTest.groovy
@@ -96,6 +96,8 @@ abstract class AbstractRatpackRoutesTest extends InstrumentationSpecification {
           hasNoParent()
           attributes {
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" { it == "localhost" || it == null }
             "$SemanticAttributes.NET_HOST_PORT" { it == app.bindPort || it == null }
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" { it == "127.0.0.1" || it == null }
@@ -104,7 +106,6 @@ abstract class AbstractRatpackRoutesTest extends InstrumentationSpecification {
             "$SemanticAttributes.NET_SOCK_HOST_PORT" { it instanceof Long || it == null }
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_TARGET" "/$path"

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpAttributesGetter.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.ratpack.v1_7;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesGetter;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.List;
 import javax.annotation.Nullable;
 import ratpack.handling.Context;
@@ -45,22 +44,6 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   @Override
   public List<String> getRequestHeader(Request request, String name) {
     return request.getHeaders().getAll(name);
-  }
-
-  @Override
-  @Nullable
-  public String getFlavor(Request request) {
-    switch (request.getProtocol()) {
-      case "HTTP/1.0":
-        return SemanticAttributes.HttpFlavorValues.HTTP_1_0;
-      case "HTTP/1.1":
-        return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
-      case "HTTP/2.0":
-        return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
-      default:
-        // fall through
-    }
-    return null;
   }
 
   @Override

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackNetServerAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackNetServerAttributesGetter.java
@@ -24,6 +24,26 @@ public final class RatpackNetServerAttributesGetter implements NetServerAttribut
 
   @Nullable
   @Override
+  public String getProtocolName(Request request) {
+    String protocol = request.getProtocol();
+    if (protocol.startsWith("HTTP/")) {
+      return "http";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(Request request) {
+    String protocol = request.getProtocol();
+    if (protocol.startsWith("HTTP/")) {
+      return protocol.substring("HTTP/".length());
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
   public String getHostName(Request request) {
     PublicAddress publicAddress = getPublicAddress(request);
     return publicAddress == null ? null : publicAddress.get().getHost();

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletHttpAttributesGetter.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.restlet.v1_1;
 import static io.opentelemetry.instrumentation.restlet.v1_1.RestletHeadersGetter.getHeaders;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesGetter;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -49,23 +48,6 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
       return Collections.emptyList();
     }
     return parametersToList(headers.subList(name, /* ignoreCase= */ true));
-  }
-
-  @Override
-  @Nullable
-  public String getFlavor(Request request) {
-    String version = (String) request.getAttributes().get("org.restlet.http.version");
-    switch (version) {
-      case "HTTP/1.0":
-        return SemanticAttributes.HttpFlavorValues.HTTP_1_0;
-      case "HTTP/1.1":
-        return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
-      case "HTTP/2.0":
-        return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
-      default:
-        // fall through
-    }
-    return null;
   }
 
   @Override

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletNetAttributesGetter.java
@@ -39,7 +39,7 @@ final class RestletNetAttributesGetter implements NetServerAttributesGetter<Requ
     return null;
   }
 
-  private String getProtocolString(Request request) {
+  private static String getProtocolString(Request request) {
     return (String) request.getAttributes().get("org.restlet.http.version");
   }
 

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletNetAttributesGetter.java
@@ -21,6 +21,30 @@ final class RestletNetAttributesGetter implements NetServerAttributesGetter<Requ
 
   @Nullable
   @Override
+  public String getProtocolName(Request request) {
+    String protocol = getProtocolString(request);
+    if (protocol.startsWith("HTTP/")) {
+      return "http";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(Request request) {
+    String protocol = getProtocolString(request);
+    if (protocol.startsWith("HTTP/")) {
+      return protocol.substring("HTTP/".length());
+    }
+    return null;
+  }
+
+  private String getProtocolString(Request request) {
+    return (String) request.getAttributes().get("org.restlet.http.version");
+  }
+
+  @Nullable
+  @Override
   public String getHostName(Request request) {
     HttpCall call = httpCall(request);
     return call == null ? null : call.getHostDomain();

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.restlet.v2_0.internal;
 import static io.opentelemetry.instrumentation.restlet.v2_0.internal.RestletHeadersGetter.getHeaders;
 
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesGetter;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -51,22 +50,6 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
       return Collections.emptyList();
     }
     return Arrays.asList(headers.getValuesArray(name, true));
-  }
-
-  @Override
-  @Nullable
-  public String getFlavor(Request request) {
-    switch (request.getProtocol().toString()) {
-      case "HTTP/1.0":
-        return SemanticAttributes.HttpFlavorValues.HTTP_1_0;
-      case "HTTP/1.1":
-        return SemanticAttributes.HttpFlavorValues.HTTP_1_1;
-      case "HTTP/2.0":
-        return SemanticAttributes.HttpFlavorValues.HTTP_2_0;
-      default:
-        // fall through
-    }
-    return null;
   }
 
   @Override

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletNetAttributesGetter.java
@@ -85,6 +85,18 @@ public final class RestletNetAttributesGetter implements NetServerAttributesGett
 
   @Nullable
   @Override
+  public String getProtocolName(Request request) {
+    return request.getProtocol().getSchemeName();
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(Request request) {
+    return request.getProtocol().getVersion();
+  }
+
+  @Nullable
+  @Override
   public String getHostName(Request request) {
     if (GET_HOST_DOMAIN == null) {
       return null;

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
@@ -50,19 +50,6 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
 
   @Override
   @Nullable
-  public String getFlavor(ServletRequestContext<REQUEST> requestContext) {
-    String flavor = accessor.getRequestProtocol(requestContext.request());
-    if (flavor != null) {
-      // remove HTTP/ prefix to comply with semantic conventions
-      if (flavor.startsWith("HTTP/")) {
-        flavor = flavor.substring("HTTP/".length());
-      }
-    }
-    return flavor;
-  }
-
-  @Override
-  @Nullable
   public Integer getStatusCode(
       ServletRequestContext<REQUEST> requestContext,
       ServletResponseContext<RESPONSE> responseContext,

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesGetter.java
@@ -26,6 +26,26 @@ public class ServletNetAttributesGetter<REQUEST, RESPONSE>
 
   @Nullable
   @Override
+  public String getProtocolName(ServletRequestContext<REQUEST> requestContext) {
+    String protocol = accessor.getRequestProtocol(requestContext.request());
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return "http";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(ServletRequestContext<REQUEST> requestContext) {
+    String protocol = accessor.getRequestProtocol(requestContext.request());
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return protocol.substring("HTTP/".length());
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
   public String getHostName(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestServerName(requestContext.request());
   }

--- a/instrumentation/spark-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/sparkjava/SparkJavaBasedTest.java
+++ b/instrumentation/spark-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/sparkjava/SparkJavaBasedTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.sparkjava;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
@@ -64,12 +65,13 @@ public class SparkJavaBasedTest {
                                 equalTo(SemanticAttributes.HTTP_TARGET, "/param/asdf1234"),
                                 equalTo(SemanticAttributes.HTTP_METHOD, "GET"),
                                 equalTo(SemanticAttributes.HTTP_STATUS_CODE, 200),
-                                equalTo(SemanticAttributes.HTTP_FLAVOR, "1.1"),
                                 satisfies(
                                     SemanticAttributes.HTTP_USER_AGENT,
                                     val -> val.isInstanceOf(String.class)),
                                 equalTo(SemanticAttributes.HTTP_ROUTE, "/param/:param"),
                                 equalTo(SemanticAttributes.NET_TRANSPORT, IP_TCP),
+                                equalTo(stringKey("net.protocol.name"), "http"),
+                                equalTo(stringKey("net.protocol.version"), "1.1"),
                                 equalTo(SemanticAttributes.NET_HOST_NAME, "localhost"),
                                 equalTo(SemanticAttributes.NET_HOST_PORT, port),
                                 equalTo(SemanticAttributes.NET_SOCK_PEER_ADDR, "127.0.0.1"),

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/SpringWebfluxTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/SpringWebfluxTest.java
@@ -13,7 +13,6 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.EXCEP
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.EXCEPTION_TYPE;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_FLAVOR;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH;
@@ -114,6 +113,8 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NET_TRANSPORT, IP_TCP),
+                            equalTo(stringKey("net.protocol.name"), "http"),
+                            equalTo(stringKey("net.protocol.version"), "1.1"),
                             equalTo(NET_SOCK_PEER_ADDR, "127.0.0.1"),
                             satisfies(NET_SOCK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(NET_SOCK_HOST_ADDR, "127.0.0.1"),
@@ -123,7 +124,6 @@ public class SpringWebfluxTest {
                             equalTo(HTTP_METHOD, "GET"),
                             equalTo(HTTP_STATUS_CODE, 200),
                             equalTo(HTTP_SCHEME, "http"),
-                            equalTo(HTTP_FLAVOR, "1.1"),
                             satisfies(HTTP_USER_AGENT, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, parameter.urlPathWithVariables),
                             satisfies(
@@ -238,6 +238,8 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NET_TRANSPORT, IP_TCP),
+                            equalTo(stringKey("net.protocol.name"), "http"),
+                            equalTo(stringKey("net.protocol.version"), "1.1"),
                             equalTo(NET_SOCK_PEER_ADDR, "127.0.0.1"),
                             satisfies(NET_SOCK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(NET_SOCK_HOST_ADDR, "127.0.0.1"),
@@ -247,7 +249,6 @@ public class SpringWebfluxTest {
                             equalTo(HTTP_METHOD, "GET"),
                             equalTo(HTTP_STATUS_CODE, 200),
                             equalTo(HTTP_SCHEME, "http"),
-                            equalTo(HTTP_FLAVOR, "1.1"),
                             satisfies(HTTP_USER_AGENT, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, parameter.urlPathWithVariables),
                             satisfies(
@@ -357,6 +358,8 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NET_TRANSPORT, IP_TCP),
+                            equalTo(stringKey("net.protocol.name"), "http"),
+                            equalTo(stringKey("net.protocol.version"), "1.1"),
                             equalTo(NET_SOCK_PEER_ADDR, "127.0.0.1"),
                             satisfies(NET_SOCK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(NET_SOCK_HOST_ADDR, "127.0.0.1"),
@@ -366,7 +369,6 @@ public class SpringWebfluxTest {
                             equalTo(HTTP_METHOD, "GET"),
                             equalTo(HTTP_STATUS_CODE, 200),
                             equalTo(HTTP_SCHEME, "http"),
-                            equalTo(HTTP_FLAVOR, "1.1"),
                             satisfies(HTTP_USER_AGENT, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, parameter.urlPathWithVariables),
                             satisfies(
@@ -441,6 +443,8 @@ public class SpringWebfluxTest {
                         .hasStatus(StatusData.unset())
                         .hasAttributesSatisfyingExactly(
                             equalTo(NET_TRANSPORT, IP_TCP),
+                            equalTo(stringKey("net.protocol.name"), "http"),
+                            equalTo(stringKey("net.protocol.version"), "1.1"),
                             equalTo(NET_SOCK_PEER_ADDR, "127.0.0.1"),
                             satisfies(NET_SOCK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(NET_SOCK_HOST_ADDR, "127.0.0.1"),
@@ -450,7 +454,6 @@ public class SpringWebfluxTest {
                             equalTo(HTTP_METHOD, "GET"),
                             equalTo(HTTP_STATUS_CODE, 404),
                             equalTo(HTTP_SCHEME, "http"),
-                            equalTo(HTTP_FLAVOR, "1.1"),
                             satisfies(HTTP_USER_AGENT, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/**"),
                             satisfies(
@@ -508,6 +511,8 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NET_TRANSPORT, IP_TCP),
+                            equalTo(stringKey("net.protocol.name"), "http"),
+                            equalTo(stringKey("net.protocol.version"), "1.1"),
                             equalTo(NET_SOCK_PEER_ADDR, "127.0.0.1"),
                             satisfies(NET_SOCK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(NET_SOCK_HOST_ADDR, "127.0.0.1"),
@@ -517,7 +522,6 @@ public class SpringWebfluxTest {
                             equalTo(HTTP_METHOD, "POST"),
                             equalTo(HTTP_STATUS_CODE, 202),
                             equalTo(HTTP_SCHEME, "http"),
-                            equalTo(HTTP_FLAVOR, "1.1"),
                             satisfies(HTTP_USER_AGENT, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/echo"),
                             satisfies(
@@ -560,6 +564,8 @@ public class SpringWebfluxTest {
                         .hasStatus(StatusData.error())
                         .hasAttributesSatisfyingExactly(
                             equalTo(NET_TRANSPORT, IP_TCP),
+                            equalTo(stringKey("net.protocol.name"), "http"),
+                            equalTo(stringKey("net.protocol.version"), "1.1"),
                             equalTo(NET_SOCK_PEER_ADDR, "127.0.0.1"),
                             satisfies(NET_SOCK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(NET_SOCK_HOST_ADDR, "127.0.0.1"),
@@ -569,7 +575,6 @@ public class SpringWebfluxTest {
                             equalTo(HTTP_METHOD, "GET"),
                             equalTo(HTTP_STATUS_CODE, 500),
                             equalTo(HTTP_SCHEME, "http"),
-                            equalTo(HTTP_FLAVOR, "1.1"),
                             satisfies(HTTP_USER_AGENT, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, parameter.urlPathWithVariables),
                             satisfies(
@@ -651,6 +656,8 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NET_TRANSPORT, IP_TCP),
+                            equalTo(stringKey("net.protocol.name"), "http"),
+                            equalTo(stringKey("net.protocol.version"), "1.1"),
                             equalTo(NET_SOCK_PEER_ADDR, "127.0.0.1"),
                             satisfies(NET_SOCK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(NET_SOCK_HOST_ADDR, "127.0.0.1"),
@@ -660,7 +667,6 @@ public class SpringWebfluxTest {
                             equalTo(HTTP_METHOD, "GET"),
                             equalTo(HTTP_STATUS_CODE, 307),
                             equalTo(HTTP_SCHEME, "http"),
-                            equalTo(HTTP_FLAVOR, "1.1"),
                             satisfies(HTTP_USER_AGENT, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/double-greet-redirect"),
                             satisfies(
@@ -691,6 +697,8 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NET_TRANSPORT, IP_TCP),
+                            equalTo(stringKey("net.protocol.name"), "http"),
+                            equalTo(stringKey("net.protocol.version"), "1.1"),
                             equalTo(NET_SOCK_PEER_ADDR, "127.0.0.1"),
                             satisfies(NET_SOCK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(NET_SOCK_HOST_ADDR, "127.0.0.1"),
@@ -700,7 +708,6 @@ public class SpringWebfluxTest {
                             equalTo(HTTP_METHOD, "GET"),
                             equalTo(HTTP_STATUS_CODE, 200),
                             equalTo(HTTP_SCHEME, "http"),
-                            equalTo(HTTP_FLAVOR, "1.1"),
                             satisfies(HTTP_USER_AGENT, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, "/double-greet"),
                             satisfies(
@@ -754,6 +761,8 @@ public class SpringWebfluxTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(NET_TRANSPORT, IP_TCP),
+                            equalTo(stringKey("net.protocol.name"), "http"),
+                            equalTo(stringKey("net.protocol.version"), "1.1"),
                             equalTo(NET_SOCK_PEER_ADDR, "127.0.0.1"),
                             satisfies(NET_SOCK_PEER_PORT, val -> val.isInstanceOf(Long.class)),
                             equalTo(NET_SOCK_HOST_ADDR, "127.0.0.1"),
@@ -763,7 +772,6 @@ public class SpringWebfluxTest {
                             equalTo(HTTP_METHOD, "GET"),
                             equalTo(HTTP_STATUS_CODE, 200),
                             equalTo(HTTP_SCHEME, "http"),
-                            equalTo(HTTP_FLAVOR, "1.1"),
                             satisfies(HTTP_USER_AGENT, val -> val.isInstanceOf(String.class)),
                             equalTo(HTTP_ROUTE, parameter.urlPathWithVariables),
                             satisfies(

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerHttpAttributesGetter.java
@@ -42,12 +42,6 @@ enum WebfluxServerHttpAttributesGetter
 
   @Nullable
   @Override
-  public String getFlavor(ServerWebExchange request) {
-    return null;
-  }
-
-  @Nullable
-  @Override
   public String getTarget(ServerWebExchange request) {
     String path = request.getRequest().getURI().getPath();
     String query = request.getRequest().getURI().getQuery();

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
@@ -32,19 +32,6 @@ enum SpringWebMvcHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public String getFlavor(HttpServletRequest request) {
-    String flavor = request.getProtocol();
-    if (flavor == null) {
-      return null;
-    }
-    if (flavor.startsWith("HTTP/")) {
-      flavor = flavor.substring("HTTP/".length());
-    }
-    return flavor;
-  }
-
-  @Override
   public Integer getStatusCode(
       HttpServletRequest request, HttpServletResponse response, @Nullable Throwable error) {
 

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcNetAttributesGetter.java
@@ -20,6 +20,26 @@ enum SpringWebMvcNetAttributesGetter implements NetServerAttributesGetter<HttpSe
 
   @Nullable
   @Override
+  public String getProtocolName(HttpServletRequest request) {
+    String protocol = request.getProtocol();
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return "http";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(HttpServletRequest request) {
+    String protocol = request.getProtocol();
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return protocol.substring("HTTP/".length());
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
   public String getHostName(HttpServletRequest request) {
     return request.getServerName();
   }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcHttpAttributesGetter.java
@@ -32,19 +32,6 @@ enum SpringWebMvcHttpAttributesGetter
   }
 
   @Override
-  @Nullable
-  public String getFlavor(HttpServletRequest request) {
-    String flavor = request.getProtocol();
-    if (flavor == null) {
-      return null;
-    }
-    if (flavor.startsWith("HTTP/")) {
-      flavor = flavor.substring("HTTP/".length());
-    }
-    return flavor;
-  }
-
-  @Override
   public Integer getStatusCode(
       HttpServletRequest request, HttpServletResponse response, @Nullable Throwable error) {
 

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcNetAttributesGetter.java
@@ -20,6 +20,26 @@ enum SpringWebMvcNetAttributesGetter implements NetServerAttributesGetter<HttpSe
 
   @Nullable
   @Override
+  public String getProtocolName(HttpServletRequest request) {
+    String protocol = request.getProtocol();
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return "http";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(HttpServletRequest request) {
+    String protocol = request.getProtocol();
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return protocol.substring("HTTP/".length());
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
   public String getHostName(HttpServletRequest request) {
     return request.getServerName();
   }

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
@@ -47,19 +47,6 @@ public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public String getFlavor(Request request) {
-    String flavor = messageBytesToString(request.protocol());
-    if (flavor != null) {
-      // remove HTTP/ prefix to comply with semantic conventions
-      if (flavor.startsWith("HTTP/")) {
-        flavor = flavor.substring("HTTP/".length());
-      }
-    }
-    return flavor;
-  }
-
-  @Override
-  @Nullable
   public Integer getStatusCode(Request request, Response response, @Nullable Throwable error) {
     return response.getStatus();
   }

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesGetter.java
@@ -23,6 +23,26 @@ public class TomcatNetAttributesGetter implements NetServerAttributesGetter<Requ
 
   @Nullable
   @Override
+  public String getProtocolName(Request request) {
+    String protocol = messageBytesToString(request.protocol());
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return "http";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(Request request) {
+    String protocol = messageBytesToString(request.protocol());
+    if (protocol != null && protocol.startsWith("HTTP/")) {
+      return protocol.substring("HTTP/".length());
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
   public String getHostName(Request request) {
     return messageBytesToString(request.serverName());
   }

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
@@ -27,16 +27,6 @@ public class UndertowHttpAttributesGetter
   }
 
   @Override
-  public String getFlavor(HttpServerExchange exchange) {
-    String flavor = exchange.getProtocol().toString();
-    // remove HTTP/ prefix to comply with semantic conventions
-    if (flavor.startsWith("HTTP/")) {
-      flavor = flavor.substring("HTTP/".length());
-    }
-    return flavor;
-  }
-
-  @Override
   public Integer getStatusCode(
       HttpServerExchange exchange, HttpServerExchange unused, @Nullable Throwable error) {
     return exchange.getStatusCode();

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
@@ -21,6 +21,26 @@ public class UndertowNetAttributesGetter
 
   @Nullable
   @Override
+  public String getProtocolName(HttpServerExchange exchange) {
+    String protocol = exchange.getProtocol().toString();
+    if (protocol.startsWith("HTTP/")) {
+      return "http";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getProtocolVersion(HttpServerExchange exchange) {
+    String protocol = exchange.getProtocol().toString();
+    if (protocol.startsWith("HTTP/")) {
+      return protocol.substring("HTTP/".length());
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
   public String getHostName(HttpServerExchange exchange) {
     return exchange.getHostName();
   }

--- a/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
+++ b/instrumentation/undertow-1.4/javaagent/src/test/groovy/UndertowServerTest.groovy
@@ -143,12 +143,13 @@ class UndertowServerTest extends HttpServerTest<Undertow> implements AgentTestTr
             "$SemanticAttributes.HTTP_TARGET" uri.getPath()
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" TEST_USER_AGENT
             "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_TARGET" "/sendResponse"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" uri.host
             "$SemanticAttributes.NET_HOST_PORT" uri.port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
@@ -197,12 +198,13 @@ class UndertowServerTest extends HttpServerTest<Undertow> implements AgentTestTr
             "$SemanticAttributes.HTTP_TARGET" uri.getPath()
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" TEST_USER_AGENT
             "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
             "$SemanticAttributes.HTTP_SCHEME" "http"
             "$SemanticAttributes.HTTP_TARGET" "/sendResponseWithException"
             "$SemanticAttributes.NET_TRANSPORT" SemanticAttributes.NetTransportValues.IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_HOST_NAME" uri.host
             "$SemanticAttributes.NET_HOST_PORT" uri.port
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/latestDepTest/groovy/VertxReactivePropagationTest.groovy
@@ -64,6 +64,8 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
           hasNoParent()
           attributes {
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
             "$SemanticAttributes.NET_SOCK_PEER_PORT" Long
             "$SemanticAttributes.NET_SOCK_HOST_ADDR" "127.0.0.1"
@@ -73,7 +75,6 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" "/listProducts"
             "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
@@ -157,6 +158,8 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
             childOf(span(0))
             attributes {
               "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+              "net.protocol.name" "http"
+              "net.protocol.version" "1.1"
               "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
               "$SemanticAttributes.NET_SOCK_PEER_PORT" Long
               "$SemanticAttributes.NET_SOCK_HOST_ADDR" "127.0.0.1"
@@ -166,7 +169,6 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
               "$SemanticAttributes.HTTP_METHOD" "GET"
               "$SemanticAttributes.HTTP_STATUS_CODE" 200
               "$SemanticAttributes.HTTP_SCHEME" "http"
-              "$SemanticAttributes.HTTP_FLAVOR" "1.1"
               "$SemanticAttributes.HTTP_USER_AGENT" String
               "$SemanticAttributes.HTTP_ROUTE" "/listProducts"
               "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long

--- a/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/version35Test/groovy/VertxReactivePropagationTest.groovy
+++ b/instrumentation/vertx/vertx-rx-java-3.5/javaagent/src/version35Test/groovy/VertxReactivePropagationTest.groovy
@@ -64,6 +64,8 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
           hasNoParent()
           attributes {
             "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+            "net.protocol.name" "http"
+            "net.protocol.version" "1.1"
             "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
             "$SemanticAttributes.NET_SOCK_PEER_PORT" Long
             "$SemanticAttributes.NET_SOCK_HOST_ADDR" "127.0.0.1"
@@ -73,7 +75,6 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
             "$SemanticAttributes.HTTP_METHOD" "GET"
             "$SemanticAttributes.HTTP_STATUS_CODE" 200
             "$SemanticAttributes.HTTP_SCHEME" "http"
-            "$SemanticAttributes.HTTP_FLAVOR" "1.1"
             "$SemanticAttributes.HTTP_USER_AGENT" String
             "$SemanticAttributes.HTTP_ROUTE" "/listProducts"
             "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
@@ -157,6 +158,8 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
             childOf(span(0))
             attributes {
               "$SemanticAttributes.NET_TRANSPORT" IP_TCP
+              "net.protocol.name" "http"
+              "net.protocol.version" "1.1"
               "$SemanticAttributes.NET_SOCK_PEER_ADDR" "127.0.0.1"
               "$SemanticAttributes.NET_SOCK_PEER_PORT" Long
               "$SemanticAttributes.NET_SOCK_HOST_ADDR" "127.0.0.1"
@@ -166,7 +169,6 @@ class VertxReactivePropagationTest extends AgentInstrumentationSpecification {
               "$SemanticAttributes.HTTP_METHOD" "GET"
               "$SemanticAttributes.HTTP_STATUS_CODE" 200
               "$SemanticAttributes.HTTP_SCHEME" "http"
-              "$SemanticAttributes.HTTP_FLAVOR" "1.1"
               "$SemanticAttributes.HTTP_USER_AGENT" String
               "$SemanticAttributes.HTTP_ROUTE" "/listProducts"
               "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/AppServerTest.groovy
@@ -121,7 +121,8 @@ abstract class AppServerTest extends SmokeTest {
     traces.countFilteredAttributes("http.target", "/app/headers") == 1
 
     and: "Number of spans with http protocol version"
-    traces.countFilteredAttributes("http.flavor", "1.1") == 2
+    traces.countFilteredAttributes("net.protocol.name", "http") == 3
+    traces.countFilteredAttributes("net.protocol.version", "1.1") == 3
 
     and: "Number of spans tagged with current otel library version"
     traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 3
@@ -229,7 +230,8 @@ abstract class AppServerTest extends SmokeTest {
     traces.countFilteredAttributes("http.target", "/app/WEB-INF/web.xml") == 1
 
     and: "Number of spans with http protocol version"
-    traces.countFilteredAttributes("http.flavor", "1.1") == 1
+    traces.countFilteredAttributes("net.protocol.name", "http") == 1
+    traces.countFilteredAttributes("net.protocol.version", "1.1") == 1
 
     and: "Number of spans tagged with current otel library version"
     traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == traces.countSpans()
@@ -306,7 +308,8 @@ abstract class AppServerTest extends SmokeTest {
     traces.countFilteredAttributes("http.target", "/this-is-definitely-not-there-but-there-should-be-a-trace-nevertheless") == 1
 
     and: "Number of spans with http protocol version"
-    traces.countFilteredAttributes("http.flavor", "1.1") == 1
+    traces.countFilteredAttributes("net.protocol.name", "http") == 1
+    traces.countFilteredAttributes("net.protocol.version", "1.1") == 1
 
     and: "Number of spans tagged with current otel library version"
     traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == traces.countSpans()
@@ -353,7 +356,8 @@ abstract class AppServerTest extends SmokeTest {
     traces.countFilteredAttributes("http.target", "/app/headers") == 1
 
     and: "Number of spans with http protocol version"
-    traces.countFilteredAttributes("http.flavor", "1.1") == 2
+    traces.countFilteredAttributes("net.protocol.name", "http") == 3
+    traces.countFilteredAttributes("net.protocol.version", "1.1") == 3
 
     and: "Number of spans tagged with current otel library version"
     traces.countFilteredResourceAttributes("telemetry.auto.version", currentAgentVersion) == 3

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
@@ -164,12 +164,6 @@ final class TestInstrumenters {
 
     @Nullable
     @Override
-    public String getFlavor(String unused) {
-      return null;
-    }
-
-    @Nullable
-    @Override
     public String getTarget(String unused) {
       return null;
     }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -25,6 +25,7 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
 import io.opentelemetry.instrumentation.testing.GlobalTraceUtil;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
@@ -579,10 +580,14 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
           assertThat(attrs).containsEntry(SemanticAttributes.HTTP_METHOD, method);
           assertThat(attrs).containsEntry(SemanticAttributes.HTTP_STATUS_CODE, endpoint.status);
 
-          if (attrs.get(SemanticAttributes.HTTP_FLAVOR) != null) {
+          if (attrs.get(NetAttributes.NET_PROTOCOL_NAME) != null) {
+            assertThat(attrs).containsEntry(NetAttributes.NET_PROTOCOL_NAME, "http");
+          }
+          if (attrs.get(NetAttributes.NET_PROTOCOL_VERSION) != null) {
             assertThat(attrs)
                 .hasEntrySatisfying(
-                    SemanticAttributes.HTTP_FLAVOR, entry -> assertThat(entry).isIn("1.1", "2.0"));
+                    NetAttributes.NET_PROTOCOL_VERSION,
+                    entry -> assertThat(entry).isIn("1.1", "2.0"));
           }
           assertThat(attrs).containsEntry(SemanticAttributes.HTTP_USER_AGENT, TEST_USER_AGENT);
 


### PR DESCRIPTION
…ions

Continuation of #8131
Implements the other half of the https://github.com/open-telemetry/opentelemetry-specification/pull/3272 spec PR
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4519