### PR TITLE
[fix]: fix the missing quotation mark

### DIFF
--- a/instrumentation/pulsar/pulsar-2.8/README.md
+++ b/instrumentation/pulsar/pulsar-2.8/README.md
@@ -2,4 +2,4 @@
 
 | System property | Type | Default | Description |
 |---|---|---|---|
-| `otel.instrumentation.pulsar.experimental-span-attributes` | `Boolean | `false` | Enable the capture of experimental span attributes. |
+| `otel.instrumentation.pulsar.experimental-span-attributes` | `Boolean` | `false` | Enable the capture of experimental span attributes. |


### PR DESCRIPTION
Add the missing quotation mark in the Pulsar instrumentation readme.