### PR TITLE
Implement new stable URL semantic conventions

### DIFF
--- a/instrumentation-api-semconv/build.gradle.kts
+++ b/instrumentation-api-semconv/build.gradle.kts
@@ -75,6 +75,10 @@ tasks {
     dependsOn("generateJflex")
   }
 
+  test {
+    jvmArgs("-Dotel.instrumentation.http.prefer-forwarded-url-scheme=true")
+  }
+
   check {
     dependsOn(testing.suites)
   }

--- a/instrumentation-api-semconv/build.gradle.kts
+++ b/instrumentation-api-semconv/build.gradle.kts
@@ -19,8 +19,43 @@ dependencies {
   annotationProcessor("com.google.auto.value:auto-value")
 
   testImplementation(project(":testing-common"))
-  testImplementation("io.opentelemetry:opentelemetry-sdk-metrics")
+  testImplementation("io.opentelemetry:opentelemetry-sdk")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+}
+
+testing {
+  suites {
+    val testStableHttpSemconv by registering(JvmTestSuite::class) {
+      dependencies {
+        implementation(project())
+        implementation(project(":testing-common"))
+        implementation("io.opentelemetry:opentelemetry-sdk")
+        implementation("io.opentelemetry:opentelemetry-sdk-testing")
+      }
+      targets {
+        all {
+          testTask.configure {
+            jvmArgs("-Dotel.semconv-stability.opt-in=http")
+          }
+        }
+      }
+    }
+    val testBothHttpSemconv by registering(JvmTestSuite::class) {
+      dependencies {
+        implementation(project())
+        implementation(project(":testing-common"))
+        implementation("io.opentelemetry:opentelemetry-sdk")
+        implementation("io.opentelemetry:opentelemetry-sdk-testing")
+      }
+      targets {
+        all {
+          testTask.configure {
+            jvmArgs("-Dotel.semconv-stability.opt-in=http/dup")
+          }
+        }
+      }
+    }
+  }
 }
 
 tasks {
@@ -38,5 +73,9 @@ tasks {
 
   sourcesJar {
     dependsOn("generateJflex")
+  }
+
+  check {
+    dependsOn(testing.suites)
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
@@ -78,6 +78,7 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
     internalUrlExtractor =
         new InternalUrlAttributesExtractor<>(
             httpAttributesGetter,
+            /* alternateSchemeProvider= */ request -> null,
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv());
     internalNetExtractor =

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesGetter.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
-import io.opentelemetry.instrumentation.api.instrumenter.url.UrlAttributesGetter;
 import javax.annotation.Nullable;
 
 /**
@@ -16,13 +15,13 @@ import javax.annotation.Nullable;
  * various HTTP client attributes in a type-generic way.
  */
 public interface HttpClientAttributesGetter<REQUEST, RESPONSE>
-    extends HttpCommonAttributesGetter<REQUEST, RESPONSE>, UrlAttributesGetter<REQUEST> {
+    extends HttpCommonAttributesGetter<REQUEST, RESPONSE> {
 
   /**
    * Returns the full request URL.
    *
    * @deprecated This method is deprecated and will be removed in a future release. Implement {@link
-   *     #getFullUrl(Object)} instead.
+   *     #getUrlFull(Object)} instead.
    */
   @Deprecated
   @Nullable
@@ -31,10 +30,14 @@ public interface HttpClientAttributesGetter<REQUEST, RESPONSE>
   }
 
   // TODO: make this required to implement
-  /** {@inheritDoc} */
+  /**
+   * Returns the absolute URL describing a network resource according to <a
+   * href="https://www.rfc-editor.org/rfc/rfc3986">RFC3986</a>.
+   *
+   * <p>Examples: {@code https://www.foo.bar/search?q=OpenTelemetry#SemConv}; {@code //localhost}
+   */
   @Nullable
-  @Override
-  default String getFullUrl(REQUEST request) {
+  default String getUrlFull(REQUEST request) {
     return getUrl(request);
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
+import io.opentelemetry.instrumentation.api.instrumenter.url.UrlAttributesGetter;
 import javax.annotation.Nullable;
 
 /**
@@ -15,8 +16,25 @@ import javax.annotation.Nullable;
  * various HTTP client attributes in a type-generic way.
  */
 public interface HttpClientAttributesGetter<REQUEST, RESPONSE>
-    extends HttpCommonAttributesGetter<REQUEST, RESPONSE> {
+    extends HttpCommonAttributesGetter<REQUEST, RESPONSE>, UrlAttributesGetter<REQUEST> {
 
+  /**
+   * Returns the full request URL.
+   *
+   * @deprecated This method is deprecated and will be removed in a future release. Implement {@link
+   *     #getFullUrl(Object)} instead.
+   */
+  @Deprecated
   @Nullable
-  String getUrl(REQUEST request);
+  default String getUrl(REQUEST request) {
+    return null;
+  }
+
+  // TODO: make this required to implement
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getFullUrl(REQUEST request) {
+    return getUrl(request);
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -102,9 +102,9 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
     internalNetExtractor.onStart(attributes, request);
 
     if (SemconvStability.emitOldHttpSemconv()) {
-      String forwardedProto = forwardedProto(request);
-      String value = forwardedProto != null ? forwardedProto : getter.getUrlScheme(request);
-      internalSet(attributes, SemanticAttributes.HTTP_SCHEME, value);
+      // in case the Forwarded header is provided override the scheme set by the
+      // internalUrlExtractor
+      internalSet(attributes, SemanticAttributes.HTTP_SCHEME, forwardedProto(request));
     }
     internalSet(attributes, SemanticAttributes.HTTP_ROUTE, getter.getRoute(request));
     internalSet(attributes, SemanticAttributes.HTTP_CLIENT_IP, clientIp(request));

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
+import io.opentelemetry.instrumentation.api.instrumenter.url.UrlAttributesGetter;
 import javax.annotation.Nullable;
 
 /**
@@ -15,16 +16,34 @@ import javax.annotation.Nullable;
  * various HTTP server attributes in a type-generic way.
  */
 public interface HttpServerAttributesGetter<REQUEST, RESPONSE>
-    extends HttpCommonAttributesGetter<REQUEST, RESPONSE> {
+    extends HttpCommonAttributesGetter<REQUEST, RESPONSE>, UrlAttributesGetter<REQUEST> {
 
+
+  /**
+   * Returns the URI scheme.
+   *
+   * @deprecated This method is deprecated and will be removed in a future release. Implement {@link
+   *     #getUrlScheme(Object)} instead.
+   */
+  @Deprecated
   @Nullable
-  String getScheme(REQUEST request);
+  default String getScheme(REQUEST request) {
+    return null;
+  }
+
+  // TODO: make this required to implement
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getUrlScheme(REQUEST request) {
+    return getScheme(request);
+  }
 
   /**
    * Returns the path and query pieces of the URL, joined by the {@code ?} character.
    *
    * @deprecated This method is deprecated and will be removed in the following release. Implement
-   *     {@link #getPath(Object)} and {@link #getQuery(Object)} instead.
+   *     {@link #getUrlPath(Object)} and {@link #getUrlQuery(Object)} instead.
    */
   @Deprecated
   @Nullable
@@ -32,8 +51,11 @@ public interface HttpServerAttributesGetter<REQUEST, RESPONSE>
     return null;
   }
 
+  // TODO: make this required to implement
+  /** {@inheritDoc} */
   @Nullable
-  default String getPath(REQUEST request) {
+  @Override
+  default String getUrlPath(REQUEST request) {
     String target = getTarget(request);
     if (target == null) {
       return null;
@@ -42,8 +64,11 @@ public interface HttpServerAttributesGetter<REQUEST, RESPONSE>
     return separatorPos == -1 ? target : target.substring(0, separatorPos);
   }
 
+  // TODO: make this required to implement
+  /** {@inheritDoc} */
   @Nullable
-  default String getQuery(REQUEST request) {
+  @Override
+  default String getUrlQuery(REQUEST request) {
     String target = getTarget(request);
     if (target == null) {
       return null;

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
@@ -18,7 +18,6 @@ import javax.annotation.Nullable;
 public interface HttpServerAttributesGetter<REQUEST, RESPONSE>
     extends HttpCommonAttributesGetter<REQUEST, RESPONSE>, UrlAttributesGetter<REQUEST> {
 
-
   /**
    * Returns the URI scheme.
    *

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesExtractor.java
@@ -34,7 +34,10 @@ public final class UrlAttributesExtractor<REQUEST, RESPONSE>
     // the UrlAttributesExtractor will always emit new semconv
     internalExtractor =
         new InternalUrlAttributesExtractor<>(
-            getter, /* emitStableUrlAttributes= */ true, /* emitOldHttpAttributes= */ false);
+            getter,
+            /* alternateSchemeProvider= */ request -> null,
+            /* emitStableUrlAttributes= */ true,
+            /* emitOldHttpAttributes= */ false);
   }
 
   @Override

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesExtractor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.url;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.url.internal.InternalUrlAttributesExtractor;
+import javax.annotation.Nullable;
+
+/**
+ * Extractor of <a
+ * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/url.md#attributes">URL
+ * attributes</a>.
+ */
+public final class UrlAttributesExtractor<REQUEST, RESPONSE>
+    implements AttributesExtractor<REQUEST, RESPONSE> {
+
+  /**
+   * Returns a new {@link UrlAttributesExtractor} that will use the passed {@link
+   * UrlAttributesGetter}.
+   */
+  public static <REQUEST, RESPONSE> UrlAttributesExtractor<REQUEST, RESPONSE> create(
+      UrlAttributesGetter<REQUEST> getter) {
+    return new UrlAttributesExtractor<>(getter);
+  }
+
+  private final InternalUrlAttributesExtractor<REQUEST> internalExtractor;
+
+  UrlAttributesExtractor(UrlAttributesGetter<REQUEST> getter) {
+    // the UrlAttributesExtractor will always emit new semconv
+    internalExtractor =
+        new InternalUrlAttributesExtractor<>(
+            getter, /* emitStableUrlAttributes= */ true, /* emitOldHttpAttributes= */ false);
+  }
+
+  @Override
+  public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
+    internalExtractor.onStart(attributes, request);
+  }
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {}
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesGetter.java
@@ -17,17 +17,6 @@ import javax.annotation.Nullable;
 public interface UrlAttributesGetter<REQUEST> {
 
   /**
-   * Returns the absolute URL describing a network resource according to <a
-   * href="https://www.rfc-editor.org/rfc/rfc3986">RFC3986</a>.
-   *
-   * <p>Examples: {@code https://www.foo.bar/search?q=OpenTelemetry#SemConv}; {@code //localhost}
-   */
-  @Nullable
-  default String getFullUrl(REQUEST request) {
-    return null;
-  }
-
-  /**
    * Returns the <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.1">URI scheme</a>
    * component identifying the used protocol.
    *

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesGetter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.url;
+
+import javax.annotation.Nullable;
+
+/**
+ * An interface for getting URL attributes.
+ *
+ * <p>Instrumentation authors will create implementations of this interface for their specific
+ * library/framework. It will be used by the {@link UrlAttributesExtractor} (or other convention
+ * specific extractors) to obtain the various URL attributes in a type-generic way.
+ */
+public interface UrlAttributesGetter<REQUEST> {
+
+  /**
+   * Returns the absolute URL describing a network resource according to <a
+   * href="https://www.rfc-editor.org/rfc/rfc3986">RFC3986</a>.
+   *
+   * <p>Examples: {@code https://www.foo.bar/search?q=OpenTelemetry#SemConv}; {@code //localhost}
+   */
+  @Nullable
+  default String getFullUrl(REQUEST request) {
+    return null;
+  }
+
+  /**
+   * Returns the <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.1">URI scheme</a>
+   * component identifying the used protocol.
+   *
+   * <p>Examples: {@code https}, {@code ftp}, {@code telnet}
+   */
+  @Nullable
+  default String getUrlScheme(REQUEST request) {
+    return null;
+  }
+
+  /**
+   * Returns the <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.3">URI path</a>
+   * component.
+   *
+   * <p>Examples: {@code /search}
+   */
+  @Nullable
+  default String getUrlPath(REQUEST request) {
+    return null;
+  }
+
+  /**
+   * Returns the <a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.4">URI query</a>
+   * component.
+   *
+   * <p>Examples: {@code q=OpenTelemetry}
+   */
+  @Nullable
+  default String getUrlQuery(REQUEST request) {
+    return null;
+  }
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/internal/InternalUrlAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/internal/InternalUrlAttributesExtractor.java
@@ -64,6 +64,6 @@ public final class InternalUrlAttributesExtractor<REQUEST> {
     if (path == null && query == null) {
       return null;
     }
-    return (path == null ? "" : path) + (query == null || query.isEmpty() ? "" : "?" + query);
+    return (path == null ? "" : path) + (query == null ? "" : "?" + query);
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/internal/InternalUrlAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/internal/InternalUrlAttributesExtractor.java
@@ -64,6 +64,6 @@ public final class InternalUrlAttributesExtractor<REQUEST> {
     if (path == null && query == null) {
       return null;
     }
-    return (path == null ? "" : path) + (query == null ? "" : "?" + query);
+    return (path == null ? "" : path) + (query == null || query.isEmpty() ? "" : "?" + query);
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/internal/InternalUrlAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/internal/InternalUrlAttributesExtractor.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.url.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.url.UrlAttributesGetter;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class InternalUrlAttributesExtractor<REQUEST> {
+
+  private final UrlAttributesGetter<REQUEST> getter;
+  private final boolean emitStableUrlAttributes;
+  private final boolean emitOldHttpAttributes;
+
+  public InternalUrlAttributesExtractor(
+      UrlAttributesGetter<REQUEST> getter,
+      boolean emitStableUrlAttributes,
+      boolean emitOldHttpAttributes) {
+    this.getter = getter;
+    this.emitStableUrlAttributes = emitStableUrlAttributes;
+    this.emitOldHttpAttributes = emitOldHttpAttributes;
+  }
+
+  public void onStart(AttributesBuilder attributes, REQUEST request) {
+    String fullUrl = stripSensitiveData(getter.getFullUrl(request));
+    String urlScheme = getter.getUrlScheme(request);
+    String urlPath = getter.getUrlPath(request);
+    String urlQuery = getter.getUrlQuery(request);
+
+    if (emitStableUrlAttributes) {
+      internalSet(attributes, UrlAttributes.URL_FULL, fullUrl);
+      internalSet(attributes, UrlAttributes.URL_SCHEME, urlScheme);
+      internalSet(attributes, UrlAttributes.URL_PATH, urlPath);
+      internalSet(attributes, UrlAttributes.URL_QUERY, urlQuery);
+    }
+    if (emitOldHttpAttributes) {
+      internalSet(attributes, SemanticAttributes.HTTP_URL, fullUrl);
+      internalSet(attributes, SemanticAttributes.HTTP_SCHEME, urlScheme);
+      internalSet(attributes, SemanticAttributes.HTTP_TARGET, getTarget(urlPath, urlQuery));
+    }
+  }
+
+  @Nullable
+  private static String stripSensitiveData(@Nullable String url) {
+    if (url == null || url.isEmpty()) {
+      return url;
+    }
+
+    int schemeEndIndex = url.indexOf(':');
+
+    if (schemeEndIndex == -1) {
+      // not a valid url
+      return url;
+    }
+
+    int len = url.length();
+    if (len <= schemeEndIndex + 2
+        || url.charAt(schemeEndIndex + 1) != '/'
+        || url.charAt(schemeEndIndex + 2) != '/') {
+      // has no authority component
+      return url;
+    }
+
+    // look for the end of the authority component:
+    //   '/', '?', '#' ==> start of path
+    int index;
+    int atIndex = -1;
+    for (index = schemeEndIndex + 3; index < len; index++) {
+      char c = url.charAt(index);
+
+      if (c == '@') {
+        atIndex = index;
+      }
+
+      if (c == '/' || c == '?' || c == '#') {
+        break;
+      }
+    }
+
+    if (atIndex == -1 || atIndex == len - 1) {
+      return url;
+    }
+    return url.substring(0, schemeEndIndex + 3) + "REDACTED:REDACTED" + url.substring(atIndex);
+  }
+
+  @Nullable
+  private static String getTarget(@Nullable String path, @Nullable String query) {
+    if (path == null && query == null) {
+      return null;
+    }
+    return (path == null ? "" : path) + (query == null || query.isEmpty() ? "" : "?" + query);
+  }
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/internal/UrlAttributes.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/url/internal/UrlAttributes.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.url.internal;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class UrlAttributes {
+
+  // FIXME: remove this class and replace its usages with SemanticAttributes once schema 1.21 is
+  // released
+
+  public static final AttributeKey<String> URL_FULL = stringKey("url.full");
+
+  public static final AttributeKey<String> URL_SCHEME = stringKey("url.scheme");
+
+  public static final AttributeKey<String> URL_PATH = stringKey("url.path");
+
+  public static final AttributeKey<String> URL_QUERY = stringKey("url.query");
+
+  private UrlAttributes() {}
+}

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -39,7 +39,7 @@ class HttpClientAttributesExtractorTest {
       implements HttpClientAttributesGetter<Map<String, String>, Map<String, String>> {
 
     @Override
-    public String getFullUrl(Map<String, String> request) {
+    public String getUrlFull(Map<String, String> request) {
       return request.get("url");
     }
 

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -39,13 +39,13 @@ class HttpClientAttributesExtractorTest {
       implements HttpClientAttributesGetter<Map<String, String>, Map<String, String>> {
 
     @Override
-    public String getMethod(Map<String, String> request) {
-      return request.get("method");
+    public String getFullUrl(Map<String, String> request) {
+      return request.get("url");
     }
 
     @Override
-    public String getUrl(Map<String, String> request) {
-      return request.get("url");
+    public String getMethod(Map<String, String> request) {
+      return request.get("method");
     }
 
     @Override
@@ -177,12 +177,19 @@ class HttpClientAttributesExtractorTest {
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
       return Stream.of(
-          arguments("https://user1:secret@github.com", "https://github.com"),
-          arguments("https://user1:secret@github.com/path/", "https://github.com/path/"),
-          arguments("https://user1:secret@github.com#test.html", "https://github.com#test.html"),
-          arguments("https://user1:secret@github.com?foo=b@r", "https://github.com?foo=b@r"),
+          arguments("https://user1:secret@github.com", "https://REDACTED:REDACTED@github.com"),
           arguments(
-              "https://user1:secret@github.com/p@th?foo=b@r", "https://github.com/p@th?foo=b@r"),
+              "https://user1:secret@github.com/path/",
+              "https://REDACTED:REDACTED@github.com/path/"),
+          arguments(
+              "https://user1:secret@github.com#test.html",
+              "https://REDACTED:REDACTED@github.com#test.html"),
+          arguments(
+              "https://user1:secret@github.com?foo=b@r",
+              "https://REDACTED:REDACTED@github.com?foo=b@r"),
+          arguments(
+              "https://user1:secret@github.com/p@th?foo=b@r",
+              "https://REDACTED:REDACTED@github.com/p@th?foo=b@r"),
           arguments("https://github.com/p@th?foo=b@r", "https://github.com/p@th?foo=b@r"),
           arguments("https://github.com#t@st.html", "https://github.com#t@st.html"),
           arguments("user1:secret@github.com", "user1:secret@github.com"),

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -316,7 +316,7 @@ class HttpServerAttributesExtractorTest {
       return Stream.of(
           arguments(null, null, null),
           arguments("path", null, "path"),
-          arguments("path", "", "path"),
+          arguments("path", "", "path?"),
           arguments(null, "query", "?query"),
           arguments("path", "query", "path?query"));
     }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -44,19 +44,19 @@ class HttpServerAttributesExtractorTest {
     }
 
     @Override
-    public String getScheme(Map<String, Object> request) {
+    public String getUrlScheme(Map<String, Object> request) {
       return (String) request.get("scheme");
     }
 
     @Nullable
     @Override
-    public String getPath(Map<String, Object> request) {
+    public String getUrlPath(Map<String, Object> request) {
       return (String) request.get("path");
     }
 
     @Nullable
     @Override
-    public String getQuery(Map<String, Object> request) {
+    public String getUrlQuery(Map<String, Object> request) {
       return (String) request.get("query");
     }
 
@@ -146,9 +146,9 @@ class HttpServerAttributesExtractorTest {
             singletonList("Custom-Response-Header"),
             routeFromContext);
 
-    AttributesBuilder attributes = Attributes.builder();
-    extractor.onStart(attributes, Context.root(), request);
-    assertThat(attributes.build())
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_HOST_NAME, "github.com"),
             entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
@@ -163,22 +163,12 @@ class HttpServerAttributesExtractorTest {
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")));
 
-    extractor.onEnd(attributes, Context.root(), request, response, null);
-    assertThat(attributes.build())
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, response, null);
+    assertThat(endAttributes.build())
         .containsOnly(
-            entry(SemanticAttributes.NET_HOST_NAME, "github.com"),
-            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
-            entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
-            entry(SemanticAttributes.HTTP_METHOD, "POST"),
-            entry(SemanticAttributes.HTTP_SCHEME, "https"),
-            entry(SemanticAttributes.HTTP_TARGET, "/repositories/1?details=true"),
-            entry(SemanticAttributes.USER_AGENT_ORIGINAL, "okhttp 3.x"),
             entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{repoId}"),
-            entry(SemanticAttributes.HTTP_CLIENT_IP, "1.1.1.1"),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
-            entry(
-                AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
-                asList("123", "456")),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
             entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
             entry(

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -316,7 +316,7 @@ class HttpServerAttributesExtractorTest {
       return Stream.of(
           arguments(null, null, null),
           arguments("path", null, "path"),
-          arguments("path", "", "path?"),
+          arguments("path", "", "path"),
           arguments(null, "query", "?query"),
           arguments("path", "query", "path?query"));
     }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesExtractorTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.url;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.url.internal.UrlAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+class UrlAttributesExtractorTest {
+
+  static class TestUrlAttributesGetter implements UrlAttributesGetter<Map<String, String>> {
+    @Nullable
+    @Override
+    public String getFullUrl(Map<String, String> request) {
+      return request.get("url");
+    }
+
+    @Nullable
+    @Override
+    public String getUrlScheme(Map<String, String> request) {
+      return request.get("scheme");
+    }
+
+    @Nullable
+    @Override
+    public String getUrlPath(Map<String, String> request) {
+      return request.get("path");
+    }
+
+    @Nullable
+    @Override
+    public String getUrlQuery(Map<String, String> request) {
+      return request.get("query");
+    }
+  }
+
+  @Test
+  void allAttributes() {
+    Map<String, String> request = new HashMap<>();
+    request.put("url", "https://opentelemetry.io/test?q=Java");
+    request.put("scheme", "https");
+    request.put("path", "/test");
+    request.put("query", "q=Java");
+
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        UrlAttributesExtractor.create(new TestUrlAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build())
+        .containsOnly(
+            entry(UrlAttributes.URL_FULL, "https://opentelemetry.io/test?q=Java"),
+            entry(UrlAttributes.URL_SCHEME, "https"),
+            entry(UrlAttributes.URL_PATH, "/test"),
+            entry(UrlAttributes.URL_QUERY, "q=Java"));
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, null, null);
+    assertThat(endAttributes.build()).isEmpty();
+  }
+
+  @Test
+  void noAttributes() {
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        UrlAttributesExtractor.create(new TestUrlAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), emptyMap());
+    assertThat(startAttributes.build()).isEmpty();
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), emptyMap(), null, null);
+    assertThat(endAttributes.build()).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(SanitizeUserInfoArguments.class)
+  void sanitizeUserInfo(String url, String expectedResult) {
+    Map<String, String> request = new HashMap<>();
+    request.put("url", url);
+
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        UrlAttributesExtractor.create(new TestUrlAttributesGetter());
+
+    AttributesBuilder attributes = Attributes.builder();
+    extractor.onStart(attributes, Context.root(), request);
+
+    assertThat(attributes.build()).containsOnly(entry(UrlAttributes.URL_FULL, expectedResult));
+  }
+
+  static final class SanitizeUserInfoArguments implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          arguments("https://user1:secret@github.com", "https://REDACTED:REDACTED@github.com"),
+          arguments(
+              "https://user1:secret@github.com/path/",
+              "https://REDACTED:REDACTED@github.com/path/"),
+          arguments(
+              "https://user1:secret@github.com#test.html",
+              "https://REDACTED:REDACTED@github.com#test.html"),
+          arguments(
+              "https://user1:secret@github.com?foo=b@r",
+              "https://REDACTED:REDACTED@github.com?foo=b@r"),
+          arguments(
+              "https://user1:secret@github.com/p@th?foo=b@r",
+              "https://REDACTED:REDACTED@github.com/p@th?foo=b@r"),
+          arguments("https://github.com/p@th?foo=b@r", "https://github.com/p@th?foo=b@r"),
+          arguments("https://github.com#t@st.html", "https://github.com#t@st.html"),
+          arguments("user1:secret@github.com", "user1:secret@github.com"),
+          arguments("https://github.com@", "https://github.com@"));
+    }
+  }
+}

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/url/UrlAttributesExtractorTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.api.instrumenter.url;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -17,23 +16,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.url.internal.UrlAttributes;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 
 class UrlAttributesExtractorTest {
 
   static class TestUrlAttributesGetter implements UrlAttributesGetter<Map<String, String>> {
-    @Nullable
-    @Override
-    public String getFullUrl(Map<String, String> request) {
-      return request.get("url");
-    }
 
     @Nullable
     @Override
@@ -57,7 +45,6 @@ class UrlAttributesExtractorTest {
   @Test
   void allAttributes() {
     Map<String, String> request = new HashMap<>();
-    request.put("url", "https://opentelemetry.io/test?q=Java");
     request.put("scheme", "https");
     request.put("path", "/test");
     request.put("query", "q=Java");
@@ -69,7 +56,6 @@ class UrlAttributesExtractorTest {
     extractor.onStart(startAttributes, Context.root(), request);
     assertThat(startAttributes.build())
         .containsOnly(
-            entry(UrlAttributes.URL_FULL, "https://opentelemetry.io/test?q=Java"),
             entry(UrlAttributes.URL_SCHEME, "https"),
             entry(UrlAttributes.URL_PATH, "/test"),
             entry(UrlAttributes.URL_QUERY, "q=Java"));
@@ -91,45 +77,5 @@ class UrlAttributesExtractorTest {
     AttributesBuilder endAttributes = Attributes.builder();
     extractor.onEnd(endAttributes, Context.root(), emptyMap(), null, null);
     assertThat(endAttributes.build()).isEmpty();
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(SanitizeUserInfoArguments.class)
-  void sanitizeUserInfo(String url, String expectedResult) {
-    Map<String, String> request = new HashMap<>();
-    request.put("url", url);
-
-    AttributesExtractor<Map<String, String>, Void> extractor =
-        UrlAttributesExtractor.create(new TestUrlAttributesGetter());
-
-    AttributesBuilder attributes = Attributes.builder();
-    extractor.onStart(attributes, Context.root(), request);
-
-    assertThat(attributes.build()).containsOnly(entry(UrlAttributes.URL_FULL, expectedResult));
-  }
-
-  static final class SanitizeUserInfoArguments implements ArgumentsProvider {
-
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-      return Stream.of(
-          arguments("https://user1:secret@github.com", "https://REDACTED:REDACTED@github.com"),
-          arguments(
-              "https://user1:secret@github.com/path/",
-              "https://REDACTED:REDACTED@github.com/path/"),
-          arguments(
-              "https://user1:secret@github.com#test.html",
-              "https://REDACTED:REDACTED@github.com#test.html"),
-          arguments(
-              "https://user1:secret@github.com?foo=b@r",
-              "https://REDACTED:REDACTED@github.com?foo=b@r"),
-          arguments(
-              "https://user1:secret@github.com/p@th?foo=b@r",
-              "https://REDACTED:REDACTED@github.com/p@th?foo=b@r"),
-          arguments("https://github.com/p@th?foo=b@r", "https://github.com/p@th?foo=b@r"),
-          arguments("https://github.com#t@st.html", "https://github.com#t@st.html"),
-          arguments("user1:secret@github.com", "user1:secret@github.com"),
-          arguments("https://github.com@", "https://github.com@"));
-    }
   }
 }

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
@@ -33,7 +33,7 @@ class HttpClientAttributesExtractorBothSemconvTest {
       implements HttpClientAttributesGetter<Map<String, String>, Map<String, String>> {
 
     @Override
-    public String getFullUrl(Map<String, String> request) {
+    public String getUrlFull(Map<String, String> request) {
       return request.get("url");
     }
 

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.http;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
+import io.opentelemetry.instrumentation.api.instrumenter.url.internal.UrlAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToIntFunction;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class HttpClientAttributesExtractorBothSemconvTest {
+
+  static class TestHttpClientAttributesGetter
+      implements HttpClientAttributesGetter<Map<String, String>, Map<String, String>> {
+
+    @Override
+    public String getFullUrl(Map<String, String> request) {
+      return request.get("url");
+    }
+
+    @Override
+    public String getMethod(Map<String, String> request) {
+      return request.get("method");
+    }
+
+    @Override
+    public List<String> getRequestHeader(Map<String, String> request, String name) {
+      String value = request.get("header." + name);
+      return value == null ? emptyList() : asList(value.split(","));
+    }
+
+    @Override
+    public Integer getStatusCode(
+        Map<String, String> request, Map<String, String> response, @Nullable Throwable error) {
+      return Integer.parseInt(response.get("statusCode"));
+    }
+
+    @Override
+    public List<String> getResponseHeader(
+        Map<String, String> request, Map<String, String> response, String name) {
+      String value = response.get("header." + name);
+      return value == null ? emptyList() : asList(value.split(","));
+    }
+  }
+
+  static class TestNetClientAttributesGetter
+      implements NetClientAttributesGetter<Map<String, String>, Map<String, String>> {
+
+    @Nullable
+    @Override
+    public String getProtocolName(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("protocolName");
+    }
+
+    @Nullable
+    @Override
+    public String getProtocolVersion(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("protocolVersion");
+    }
+
+    @Nullable
+    @Override
+    public String getPeerName(Map<String, String> request) {
+      return request.get("peerName");
+    }
+
+    @Nullable
+    @Override
+    public Integer getPeerPort(Map<String, String> request) {
+      String statusCode = request.get("peerPort");
+      return statusCode == null ? null : Integer.parseInt(statusCode);
+    }
+  }
+
+  @Test
+  void normal() {
+    Map<String, String> request = new HashMap<>();
+    request.put("method", "POST");
+    request.put("url", "http://github.com");
+    request.put("header.content-length", "10");
+    request.put("header.user-agent", "okhttp 3.x");
+    request.put("header.custom-request-header", "123,456");
+    request.put("protocolName", "http");
+    request.put("protocolVersion", "1.1");
+    request.put("peerName", "github.com");
+    request.put("peerPort", "123");
+
+    Map<String, String> response = new HashMap<>();
+    response.put("statusCode", "202");
+    response.put("header.content-length", "20");
+    response.put("header.custom-response-header", "654,321");
+
+    ToIntFunction<Context> resendCountFromContext = context -> 2;
+
+    AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+        new HttpClientAttributesExtractor<>(
+            new TestHttpClientAttributesGetter(),
+            new TestNetClientAttributesGetter(),
+            singletonList("Custom-Request-Header"),
+            singletonList("Custom-Response-Header"),
+            resendCountFromContext);
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.HTTP_METHOD, "POST"),
+            entry(SemanticAttributes.HTTP_URL, "http://github.com"),
+            entry(UrlAttributes.URL_FULL, "http://github.com"),
+            entry(SemanticAttributes.USER_AGENT_ORIGINAL, "okhttp 3.x"),
+            entry(
+                AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
+                asList("123", "456")),
+            entry(SemanticAttributes.NET_PEER_NAME, "github.com"),
+            entry(SemanticAttributes.NET_PEER_PORT, 123L));
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, response, null);
+    assertThat(endAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
+            entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
+            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
+            entry(SemanticAttributes.HTTP_RESEND_COUNT, 2L),
+            entry(
+                AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
+                asList("654", "321")),
+            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"));
+  }
+}

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
@@ -147,7 +147,7 @@ class HttpServerAttributesExtractorBothSemconvTest {
             entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
             entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
-            entry(SemanticAttributes.HTTP_SCHEME, "https"),
+            entry(SemanticAttributes.HTTP_SCHEME, "http"),
             entry(SemanticAttributes.HTTP_TARGET, "/repositories/1?details=true"),
             entry(UrlAttributes.URL_SCHEME, "http"),
             entry(UrlAttributes.URL_PATH, "/repositories/1"),

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.http;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
+import io.opentelemetry.instrumentation.api.instrumenter.url.internal.UrlAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class HttpServerAttributesExtractorBothSemconvTest {
+
+  static class TestHttpServerAttributesGetter
+      implements HttpServerAttributesGetter<Map<String, Object>, Map<String, Object>> {
+
+    @Override
+    public String getMethod(Map<String, Object> request) {
+      return (String) request.get("method");
+    }
+
+    @Override
+    public String getUrlScheme(Map<String, Object> request) {
+      return (String) request.get("scheme");
+    }
+
+    @Nullable
+    @Override
+    public String getUrlPath(Map<String, Object> request) {
+      return (String) request.get("path");
+    }
+
+    @Nullable
+    @Override
+    public String getUrlQuery(Map<String, Object> request) {
+      return (String) request.get("query");
+    }
+
+    @Override
+    public String getRoute(Map<String, Object> request) {
+      return (String) request.get("route");
+    }
+
+    @Override
+    public List<String> getRequestHeader(Map<String, Object> request, String name) {
+      String values = (String) request.get("header." + name);
+      return values == null ? emptyList() : asList(values.split(","));
+    }
+
+    @Override
+    public Integer getStatusCode(
+        Map<String, Object> request, Map<String, Object> response, @Nullable Throwable error) {
+      String value = (String) response.get("statusCode");
+      return value == null ? null : Integer.parseInt(value);
+    }
+
+    @Override
+    public List<String> getResponseHeader(
+        Map<String, Object> request, Map<String, Object> response, String name) {
+      String values = (String) response.get("header." + name);
+      return values == null ? emptyList() : asList(values.split(","));
+    }
+  }
+
+  static class TestNetServerAttributesGetter
+      implements NetServerAttributesGetter<Map<String, Object>> {
+
+    @Nullable
+    @Override
+    public String getProtocolName(Map<String, Object> request) {
+      return (String) request.get("protocolName");
+    }
+
+    @Nullable
+    @Override
+    public String getProtocolVersion(Map<String, Object> request) {
+      return (String) request.get("protocolVersion");
+    }
+
+    @Nullable
+    @Override
+    public String getHostName(Map<String, Object> request) {
+      return (String) request.get("hostName");
+    }
+
+    @Nullable
+    @Override
+    public Integer getHostPort(Map<String, Object> request) {
+      return (Integer) request.get("hostPort");
+    }
+  }
+
+  @Test
+  void normal() {
+    Map<String, Object> request = new HashMap<>();
+    request.put("method", "POST");
+    request.put("url", "http://github.com");
+    request.put("path", "/repositories/1");
+    request.put("query", "details=true");
+    request.put("scheme", "http");
+    request.put("header.content-length", "10");
+    request.put("route", "/repositories/{id}");
+    request.put("header.user-agent", "okhttp 3.x");
+    request.put("header.host", "github.com");
+    request.put("header.forwarded", "for=1.1.1.1;proto=https");
+    request.put("header.custom-request-header", "123,456");
+    request.put("protocolName", "http");
+    request.put("protocolVersion", "2.0");
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("statusCode", "202");
+    response.put("header.content-length", "20");
+    response.put("header.custom-response-header", "654,321");
+
+    Function<Context, String> routeFromContext = ctx -> "/repositories/{repoId}";
+
+    HttpServerAttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
+        new HttpServerAttributesExtractor<>(
+            new TestHttpServerAttributesGetter(),
+            new TestNetServerAttributesGetter(),
+            singletonList("Custom-Request-Header"),
+            singletonList("Custom-Response-Header"),
+            routeFromContext);
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.NET_HOST_NAME, "github.com"),
+            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
+            entry(SemanticAttributes.HTTP_METHOD, "POST"),
+            entry(SemanticAttributes.HTTP_SCHEME, "https"),
+            entry(SemanticAttributes.HTTP_TARGET, "/repositories/1?details=true"),
+            entry(UrlAttributes.URL_SCHEME, "http"),
+            entry(UrlAttributes.URL_PATH, "/repositories/1"),
+            entry(UrlAttributes.URL_QUERY, "details=true"),
+            entry(SemanticAttributes.USER_AGENT_ORIGINAL, "okhttp 3.x"),
+            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
+            entry(SemanticAttributes.HTTP_CLIENT_IP, "1.1.1.1"),
+            entry(
+                AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
+                asList("123", "456")));
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, response, null);
+    assertThat(endAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{repoId}"),
+            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
+            entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
+            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
+            entry(
+                AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
+                asList("654", "321")));
+  }
+}

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.http;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
+import io.opentelemetry.instrumentation.api.instrumenter.url.internal.UrlAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToIntFunction;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class HttpClientAttributesExtractorStableSemconvTest {
+
+  static class TestHttpClientAttributesGetter
+      implements HttpClientAttributesGetter<Map<String, String>, Map<String, String>> {
+
+    @Override
+    public String getFullUrl(Map<String, String> request) {
+      return request.get("url");
+    }
+
+    @Override
+    public String getMethod(Map<String, String> request) {
+      return request.get("method");
+    }
+
+    @Override
+    public List<String> getRequestHeader(Map<String, String> request, String name) {
+      String value = request.get("header." + name);
+      return value == null ? emptyList() : asList(value.split(","));
+    }
+
+    @Override
+    public Integer getStatusCode(
+        Map<String, String> request, Map<String, String> response, @Nullable Throwable error) {
+      return Integer.parseInt(response.get("statusCode"));
+    }
+
+    @Override
+    public List<String> getResponseHeader(
+        Map<String, String> request, Map<String, String> response, String name) {
+      String value = response.get("header." + name);
+      return value == null ? emptyList() : asList(value.split(","));
+    }
+  }
+
+  static class TestNetClientAttributesGetter
+      implements NetClientAttributesGetter<Map<String, String>, Map<String, String>> {
+
+    @Nullable
+    @Override
+    public String getProtocolName(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("protocolName");
+    }
+
+    @Nullable
+    @Override
+    public String getProtocolVersion(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("protocolVersion");
+    }
+
+    @Nullable
+    @Override
+    public String getPeerName(Map<String, String> request) {
+      return request.get("peerName");
+    }
+
+    @Nullable
+    @Override
+    public Integer getPeerPort(Map<String, String> request) {
+      String statusCode = request.get("peerPort");
+      return statusCode == null ? null : Integer.parseInt(statusCode);
+    }
+  }
+
+  @Test
+  void normal() {
+    Map<String, String> request = new HashMap<>();
+    request.put("method", "POST");
+    request.put("url", "http://github.com");
+    request.put("header.content-length", "10");
+    request.put("header.user-agent", "okhttp 3.x");
+    request.put("header.custom-request-header", "123,456");
+    request.put("protocolName", "http");
+    request.put("protocolVersion", "1.1");
+    request.put("peerName", "github.com");
+    request.put("peerPort", "123");
+
+    Map<String, String> response = new HashMap<>();
+    response.put("statusCode", "202");
+    response.put("header.content-length", "20");
+    response.put("header.custom-response-header", "654,321");
+
+    ToIntFunction<Context> resendCountFromContext = context -> 2;
+
+    AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+        new HttpClientAttributesExtractor<>(
+            new TestHttpClientAttributesGetter(),
+            new TestNetClientAttributesGetter(),
+            singletonList("Custom-Request-Header"),
+            singletonList("Custom-Response-Header"),
+            resendCountFromContext);
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.HTTP_METHOD, "POST"),
+            entry(UrlAttributes.URL_FULL, "http://github.com"),
+            entry(SemanticAttributes.USER_AGENT_ORIGINAL, "okhttp 3.x"),
+            entry(
+                AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
+                asList("123", "456")),
+            entry(SemanticAttributes.NET_PEER_NAME, "github.com"),
+            entry(SemanticAttributes.NET_PEER_PORT, 123L));
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, response, null);
+    assertThat(endAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
+            entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
+            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
+            entry(SemanticAttributes.HTTP_RESEND_COUNT, 2L),
+            entry(
+                AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
+                asList("654", "321")),
+            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"));
+  }
+}

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
@@ -33,7 +33,7 @@ class HttpClientAttributesExtractorStableSemconvTest {
       implements HttpClientAttributesGetter<Map<String, String>, Map<String, String>> {
 
     @Override
-    public String getFullUrl(Map<String, String> request) {
+    public String getUrlFull(Map<String, String> request) {
       return request.get("url");
     }
 

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorStableSemconvTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.http;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
+import io.opentelemetry.instrumentation.api.instrumenter.url.internal.UrlAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class HttpServerAttributesExtractorStableSemconvTest {
+
+  static class TestHttpServerAttributesGetter
+      implements HttpServerAttributesGetter<Map<String, Object>, Map<String, Object>> {
+
+    @Override
+    public String getMethod(Map<String, Object> request) {
+      return (String) request.get("method");
+    }
+
+    @Override
+    public String getUrlScheme(Map<String, Object> request) {
+      return (String) request.get("scheme");
+    }
+
+    @Nullable
+    @Override
+    public String getUrlPath(Map<String, Object> request) {
+      return (String) request.get("path");
+    }
+
+    @Nullable
+    @Override
+    public String getUrlQuery(Map<String, Object> request) {
+      return (String) request.get("query");
+    }
+
+    @Override
+    public String getRoute(Map<String, Object> request) {
+      return (String) request.get("route");
+    }
+
+    @Override
+    public List<String> getRequestHeader(Map<String, Object> request, String name) {
+      String values = (String) request.get("header." + name);
+      return values == null ? emptyList() : asList(values.split(","));
+    }
+
+    @Override
+    public Integer getStatusCode(
+        Map<String, Object> request, Map<String, Object> response, @Nullable Throwable error) {
+      String value = (String) response.get("statusCode");
+      return value == null ? null : Integer.parseInt(value);
+    }
+
+    @Override
+    public List<String> getResponseHeader(
+        Map<String, Object> request, Map<String, Object> response, String name) {
+      String values = (String) response.get("header." + name);
+      return values == null ? emptyList() : asList(values.split(","));
+    }
+  }
+
+  static class TestNetServerAttributesGetter
+      implements NetServerAttributesGetter<Map<String, Object>> {
+
+    @Nullable
+    @Override
+    public String getProtocolName(Map<String, Object> request) {
+      return (String) request.get("protocolName");
+    }
+
+    @Nullable
+    @Override
+    public String getProtocolVersion(Map<String, Object> request) {
+      return (String) request.get("protocolVersion");
+    }
+
+    @Nullable
+    @Override
+    public String getHostName(Map<String, Object> request) {
+      return (String) request.get("hostName");
+    }
+
+    @Nullable
+    @Override
+    public Integer getHostPort(Map<String, Object> request) {
+      return (Integer) request.get("hostPort");
+    }
+  }
+
+  @Test
+  void normal() {
+    Map<String, Object> request = new HashMap<>();
+    request.put("method", "POST");
+    request.put("url", "http://github.com");
+    request.put("path", "/repositories/1");
+    request.put("query", "details=true");
+    request.put("scheme", "http");
+    request.put("header.content-length", "10");
+    request.put("route", "/repositories/{id}");
+    request.put("header.user-agent", "okhttp 3.x");
+    request.put("header.host", "github.com");
+    request.put("header.forwarded", "for=1.1.1.1;proto=https");
+    request.put("header.custom-request-header", "123,456");
+    request.put("protocolName", "http");
+    request.put("protocolVersion", "2.0");
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("statusCode", "202");
+    response.put("header.content-length", "20");
+    response.put("header.custom-response-header", "654,321");
+
+    Function<Context, String> routeFromContext = ctx -> "/repositories/{repoId}";
+
+    HttpServerAttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
+        new HttpServerAttributesExtractor<>(
+            new TestHttpServerAttributesGetter(),
+            new TestNetServerAttributesGetter(),
+            singletonList("Custom-Request-Header"),
+            singletonList("Custom-Response-Header"),
+            routeFromContext);
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.NET_HOST_NAME, "github.com"),
+            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
+            entry(SemanticAttributes.HTTP_METHOD, "POST"),
+            entry(UrlAttributes.URL_SCHEME, "http"),
+            entry(UrlAttributes.URL_PATH, "/repositories/1"),
+            entry(UrlAttributes.URL_QUERY, "details=true"),
+            entry(SemanticAttributes.USER_AGENT_ORIGINAL, "okhttp 3.x"),
+            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{id}"),
+            entry(SemanticAttributes.HTTP_CLIENT_IP, "1.1.1.1"),
+            entry(
+                AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
+                asList("123", "456")));
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, response, null);
+    assertThat(endAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{repoId}"),
+            entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
+            entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),
+            entry(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, 20L),
+            entry(
+                AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
+                asList("654", "321")));
+  }
+}

--- a/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
+++ b/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
@@ -60,13 +60,13 @@ public class InstrumenterBenchmark {
     INSTANCE;
 
     @Override
-    public String getMethod(Void unused) {
-      return "GET";
+    public String getFullUrl(Void unused) {
+      return "https://opentelemetry.io/benchmark";
     }
 
     @Override
-    public String getUrl(Void unused) {
-      return "https://opentelemetry.io/benchmark";
+    public String getMethod(Void unused) {
+      return "GET";
     }
 
     @Override

--- a/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
+++ b/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
@@ -60,7 +60,7 @@ public class InstrumenterBenchmark {
     INSTANCE;
 
     @Override
-    public String getFullUrl(Void unused) {
+    public String getUrlFull(Void unused) {
       return "https://opentelemetry.io/benchmark";
     }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+import static java.util.Arrays.asList;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class SemconvStability {
+
+  private static final boolean emitOldHttpSemconv;
+  private static final boolean emitStableHttpSemconv;
+
+  static {
+    boolean old = true;
+    boolean stable = false;
+
+    String value = ConfigPropertiesUtil.getString("otel.semconv-stability.opt-in");
+    if (value != null) {
+      Set<String> values = new HashSet<>(asList(value.split(",")));
+      if (values.contains("http")) {
+        old = false;
+        stable = true;
+      }
+      // no else -- technically it's possible to set "http,http/dup", in which case we should emit
+      // both sets of attributes
+      if (values.contains("http/dup")) {
+        old = true;
+        stable = true;
+      }
+    }
+
+    emitOldHttpSemconv = old;
+    emitStableHttpSemconv = stable;
+  }
+
+  public static boolean emitOldHttpSemconv() {
+    return emitOldHttpSemconv;
+  }
+
+  public static boolean emitStableHttpSemconv() {
+    return emitStableHttpSemconv;
+  }
+
+  private SemconvStability() {}
+}

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientAttributesGetter.java
@@ -16,7 +16,7 @@ class AkkaHttpClientAttributesGetter
     implements HttpClientAttributesGetter<HttpRequest, HttpResponse> {
 
   @Override
-  public String getUrl(HttpRequest httpRequest) {
+  public String getFullUrl(HttpRequest httpRequest) {
     return httpRequest.uri().toString();
   }
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpClientAttributesGetter.java
@@ -16,7 +16,7 @@ class AkkaHttpClientAttributesGetter
     implements HttpClientAttributesGetter<HttpRequest, HttpResponse> {
 
   @Override
-  public String getFullUrl(HttpRequest httpRequest) {
+  public String getUrlFull(HttpRequest httpRequest) {
     return httpRequest.uri().toString();
   }
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
@@ -39,18 +39,18 @@ class AkkaHttpServerAttributesGetter
   }
 
   @Override
-  public String getScheme(HttpRequest request) {
+  public String getUrlScheme(HttpRequest request) {
     return request.uri().scheme();
   }
 
   @Override
-  public String getPath(HttpRequest request) {
+  public String getUrlPath(HttpRequest request) {
     return request.uri().path().toString();
   }
 
   @Nullable
   @Override
-  public String getQuery(HttpRequest request) {
+  public String getUrlQuery(HttpRequest request) {
     Option<String> queryString = request.uri().rawQueryString();
     return queryString.isDefined() ? queryString.get() : null;
   }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesGetter.java
@@ -22,7 +22,7 @@ final class ApacheHttpAsyncClientHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(ApacheHttpClientRequest request) {
+  public String getFullUrl(ApacheHttpClientRequest request) {
     return request.getUrl();
   }
 

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientHttpAttributesGetter.java
@@ -22,7 +22,7 @@ final class ApacheHttpAsyncClientHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(ApacheHttpClientRequest request) {
+  public String getUrlFull(ApacheHttpClientRequest request) {
     return request.getUrl();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
@@ -26,7 +26,7 @@ final class ApacheHttpClientHttpAttributesGetter
 
   // mirroring implementation HttpMethodBase.getURI(), to avoid converting to URI and back to String
   @Override
-  public String getUrl(HttpMethod request) {
+  public String getFullUrl(HttpMethod request) {
     HostConfiguration hostConfiguration = request.getHostConfiguration();
     if (hostConfiguration == null || hostConfiguration.getProtocol() == null) {
       String queryString = request.getQueryString();

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientHttpAttributesGetter.java
@@ -26,7 +26,7 @@ final class ApacheHttpClientHttpAttributesGetter
 
   // mirroring implementation HttpMethodBase.getURI(), to avoid converting to URI and back to String
   @Override
-  public String getFullUrl(HttpMethod request) {
+  public String getUrlFull(HttpMethod request) {
     HostConfiguration hostConfiguration = request.getHostConfiguration();
     if (hostConfiguration == null || hostConfiguration.getProtocol() == null) {
       String queryString = request.getQueryString();

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesGetter.java
@@ -21,7 +21,7 @@ final class ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(ApacheHttpClientRequest request) {
+  public String getFullUrl(ApacheHttpClientRequest request) {
     return request.getUrl();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientHttpAttributesGetter.java
@@ -21,7 +21,7 @@ final class ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(ApacheHttpClientRequest request) {
+  public String getUrlFull(ApacheHttpClientRequest request) {
     return request.getUrl();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesGetter.java
@@ -23,7 +23,7 @@ enum ApacheHttpClientHttpAttributesGetter
 
   @Override
   @Nullable
-  public String getFullUrl(ApacheHttpClientRequest request) {
+  public String getUrlFull(ApacheHttpClientRequest request) {
     return request.getUrl();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientHttpAttributesGetter.java
@@ -23,7 +23,7 @@ enum ApacheHttpClientHttpAttributesGetter
 
   @Override
   @Nullable
-  public String getUrl(ApacheHttpClientRequest request) {
+  public String getFullUrl(ApacheHttpClientRequest request) {
     return request.getUrl();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
@@ -25,7 +25,7 @@ final class ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(HttpRequest request) {
+  public String getFullUrl(HttpRequest request) {
     // similar to org.apache.hc.core5.http.message.BasicHttpRequest.getUri()
     // not calling getUri() to avoid unnecessary conversion
     StringBuilder url = new StringBuilder();

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientHttpAttributesGetter.java
@@ -25,7 +25,7 @@ final class ApacheHttpClientHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(HttpRequest request) {
+  public String getUrlFull(HttpRequest request) {
     // similar to org.apache.hc.core5.http.message.BasicHttpRequest.getUri()
     // not calling getUri() to avoid unnecessary conversion
     StringBuilder url = new StringBuilder();

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
@@ -23,7 +23,7 @@ enum ArmeriaHttpClientAttributesGetter
   }
 
   @Override
-  public String getUrl(RequestContext ctx) {
+  public String getFullUrl(RequestContext ctx) {
     HttpRequest request = request(ctx);
     StringBuilder uri = new StringBuilder();
     String scheme = request.scheme();

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientAttributesGetter.java
@@ -23,7 +23,7 @@ enum ArmeriaHttpClientAttributesGetter
   }
 
   @Override
-  public String getFullUrl(RequestContext ctx) {
+  public String getUrlFull(RequestContext ctx) {
     HttpRequest request = request(ctx);
     StringBuilder uri = new StringBuilder();
     String scheme = request.scheme();

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
@@ -25,12 +25,12 @@ enum ArmeriaHttpServerAttributesGetter
 
   @Override
   @Nullable
-  public String getScheme(RequestContext ctx) {
+  public String getUrlScheme(RequestContext ctx) {
     return request(ctx).scheme();
   }
 
   @Override
-  public String getPath(RequestContext ctx) {
+  public String getUrlPath(RequestContext ctx) {
     String fullPath = request(ctx).path();
     int separatorPos = fullPath.indexOf('?');
     return separatorPos == -1 ? fullPath : fullPath.substring(0, separatorPos);
@@ -38,7 +38,7 @@ enum ArmeriaHttpServerAttributesGetter
 
   @Nullable
   @Override
-  public String getQuery(RequestContext ctx) {
+  public String getUrlQuery(RequestContext ctx) {
     String fullPath = request(ctx).path();
     int separatorPos = fullPath.indexOf('?');
     return separatorPos == -1 ? null : fullPath.substring(separatorPos + 1);

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesGetter.java
@@ -21,7 +21,7 @@ final class AsyncHttpClientHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(Request request) {
+  public String getFullUrl(Request request) {
     return request.getUri().toUrl();
   }
 

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientHttpAttributesGetter.java
@@ -21,7 +21,7 @@ final class AsyncHttpClientHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(Request request) {
+  public String getUrlFull(Request request) {
     return request.getUri().toUrl();
   }
 

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesGetter.java
@@ -19,7 +19,7 @@ final class AsyncHttpClientHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(RequestContext requestContext) {
+  public String getFullUrl(RequestContext requestContext) {
     return requestContext.getRequest().getUri().toUrl();
   }
 

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientHttpAttributesGetter.java
@@ -19,7 +19,7 @@ final class AsyncHttpClientHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(RequestContext requestContext) {
+  public String getUrlFull(RequestContext requestContext) {
     return requestContext.getRequest().getUri().toUrl();
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkHttpAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkHttpAttributesGetter.java
@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
 class AwsSdkHttpAttributesGetter implements HttpClientAttributesGetter<Request<?>, Response<?>> {
 
   @Override
-  public String getFullUrl(Request<?> request) {
+  public String getUrlFull(Request<?> request) {
     return request.getEndpoint().toString();
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkHttpAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkHttpAttributesGetter.java
@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
 class AwsSdkHttpAttributesGetter implements HttpClientAttributesGetter<Request<?>, Response<?>> {
 
   @Override
-  public String getUrl(Request<?> request) {
+  public String getFullUrl(Request<?> request) {
     return request.getEndpoint().toString();
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpAttributesGetter.java
@@ -18,7 +18,7 @@ class AwsSdkHttpAttributesGetter
     implements HttpClientAttributesGetter<ExecutionAttributes, SdkHttpResponse> {
 
   @Override
-  public String getFullUrl(ExecutionAttributes request) {
+  public String getUrlFull(ExecutionAttributes request) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     return httpRequest.getUri().toString();

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkHttpAttributesGetter.java
@@ -18,7 +18,7 @@ class AwsSdkHttpAttributesGetter
     implements HttpClientAttributesGetter<ExecutionAttributes, SdkHttpResponse> {
 
   @Override
-  public String getUrl(ExecutionAttributes request) {
+  public String getFullUrl(ExecutionAttributes request) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     return httpRequest.getUri().toString();

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesGetter.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesGetter.java
@@ -21,7 +21,7 @@ final class GoogleHttpClientHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(HttpRequest httpRequest) {
+  public String getUrlFull(HttpRequest httpRequest) {
     return httpRequest.getUrl().build();
   }
 

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesGetter.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientHttpAttributesGetter.java
@@ -21,7 +21,7 @@ final class GoogleHttpClientHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(HttpRequest httpRequest) {
+  public String getFullUrl(HttpRequest httpRequest) {
     return httpRequest.getUrl().build();
   }
 

--- a/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
@@ -49,19 +49,19 @@ final class GrizzlyHttpAttributesGetter
   }
 
   @Override
-  public String getScheme(HttpRequestPacket request) {
+  public String getUrlScheme(HttpRequestPacket request) {
     return request.isSecure() ? "https" : "http";
   }
 
   @Nullable
   @Override
-  public String getPath(HttpRequestPacket request) {
+  public String getUrlPath(HttpRequestPacket request) {
     return request.getRequestURI();
   }
 
   @Nullable
   @Override
-  public String getQuery(HttpRequestPacket request) {
+  public String getUrlQuery(HttpRequestPacket request) {
     return request.getQueryString();
   }
 }

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesGetter.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesGetter.java
@@ -22,7 +22,7 @@ class HttpUrlHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(HttpURLConnection connection) {
+  public String getUrlFull(HttpURLConnection connection) {
     return connection.getURL().toExternalForm();
   }
 

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesGetter.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlHttpAttributesGetter.java
@@ -22,7 +22,7 @@ class HttpUrlHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(HttpURLConnection connection) {
+  public String getFullUrl(HttpURLConnection connection) {
     return connection.getURL().toExternalForm();
   }
 

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/JavaHttpClientAttributesGetter.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/JavaHttpClientAttributesGetter.java
@@ -25,7 +25,7 @@ enum JavaHttpClientAttributesGetter
   }
 
   @Override
-  public String getFullUrl(HttpRequest httpRequest) {
+  public String getUrlFull(HttpRequest httpRequest) {
     return httpRequest.uri().toString();
   }
 

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/JavaHttpClientAttributesGetter.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/JavaHttpClientAttributesGetter.java
@@ -25,7 +25,7 @@ enum JavaHttpClientAttributesGetter
   }
 
   @Override
-  public String getUrl(HttpRequest httpRequest) {
+  public String getFullUrl(HttpRequest httpRequest) {
     return httpRequest.uri().toString();
   }
 

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesGetter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesGetter.java
@@ -24,7 +24,7 @@ final class JaxRsClientHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(ClientRequest httpRequest) {
+  public String getFullUrl(ClientRequest httpRequest) {
     return httpRequest.getURI().toString();
   }
 

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesGetter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientHttpAttributesGetter.java
@@ -24,7 +24,7 @@ final class JaxRsClientHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(ClientRequest httpRequest) {
+  public String getUrlFull(ClientRequest httpRequest) {
     return httpRequest.getURI().toString();
   }
 

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
@@ -22,7 +22,7 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
 
   @Override
   @Nullable
-  public String getUrl(Request request) {
+  public String getFullUrl(Request request) {
     return request.getURI().toString();
   }
 

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
@@ -22,7 +22,7 @@ enum JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Reque
 
   @Override
   @Nullable
-  public String getFullUrl(Request request) {
+  public String getUrlFull(Request request) {
     return request.getURI().toString();
   }
 

--- a/instrumentation/jodd-http-4.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpHttpAttributesGetter.java
+++ b/instrumentation/jodd-http-4.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpHttpAttributesGetter.java
@@ -20,7 +20,7 @@ final class JoddHttpHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(HttpRequest request) {
+  public String getUrlFull(HttpRequest request) {
     return request.url();
   }
 

--- a/instrumentation/jodd-http-4.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpHttpAttributesGetter.java
+++ b/instrumentation/jodd-http-4.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpHttpAttributesGetter.java
@@ -20,7 +20,7 @@ final class JoddHttpHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(HttpRequest request) {
+  public String getFullUrl(HttpRequest request) {
     return request.url();
   }
 

--- a/instrumentation/jodd-http-4.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpHttpAttributesGetterTest.java
+++ b/instrumentation/jodd-http-4.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpHttpAttributesGetterTest.java
@@ -39,7 +39,7 @@ class JoddHttpHttpAttributesGetterTest {
             .query("param2", "val2");
     assertEquals(
         "http://test.com/test/subpath?param1=val1&param2=val1&param2=val2",
-        attributesGetter.getUrl(request));
+        attributesGetter.getFullUrl(request));
   }
 
   @Test

--- a/instrumentation/jodd-http-4.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpHttpAttributesGetterTest.java
+++ b/instrumentation/jodd-http-4.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpHttpAttributesGetterTest.java
@@ -39,7 +39,7 @@ class JoddHttpHttpAttributesGetterTest {
             .query("param2", "val2");
     assertEquals(
         "http://test.com/test/subpath?param1=val1&param2=val1&param2=val2",
-        attributesGetter.getFullUrl(request));
+        attributesGetter.getUrlFull(request));
   }
 
   @Test

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
@@ -30,15 +30,15 @@ internal enum class KtorHttpServerAttributesGetter :
     return response.headers.allValues().getAll(name) ?: emptyList()
   }
 
-  override fun getScheme(request: ApplicationRequest): String {
+  override fun getUrlScheme(request: ApplicationRequest): String {
     return request.origin.scheme
   }
 
-  override fun getPath(request: ApplicationRequest): String {
+  override fun getUrlPath(request: ApplicationRequest): String {
     return request.path()
   }
 
-  override fun getQuery(request: ApplicationRequest): String {
+  override fun getUrlQuery(request: ApplicationRequest): String {
     return request.queryString()
   }
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorHttpClientAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorHttpClientAttributesGetter.kt
@@ -11,7 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttribut
 
 internal object KtorHttpClientAttributesGetter : HttpClientAttributesGetter<HttpRequestData, HttpResponse> {
 
-  override fun getFullUrl(request: HttpRequestData) =
+  override fun getUrlFull(request: HttpRequestData) =
     request.url.toString()
 
   override fun getMethod(request: HttpRequestData) =

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorHttpClientAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorHttpClientAttributesGetter.kt
@@ -11,7 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttribut
 
 internal object KtorHttpClientAttributesGetter : HttpClientAttributesGetter<HttpRequestData, HttpResponse> {
 
-  override fun getUrl(request: HttpRequestData) =
+  override fun getFullUrl(request: HttpRequestData) =
     request.url.toString()
 
   override fun getMethod(request: HttpRequestData) =

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorHttpServerAttributesGetter.kt
@@ -30,15 +30,15 @@ internal enum class KtorHttpServerAttributesGetter :
     return response.headers.allValues().getAll(name) ?: emptyList()
   }
 
-  override fun getScheme(request: ApplicationRequest): String {
+  override fun getUrlScheme(request: ApplicationRequest): String {
     return request.origin.scheme
   }
 
-  override fun getPath(request: ApplicationRequest): String {
+  override fun getUrlPath(request: ApplicationRequest): String {
     return request.path()
   }
 
-  override fun getQuery(request: ApplicationRequest): String {
+  override fun getUrlQuery(request: ApplicationRequest): String {
     return request.queryString()
   }
 }

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesGetter.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesGetter.java
@@ -22,7 +22,7 @@ class KubernetesHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(Request request) {
+  public String getUrlFull(Request request) {
     return request.url().toString();
   }
 

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesGetter.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesHttpAttributesGetter.java
@@ -22,7 +22,7 @@ class KubernetesHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(Request request) {
+  public String getFullUrl(Request request) {
     return request.url().toString();
   }
 

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
@@ -38,19 +38,19 @@ public class LibertyDispatcherHttpAttributesGetter
 
   @Override
   @Nullable
-  public String getScheme(LibertyRequest libertyRequest) {
+  public String getUrlScheme(LibertyRequest libertyRequest) {
     return libertyRequest.getScheme();
   }
 
   @Nullable
   @Override
-  public String getPath(LibertyRequest request) {
+  public String getUrlPath(LibertyRequest request) {
     return request.getRequestUri();
   }
 
   @Nullable
   @Override
-  public String getQuery(LibertyRequest request) {
+  public String getUrlQuery(LibertyRequest request) {
     return request.getQueryString();
   }
 }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectHttpAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectHttpAttributesGetter.java
@@ -18,7 +18,7 @@ enum NettyConnectHttpAttributesGetter
 
   @Nullable
   @Override
-  public String getFullUrl(NettyConnectionRequest nettyConnectionRequest) {
+  public String getUrlFull(NettyConnectionRequest nettyConnectionRequest) {
     return null;
   }
 

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectHttpAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectHttpAttributesGetter.java
@@ -18,7 +18,7 @@ enum NettyConnectHttpAttributesGetter
 
   @Nullable
   @Override
-  public String getUrl(NettyConnectionRequest nettyConnectionRequest) {
+  public String getFullUrl(NettyConnectionRequest nettyConnectionRequest) {
     return null;
   }
 

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientAttributesGetter.java
@@ -20,7 +20,7 @@ final class NettyHttpClientAttributesGetter
 
   @Override
   @Nullable
-  public String getFullUrl(HttpRequestAndChannel requestAndChannel) {
+  public String getUrlFull(HttpRequestAndChannel requestAndChannel) {
     try {
       String hostHeader = getHost(requestAndChannel);
       String target = requestAndChannel.request().getUri();

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyHttpClientAttributesGetter.java
@@ -20,7 +20,7 @@ final class NettyHttpClientAttributesGetter
 
   @Override
   @Nullable
-  public String getUrl(HttpRequestAndChannel requestAndChannel) {
+  public String getFullUrl(HttpRequestAndChannel requestAndChannel) {
     try {
       String hostHeader = getHost(requestAndChannel);
       String target = requestAndChannel.request().getUri();

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
@@ -38,19 +38,19 @@ final class NettyHttpServerAttributesGetter
   }
 
   @Override
-  public String getScheme(HttpRequestAndChannel requestAndChannel) {
+  public String getUrlScheme(HttpRequestAndChannel requestAndChannel) {
     return HttpSchemeUtil.getScheme(requestAndChannel);
   }
 
   @Override
-  public String getPath(HttpRequestAndChannel requestAndChannel) {
+  public String getUrlPath(HttpRequestAndChannel requestAndChannel) {
     String fullPath = requestAndChannel.request().getUri();
     int separatorPos = fullPath.indexOf('?');
     return separatorPos == -1 ? fullPath : fullPath.substring(0, separatorPos);
   }
 
   @Override
-  public String getQuery(HttpRequestAndChannel requestAndChannel) {
+  public String getUrlQuery(HttpRequestAndChannel requestAndChannel) {
     String fullPath = requestAndChannel.request().getUri();
     int separatorPos = fullPath.indexOf('?');
     return separatorPos == -1 ? null : fullPath.substring(separatorPos + 1);

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectHttpAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectHttpAttributesGetter.java
@@ -18,7 +18,7 @@ enum NettyConnectHttpAttributesGetter
 
   @Nullable
   @Override
-  public String getFullUrl(NettyConnectionRequest nettyConnectionRequest) {
+  public String getUrlFull(NettyConnectionRequest nettyConnectionRequest) {
     return null;
   }
 

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectHttpAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectHttpAttributesGetter.java
@@ -18,7 +18,7 @@ enum NettyConnectHttpAttributesGetter
 
   @Nullable
   @Override
-  public String getUrl(NettyConnectionRequest nettyConnectionRequest) {
+  public String getFullUrl(NettyConnectionRequest nettyConnectionRequest) {
     return null;
   }
 

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyHttpClientAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyHttpClientAttributesGetter.java
@@ -20,7 +20,7 @@ final class NettyHttpClientAttributesGetter
 
   @Override
   @Nullable
-  public String getFullUrl(HttpRequestAndChannel requestAndChannel) {
+  public String getUrlFull(HttpRequestAndChannel requestAndChannel) {
     try {
       String hostHeader = getHost(requestAndChannel);
       String target = requestAndChannel.request().getUri();

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyHttpClientAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyHttpClientAttributesGetter.java
@@ -20,7 +20,7 @@ final class NettyHttpClientAttributesGetter
 
   @Override
   @Nullable
-  public String getUrl(HttpRequestAndChannel requestAndChannel) {
+  public String getFullUrl(HttpRequestAndChannel requestAndChannel) {
     try {
       String hostHeader = getHost(requestAndChannel);
       String target = requestAndChannel.request().getUri();

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyHttpServerAttributesGetter.java
@@ -38,19 +38,19 @@ final class NettyHttpServerAttributesGetter
   }
 
   @Override
-  public String getScheme(HttpRequestAndChannel requestAndChannel) {
+  public String getUrlScheme(HttpRequestAndChannel requestAndChannel) {
     return HttpSchemeUtil.getScheme(requestAndChannel);
   }
 
   @Override
-  public String getPath(HttpRequestAndChannel requestAndChannel) {
+  public String getUrlPath(HttpRequestAndChannel requestAndChannel) {
     String fullPath = requestAndChannel.request().getUri();
     int separatorPos = fullPath.indexOf('?');
     return separatorPos == -1 ? fullPath : fullPath.substring(0, separatorPos);
   }
 
   @Override
-  public String getQuery(HttpRequestAndChannel requestAndChannel) {
+  public String getUrlQuery(HttpRequestAndChannel requestAndChannel) {
     String fullPath = requestAndChannel.request().getUri();
     int separatorPos = fullPath.indexOf('?');
     return separatorPos == -1 ? null : fullPath.substring(separatorPos + 1);

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesGetter.java
@@ -19,7 +19,7 @@ final class OkHttp2HttpAttributesGetter implements HttpClientAttributesGetter<Re
   }
 
   @Override
-  public String getFullUrl(Request request) {
+  public String getUrlFull(Request request) {
     return request.urlString();
   }
 

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2HttpAttributesGetter.java
@@ -19,7 +19,7 @@ final class OkHttp2HttpAttributesGetter implements HttpClientAttributesGetter<Re
   }
 
   @Override
-  public String getUrl(Request request) {
+  public String getFullUrl(Request request) {
     return request.urlString();
   }
 

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpAttributesGetter.java
@@ -20,7 +20,7 @@ enum OkHttpAttributesGetter implements HttpClientAttributesGetter<Request, Respo
   }
 
   @Override
-  public String getUrl(Request request) {
+  public String getFullUrl(Request request) {
     return request.url().toString();
   }
 

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpAttributesGetter.java
@@ -20,7 +20,7 @@ enum OkHttpAttributesGetter implements HttpClientAttributesGetter<Request, Respo
   }
 
   @Override
-  public String getFullUrl(Request request) {
+  public String getUrlFull(Request request) {
     return request.url().toString();
   }
 

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
@@ -39,19 +39,19 @@ enum MockHttpServerAttributesGetter implements HttpServerAttributesGetter<String
 
   @Nullable
   @Override
-  public String getScheme(String s) {
+  public String getUrlScheme(String s) {
     return null;
   }
 
   @Nullable
   @Override
-  public String getPath(String s) {
+  public String getUrlPath(String s) {
     return null;
   }
 
   @Nullable
   @Override
-  public String getQuery(String s) {
+  public String getUrlQuery(String s) {
     return null;
   }
 }

--- a/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesGetter.java
+++ b/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesGetter.java
@@ -20,7 +20,7 @@ final class PlayWsClientHttpAttributesGetter
   }
 
   @Override
-  public String getUrl(Request request) {
+  public String getFullUrl(Request request) {
     return request.getUri().toUrl();
   }
 

--- a/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesGetter.java
+++ b/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientHttpAttributesGetter.java
@@ -20,7 +20,7 @@ final class PlayWsClientHttpAttributesGetter
   }
 
   @Override
-  public String getFullUrl(Request request) {
+  public String getUrlFull(Request request) {
     return request.getUri().toUrl();
   }
 

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpAttributesGetter.java
@@ -23,7 +23,7 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
 
   @Override
   @Nullable
-  public String getScheme(Request request) {
+  public String getUrlScheme(Request request) {
     Context ratpackContext = request.get(Context.class);
     if (ratpackContext == null) {
       return null;
@@ -36,14 +36,14 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
   }
 
   @Override
-  public String getPath(Request request) {
+  public String getUrlPath(Request request) {
     String path = request.getPath();
     return path.startsWith("/") ? path : "/" + path;
   }
 
   @Nullable
   @Override
-  public String getQuery(Request request) {
+  public String getUrlQuery(Request request) {
     return request.getQuery();
   }
 

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpClientAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpClientAttributesGetter.java
@@ -17,7 +17,7 @@ enum RatpackHttpClientAttributesGetter
 
   @Nullable
   @Override
-  public String getUrl(RequestSpec requestSpec) {
+  public String getFullUrl(RequestSpec requestSpec) {
     return requestSpec.getUri().toString();
   }
 

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpClientAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpClientAttributesGetter.java
@@ -17,7 +17,7 @@ enum RatpackHttpClientAttributesGetter
 
   @Nullable
   @Override
-  public String getFullUrl(RequestSpec requestSpec) {
+  public String getUrlFull(RequestSpec requestSpec) {
     return requestSpec.getUri().toString();
   }
 

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
@@ -17,7 +17,7 @@ final class ReactorNettyHttpClientAttributesGetter
     implements HttpClientAttributesGetter<HttpClientConfig, HttpClientResponse> {
 
   @Override
-  public String getUrl(HttpClientConfig request) {
+  public String getFullUrl(HttpClientConfig request) {
     String uri = request.uri();
     if (isAbsolute(uri)) {
       return uri;

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyHttpClientAttributesGetter.java
@@ -17,7 +17,7 @@ final class ReactorNettyHttpClientAttributesGetter
     implements HttpClientAttributesGetter<HttpClientConfig, HttpClientResponse> {
 
   @Override
-  public String getFullUrl(HttpClientConfig request) {
+  public String getUrlFull(HttpClientConfig request) {
     String uri = request.uri();
     if (isAbsolute(uri)) {
       return uri;

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletHttpAttributesGetter.java
@@ -28,19 +28,19 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
 
   @Override
   @Nullable
-  public String getScheme(Request request) {
+  public String getUrlScheme(Request request) {
     return request.getOriginalRef().getScheme();
   }
 
   @Nullable
   @Override
-  public String getPath(Request request) {
+  public String getUrlPath(Request request) {
     return request.getOriginalRef().getPath();
   }
 
   @Nullable
   @Override
-  public String getQuery(Request request) {
+  public String getUrlQuery(Request request) {
     return request.getOriginalRef().getQuery();
   }
 

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
@@ -30,19 +30,19 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public String getScheme(Request request) {
+  public String getUrlScheme(Request request) {
     return request.getOriginalRef().getScheme();
   }
 
   @Nullable
   @Override
-  public String getPath(Request request) {
+  public String getUrlPath(Request request) {
     return request.getOriginalRef().getPath();
   }
 
   @Nullable
   @Override
-  public String getQuery(Request request) {
+  public String getUrlQuery(Request request) {
     return request.getOriginalRef().getQuery();
   }
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
@@ -27,19 +27,19 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
 
   @Override
   @Nullable
-  public String getScheme(ServletRequestContext<REQUEST> requestContext) {
+  public String getUrlScheme(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestScheme(requestContext.request());
   }
 
   @Nullable
   @Override
-  public String getPath(ServletRequestContext<REQUEST> requestContext) {
+  public String getUrlPath(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestUri(requestContext.request());
   }
 
   @Nullable
   @Override
-  public String getQuery(ServletRequestContext<REQUEST> requestContext) {
+  public String getUrlQuery(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestQueryString(requestContext.request());
   }
 

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebHttpAttributesGetter.java
@@ -27,7 +27,7 @@ enum SpringWebHttpAttributesGetter
 
   @Override
   @Nullable
-  public String getUrl(HttpRequest httpRequest) {
+  public String getFullUrl(HttpRequest httpRequest) {
     return httpRequest.getURI().toString();
   }
 

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebHttpAttributesGetter.java
@@ -27,7 +27,7 @@ enum SpringWebHttpAttributesGetter
 
   @Override
   @Nullable
-  public String getFullUrl(HttpRequest httpRequest) {
+  public String getUrlFull(HttpRequest httpRequest) {
     return httpRequest.getURI().toString();
   }
 

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerHttpAttributesGetter.java
@@ -42,19 +42,19 @@ enum WebfluxServerHttpAttributesGetter
 
   @Nullable
   @Override
-  public String getScheme(ServerWebExchange request) {
+  public String getUrlScheme(ServerWebExchange request) {
     return request.getRequest().getURI().getScheme();
   }
 
   @Nullable
   @Override
-  public String getPath(ServerWebExchange request) {
+  public String getUrlPath(ServerWebExchange request) {
     return request.getRequest().getURI().getPath();
   }
 
   @Nullable
   @Override
-  public String getQuery(ServerWebExchange request) {
+  public String getUrlQuery(ServerWebExchange request) {
     return request.getRequest().getURI().getQuery();
   }
 

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/internal/WebClientHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/internal/WebClientHttpAttributesGetter.java
@@ -18,7 +18,7 @@ enum WebClientHttpAttributesGetter
   INSTANCE;
 
   @Override
-  public String getUrl(ClientRequest request) {
+  public String getFullUrl(ClientRequest request) {
     return request.url().toString();
   }
 

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/internal/WebClientHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/internal/WebClientHttpAttributesGetter.java
@@ -18,7 +18,7 @@ enum WebClientHttpAttributesGetter
   INSTANCE;
 
   @Override
-  public String getFullUrl(ClientRequest request) {
+  public String getUrlFull(ClientRequest request) {
     return request.url().toString();
   }
 

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
@@ -65,19 +65,19 @@ enum SpringWebMvcHttpAttributesGetter
 
   @Override
   @Nullable
-  public String getScheme(HttpServletRequest request) {
+  public String getUrlScheme(HttpServletRequest request) {
     return request.getScheme();
   }
 
   @Nullable
   @Override
-  public String getPath(HttpServletRequest request) {
+  public String getUrlPath(HttpServletRequest request) {
     return request.getRequestURI();
   }
 
   @Nullable
   @Override
-  public String getQuery(HttpServletRequest request) {
+  public String getUrlQuery(HttpServletRequest request) {
     return request.getQueryString();
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcHttpAttributesGetter.java
@@ -65,19 +65,19 @@ enum SpringWebMvcHttpAttributesGetter
 
   @Override
   @Nullable
-  public String getScheme(HttpServletRequest request) {
+  public String getUrlScheme(HttpServletRequest request) {
     return request.getScheme();
   }
 
   @Nullable
   @Override
-  public String getPath(HttpServletRequest request) {
+  public String getUrlPath(HttpServletRequest request) {
     return request.getRequestURI();
   }
 
   @Nullable
   @Override
-  public String getQuery(HttpServletRequest request) {
+  public String getUrlQuery(HttpServletRequest request) {
     return request.getQueryString();
   }
 }

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
@@ -24,20 +24,20 @@ public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Re
 
   @Override
   @Nullable
-  public String getScheme(Request request) {
+  public String getUrlScheme(Request request) {
     MessageBytes schemeMessageBytes = request.scheme();
     return schemeMessageBytes.isNull() ? "http" : messageBytesToString(schemeMessageBytes);
   }
 
   @Nullable
   @Override
-  public String getPath(Request request) {
+  public String getUrlPath(Request request) {
     return messageBytesToString(request.requestURI());
   }
 
   @Nullable
   @Override
-  public String getQuery(Request request) {
+  public String getUrlQuery(Request request) {
     return messageBytesToString(request.queryString());
   }
 

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
@@ -41,19 +41,19 @@ public class UndertowHttpAttributesGetter
 
   @Override
   @Nullable
-  public String getScheme(HttpServerExchange exchange) {
+  public String getUrlScheme(HttpServerExchange exchange) {
     return exchange.getRequestScheme();
   }
 
   @Nullable
   @Override
-  public String getPath(HttpServerExchange exchange) {
+  public String getUrlPath(HttpServerExchange exchange) {
     return exchange.getRequestPath();
   }
 
   @Nullable
   @Override
-  public String getQuery(HttpServerExchange exchange) {
+  public String getUrlQuery(HttpServerExchange exchange) {
     return exchange.getQueryString();
   }
 }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3HttpAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3HttpAttributesGetter.java
@@ -15,7 +15,7 @@ final class Vertx3HttpAttributesGetter extends AbstractVertxHttpAttributesGetter
       VirtualField.find(HttpClientRequest.class, VertxRequestInfo.class);
 
   @Override
-  public String getUrl(HttpClientRequest request) {
+  public String getFullUrl(HttpClientRequest request) {
     String uri = request.uri();
     // Uri should be relative, but it is possible to misuse vert.x api and pass an absolute uri
     // where relative is expected.

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3HttpAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3HttpAttributesGetter.java
@@ -15,7 +15,7 @@ final class Vertx3HttpAttributesGetter extends AbstractVertxHttpAttributesGetter
       VirtualField.find(HttpClientRequest.class, VertxRequestInfo.class);
 
   @Override
-  public String getFullUrl(HttpClientRequest request) {
+  public String getUrlFull(HttpClientRequest request) {
     String uri = request.uri();
     // Uri should be relative, but it is possible to misuse vert.x api and pass an absolute uri
     // where relative is expected.

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4HttpAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4HttpAttributesGetter.java
@@ -11,7 +11,7 @@ import io.vertx.core.http.HttpClientRequest;
 final class Vertx4HttpAttributesGetter extends AbstractVertxHttpAttributesGetter {
 
   @Override
-  public String getUrl(HttpClientRequest request) {
+  public String getFullUrl(HttpClientRequest request) {
     String uri = request.getURI();
     if (!isAbsolute(uri)) {
       uri = request.absoluteURI();

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4HttpAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4HttpAttributesGetter.java
@@ -11,7 +11,7 @@ import io.vertx.core.http.HttpClientRequest;
 final class Vertx4HttpAttributesGetter extends AbstractVertxHttpAttributesGetter {
 
   @Override
-  public String getFullUrl(HttpClientRequest request) {
+  public String getUrlFull(HttpClientRequest request) {
     String uri = request.getURI();
     if (!isAbsolute(uri)) {
       uri = request.absoluteURI();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -199,6 +199,7 @@ public class AgentInstaller {
     for (String property :
         asList(
             "otel.instrumentation.experimental.span-suppression-strategy",
+            "otel.instrumentation.http.prefer-forwarded-url-scheme",
             "otel.semconv-stability.opt-in")) {
       String value = config.getString(property);
       if (value != null) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.javaagent.tooling.OpenTelemetryInstaller.installO
 import static io.opentelemetry.javaagent.tooling.SafeServiceLoader.load;
 import static io.opentelemetry.javaagent.tooling.SafeServiceLoader.loadOrdered;
 import static io.opentelemetry.javaagent.tooling.Utils.getResourceName;
+import static java.util.Arrays.asList;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
 import static net.bytebuddy.matcher.ElementMatchers.any;
@@ -195,9 +196,14 @@ public class AgentInstaller {
   }
 
   private static void copyNecessaryConfigToSystemProperties(ConfigProperties config) {
-    String value = config.getString("otel.instrumentation.experimental.span-suppression-strategy");
-    if (value != null) {
-      System.setProperty("otel.instrumentation.experimental.span-suppression-strategy", value);
+    for (String property :
+        asList(
+            "otel.instrumentation.experimental.span-suppression-strategy",
+            "otel.semconv-stability.opt-in")) {
+      String value = config.getString(property);
+      if (value != null) {
+        System.setProperty(property, value);
+      }
     }
   }
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
@@ -164,19 +164,19 @@ final class TestInstrumenters {
 
     @Nullable
     @Override
-    public String getScheme(String unused) {
+    public String getUrlScheme(String unused) {
       return null;
     }
 
     @Nullable
     @Override
-    public String getPath(String s) {
+    public String getUrlPath(String s) {
       return null;
     }
 
     @Nullable
     @Override
-    public String getQuery(String s) {
+    public String getUrlQuery(String s) {
       return null;
     }
 


### PR DESCRIPTION
... and use them as part of the HTTP extractors - the HTTP getters now extend the `UrlAttributesGetter`, and override the methods that HTTP semconv is interested in.

This PR also sets up the `OTEL_SEMCONV_STABILITY_OPT_IN` env var handling, and adds some tests that cover all 3 possible variants of emitted attribute sets.