### PR TITLE
Set timeout for r2dbc test

### DIFF
--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -147,7 +147,7 @@ public abstract class AbstractR2dbcStatementTest {
                               .flatMapMany(result -> result.map((row, metadata) -> ""))
                               .concatWith(Mono.from(connection.close()).cast(String.class)))
                   .doFinally(e -> getTesting().runWithSpan("child", () -> {}))
-                  .blockLast();
+                  .blockLast(Duration.ofMinutes(1));
             });
 
     getTesting()


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8268
Timeout happening inside test should give more info than test getting killed on 15min timeout.