### PR TITLE
Move relocate rule for sdk incubator extension

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
@@ -30,12 +30,12 @@ tasks.withType<ShadowJar>().configureEach {
   relocate("io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api")
   relocate("io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv")
   relocate("io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context")
+  relocate("io.opentelemetry.extension.incubator", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.incubator")
 
   // relocate(the OpenTelemetry extensions that are used by instrumentation modules)
   // these extensions live in the AgentClassLoader, and are injected into the user's class loader
   // by the instrumentation modules that use them
   relocate("io.opentelemetry.extension.aws", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.aws")
-  relocate("io.opentelemetry.extension.incubator", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.incubator")
   relocate("io.opentelemetry.extension.kotlin", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.kotlin")
 
   // this is for instrumentation of opentelemetry-api and opentelemetry-instrumentation-api

--- a/examples/distro/gradle/shadow.gradle
+++ b/examples/distro/gradle/shadow.gradle
@@ -13,6 +13,7 @@ ext.relocatePackages = { shadowJar ->
   shadowJar.relocate("io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api")
   shadowJar.relocate("io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv")
   shadowJar.relocate("io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context")
+  shadowJar.relocate("io.opentelemetry.extension.incubator", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.incubator")
 
   // relocate the OpenTelemetry extensions that are used by instrumentation modules
   // these extensions live in the AgentClassLoader, and are injected into the user's class loader


### PR DESCRIPTION
Currently relocate rule for `opentelemetry-extension-incubator` is grouped with other extensions, but the comment there says that these classes are in `AgentLoader` which is not true for `opentelemetry-extension-incubator`. Also add the same relocate rule to example distro.