### PR TITLE
Fix runtime-metrics-java17 tests on openj9

### DIFF
--- a/instrumentation/runtime-metrics/runtime-metrics-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/JfrExtension.java
+++ b/instrumentation/runtime-metrics/runtime-metrics-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/JfrExtension.java
@@ -47,7 +47,10 @@ public class JfrExtension implements BeforeEachCallback, AfterEachCallback {
     RuntimeMetricsBuilder builder = RuntimeMetrics.builder(sdk);
     builderConsumer.accept(builder);
     runtimeMetrics = builder.build();
-    runtimeMetrics.getStartUpLatch().await(30, TimeUnit.SECONDS);
+    RuntimeMetrics.JfrRuntimeMetrics jfrRuntimeMetrics = runtimeMetrics.getJfrRuntimeMetrics();
+    if (jfrRuntimeMetrics != null) {
+      jfrRuntimeMetrics.getStartUpLatch().await(30, TimeUnit.SECONDS);
+    }
   }
 
   @Override

--- a/instrumentation/runtime-metrics/runtime-metrics-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsBuilderTest.java
+++ b/instrumentation/runtime-metrics/runtime-metrics-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsBuilderTest.java
@@ -66,7 +66,7 @@ class RuntimeMetricsBuilderTest {
     var openTelemetry = OpenTelemetry.noop();
     try (var jfrTelemetry = new RuntimeMetricsBuilder(openTelemetry).build()) {
       assertThat(jfrTelemetry.getOpenTelemetry()).isSameAs(openTelemetry);
-      assertThat(jfrTelemetry.getRecordedEventHandlers())
+      assertThat(jfrTelemetry.getJfrRuntimeMetrics().getRecordedEventHandlers())
           .hasSizeGreaterThan(0)
           .allSatisfy(handler -> assertThat(handler.getFeature().isDefaultEnabled()).isTrue());
     }

--- a/instrumentation/runtime-metrics/runtime-metrics-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsTest.java
+++ b/instrumentation/runtime-metrics/runtime-metrics-java17/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java17/RuntimeMetricsTest.java
@@ -71,7 +71,7 @@ class RuntimeMetricsTest {
   void builder() {
     try (var jfrTelemetry = RuntimeMetrics.builder(sdk).build()) {
       assertThat(jfrTelemetry.getOpenTelemetry()).isSameAs(sdk);
-      assertThat(jfrTelemetry.getRecordedEventHandlers())
+      assertThat(jfrTelemetry.getJfrRuntimeMetrics().getRecordedEventHandlers())
           .hasSizeGreaterThan(0)
           .allSatisfy(handler -> assertThat(handler.getFeature().isDefaultEnabled()).isTrue());
     }
@@ -82,7 +82,10 @@ class RuntimeMetricsTest {
     try (RuntimeMetrics jfrTelemetry = RuntimeMetrics.builder(sdk).build()) {
       // Track whether RecordingStream has been closed
       AtomicBoolean recordingStreamClosed = new AtomicBoolean(false);
-      jfrTelemetry.getRecordingStream().onClose(() -> recordingStreamClosed.set(true));
+      jfrTelemetry
+          .getJfrRuntimeMetrics()
+          .getRecordingStream()
+          .onClose(() -> recordingStreamClosed.set(true));
 
       assertThat(reader.collectAllMetrics()).isNotEmpty();
 


### PR DESCRIPTION
Caused by https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8165