### PR TITLE
Correct link to environment variable configuration spec

### DIFF
--- a/docs/agent-features.md
+++ b/docs/agent-features.md
@@ -11,7 +11,7 @@ provides.
 - Bundled propagators
   - [W3C TraceContext / Baggage](https://www.w3.org/TR/trace-context/)
   - All Java [trace propagator extensions](https://github.com/open-telemetry/opentelemetry-java/tree/main/extensions/trace-propagators)
-- Environment variable configuration as per [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md)
+- Environment variable configuration as per [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)
   - Additional support for system properties for same variables by transforming UPPER_UNDERSCORE -> lower.dot
   - Ability to disable individual instrumentation, or only enable certain ones.
 - Ability to load a custom exporter via an external JAR library


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8364
`sdk-environment-variables.md` was moved in https://github.com/open-telemetry/opentelemetry-specification/pull/3434