### PR TITLE
Set up EarlyInitAgentConfig even earlier

### DIFF
--- a/javaagent-internal-logging-application/src/main/java/io/opentelemetry/javaagent/logging/application/ApplicationLoggingCustomizer.java
+++ b/javaagent-internal-logging-application/src/main/java/io/opentelemetry/javaagent/logging/application/ApplicationLoggingCustomizer.java
@@ -6,10 +6,10 @@
 package io.opentelemetry.javaagent.logging.application;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.javaagent.bootstrap.InternalLogger;
 import io.opentelemetry.javaagent.bootstrap.logging.ApplicationLoggerBridge;
 import io.opentelemetry.javaagent.tooling.LoggingCustomizer;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 
 @AutoService(LoggingCustomizer.class)
 public final class ApplicationLoggingCustomizer implements LoggingCustomizer {
@@ -20,10 +20,9 @@ public final class ApplicationLoggingCustomizer implements LoggingCustomizer {
   }
 
   @Override
-  public void init() {
+  public void init(EarlyInitAgentConfig earlyConfig) {
     int limit =
-        ConfigPropertiesUtil.getInt(
-            "otel.javaagent.logging.application.logs-buffer-max-records", 2048);
+        earlyConfig.getInt("otel.javaagent.logging.application.logs-buffer-max-records", 2048);
     InMemoryLogStore inMemoryLogStore = new InMemoryLogStore(limit);
     ApplicationLoggerFactory loggerFactory = new ApplicationLoggerFactory(inMemoryLogStore);
     // register a shutdown hook that'll dump the logs to stderr in case something goes wrong

--- a/javaagent-internal-logging-simple/src/main/java/io/opentelemetry/javaagent/logging/simple/Slf4jSimpleLoggingCustomizer.java
+++ b/javaagent-internal-logging-simple/src/main/java/io/opentelemetry/javaagent/logging/simple/Slf4jSimpleLoggingCustomizer.java
@@ -36,7 +36,7 @@ public final class Slf4jSimpleLoggingCustomizer implements LoggingCustomizer {
     setSystemPropertyDefault(
         SIMPLE_LOGGER_DATE_TIME_FORMAT_PROPERTY, SIMPLE_LOGGER_DATE_TIME_FORMAT_DEFAULT);
 
-    if (earlyConfig.getBoolean("otel.javaagent.debut", false)) {
+    if (earlyConfig.getBoolean("otel.javaagent.debug", false)) {
       setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, "DEBUG");
       setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "okhttp3.internal.http2", "INFO");
     }

--- a/javaagent-internal-logging-simple/src/main/java/io/opentelemetry/javaagent/logging/simple/Slf4jSimpleLoggingCustomizer.java
+++ b/javaagent-internal-logging-simple/src/main/java/io/opentelemetry/javaagent/logging/simple/Slf4jSimpleLoggingCustomizer.java
@@ -8,7 +8,7 @@ package io.opentelemetry.javaagent.logging.simple;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.bootstrap.InternalLogger;
 import io.opentelemetry.javaagent.tooling.LoggingCustomizer;
-import java.util.Locale;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 import org.slf4j.LoggerFactory;
 
 @AutoService(LoggingCustomizer.class)
@@ -31,12 +31,12 @@ public final class Slf4jSimpleLoggingCustomizer implements LoggingCustomizer {
   }
 
   @Override
-  public void init() {
+  public void init(EarlyInitAgentConfig earlyConfig) {
     setSystemPropertyDefault(SIMPLE_LOGGER_SHOW_DATE_TIME_PROPERTY, "true");
     setSystemPropertyDefault(
         SIMPLE_LOGGER_DATE_TIME_FORMAT_PROPERTY, SIMPLE_LOGGER_DATE_TIME_FORMAT_DEFAULT);
 
-    if (isDebugMode()) {
+    if (earlyConfig.getBoolean("otel.javaagent.debut", false)) {
       setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, "DEBUG");
       setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "okhttp3.internal.http2", "INFO");
     }
@@ -62,27 +62,5 @@ public final class Slf4jSimpleLoggingCustomizer implements LoggingCustomizer {
     if (System.getProperty(property) == null) {
       System.setProperty(property, value);
     }
-  }
-
-  /**
-   * Determine if we should log in debug level according to otel.javaagent.debug
-   *
-   * @return true if we should
-   */
-  private static boolean isDebugMode() {
-    String tracerDebugLevelSysprop = "otel.javaagent.debug";
-    String tracerDebugLevelProp = System.getProperty(tracerDebugLevelSysprop);
-
-    if (tracerDebugLevelProp != null) {
-      return Boolean.parseBoolean(tracerDebugLevelProp);
-    }
-
-    String tracerDebugLevelEnv =
-        System.getenv(tracerDebugLevelSysprop.replace('.', '_').toUpperCase(Locale.ROOT));
-
-    if (tracerDebugLevelEnv != null) {
-      return Boolean.parseBoolean(tracerDebugLevelEnv);
-    }
-    return false;
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -80,7 +80,8 @@ public class AgentInstaller {
 
   private static final Map<String, List<Runnable>> CLASS_LOAD_CALLBACKS = new HashMap<>();
 
-  public static void installBytebuddyAgent(Instrumentation inst, ClassLoader extensionClassLoader) {
+  public static void installBytebuddyAgent(
+      Instrumentation inst, ClassLoader extensionClassLoader, EarlyInitAgentConfig earlyConfig) {
     addByteBuddyRawSetting();
 
     Integer strictContextStressorMillis = Integer.getInteger(STRICT_CONTEXT_STRESSOR_MILLIS);
@@ -90,8 +91,7 @@ public class AgentInstaller {
     }
 
     logVersionInfo();
-    EarlyInitAgentConfig agentConfig = EarlyInitAgentConfig.create();
-    if (agentConfig.getBoolean(JAVAAGENT_ENABLED_CONFIG, true)) {
+    if (earlyConfig.getBoolean(JAVAAGENT_ENABLED_CONFIG, true)) {
       setupUnsafe(inst);
       List<AgentListener> agentListeners = loadOrdered(AgentListener.class, extensionClassLoader);
       installBytebuddyAgent(inst, extensionClassLoader, agentListeners);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/LoggingCustomizer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/LoggingCustomizer.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.tooling;
 
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 
 // only one LoggingCustomizer is allowed, and its presence will suppress the
@@ -21,7 +22,7 @@ public interface LoggingCustomizer {
   // note that if this throws an exception, it will end up calling onStartupFailure, because
   // otherwise that exception will bubble up to OpenTelemetryAgent where a distro cannot control the
   // logging of it.
-  void init();
+  void init(EarlyInitAgentConfig earlyConfig);
 
   /**
    * Register a callback which will be called on synchronous startup success.
@@ -34,7 +35,7 @@ public interface LoggingCustomizer {
 
   /**
    * Register a callback which will be called on synchronous startup failure (including if {@link
-   * #init()} fails).
+   * #init(EarlyInitAgentConfig)} fails).
    *
    * <p>Synchronous startup may or may not include running {@link
    * io.opentelemetry.javaagent.extension.AgentListener#afterAgent(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/NoopLoggingCustomizer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/NoopLoggingCustomizer.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.tooling;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
 
 @AutoService(LoggingCustomizer.class)
 public final class NoopLoggingCustomizer implements LoggingCustomizer {
@@ -16,7 +17,7 @@ public final class NoopLoggingCustomizer implements LoggingCustomizer {
   }
 
   @Override
-  public void init() {}
+  public void init(EarlyInitAgentConfig earlyConfig) {}
 
   @Override
   @SuppressWarnings("SystemOut")

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigurationPropertiesSupplier.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/ConfigurationPropertiesSupplier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.config;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+
+@AutoService(AutoConfigurationCustomizerProvider.class)
+public final class ConfigurationPropertiesSupplier implements AutoConfigurationCustomizerProvider {
+
+  @Override
+  public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration.addPropertiesSupplier(ConfigurationFile::getProperties);
+  }
+
+  @Override
+  public int order() {
+    // make sure it runs after all the user-provided customizers
+    return Integer.MAX_VALUE;
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/EarlyInitAgentConfig.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/EarlyInitAgentConfig.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.tooling.config;
 
 import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Agent config class that is only supposed to be used before the SDK (and {@link
@@ -15,7 +16,7 @@ import java.util.Map;
 public final class EarlyInitAgentConfig {
 
   public static EarlyInitAgentConfig create() {
-    return new EarlyInitAgentConfig(ConfigurationFileLoader.getConfigFileContents());
+    return new EarlyInitAgentConfig(ConfigurationFile.getProperties());
   }
 
   private final Map<String, String> configFileContents;
@@ -24,10 +25,34 @@ public final class EarlyInitAgentConfig {
     this.configFileContents = configFileContents;
   }
 
+  @Nullable
+  public String getString(String propertyName) {
+    String value = ConfigPropertiesUtil.getString(propertyName);
+    if (value != null) {
+      return value;
+    }
+    return configFileContents.get(propertyName);
+  }
+
   public boolean getBoolean(String propertyName, boolean defaultValue) {
     String configFileValueStr = configFileContents.get(propertyName);
     boolean configFileValue =
         configFileValueStr == null ? defaultValue : Boolean.parseBoolean(configFileValueStr);
     return ConfigPropertiesUtil.getBoolean(propertyName, configFileValue);
+  }
+
+  public int getInt(String propertyName, int defaultValue) {
+    try {
+      String configFileValueStr = configFileContents.get(propertyName);
+      int configFileValue =
+          configFileValueStr == null ? defaultValue : Integer.parseInt(configFileValueStr);
+      return ConfigPropertiesUtil.getInt(propertyName, configFileValue);
+    } catch (NumberFormatException ignored) {
+      return defaultValue;
+    }
+  }
+
+  public void logEarlyConfigErrorsIfAny() {
+    ConfigurationFile.logErrorIfAny();
   }
 }

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/test/HelperInjectionTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/test/HelperInjectionTest.groovy
@@ -9,6 +9,7 @@ package io.opentelemetry.javaagent.test
 import io.opentelemetry.javaagent.tooling.AgentInstaller
 import io.opentelemetry.javaagent.tooling.HelperInjector
 import io.opentelemetry.javaagent.tooling.Utils
+import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig
 import net.bytebuddy.agent.ByteBuddyAgent
 import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.dynamic.ClassFileLocator
@@ -61,7 +62,7 @@ class HelperInjectionTest extends Specification {
   def "helpers injected on bootstrap classloader"() {
     setup:
     ByteBuddyAgent.install()
-    AgentInstaller.installBytebuddyAgent(ByteBuddyAgent.getInstrumentation(), this.class.classLoader)
+    AgentInstaller.installBytebuddyAgent(ByteBuddyAgent.getInstrumentation(), this.class.classLoader, EarlyInitAgentConfig.create())
     String helperClassName = HelperInjectionTest.getPackage().getName() + '.HelperClass'
     HelperInjector injector = new HelperInjector("test", [helperClassName], [], this.class.classLoader, ByteBuddyAgent.getInstrumentation())
     URLClassLoader bootstrapChild = new URLClassLoader(new URL[0], (ClassLoader) null)

--- a/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/config/ConfigurationFileTest.groovy
+++ b/javaagent-tooling/src/test/groovy/io/opentelemetry/javaagent/tooling/config/ConfigurationFileTest.groovy
@@ -28,7 +28,7 @@ class ConfigurationFileTest extends Specification {
     environmentVariables.set("OTEL_JAVAAGENT_CONFIGURATION_FILE", path)
 
     when:
-    def properties = ConfigurationFileLoader.loadConfigFile()
+    def properties = ConfigurationFile.loadConfigFile()
 
     then:
     properties.get("property1") == "val-env"
@@ -40,7 +40,7 @@ class ConfigurationFileTest extends Specification {
     System.setProperty("otel.javaagent.configuration-file", path)
 
     when:
-    def properties = ConfigurationFileLoader.loadConfigFile()
+    def properties = ConfigurationFile.loadConfigFile()
 
     then:
     properties.get("property1") == "val-sys"
@@ -55,7 +55,7 @@ class ConfigurationFileTest extends Specification {
     System.setProperty("otel.javaagent.configuration-file", pathSys)
 
     when:
-    def properties = ConfigurationFileLoader.loadConfigFile()
+    def properties = ConfigurationFile.loadConfigFile()
 
     then:
     properties.get("property1") == "val-sys"
@@ -67,7 +67,7 @@ class ConfigurationFileTest extends Specification {
     environmentVariables.set("OTEL_JAVAAGENT_CONFIGURATION_FILE", "somePath")
 
     when:
-    def properties = ConfigurationFileLoader.loadConfigFile()
+    def properties = ConfigurationFile.loadConfigFile()
 
     then:
     properties.isEmpty()
@@ -75,7 +75,7 @@ class ConfigurationFileTest extends Specification {
 
   def "should return empty properties if property is not set"() {
     when:
-    def properties = ConfigurationFileLoader.loadConfigFile()
+    def properties = ConfigurationFile.loadConfigFile()
 
     then:
     properties.isEmpty()

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigurationPropertiesSupplierTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/ConfigurationPropertiesSupplierTest.java
@@ -26,8 +26,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junitpioneer.jupiter.ClearSystemProperty;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
-@ClearSystemProperty(key = ConfigurationFileLoader.CONFIGURATION_FILE_PROPERTY)
-class ConfigurationFileLoaderTest {
+@ClearSystemProperty(key = ConfigurationFile.CONFIGURATION_FILE_PROPERTY)
+class ConfigurationPropertiesSupplierTest {
 
   @BeforeAll
   @AfterAll
@@ -44,7 +44,7 @@ class ConfigurationFileLoaderTest {
     // given
     Path configFile = tempDir.resolve("test-config.properties");
     Files.write(configFile, singleton("custom.key = 42"));
-    System.setProperty(ConfigurationFileLoader.CONFIGURATION_FILE_PROPERTY, configFile.toString());
+    System.setProperty(ConfigurationFile.CONFIGURATION_FILE_PROPERTY, configFile.toString());
 
     // when
     AutoConfiguredOpenTelemetrySdk autoConfiguredSdk =

--- a/javaagent-tooling/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
+++ b/javaagent-tooling/src/test/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
@@ -1,2 +1,2 @@
-io.opentelemetry.javaagent.tooling.config.ConfigurationFileLoader
-io.opentelemetry.javaagent.tooling.config.ConfigurationFileLoaderTest$UserCustomPropertiesSupplier
+io.opentelemetry.javaagent.tooling.config.ConfigurationPropertiesSupplier
+io.opentelemetry.javaagent.tooling.config.ConfigurationPropertiesSupplierTest$UserCustomPropertiesSupplier


### PR DESCRIPTION
Resolves #8396
And is an alternative approach to #8381

I moved the `EarlyInitAgentConfig` creation even earlier, allowing `otel.javaagent.logging` and `otel.javaagent.extensions` to be specified in the config file; and also cleaned up some of the debug mode usages, where apparently not all of the `if (debug)` branches would trigger if you enabled debug mode via config file.