### PR TITLE
Allow users to set `otel.javaagent.logging` in config.properties file

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -90,8 +90,7 @@ public class AgentInstaller {
     }
 
     logVersionInfo();
-    EarlyInitAgentConfig agentConfig = EarlyInitAgentConfig.create();
-    if (agentConfig.getBoolean(JAVAAGENT_ENABLED_CONFIG, true)) {
+    if (EarlyInitAgentConfig.INSTANCE.getBoolean(JAVAAGENT_ENABLED_CONFIG, true)) {
       setupUnsafe(inst);
       List<AgentListener> agentListeners = loadOrdered(AgentListener.class, extensionClassLoader);
       installBytebuddyAgent(inst, extensionClassLoader, agentListeners);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
@@ -6,10 +6,10 @@
 package io.opentelemetry.javaagent.tooling;
 
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.instrumentation.api.internal.cache.weaklockfree.WeakConcurrentMapCleaner;
 import io.opentelemetry.javaagent.bootstrap.AgentInitializer;
 import io.opentelemetry.javaagent.bootstrap.AgentStarter;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 import java.io.File;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
@@ -69,7 +69,8 @@ public class AgentStarterImpl implements AgentStarter {
   public void start() {
     extensionClassLoader = createExtensionClassLoader(getClass().getClassLoader());
 
-    String loggerImplementationName = ConfigPropertiesUtil.getString("otel.javaagent.logging");
+    String loggerImplementationName =
+        EarlyInitAgentConfig.INSTANCE.getString("otel.javaagent.logging");
     // default to the built-in stderr slf4j-simple logger
     if (loggerImplementationName == null) {
       loggerImplementationName = "simple";

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/EarlyInitAgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/EarlyInitAgentConfig.java
@@ -14,9 +14,8 @@ import java.util.Map;
  */
 public final class EarlyInitAgentConfig {
 
-  public static EarlyInitAgentConfig create() {
-    return new EarlyInitAgentConfig(ConfigurationFileLoader.getConfigFileContents());
-  }
+  public static final EarlyInitAgentConfig INSTANCE =
+      new EarlyInitAgentConfig(ConfigurationFileLoader.getConfigFileContents());
 
   private final Map<String, String> configFileContents;
 
@@ -29,5 +28,12 @@ public final class EarlyInitAgentConfig {
     boolean configFileValue =
         configFileValueStr == null ? defaultValue : Boolean.parseBoolean(configFileValueStr);
     return ConfigPropertiesUtil.getBoolean(propertyName, configFileValue);
+  }
+
+  public String getString(String propertyName) {
+    String configPropertiesUtilValue = ConfigPropertiesUtil.getString(propertyName);
+    return configPropertiesUtilValue != null
+        ? configPropertiesUtilValue
+        : configFileContents.get(propertyName);
   }
 }


### PR DESCRIPTION
Currently the `otel.javaagent.logging` property will only be read from env vars / system properties.  This change will mean the option can be set in the config.properties file

* Will attempt to read `otel.javaagent.logging` value from config.properties if not found in `ConfigPropertiesUtil`
* Change access to `EarlyInitAgentConfig` via a new `INSTANCE` constant