### PR TITLE
Fix flaky vertx sql test

### DIFF
--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientTest.java
@@ -99,8 +99,9 @@ class VertxSqlClientTest {
 
   @Test
   void testSimpleSelect() throws Exception {
-    CompletableFuture<Object> result = new CompletableFuture<>();
-    result.whenComplete((rows, throwable) -> testing.runWithSpan("callback", () -> {}));
+    CompletableFuture<Object> future = new CompletableFuture<>();
+    CompletableFuture<Object> result =
+        future.whenComplete((rows, throwable) -> testing.runWithSpan("callback", () -> {}));
     testing.runWithSpan(
         "parent",
         () ->
@@ -108,9 +109,9 @@ class VertxSqlClientTest {
                 .execute(
                     rowSetAsyncResult -> {
                       if (rowSetAsyncResult.succeeded()) {
-                        result.complete(rowSetAsyncResult.result());
+                        future.complete(rowSetAsyncResult.result());
                       } else {
-                        result.completeExceptionally(rowSetAsyncResult.cause());
+                        future.completeExceptionally(rowSetAsyncResult.cause());
                       }
                     }));
     result.get(30, TimeUnit.SECONDS);


### PR DESCRIPTION
Hopefully fixes https://ge.opentelemetry.io/s/i7n7zf4gym2kq/tests/:instrumentation:vertx:vertx-sql-client-4.0:javaagent:test/io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql.VertxSqlClientTest/testSimpleSelect()?expanded-stacktrace=WyIwIl0&top-execution=1
Test expects `CompletableFuture` callback to run on the thread that completes the future. Currently it is possible that it is run on the main thread that calls `get` when `get` is called at the instant when the value has been set but callback has not yet run.