### PR TITLE
Remove latest dep test limit from elasticsearch-transport-6.0

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/build.gradle.kts
@@ -39,9 +39,6 @@ dependencies {
   testImplementation(project(":instrumentation:elasticsearch:elasticsearch-transport-common:testing"))
   testImplementation("org.apache.logging.log4j:log4j-core:2.11.0")
   testImplementation("org.apache.logging.log4j:log4j-api:2.11.0")
-
-  // version 7.17.8 (which is currently the latest release) has broken module metadata
-  latestDepTestLibrary("org.elasticsearch.client:transport:7.17.7")
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
With the limit latest deps tests fail probably because there is also a `testLibrary` dependency that doesn't have a limit and test ends up running with a mix or libraries from different versions.