### PR TITLE
Deprecate InetSocketAddressNetServerAttributesGetter and move its met…

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetter.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.net;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
@@ -27,48 +25,24 @@ public abstract class InetSocketAddressNetClientAttributesGetter<REQUEST, RESPON
   @Nullable
   @Override
   public String getSockFamily(REQUEST request, @Nullable RESPONSE response) {
-    InetSocketAddress address = getPeerSocketAddress(request, response);
-    if (address == null) {
-      return null;
-    }
-    InetAddress remoteAddress = address.getAddress();
-    if (remoteAddress instanceof Inet6Address) {
-      return "inet6";
-    }
-    return null;
+    return InetSocketAddressUtil.getSockFamily(getPeerSocketAddress(request, response), null);
   }
 
   @Override
   @Nullable
   public final String getSockPeerAddr(REQUEST request, @Nullable RESPONSE response) {
-    InetSocketAddress address = getPeerSocketAddress(request, response);
-    if (address == null) {
-      return null;
-    }
-    InetAddress remoteAddress = address.getAddress();
-    if (remoteAddress != null) {
-      return remoteAddress.getHostAddress();
-    }
-    return null;
+    return InetSocketAddressUtil.getHostAddress(getPeerSocketAddress(request, response));
   }
 
   @Override
   @Nullable
   public String getSockPeerName(REQUEST request, @Nullable RESPONSE response) {
-    InetSocketAddress address = getPeerSocketAddress(request, response);
-    if (address == null) {
-      return null;
-    }
-    return address.getHostString();
+    return InetSocketAddressUtil.getHostName(getPeerSocketAddress(request, response));
   }
 
   @Nullable
   @Override
   public Integer getSockPeerPort(REQUEST request, @Nullable RESPONSE response) {
-    InetSocketAddress address = getPeerSocketAddress(request, response);
-    if (address == null) {
-      return null;
-    }
-    return address.getPort();
+    return InetSocketAddressUtil.getPort(getPeerSocketAddress(request, response));
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetter.java
@@ -5,86 +5,28 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.net;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
 /**
  * Extractor of <a
  * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes">Network
- * attributes</a> from a {@link InetSocketAddress}. Most network libraries will provide access to a
- * {@link InetSocketAddress} so this is a convenient alternative to {@link
- * NetServerAttributesExtractor}. There is no meaning to implement both in the same instrumentation.
+ * attributes</a> from a {@link InetSocketAddress}.
+ *
+ * @deprecated Use {@link NetServerAttributesGetter} and its {@link
+ *     NetServerAttributesGetter#getPeerSocketAddress(Object)} {@link
+ *     NetServerAttributesGetter#getHostSocketAddress(Object)} methods instead.
  */
+@Deprecated
 public abstract class InetSocketAddressNetServerAttributesGetter<REQUEST>
     implements NetServerAttributesGetter<REQUEST> {
 
   @Nullable
-  protected abstract InetSocketAddress getPeerSocketAddress(REQUEST request);
+  @Override
+  public abstract InetSocketAddress getPeerSocketAddress(REQUEST request);
 
   // optional
   @Nullable
-  protected abstract InetSocketAddress getHostSocketAddress(REQUEST request);
-
-  @Nullable
   @Override
-  public String getSockFamily(REQUEST request) {
-    InetSocketAddress address = getPeerSocketAddress(request);
-    if (address == null) {
-      address = getHostSocketAddress(request);
-    }
-    if (address == null) {
-      return null;
-    }
-    InetAddress inetAddress = address.getAddress();
-    if (inetAddress instanceof Inet6Address) {
-      return "inet6";
-    }
-    return null;
-  }
-
-  @Override
-  @Nullable
-  public final String getSockPeerAddr(REQUEST request) {
-    return getAddress(getPeerSocketAddress(request));
-  }
-
-  @Override
-  @Nullable
-  public final Integer getSockPeerPort(REQUEST request) {
-    return getPort(getPeerSocketAddress(request));
-  }
-
-  @Nullable
-  @Override
-  public String getSockHostAddr(REQUEST request) {
-    return getAddress(getHostSocketAddress(request));
-  }
-
-  @Nullable
-  @Override
-  public Integer getSockHostPort(REQUEST request) {
-    return getPort(getHostSocketAddress(request));
-  }
-
-  @Nullable
-  private static String getAddress(InetSocketAddress address) {
-    if (address == null) {
-      return null;
-    }
-    InetAddress remoteAddress = address.getAddress();
-    if (remoteAddress != null) {
-      return remoteAddress.getHostAddress();
-    }
-    return null;
-  }
-
-  @Nullable
-  private static Integer getPort(InetSocketAddress address) {
-    if (address == null) {
-      return null;
-    }
-    return address.getPort();
-  }
+  public abstract InetSocketAddress getHostSocketAddress(REQUEST request);
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressUtil.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.net;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import javax.annotation.Nullable;
+
+final class InetSocketAddressUtil {
+
+  @Nullable
+  static String getSockFamily(
+      @Nullable InetSocketAddress address, @Nullable InetSocketAddress otherAddress) {
+    if (address == null) {
+      address = otherAddress;
+    }
+    if (address == null) {
+      return null;
+    }
+    InetAddress remoteAddress = address.getAddress();
+    if (remoteAddress instanceof Inet6Address) {
+      return "inet6";
+    }
+    return null;
+  }
+
+  @Nullable
+  static String getHostName(@Nullable InetSocketAddress address) {
+    if (address == null) {
+      return null;
+    }
+    return address.getHostString();
+  }
+
+  @Nullable
+  static String getHostAddress(@Nullable InetSocketAddress address) {
+    if (address == null) {
+      return null;
+    }
+    InetAddress remoteAddress = address.getAddress();
+    if (remoteAddress == null) {
+      return null;
+    }
+    return remoteAddress.getHostAddress();
+  }
+
+  @Nullable
+  static Integer getPort(@Nullable InetSocketAddress address) {
+    if (address == null) {
+      return null;
+    }
+    return address.getPort();
+  }
+
+  private InetSocketAddressUtil() {}
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
@@ -15,8 +15,7 @@ import javax.annotation.Nullable;
 /**
  * Extractor of <a
  * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes">Network
- * attributes</a>. It is common to have access to {@link java.net.InetSocketAddress}, in which case
- * it is more convenient to use {@link InetSocketAddressNetServerAttributesGetter}.
+ * attributes</a>.
  */
 public final class NetServerAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.net;
 
+import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
 /**
@@ -48,28 +49,105 @@ public interface NetServerAttributesGetter<REQUEST> {
   @Nullable
   Integer getHostPort(REQUEST request);
 
+  /**
+   * Returns the protocol <a
+   * href="https://man7.org/linux/man-pages/man7/address_families.7.html">address family</a> which
+   * is used for communication.
+   *
+   * <p>Examples: `inet`, `inet6`.
+   *
+   * <p>By default, this method attempts to retrieve the address family using one of the {@link
+   * #getPeerSocketAddress(Object)} and {@link #getHostSocketAddress(Object)} methods. If neither of
+   * these methods is implemented, it will simply return {@code null}. If the instrumented library
+   * does not expose {@link InetSocketAddress} in its API, you might want to implement this method
+   * instead of {@link #getPeerSocketAddress(Object)} and {@link #getHostSocketAddress(Object)}.
+   */
   @Nullable
   default String getSockFamily(REQUEST request) {
+    return InetSocketAddressUtil.getSockFamily(
+        getPeerSocketAddress(request), getHostSocketAddress(request));
+  }
+
+  /**
+   * Returns an {@link InetSocketAddress} object representing the peer socket address.
+   *
+   * <p>Implementing this method is equivalent to implementing all three of {@link
+   * #getSockFamily(Object)}, {@link #getSockPeerAddr(Object)} and {@link #getSockPeerPort(Object)}.
+   */
+  @Nullable
+  default InetSocketAddress getPeerSocketAddress(REQUEST request) {
     return null;
   }
 
+  /**
+   * Returns the remote socket peer address: IPv4 or IPv6 for internet protocols, path for local
+   * communication, etc.
+   *
+   * <p>Examples: `127.0.0.1`, `/tmp/mysql.sock`.
+   *
+   * <p>By default, this method attempts to retrieve the peer address using the {@link
+   * #getPeerSocketAddress(Object)} method. If this method is not implemented, it will simply return
+   * {@code null}. If the instrumented library does not expose {@link InetSocketAddress} in its API,
+   * you might want to implement this method instead of {@link #getPeerSocketAddress(Object)}.
+   */
   @Nullable
   default String getSockPeerAddr(REQUEST request) {
-    return null;
+    return InetSocketAddressUtil.getHostAddress(getPeerSocketAddress(request));
   }
 
+  /**
+   * Returns the remote socket peer port.
+   *
+   * <p>Examples: `16456`.
+   *
+   * <p>By default, this method attempts to retrieve the peer port using the {@link
+   * #getPeerSocketAddress(Object)} method. If this method is not implemented, it will simply return
+   * {@code null}. If the instrumented library does not expose {@link InetSocketAddress} in its API,
+   * you might want to implement this method instead of {@link #getPeerSocketAddress(Object)}.
+   */
   @Nullable
   default Integer getSockPeerPort(REQUEST request) {
+    return InetSocketAddressUtil.getPort(getPeerSocketAddress(request));
+  }
+
+  /**
+   * Returns an {@link InetSocketAddress} object representing the host socket address.
+   *
+   * <p>Implementing this method is equivalent to implementing all three of {@link
+   * #getSockFamily(Object)}, {@link #getSockHostAddr(Object)} and {@link #getSockHostPort(Object)}.
+   */
+  @Nullable
+  default InetSocketAddress getHostSocketAddress(REQUEST request) {
     return null;
   }
 
+  /**
+   * Returns the local socket address. Useful in case of a multi-IP host.
+   *
+   * <p>Examples: `192.168.0.1`.
+   *
+   * <p>By default, this method attempts to retrieve the host address using the {@link
+   * #getHostSocketAddress(Object)} method. If this method is not implemented, it will simply return
+   * {@code null}. If the instrumented library does not expose {@link InetSocketAddress} in its API,
+   * you might want to implement this method instead of {@link #getHostSocketAddress(Object)}.
+   */
   @Nullable
   default String getSockHostAddr(REQUEST request) {
-    return null;
+    return InetSocketAddressUtil.getHostAddress(getHostSocketAddress(request));
   }
 
+  /**
+   * Returns the local socket port number.
+   *
+   * <p>Examples: `35555`.
+   *
+   * <p>By default, this method attempts to retrieve the host port using the {@link
+   * #getHostSocketAddress(Object)} method. If this method is not implemented, it will simply return
+   * {@code null}. If the instrumented library does not expose {@link InetSocketAddress} in its API,
+   * you might want to implement this method instead of {@link #getHostSocketAddress(Object)}.
+   */
   @Nullable
   default Integer getSockHostPort(REQUEST request) {
-    return null;
+    return InetSocketAddressUtil.getPort(getHostSocketAddress(request));
   }
 }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
@@ -21,33 +21,33 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class InetSocketAddressNetServerAttributesGetterTest {
 
-  final InetSocketAddressNetServerAttributesGetter<Addresses> getter =
-      new InetSocketAddressNetServerAttributesGetter<Addresses>() {
+  static class TestNetServerAttributesGetter implements NetServerAttributesGetter<Addresses> {
 
-        @Override
-        public String getHostName(Addresses request) {
-          // net.host.name and net.host.port are tested in NetClientAttributesExtractorTest
-          return null;
-        }
+    @Override
+    public String getHostName(Addresses request) {
+      // net.host.name and net.host.port are tested in NetClientAttributesExtractorTest
+      return null;
+    }
 
-        @Override
-        public Integer getHostPort(Addresses request) {
-          // net.host.name and net.host.port are tested in NetClientAttributesExtractorTest
-          return null;
-        }
+    @Override
+    public Integer getHostPort(Addresses request) {
+      // net.host.name and net.host.port are tested in NetClientAttributesExtractorTest
+      return null;
+    }
 
-        @Override
-        protected InetSocketAddress getPeerSocketAddress(Addresses request) {
-          return request.peer;
-        }
+    @Override
+    public InetSocketAddress getPeerSocketAddress(Addresses request) {
+      return request.peer;
+    }
 
-        @Override
-        protected InetSocketAddress getHostSocketAddress(Addresses request) {
-          return request.host;
-        }
-      };
+    @Override
+    public InetSocketAddress getHostSocketAddress(Addresses request) {
+      return request.host;
+    }
+  }
+
   private final AttributesExtractor<Addresses, Addresses> extractor =
-      NetServerAttributesExtractor.create(getter);
+      NetServerAttributesExtractor.create(new TestNetServerAttributesGetter());
 
   @Test
   void noInetSocketAddress() {

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetServerAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetServerAttributesGetter.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.instrumentation.apachedubbo.v2_7.internal;
 
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboRequest;
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
@@ -15,7 +15,7 @@ import javax.annotation.Nullable;
  * any time.
  */
 public final class DubboNetServerAttributesGetter
-    extends InetSocketAddressNetServerAttributesGetter<DubboRequest> {
+    implements NetServerAttributesGetter<DubboRequest> {
 
   @Nullable
   @Override
@@ -31,13 +31,13 @@ public final class DubboNetServerAttributesGetter
 
   @Override
   @Nullable
-  protected InetSocketAddress getPeerSocketAddress(DubboRequest request) {
+  public InetSocketAddress getPeerSocketAddress(DubboRequest request) {
     return request.remoteAddress();
   }
 
   @Nullable
   @Override
-  protected InetSocketAddress getHostSocketAddress(DubboRequest request) {
+  public InetSocketAddress getHostSocketAddress(DubboRequest request) {
     return request.localAddress();
   }
 }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
@@ -7,13 +7,12 @@ package io.opentelemetry.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-final class ArmeriaNetServerAttributesGetter
-    extends InetSocketAddressNetServerAttributesGetter<RequestContext> {
+final class ArmeriaNetServerAttributesGetter implements NetServerAttributesGetter<RequestContext> {
 
   @Override
   public String getProtocolName(RequestContext ctx) {
@@ -40,7 +39,7 @@ final class ArmeriaNetServerAttributesGetter
 
   @Override
   @Nullable
-  protected InetSocketAddress getPeerSocketAddress(RequestContext ctx) {
+  public InetSocketAddress getPeerSocketAddress(RequestContext ctx) {
     SocketAddress address = ctx.remoteAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;
@@ -50,7 +49,7 @@ final class ArmeriaNetServerAttributesGetter
 
   @Nullable
   @Override
-  protected InetSocketAddress getHostSocketAddress(RequestContext ctx) {
+  public InetSocketAddress getHostSocketAddress(RequestContext ctx) {
     SocketAddress address = ctx.localAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetServerAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetServerAttributesGetter.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6.internal;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcRequest;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -15,8 +15,7 @@ import javax.annotation.Nullable;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public final class GrpcNetServerAttributesGetter
-    extends InetSocketAddressNetServerAttributesGetter<GrpcRequest> {
+public final class GrpcNetServerAttributesGetter implements NetServerAttributesGetter<GrpcRequest> {
 
   @Nullable
   @Override
@@ -31,7 +30,7 @@ public final class GrpcNetServerAttributesGetter
 
   @Override
   @Nullable
-  protected InetSocketAddress getPeerSocketAddress(GrpcRequest request) {
+  public InetSocketAddress getPeerSocketAddress(GrpcRequest request) {
     SocketAddress address = request.getPeerSocketAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;
@@ -41,7 +40,7 @@ public final class GrpcNetServerAttributesGetter
 
   @Nullable
   @Override
-  protected InetSocketAddress getHostSocketAddress(GrpcRequest grpcRequest) {
+  public InetSocketAddress getHostSocketAddress(GrpcRequest grpcRequest) {
     // TODO: later version introduces TRANSPORT_ATTR_LOCAL_ADDR, might be a good idea to use it
     return null;
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
@@ -8,7 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.netty.v3_8.server;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_UDP;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.netty.v3_8.HttpRequestAndChannel;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -17,7 +17,7 @@ import org.jboss.netty.channel.socket.DatagramChannel;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 
 final class NettyNetServerAttributesGetter
-    extends InetSocketAddressNetServerAttributesGetter<HttpRequestAndChannel> {
+    implements NetServerAttributesGetter<HttpRequestAndChannel> {
 
   @Override
   public String getTransport(HttpRequestAndChannel requestAndChannel) {
@@ -49,7 +49,7 @@ final class NettyNetServerAttributesGetter
 
   @Override
   @Nullable
-  protected InetSocketAddress getPeerSocketAddress(HttpRequestAndChannel requestAndChannel) {
+  public InetSocketAddress getPeerSocketAddress(HttpRequestAndChannel requestAndChannel) {
     SocketAddress address = requestAndChannel.channel().getRemoteAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;
@@ -59,7 +59,7 @@ final class NettyNetServerAttributesGetter
 
   @Nullable
   @Override
-  protected InetSocketAddress getHostSocketAddress(HttpRequestAndChannel requestAndChannel) {
+  public InetSocketAddress getHostSocketAddress(HttpRequestAndChannel requestAndChannel) {
     SocketAddress address = requestAndChannel.channel().getLocalAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
@@ -10,14 +10,14 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTr
 
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.handler.codec.http.HttpVersion;
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
 final class NettyNetServerAttributesGetter
-    extends InetSocketAddressNetServerAttributesGetter<HttpRequestAndChannel> {
+    implements NetServerAttributesGetter<HttpRequestAndChannel> {
 
   @Override
   public String getTransport(HttpRequestAndChannel requestAndChannel) {
@@ -49,7 +49,7 @@ final class NettyNetServerAttributesGetter
 
   @Override
   @Nullable
-  protected InetSocketAddress getPeerSocketAddress(HttpRequestAndChannel requestAndChannel) {
+  public InetSocketAddress getPeerSocketAddress(HttpRequestAndChannel requestAndChannel) {
     SocketAddress address = requestAndChannel.remoteAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;
@@ -59,7 +59,7 @@ final class NettyNetServerAttributesGetter
 
   @Nullable
   @Override
-  protected InetSocketAddress getHostSocketAddress(HttpRequestAndChannel requestAndChannel) {
+  public InetSocketAddress getHostSocketAddress(HttpRequestAndChannel requestAndChannel) {
     SocketAddress address = requestAndChannel.channel().localAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerNetAttributesGetter.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.instrumentation.spring.webflux.v5_3;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 import org.springframework.web.server.ServerWebExchange;
 
 final class WebfluxServerNetAttributesGetter
-    extends InetSocketAddressNetServerAttributesGetter<ServerWebExchange> {
+    implements NetServerAttributesGetter<ServerWebExchange> {
 
   @Nullable
   @Override
@@ -28,13 +28,13 @@ final class WebfluxServerNetAttributesGetter
 
   @Nullable
   @Override
-  protected InetSocketAddress getPeerSocketAddress(ServerWebExchange request) {
+  public InetSocketAddress getPeerSocketAddress(ServerWebExchange request) {
     return request.getRequest().getRemoteAddress();
   }
 
   @Nullable
   @Override
-  protected InetSocketAddress getHostSocketAddress(ServerWebExchange request) {
+  public InetSocketAddress getHostSocketAddress(ServerWebExchange request) {
     return request.getRequest().getLocalAddress();
   }
 }

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
@@ -5,13 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.undertow;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.InetSocketAddressNetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.undertow.server.HttpServerExchange;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
-public class UndertowNetAttributesGetter
-    extends InetSocketAddressNetServerAttributesGetter<HttpServerExchange> {
+public class UndertowNetAttributesGetter implements NetServerAttributesGetter<HttpServerExchange> {
 
   @Nullable
   @Override
@@ -47,13 +46,13 @@ public class UndertowNetAttributesGetter
 
   @Override
   @Nullable
-  protected InetSocketAddress getPeerSocketAddress(HttpServerExchange exchange) {
+  public InetSocketAddress getPeerSocketAddress(HttpServerExchange exchange) {
     return exchange.getConnection().getPeerAddress(InetSocketAddress.class);
   }
 
   @Nullable
   @Override
-  protected InetSocketAddress getHostSocketAddress(HttpServerExchange exchange) {
+  public InetSocketAddress getHostSocketAddress(HttpServerExchange exchange) {
     return exchange.getConnection().getLocalAddress(InetSocketAddress.class);
   }
 }


### PR DESCRIPTION
…hods to the interface

I think at some point I mentioned that I had thought about making the HTTP semconv getter extend the net getters (and URL getters, user agent getters etc. once we migrate to ECS names) to mimic the way the HTTP semconv "extends" (includes attributes from) other semantic conventions. This PR is a prerequisite for that -- but it is useful on its own, I think, as it simplifies the story of implementing the net getters by removing the abstract `InetSocketAddress` class.

Client side will be included in the next PR.