### PR TITLE
Fix JFR lock wait test

### DIFF
--- a/instrumentation/runtime-metrics/runtime-metrics-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/JfrCpuLockTest.java
+++ b/instrumentation/runtime-metrics/runtime-metrics-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/JfrCpuLockTest.java
@@ -38,10 +38,10 @@ class JfrCpuLockTest {
               })
           .start();
       long waitTime = Duration.ofSeconds(10).toMillis();
-      long endTIme = System.currentTimeMillis() + Duration.ofSeconds(10).toMillis();
+      long endTime = System.currentTimeMillis() + Duration.ofSeconds(10).toMillis();
       while (!done.get() && waitTime > 0) {
         done.wait(waitTime);
-        waitTime = endTIme - System.currentTimeMillis();
+        waitTime = endTime - System.currentTimeMillis();
       }
     }
 


### PR DESCRIPTION
JFR lock wait test is flaky https://ge.opentelemetry.io/s/zngwnjrscc3n6/tests/:instrumentation:runtime-telemetry-jfr:library:test/io.opentelemetry.instrumentation.runtimetelemetryjfr.JfrCpuLockTest/shouldHaveLockEvents()?top-execution=1
I believe this is caused by the fix to the JDK issue https://bugs.openjdk.org/browse/JDK-8286707 Test probably turned flaky when it started being run with `17.0.7` that includes the fix. This PR modifies the test to cause `jdk.JavaMonitorWait` event instead of relying on the jdk code to produce it.