### PR TITLE
Disable link check for failing logback appenders manual page

### DIFF
--- a/.github/scripts/markdown-link-check-config.json
+++ b/.github/scripts/markdown-link-check-config.json
@@ -10,6 +10,9 @@
     },
     {
       "pattern" : "^https://kotlinlang\\.org/docs/coroutines-overview\\.html$"
+    },
+    {
+      "pattern" : "https://logback.qos.ch/manual/appenders.html"
     }
   ]
 }


### PR DESCRIPTION
This started failing yesterday.