### PR TITLE
Pin localstack docker image version and fix vetx sql client latest dep test

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/AwsConnector.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/AwsConnector.groovy
@@ -41,7 +41,7 @@ class AwsConnector {
   static localstack() {
     AwsConnector awsConnector = new AwsConnector()
 
-    awsConnector.localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:latest"))
+    awsConnector.localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:2.0.2"))
       .withServices(LocalStackContainer.Service.SQS, LocalStackContainer.Service.SNS, LocalStackContainer.Service.S3)
       .withEnv("DEBUG", "1")
       .withEnv("SQS_PROVIDER", "elasticmq")


### PR DESCRIPTION
There is a new localstack image that causes tests to get an extra span. Instead of modifying the test I'll pin the version to the latest that worked for us because otherwise everybody who already has the image would need to pull it again to get what currently corresponds to the latest tag.