### PR TITLE
Wait for postgres to start in r2dbc tests

### DIFF
--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import reactor.core.publisher.Mono;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -114,6 +115,10 @@ public abstract class AbstractR2dbcStatementTest {
               .withExposedPorts(props.port)
               .withLogConsumer(new Slf4jLogConsumer(logger))
               .withStartupTimeout(Duration.ofMinutes(2));
+      if (props == POSTGRESQL) {
+        container.waitingFor(
+            Wait.forLogMessage(".*database system is ready to accept connections.*", 2));
+      }
       container.start();
       port = container.getMappedPort(props.port);
     }


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.relativeStartTime=P28D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=io.opentelemetry.javaagent.instrumentation.r2dbc.v1_0.R2dbcStatementTest&tests.sortField=FLAKY&tests.unstableOnly=true
R2dbc are flaky when postgres is used as database. From examining the test output it feels like the postgres container starts the server, shuts it down and then starts it again. If this is the cause of the flakiness then hopefully waiting for the second `database system is ready to accept connections` line helps.