### PR TITLE
Remove Scala conventions from project that does not compile Scala

### DIFF
--- a/instrumentation/scala-fork-join-2.8/javaagent/build.gradle.kts
+++ b/instrumentation/scala-fork-join-2.8/javaagent/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   id("otel.javaagent-instrumentation")
-  id("otel.scala-conventions")
 }
 
 muzzle {


### PR DESCRIPTION
This is in service of #2651. Using the scala plugin with old versions of the Scala library (before 2.10) causss the build to fail when the configuration cache is enabled.