### PR TITLE
Move WithSpan class presence check to instrumentation module

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/AnnotationInstrumentationModule.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/AnnotationInstrumentationModule.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.instrumentationannotations;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
 import application.io.opentelemetry.instrumentation.annotations.AddingSpanAttributes;
@@ -13,6 +14,7 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 /**
  * Instrumentation for methods annotated with {@link WithSpan} and {@link AddingSpanAttributes}
@@ -30,6 +32,11 @@ public class AnnotationInstrumentationModule extends InstrumentationModule {
     // Run first to ensure other automatic instrumentation is added after and therefore is executed
     // earlier in the instrumented method and create the span to attach attributes to.
     return -1000;
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("application.io.opentelemetry.instrumentation.annotations.WithSpan");
   }
 
   @Override

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/WithSpanInstrumentation.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/WithSpanInstrumentation.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.instrumentationannotations;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.instrumentation.instrumentationannotations.AnnotationSingletons.instrumenter;
 import static io.opentelemetry.javaagent.instrumentation.instrumentationannotations.AnnotationSingletons.instrumenterWithAttributes;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
@@ -47,11 +46,6 @@ public class WithSpanInstrumentation implements TypeInstrumentation {
                     named(
                         "application.io.opentelemetry.instrumentation.annotations.SpanAttribute"))));
     excludedMethodsMatcher = AnnotationExcludedMethods.configureExcludedMethods();
-  }
-
-  @Override
-  public ElementMatcher<ClassLoader> classLoaderOptimization() {
-    return hasClassesNamed("application.io.opentelemetry.instrumentation.annotations.WithSpan");
   }
 
   @Override


### PR DESCRIPTION
Having the class presence check on module level will also apply to https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/AddingSpanAttributesInstrumentation.java