### PR TITLE
Fix flaky http pipelining test on akka http

### DIFF
--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaActorCellInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaActorCellInstrumentation.java
@@ -12,7 +12,6 @@ import akka.dispatch.Envelope;
 import akka.dispatch.sysmsg.SystemMessage;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
-import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
 import io.opentelemetry.javaagent.bootstrap.executors.PropagatedContext;
 import io.opentelemetry.javaagent.bootstrap.executors.TaskAdviceHelper;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
@@ -52,11 +51,6 @@ public class AkkaActorCellInstrumentation implements TypeInstrumentation {
     public static void exit(@Advice.Enter Scope scope) {
       if (scope != null) {
         scope.close();
-      }
-      // akka-http instrumentation can leak scopes
-      // reset the context to clear the leaked scopes
-      if (Java8BytecodeBridge.currentContext() != Java8BytecodeBridge.rootContext()) {
-        Java8BytecodeBridge.rootContext().makeCurrent();
       }
     }
   }

--- a/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaDispatcherInstrumentation.java
+++ b/instrumentation/akka/akka-actor-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkaactor/AkkaDispatcherInstrumentation.java
@@ -42,7 +42,7 @@ public class AkkaDispatcherInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static PropagatedContext enterDispatch(@Advice.Argument(1) Envelope envelope) {
       Context context = Java8BytecodeBridge.currentContext();
-      if (ExecutorAdviceHelper.shouldPropagateContext(context, envelope)) {
+      if (ExecutorAdviceHelper.shouldPropagateContext(context, envelope.message())) {
         VirtualField<Envelope, PropagatedContext> virtualField =
             VirtualField.find(Envelope.class, PropagatedContext.class);
         return ExecutorAdviceHelper.attachContextToTask(context, virtualField, envelope);

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerInstrumentationModule.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerInstrumentationModule.java
@@ -5,12 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
 
-import static java.util.Collections.singletonList;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class AkkaHttpServerInstrumentationModule extends InstrumentationModule {
@@ -19,7 +21,14 @@ public class AkkaHttpServerInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    // in GraphInterpreterInstrumentation we instrument a class that belongs to akka-streams, make
+    // sure this runs only when akka-http is present to avoid muzzle failures
+    return hasClassesNamed("akka.http.scaladsl.HttpExt");
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new HttpExtServerInstrumentation());
+    return asList(new HttpExtServerInstrumentation(), new GraphInterpreterInstrumentation());
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaServerIgnoredTypesConfigurer.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaServerIgnoredTypesConfigurer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesBuilder;
+import io.opentelemetry.javaagent.extension.ignore.IgnoredTypesConfigurer;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+
+@AutoService(IgnoredTypesConfigurer.class)
+public class AkkaServerIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
+
+  @Override
+  public void configure(IgnoredTypesBuilder builder, ConfigProperties config) {
+    // in AkkaHttpServerInstrumentationTestAsync http pipeline test sending this message trigger
+    // processing next request, we don't want to propagate context there
+    builder.ignoreTaskClass("akka.stream.impl.fusing.ActorGraphInterpreter$AsyncInput");
+  }
+}

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/GraphInterpreterInstrumentation.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/GraphInterpreterInstrumentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import akka.stream.impl.fusing.GraphInterpreter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class GraphInterpreterInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("akka.stream.impl.fusing.GraphInterpreter");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("processPush"), GraphInterpreterInstrumentation.class.getName() + "$PushAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class PushAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static Scope onEnter(@Advice.Argument(0) GraphInterpreter.Connection connection) {
+      // processPush is called when execution passes to application or server. Here we propagate the
+      // context to the application code.
+      Context context = AkkaFlowWrapper.getContext(connection.outHandler());
+      if (context != null) {
+        return context.makeCurrent();
+      }
+      return null;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void exit(@Advice.Enter Scope scope) {
+      if (scope != null) {
+        scope.close();
+      }
+    }
+  }
+}

--- a/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/build.gradle.kts
+++ b/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/build.gradle.kts
@@ -74,10 +74,6 @@ tasks {
       dependsOn(testing.suites)
     }
   }
-
-  withType<Test>().configureEach {
-    jvmArgs("-Dio.opentelemetry.javaagent.shaded.io.opentelemetry.context.enableStrictContext=false")
-  }
 }
 
 // play-test depends on websocket-client


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.javaagent.instrumentation.akkahttp.AkkaHttpServerInstrumentationTest&tests.sortField=FLAKY&tests.unstableOnly=true
Pipelining test is flaky because in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8174 we allowed leaking the scope in akka http server instrumentation and closed the leaked scope in the actor. Apparently with pipelining it is possible that the leaked scope from previous request is active when we start handling the next pipelined request. This pr removes leaking and instead activates scope when the akka graph magic calls user code.