### PR TITLE
Enable http pipelining tests for restlet2

### DIFF
--- a/instrumentation/restlet/restlet-2.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v2_0/AbstractRestletServerTest.groovy
+++ b/instrumentation/restlet/restlet-2.0/testing/src/main/groovy/io/opentelemetry/instrumentation/restlet/v2_0/AbstractRestletServerTest.groovy
@@ -176,11 +176,6 @@ abstract class AbstractRestletServerTest extends HttpServerTest<Server> {
   }
 
   @Override
-  boolean testHttpPipelining() {
-    false
-  }
-
-  @Override
   String expectedHttpRoute(ServerEndpoint endpoint) {
     switch (endpoint) {
       case PATH_PARAM:


### PR DESCRIPTION
Pipelining test seems to pass on restlet 2, not sure why I disabled it in the first place. Maybe because it fails on restlet 1.