### PR TITLE
Fix snippet injection test

### DIFF
--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Advice.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Advice.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.v3_0;
 
+import static io.opentelemetry.javaagent.instrumentation.servlet.v3_0.Servlet3Singletons.getSnippetInjectionHelper;
 import static io.opentelemetry.javaagent.instrumentation.servlet.v3_0.Servlet3Singletons.helper;
 
 import io.opentelemetry.context.Context;
@@ -13,7 +14,6 @@ import io.opentelemetry.javaagent.bootstrap.CallDepth;
 import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
 import io.opentelemetry.javaagent.bootstrap.http.HttpServerResponseCustomizerHolder;
 import io.opentelemetry.javaagent.bootstrap.servlet.AppServerBridge;
-import io.opentelemetry.javaagent.bootstrap.servlet.ExperimentalSnippetHolder;
 import io.opentelemetry.javaagent.bootstrap.servlet.MappingResolver;
 import io.opentelemetry.javaagent.instrumentation.servlet.ServletRequestContext;
 import io.opentelemetry.javaagent.instrumentation.servlet.v3_0.snippet.SnippetInjectingResponseWrapper;
@@ -43,7 +43,7 @@ public class Servlet3Advice {
     }
     HttpServletRequest httpServletRequest = (HttpServletRequest) request;
 
-    String snippet = ExperimentalSnippetHolder.getSnippet();
+    String snippet = getSnippetInjectionHelper().getSnippet();
     if (!snippet.isEmpty()
         && !((HttpServletResponse) response)
             .containsHeader(SnippetInjectingResponseWrapper.FAKE_SNIPPET_HEADER)) {

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Singletons.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Singletons.java
@@ -42,7 +42,7 @@ public final class Servlet3Singletons {
       ResponseInstrumenterFactory.createInstrumenter(INSTRUMENTATION_NAME);
 
   private static final OutputStreamSnippetInjectionHelper SNIPPET_INJECTION_HELPER =
-      new OutputStreamSnippetInjectionHelper(ExperimentalSnippetHolder.getSnippet());
+      new OutputStreamSnippetInjectionHelper(() -> ExperimentalSnippetHolder.getSnippet());
 
   public static ServletHelper<HttpServletRequest, HttpServletResponse> helper() {
     return HELPER;

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/snippet/OutputStreamSnippetInjectionHelper.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/snippet/OutputStreamSnippetInjectionHelper.java
@@ -10,6 +10,7 @@ import static java.util.logging.Level.FINE;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 public class OutputStreamSnippetInjectionHelper {
@@ -17,10 +18,18 @@ public class OutputStreamSnippetInjectionHelper {
   private static final Logger logger =
       Logger.getLogger(OutputStreamSnippetInjectionHelper.class.getName());
 
-  private final String snippet;
+  private final Supplier<String> snippetSupplier;
 
   public OutputStreamSnippetInjectionHelper(String snippet) {
-    this.snippet = snippet;
+    this(() -> snippet);
+  }
+
+  public OutputStreamSnippetInjectionHelper(Supplier<String> snippetSupplier) {
+    this.snippetSupplier = snippetSupplier;
+  }
+
+  public String getSnippet() {
+    return snippetSupplier.get();
   }
 
   /**
@@ -53,7 +62,7 @@ public class OutputStreamSnippetInjectionHelper {
     }
     byte[] snippetBytes;
     try {
-      snippetBytes = snippet.getBytes(state.getCharacterEncoding());
+      snippetBytes = snippetSupplier.get().getBytes(state.getCharacterEncoding());
     } catch (UnsupportedEncodingException e) {
       logger.log(FINE, "UnsupportedEncodingException", e);
       return false;
@@ -79,7 +88,7 @@ public class OutputStreamSnippetInjectionHelper {
     }
     byte[] snippetBytes;
     try {
-      snippetBytes = snippet.getBytes(state.getCharacterEncoding());
+      snippetBytes = snippetSupplier.get().getBytes(state.getCharacterEncoding());
     } catch (UnsupportedEncodingException e) {
       logger.log(FINE, "UnsupportedEncodingException", e);
       return false;

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/snippet/SnippetInjectingResponseWrapper.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/snippet/SnippetInjectingResponseWrapper.java
@@ -129,7 +129,6 @@ public class SnippetInjectingResponseWrapper extends HttpServletResponseWrapper 
               MethodType.methodType(void.class),
               SnippetInjectingResponseWrapper.class);
     } catch (NoSuchMethodException | IllegalAccessException e) {
-      logger.log(FINE, "SnippetInjectingResponseWrapper setContentLengthLong", e);
       return null;
     }
   }


### PR DESCRIPTION
Tests mutate snippet which causes issues because `OutputStreamSnippetInjectionHelper` reads the snippet on startup and isn't aware of the modification. This, as far as I can tell, means that the snippet tests never pass when run with other tests, they only pass on rerun.