### PR TITLE
Make spanKindExtractor configurable in Ktor instrumentations

### DIFF
--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorServerTracing.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorServerTracing.kt
@@ -24,6 +24,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttribut
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor
+import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil
 import kotlinx.coroutines.withContext
 
 class KtorServerTracing private constructor(
@@ -44,7 +45,7 @@ class KtorServerTracing private constructor(
       (SpanStatusExtractor<ApplicationRequest, ApplicationResponse>) -> SpanStatusExtractor<in ApplicationRequest, in ApplicationResponse> = { a -> a }
 
     internal var spanKindExtractor:
-      (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<in ApplicationRequest> = { a -> a }
+      (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<ApplicationRequest> = { a -> a }
 
     fun setOpenTelemetry(openTelemetry: OpenTelemetry) {
       this.openTelemetry = openTelemetry
@@ -57,7 +58,7 @@ class KtorServerTracing private constructor(
     }
 
     fun setSpanKindExtractor(
-      extractor: (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<in ApplicationRequest>
+      extractor: (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<ApplicationRequest>
     ) {
       this.spanKindExtractor = extractor
     }
@@ -122,7 +123,8 @@ class KtorServerTracing private constructor(
         addContextCustomizer(HttpRouteHolder.create(httpAttributesGetter))
       }
 
-      val instrumenter = instrumenterBuilder.buildIncomingInstrumenter(
+      val instrumenter = InstrumenterUtil.buildUpstreamInstrumenter(
+        instrumenterBuilder,
         ApplicationRequestGetter,
         configuration.spanKindExtractor(SpanKindExtractor.alwaysServer())
       )

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorServerTracing.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorServerTracing.kt
@@ -16,6 +16,7 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.extension.kotlin.asContextElement
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteHolder
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteSource
@@ -42,6 +43,9 @@ class KtorServerTracing private constructor(
     internal var statusExtractor:
       (SpanStatusExtractor<ApplicationRequest, ApplicationResponse>) -> SpanStatusExtractor<in ApplicationRequest, in ApplicationResponse> = { a -> a }
 
+    internal var spanKindExtractor:
+      (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<in ApplicationRequest> = { a -> a }
+
     fun setOpenTelemetry(openTelemetry: OpenTelemetry) {
       this.openTelemetry = openTelemetry
     }
@@ -50,6 +54,12 @@ class KtorServerTracing private constructor(
       extractor: (SpanStatusExtractor<ApplicationRequest, ApplicationResponse>) -> SpanStatusExtractor<in ApplicationRequest, in ApplicationResponse>
     ) {
       this.statusExtractor = extractor
+    }
+
+    fun setSpanKindExtractor(
+      extractor: (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<in ApplicationRequest>
+    ) {
+      this.spanKindExtractor = extractor
     }
 
     fun addAttributeExtractor(extractor: AttributesExtractor<in ApplicationRequest, in ApplicationResponse>) {
@@ -112,7 +122,10 @@ class KtorServerTracing private constructor(
         addContextCustomizer(HttpRouteHolder.create(httpAttributesGetter))
       }
 
-      val instrumenter = instrumenterBuilder.buildServerInstrumenter(ApplicationRequestGetter)
+      val instrumenter = instrumenterBuilder.buildIncomingInstrumenter(
+        ApplicationRequestGetter,
+        configuration.spanKindExtractor(SpanKindExtractor.alwaysServer())
+      )
 
       val feature = KtorServerTracing(instrumenter)
 

--- a/instrumentation/ktor/ktor-1.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorServerSpanKindExtractorTest.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorServerSpanKindExtractorTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.ktor.v1_0
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension
+import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest
+import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension
+import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
+import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest
+import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
+import io.opentelemetry.testing.internal.armeria.common.HttpMethod
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.concurrent.TimeUnit
+import java.util.function.Consumer
+import java.util.stream.Stream
+
+class KtorServerSpanKindExtractorTest : AbstractHttpServerUsingTest<ApplicationEngine>() {
+
+  private val consumerKindEndpoint = ServerEndpoint("consumerKindEndpoint", "from-pubsub/run", 200, "")
+  private val serverKindEndpoint = ServerEndpoint("serverKindEndpoint", "from-client/run", 200, "")
+
+  companion object {
+    @JvmStatic
+    @RegisterExtension
+    val testing: InstrumentationExtension = HttpServerInstrumentationExtension.forLibrary()
+  }
+
+  @BeforeAll
+  fun setupOptions() {
+    startServer()
+  }
+
+  @AfterAll
+  fun cleanup() {
+    cleanupServer()
+  }
+
+  override fun getContextPath() = ""
+
+  override fun setupServer(): ApplicationEngine {
+    return embeddedServer(Netty, port = port) {
+      install(KtorServerTracing) {
+        setOpenTelemetry(testing.openTelemetry)
+        setSpanKindExtractor {
+          SpanKindExtractor { req ->
+            if (req.uri.startsWith("/from-pubsub/")) {
+              SpanKind.CONSUMER
+            } else {
+              SpanKind.SERVER
+            }
+          }
+        }
+      }
+
+      routing {
+        post(consumerKindEndpoint.path) {
+          call.respondText(consumerKindEndpoint.body, status = HttpStatusCode.fromValue(consumerKindEndpoint.status))
+        }
+
+        post(serverKindEndpoint.path) {
+          call.respondText(serverKindEndpoint.body, status = HttpStatusCode.fromValue(serverKindEndpoint.status))
+        }
+      }
+    }.start()
+  }
+
+  override fun stopServer(server: ApplicationEngine) {
+    server.stop(0, 10, TimeUnit.SECONDS)
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideArguments")
+  fun testSpanKindExtractor(endpoint: ServerEndpoint, expectedKind: SpanKind) {
+    val request = AggregatedHttpRequest.of(HttpMethod.valueOf("POST"), resolveAddress(endpoint))
+    val response: AggregatedHttpResponse = client.execute(request).aggregate().join()
+    assertThat(response.status().code()).isEqualTo(endpoint.status)
+
+    testing.waitAndAssertTraces(
+      Consumer { trace ->
+        trace.hasSpansSatisfyingExactly(
+          Consumer { span ->
+            span.hasKind(expectedKind)
+          }
+        )
+      }
+    )
+  }
+
+  private fun provideArguments(): Stream<Arguments> {
+    return Stream.of(
+      arguments(consumerKindEndpoint, SpanKind.CONSUMER),
+      arguments(serverKindEndpoint, SpanKind.SERVER),
+    )
+  }
+}

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorServerTracing.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorServerTracing.kt
@@ -24,6 +24,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttribut
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerMetrics
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor
+import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil
 import io.opentelemetry.instrumentation.ktor.v2_0.InstrumentationProperties.INSTRUMENTATION_NAME
 import kotlinx.coroutines.withContext
 
@@ -45,7 +46,7 @@ class KtorServerTracing private constructor(
       (SpanStatusExtractor<ApplicationRequest, ApplicationResponse>) -> SpanStatusExtractor<in ApplicationRequest, in ApplicationResponse> = { a -> a }
 
     internal var spanKindExtractor:
-      (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<in ApplicationRequest> = { a -> a }
+      (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<ApplicationRequest> = { a -> a }
 
     fun setOpenTelemetry(openTelemetry: OpenTelemetry) {
       this.openTelemetry = openTelemetry
@@ -58,7 +59,7 @@ class KtorServerTracing private constructor(
     }
 
     fun setSpanKindExtractor(
-      extractor: (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<in ApplicationRequest>
+      extractor: (SpanKindExtractor<ApplicationRequest>) -> SpanKindExtractor<ApplicationRequest>
     ) {
       this.spanKindExtractor = extractor
     }
@@ -122,7 +123,8 @@ class KtorServerTracing private constructor(
         addContextCustomizer(HttpRouteHolder.create(httpAttributesGetter))
       }
 
-      val instrumenter = instrumenterBuilder.buildIncomingInstrumenter(
+      val instrumenter = InstrumenterUtil.buildUpstreamInstrumenter(
+        instrumenterBuilder,
         ApplicationRequestGetter,
         configuration.spanKindExtractor(SpanKindExtractor.alwaysServer())
       )

--- a/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorServerSpanKindExtractorTest.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorServerSpanKindExtractorTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.ktor.v2_0.server
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension
+import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest
+import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension
+import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
+import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest
+import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse
+import io.opentelemetry.testing.internal.armeria.common.HttpMethod
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.concurrent.TimeUnit
+import java.util.function.Consumer
+import java.util.stream.Stream
+
+class KtorServerSpanKindExtractorTest : AbstractHttpServerUsingTest<ApplicationEngine>() {
+
+  private val consumerKindEndpoint = ServerEndpoint("consumerKindEndpoint", "from-pubsub/run", 200, "")
+  private val serverKindEndpoint = ServerEndpoint("serverKindEndpoint", "from-client/run", 200, "")
+
+  companion object {
+    @JvmStatic
+    @RegisterExtension
+    val testing: InstrumentationExtension = HttpServerInstrumentationExtension.forLibrary()
+  }
+
+  @BeforeAll
+  fun setupOptions() {
+    startServer()
+  }
+
+  @AfterAll
+  fun cleanup() {
+    cleanupServer()
+  }
+
+  override fun getContextPath() = ""
+
+  override fun setupServer(): ApplicationEngine {
+    return embeddedServer(Netty, port = port) {
+      install(KtorServerTracing) {
+        setOpenTelemetry(testing.openTelemetry)
+        setSpanKindExtractor {
+          SpanKindExtractor { req ->
+            if (req.uri.startsWith("/from-pubsub/")) {
+              SpanKind.CONSUMER
+            } else {
+              SpanKind.SERVER
+            }
+          }
+        }
+      }
+
+      routing {
+        post(consumerKindEndpoint.path) {
+          call.respondText(consumerKindEndpoint.body, status = HttpStatusCode.fromValue(consumerKindEndpoint.status))
+        }
+
+        post(serverKindEndpoint.path) {
+          call.respondText(serverKindEndpoint.body, status = HttpStatusCode.fromValue(serverKindEndpoint.status))
+        }
+      }
+    }.start()
+  }
+
+  override fun stopServer(server: ApplicationEngine) {
+    server.stop(0, 10, TimeUnit.SECONDS)
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideArguments")
+  fun testSpanKindExtractor(endpoint: ServerEndpoint, expectedKind: SpanKind) {
+    val request = AggregatedHttpRequest.of(HttpMethod.valueOf("POST"), resolveAddress(endpoint))
+    val response: AggregatedHttpResponse = client.execute(request).aggregate().join()
+    assertThat(response.status().code()).isEqualTo(endpoint.status)
+
+    testing.waitAndAssertTraces(
+      Consumer { trace ->
+        trace.hasSpansSatisfyingExactly(
+          Consumer { span ->
+            span.hasKind(expectedKind)
+          }
+        )
+      }
+    )
+  }
+
+  private fun provideArguments(): Stream<Arguments> {
+    return Stream.of(
+      arguments(consumerKindEndpoint, SpanKind.CONSUMER),
+      arguments(serverKindEndpoint, SpanKind.SERVER),
+    )
+  }
+}


### PR DESCRIPTION
This PR solves https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/8139. Now spanKindExtractor is configurable in Ktor instrumentations.

This make it possible to customize the SpanKind depending on the request as following:

```kt

    install(KtorServerTracing) {
        setOpenTelemetry(openTelemetry)
        setSpanKindExtractor {
            SpanKindExtractor { req ->
                if (req.uri.startsWith("/from-pubsub/")) {
                    SpanKind.CONSUMER
                } else {
                    SpanKind.SERVER
                }
            }
        }
    }
```