### PR TITLE
Use jakarta.servlet.error.exception request attribute on jetty11

### DIFF
--- a/instrumentation/jetty/jetty-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/common/JettyHelper.java
+++ b/instrumentation/jetty/jetty-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jetty/common/JettyHelper.java
@@ -57,6 +57,7 @@ public class JettyHelper<REQUEST, RESPONSE> extends ServletHelper<REQUEST, RESPO
   }
 
   private static String errorExceptionAttributeName() {
+    // this method is only used on jetty versions before 9.4
     return "javax.servlet.error.exception";
   }
 }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServlet5Test.groovy
@@ -43,7 +43,7 @@ abstract class JettyServlet5Test extends AbstractServlet5Test<Object, Object> {
     ServletContextHandler servletContext = new ServletContextHandler(null, contextPath)
     servletContext.errorHandler = new ErrorHandler() {
       protected void handleErrorPage(HttpServletRequest request, Writer writer, int code, String message) throws IOException {
-        Throwable th = (Throwable) request.getAttribute("javax.servlet.error.exception")
+        Throwable th = (Throwable) request.getAttribute("jakarta.servlet.error.exception")
         writer.write(th ? th.message : message)
       }
     }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/JettyServletHandlerTest.groovy
@@ -34,7 +34,7 @@ class JettyServletHandlerTest extends AbstractServlet5Test<Object, Object> {
     setupServlets(handler)
     server.addBean(new ErrorHandler() {
       protected void handleErrorPage(HttpServletRequest request, Writer writer, int code, String message) throws IOException {
-        Throwable th = (Throwable) request.getAttribute("javax.servlet.error.exception")
+        Throwable th = (Throwable) request.getAttribute("jakarta.servlet.error.exception")
         writer.write(th ? th.message : message)
       }
     })


### PR DESCRIPTION
I suspect that this error handler isn't really used, or maybe it was so that we changed the tests to not compare output from the error endpoint with expected value as it required configuration changes on the server to make it work.