### PR TITLE
Fix armeria latestDepTest

### DIFF
--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
@@ -24,7 +24,18 @@ enum ArmeriaHttpClientAttributesGetter
 
   @Override
   public String getUrl(RequestContext ctx) {
-    return request(ctx).uri().toString();
+    HttpRequest request = request(ctx);
+    StringBuilder uri = new StringBuilder();
+    String scheme = request.scheme();
+    if (scheme != null) {
+      uri.append(scheme).append("://");
+    }
+    String authority = request.authority();
+    if (authority != null) {
+      uri.append(authority);
+    }
+    uri.append(request.path());
+    return uri.toString();
   }
 
   @Override

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetClientAttributesGetter.java
@@ -41,12 +41,32 @@ public final class ArmeriaNetClientAttributesGetter
   @Nullable
   @Override
   public String getPeerName(RequestContext ctx) {
-    return request(ctx).uri().getHost();
+    HttpRequest request = request(ctx);
+    String authority = request.authority();
+    if (authority == null) {
+      return null;
+    }
+    int separatorPos = authority.indexOf(':');
+    return separatorPos == -1 ? authority : authority.substring(0, separatorPos);
   }
 
+  @Nullable
   @Override
   public Integer getPeerPort(RequestContext ctx) {
-    return request(ctx).uri().getPort();
+    HttpRequest request = request(ctx);
+    String authority = request.authority();
+    if (authority == null) {
+      return null;
+    }
+    int separatorPos = authority.indexOf(':');
+    if (separatorPos == -1) {
+      return null;
+    }
+    try {
+      return Integer.parseInt(authority.substring(separatorPos + 1));
+    } catch (NumberFormatException e) {
+      return null;
+    }
   }
 
   @Override

--- a/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpClientTest.java
+++ b/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpClientTest.java
@@ -57,9 +57,19 @@ public abstract class AbstractArmeriaHttpClientTest extends AbstractHttpClientTe
   @Override
   public HttpRequest buildRequest(String method, URI uri, Map<String, String> headers) {
     return HttpRequest.of(
-        RequestHeaders.builder(HttpMethod.valueOf(method), uri.toString())
+        RequestHeaders.builder()
+            .method(HttpMethod.valueOf(method))
+            .scheme(uri.getScheme())
+            .authority(uri.getAuthority())
+            .path(pathAndQuery(uri))
             .set(headers.entrySet())
             .build());
+  }
+
+  private static String pathAndQuery(URI uri) {
+    String path = uri.getPath();
+    String query = uri.getQuery();
+    return (path == null ? "" : path) + (query == null ? "" : "?" + query);
   }
 
   @Override


### PR DESCRIPTION
Armeria 1.23 released a couple hours ago, and it looks like they changed a couple of things around the `HttpRequest` & `RequestHeaders` implementations.

I removed the usage of `HttpRequest#uri()` from the getters cause it threw IllegalStateException when one of the URI components was null. Instead, we're building the URI by hand now (which is pretty much the same thing Armeria does internally, sans the nullchecks).

I also changed the way Armeria client is called in the tests -- while the previous version probably works, it generates totally wrong telemetry (I've no idea why it even works in the first place...). `RequestHeaders#path()` expects just the path, not the full URI, and is unable to reconstruct the URI because it thinks that scheme and authority haven't been provided.