### PR TITLE
Simplify/refactor `AbstractHttpClientTest` and replace protected method…

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/AbstractApacheHttpClientTest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/AbstractApacheHttpClientTest.java
@@ -20,14 +20,12 @@ import org.apache.http.protocol.HttpContext;
 
 abstract class AbstractApacheHttpClientTest<T extends HttpRequest>
     extends AbstractHttpClientTest<T> {
-  @Override
-  protected String userAgent() {
-    return "apachehttpclient";
-  }
+
+  private static final String USER_AGENT = "apachehttpclient";
 
   @Override
   protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
-    optionsBuilder.setUserAgent(userAgent());
+    optionsBuilder.setUserAgent(USER_AGENT);
     optionsBuilder.enableTestReadTimeout();
     optionsBuilder.setHttpAttributes(AbstractApacheHttpClientTest::getHttpAttributes);
   }
@@ -39,7 +37,7 @@ abstract class AbstractApacheHttpClientTest<T extends HttpRequest>
   @Override
   public T buildRequest(String method, URI uri, Map<String, String> headers) {
     T request = createRequest(method, uri);
-    request.addHeader("user-agent", userAgent());
+    request.addHeader("user-agent", USER_AGENT);
     headers.forEach(request::setHeader);
     return request;
   }

--- a/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionResponseCodeOnlyTest.java
+++ b/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionResponseCodeOnlyTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.httpurlconnection;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Map;
@@ -43,23 +44,12 @@ class HttpUrlConnectionResponseCodeOnlyTest extends AbstractHttpClientTest<HttpU
   }
 
   @Override
-  public int maxRedirects() {
-    return 20;
-  }
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+    optionsBuilder.setMaxRedirects(20);
 
-  @Override
-  public boolean testReusedRequest() {
     // HttpURLConnection can't be reused
-    return false;
-  }
-
-  @Override
-  public boolean testCallback() {
-    return false;
-  }
-
-  @Override
-  public boolean testReadTimeout() {
-    return true;
+    optionsBuilder.disableTestReusedRequest();
+    optionsBuilder.disableTestCallback();
+    optionsBuilder.enableTestReadTimeout();
   }
 }

--- a/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionTest.java
+++ b/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionTest.java
@@ -17,6 +17,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -71,24 +72,13 @@ class HttpUrlConnectionTest extends AbstractHttpClientTest<HttpURLConnection> {
   }
 
   @Override
-  public int maxRedirects() {
-    return 20;
-  }
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+    optionsBuilder.setMaxRedirects(20);
 
-  @Override
-  public boolean testReusedRequest() {
     // HttpURLConnection can't be reused
-    return false;
-  }
-
-  @Override
-  public boolean testCallback() {
-    return false;
-  }
-
-  @Override
-  public boolean testReadTimeout() {
-    return true;
+    optionsBuilder.disableTestReusedRequest();
+    optionsBuilder.disableTestCallback();
+    optionsBuilder.enableTestReadTimeout();
   }
 
   @ParameterizedTest

--- a/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionUseCachesFalseTest.java
+++ b/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionUseCachesFalseTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -53,23 +54,12 @@ class HttpUrlConnectionUseCachesFalseTest extends AbstractHttpClientTest<HttpURL
   }
 
   @Override
-  public int maxRedirects() {
-    return 20;
-  }
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+    optionsBuilder.setMaxRedirects(20);
 
-  @Override
-  public boolean testReusedRequest() {
     // HttpURLConnection can't be reused
-    return false;
-  }
-
-  @Override
-  public boolean testCallback() {
-    return false;
-  }
-
-  @Override
-  public boolean testReadTimeout() {
-    return true;
+    optionsBuilder.disableTestReusedRequest();
+    optionsBuilder.disableTestCallback();
+    optionsBuilder.enableTestReadTimeout();
   }
 }

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ClientTest.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ClientTest.java
@@ -10,6 +10,7 @@ import io.opentelemetry.instrumentation.netty.v4_1.AbstractNetty41ClientTest;
 import io.opentelemetry.instrumentation.netty.v4_1.Netty41ClientExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class Netty41ClientTest extends AbstractNetty41ClientTest {
@@ -30,7 +31,9 @@ public class Netty41ClientTest extends AbstractNetty41ClientTest {
   protected void configureChannel(Channel channel) {}
 
   @Override
-  protected boolean testReadTimeout() {
-    return true;
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+    super.configure(optionsBuilder);
+
+    optionsBuilder.enableTestReadTimeout();
   }
 }

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41NativeClientTest.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41NativeClientTest.java
@@ -19,6 +19,7 @@ import io.opentelemetry.instrumentation.netty.v4_1.AbstractNetty41ClientTest;
 import io.opentelemetry.instrumentation.netty.v4_1.Netty41ClientExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -80,7 +81,9 @@ public class Netty41NativeClientTest extends AbstractNetty41ClientTest {
   protected void configureChannel(Channel channel) {}
 
   @Override
-  protected boolean testReadTimeout() {
-    return true;
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+    super.configure(optionsBuilder);
+
+    optionsBuilder.enableTestReadTimeout();
   }
 }

--- a/instrumentation/netty/netty-4.1/library/src/test/java/io/opentelemetry/instrumentation/netty/v4_1/Netty41ClientTest.java
+++ b/instrumentation/netty/netty-4.1/library/src/test/java/io/opentelemetry/instrumentation/netty/v4_1/Netty41ClientTest.java
@@ -10,6 +10,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import java.util.Collections;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -43,32 +44,13 @@ public class Netty41ClientTest extends AbstractNetty41ClientTest {
   }
 
   @Override
-  protected boolean testReadTimeout() {
-    return false;
-  }
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+    super.configure(optionsBuilder);
 
-  @Override
-  protected boolean testErrorWithCallback() {
-    return false;
-  }
-
-  @Override
-  protected boolean testCallbackWithParent() {
-    return false;
-  }
-
-  @Override
-  protected boolean testWithClientParent() {
-    return false;
-  }
-
-  @Override
-  protected boolean testConnectionFailure() {
-    return false;
-  }
-
-  @Override
-  protected boolean testRemoteConnection() {
-    return false;
+    optionsBuilder.disableTestErrorWithCallback();
+    optionsBuilder.disableTestCallbackWithParent();
+    optionsBuilder.disableTestWithClientParent();
+    optionsBuilder.disableTestConnectionFailure();
+    optionsBuilder.disableTestRemoteConnection();
   }
 }

--- a/instrumentation/netty/netty-4.1/testing/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AbstractNetty41ClientTest.java
+++ b/instrumentation/netty/netty-4.1/testing/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AbstractNetty41ClientTest.java
@@ -16,10 +16,11 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
-import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -33,11 +34,6 @@ public abstract class AbstractNetty41ClientTest
   protected abstract Netty41ClientExtension clientExtension();
 
   protected abstract void configureChannel(Channel channel);
-
-  @Override
-  protected boolean testRedirects() {
-    return false;
-  }
 
   @Override
   public DefaultFullHttpRequest buildRequest(String method, URI uri, Map<String, String> headers) {
@@ -97,32 +93,40 @@ public abstract class AbstractNetty41ClientTest
   }
 
   @Override
-  protected String expectedClientSpanName(URI uri, String method) {
-    switch (uri.toString()) {
-      case "http://localhost:61/": // unopened port
-      case "https://192.0.2.1/": // non routable address
-        return "CONNECT";
-      default:
-        return super.expectedClientSpanName(uri, method);
-    }
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+    optionsBuilder.setHttpAttributes(AbstractNetty41ClientTest::getHttpAttributes);
+    optionsBuilder.setExpectedClientSpanNameMapper(
+        AbstractNetty41ClientTest::getExpectedClientSpanName);
+    optionsBuilder.setSingleConnectionFactory(
+        (host, port) ->
+            new SingleNettyConnection(
+                clientExtension().buildBootstrap(false, false),
+                host,
+                port,
+                this::configureChannel));
+
+    optionsBuilder.disableTestRedirects();
   }
 
-  @Override
-  protected Set<AttributeKey<?>> httpAttributes(URI uri) {
+  private static Set<AttributeKey<?>> getHttpAttributes(URI uri) {
     String uriString = uri.toString();
     // http://localhost:61/ => unopened port, https://192.0.2.1/ => non routable address
     if ("http://localhost:61/".equals(uriString) || "https://192.0.2.1/".equals(uriString)) {
       return Collections.emptySet();
     }
-    Set<AttributeKey<?>> attributes = super.httpAttributes(uri);
+    Set<AttributeKey<?>> attributes = new HashSet<>(HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES);
     attributes.remove(SemanticAttributes.NET_PEER_NAME);
     attributes.remove(SemanticAttributes.NET_PEER_PORT);
     return attributes;
   }
 
-  @Override
-  protected SingleConnection createSingleConnection(String host, int port) {
-    return new SingleNettyConnection(
-        clientExtension().buildBootstrap(false, false), host, port, this::configureChannel);
+  private static String getExpectedClientSpanName(URI uri, String method) {
+    switch (uri.toString()) {
+      case "http://localhost:61/": // unopened port
+      case "https://192.0.2.1/": // non routable address
+        return "CONNECT";
+      default:
+        return HttpClientTestOptions.DEFAULT_EXPECTED_CLIENT_SPAN_NAME_MAPPER.apply(uri, method);
+    }
   }
 }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyHttpClientTest.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-0.9/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v0_9/ReactorNettyHttpClientTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.reactornetty.v0_9;
 
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.SingleConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -34,7 +35,13 @@ class ReactorNettyHttpClientTest extends AbstractReactorNettyHttpClientTest {
   }
 
   @Override
-  public SingleConnection createSingleConnection(String host, int port) {
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+    super.configure(optionsBuilder);
+
+    optionsBuilder.setSingleConnectionFactory(ReactorNettyHttpClientTest::createSingleConnection);
+  }
+
+  private static SingleConnection createSingleConnection(String host, int port) {
     String url;
     try {
       url = new URL("http", host, port, "").toString();

--- a/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
+++ b/testing-common/src/main/groovy/io/opentelemetry/instrumentation/test/base/HttpClientTest.groovy
@@ -126,101 +126,26 @@ abstract class HttpClientTest<REQUEST> extends InstrumentationSpecification {
     }
 
     @Override
-    protected String expectedClientSpanName(URI uri, String method) {
-      return HttpClientTest.this.expectedClientSpanName(uri, method)
-    }
-
-    @Override
-    protected String userAgent() {
-      return HttpClientTest.this.userAgent()
-    }
-
-    @Override
-    protected Throwable clientSpanError(URI uri, Throwable exception) {
-      return HttpClientTest.this.clientSpanError(uri, exception)
-    }
-
-    @Override
-    protected Set<AttributeKey<?>> httpAttributes(URI uri) {
-      return HttpClientTest.this.httpAttributes(uri)
-    }
-
-    @Override
-    protected SingleConnection createSingleConnection(String host, int port) {
-      return HttpClientTest.this.createSingleConnection(host, port)
-    }
-
-    @Override
-    protected boolean testWithClientParent() {
-      return HttpClientTest.this.testWithClientParent()
-    }
-
-    @Override
-    protected boolean testRedirects() {
-      return HttpClientTest.this.testRedirects()
-    }
-
-    @Override
-    protected boolean testCircularRedirects() {
-      return HttpClientTest.this.testCircularRedirects()
-    }
-
-    // maximum number of redirects that http client follows before giving up
-    @Override
-    protected int maxRedirects() {
-      return HttpClientTest.this.maxRedirects()
-    }
-
-    @Override
-    protected boolean testReusedRequest() {
-      return HttpClientTest.this.testReusedRequest()
-    }
-
-    @Override
-    protected boolean testConnectionFailure() {
-      return HttpClientTest.this.testConnectionFailure()
-    }
-
-    @Override
-    protected boolean testRemoteConnection() {
-      return HttpClientTest.this.testRemoteConnection()
-    }
-
-    @Override
-    protected boolean testReadTimeout() {
-      return HttpClientTest.this.testReadTimeout()
-    }
-
-    @Override
-    protected boolean testHttps() {
-      return HttpClientTest.this.testHttps()
-    }
-
-    @Override
-    protected boolean testCallback() {
-      return HttpClientTest.this.testCallback()
-    }
-
-    @Override
-    protected boolean testCallbackWithParent() {
-      // FIXME: this hack is here because callback with parent is broken in play-ws when the stream()
-      // function is used.  There is no way to stop a test from a derived class hence the flag
-      return HttpClientTest.this.testCallbackWithParent()
-    }
-
-    @Override
-    protected boolean testCallbackWithImplicitParent() {
-      return HttpClientTest.this.testCallbackWithImplicitParent()
-    }
-
-    @Override
-    protected boolean testErrorWithCallback() {
-      return HttpClientTest.this.testErrorWithCallback()
-    }
-
-    @Override
     protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+      optionsBuilder.setHttpAttributes(HttpClientTest.this.&httpAttributes)
       optionsBuilder.setResponseCodeOnRedirectError(responseCodeOnRedirectError())
+      optionsBuilder.setUserAgent(HttpClientTest.this.userAgent())
+      optionsBuilder.setClientSpanErrorMapper(HttpClientTest.this.&clientSpanError)
+      optionsBuilder.setSingleConnectionFactory(HttpClientTest.this.&createSingleConnection)
+      optionsBuilder.setExpectedClientSpanNameMapper(HttpClientTest.this.&expectedClientSpanName)
+      optionsBuilder.setTestWithClientParent(HttpClientTest.this.testWithClientParent())
+      optionsBuilder.setTestRedirects(HttpClientTest.this.testRedirects())
+      optionsBuilder.setTestCircularRedirects(HttpClientTest.this.testCircularRedirects())
+      optionsBuilder.setMaxRedirects(HttpClientTest.this.maxRedirects())
+      optionsBuilder.setTestReusedRequest(HttpClientTest.this.testReusedRequest())
+      optionsBuilder.setTestConnectionFailure(HttpClientTest.this.testConnectionFailure())
+      optionsBuilder.setTestReadTimeout(HttpClientTest.this.testReadTimeout())
+      optionsBuilder.setTestRemoteConnection(HttpClientTest.this.testRemoteConnection())
+      optionsBuilder.setTestHttps(HttpClientTest.this.testHttps())
+      optionsBuilder.setTestCallback(HttpClientTest.this.testCallback())
+      optionsBuilder.setTestCallbackWithParent(HttpClientTest.this.testCallbackWithParent())
+      optionsBuilder.setTestCallbackWithImplicitParent(HttpClientTest.this.testCallbackWithImplicitParent())
+      optionsBuilder.setTestErrorWithCallback(HttpClientTest.this.testErrorWithCallback())
     }
   }
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
@@ -31,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -79,52 +77,19 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
   @BeforeAll
   void setupOptions() {
     HttpClientTestOptions.Builder builder = HttpClientTestOptions.builder();
-    // TODO(anuraaga): Have subclasses configure options directly and remove mapping of legacy
-    // protected methods.
-    builder.setHttpAttributes(this::httpAttributes);
-    builder.setExpectedClientSpanNameMapper(this::expectedClientSpanName);
-    builder.setUserAgent(userAgent());
-    builder.setClientSpanErrorMapper(this::clientSpanError);
-    builder.setSingleConnectionFactory(this::createSingleConnection);
-    if (!testWithClientParent()) {
-      builder.disableTestWithClientParent();
-    }
-    if (!testRedirects()) {
-      builder.disableTestRedirects();
-    }
-    if (!testCircularRedirects()) {
-      builder.disableTestCircularRedirects();
-    }
-    builder.setMaxRedirects(maxRedirects());
-    if (!testReusedRequest()) {
-      builder.disableTestReusedRequest();
-    }
-    if (!testConnectionFailure()) {
-      builder.disableTestConnectionFailure();
-    }
-    if (testReadTimeout()) {
-      builder.enableTestReadTimeout();
-    }
-    if (!testRemoteConnection()) {
-      builder.disableTestRemoteConnection();
-    }
-    if (!testHttps()) {
-      builder.disableTestHttps();
-    }
-    if (!testCallback()) {
-      builder.disableTestCallback();
-    }
-    if (!testCallbackWithParent()) {
-      builder.disableTestCallbackWithParent();
-    }
-    if (!testErrorWithCallback()) {
-      builder.disableTestErrorWithCallback();
-    }
-    if (testCallbackWithImplicitParent()) {
-      builder.enableTestCallbackWithImplicitParent();
-    }
     configure(builder);
     options = builder.build();
+  }
+
+  /**
+   * Override this method to configure the {@link HttpClientTestOptions} for the tested HTTP client.
+   */
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {}
+
+  // called by the HttpClientInstrumentationExtension
+  final void setTesting(InstrumentationTestRunner testing, HttpClientTestServer server) {
+    this.testing = testing;
+    this.server = server;
   }
 
   @BeforeEach
@@ -1079,98 +1044,6 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
     return span.hasName("test-http-server").hasKind(SpanKind.SERVER);
   }
 
-  protected Set<AttributeKey<?>> httpAttributes(URI uri) {
-    // FIXME (mateusz) why is this not the same as HttpClientTestOptions.DEFAULT_HTTP_ATTRIBUTES?
-    Set<AttributeKey<?>> attributes = new HashSet<>();
-    attributes.add(NetAttributes.NET_PROTOCOL_NAME);
-    attributes.add(NetAttributes.NET_PROTOCOL_VERSION);
-    attributes.add(SemanticAttributes.HTTP_URL);
-    attributes.add(SemanticAttributes.HTTP_METHOD);
-    attributes.add(SemanticAttributes.USER_AGENT_ORIGINAL);
-    return attributes;
-  }
-
-  protected String expectedClientSpanName(URI uri, String method) {
-    return HttpClientTestOptions.DEFAULT_EXPECTED_CLIENT_SPAN_NAME_MAPPER.apply(uri, method);
-  }
-
-  @Nullable
-  protected String userAgent() {
-    return null;
-  }
-
-  @CanIgnoreReturnValue
-  protected Throwable clientSpanError(URI uri, Throwable exception) {
-    return exception;
-  }
-
-  // This method should create either a single connection to the target uri or a http client
-  // which is guaranteed to use the same connection for all requests
-  @Nullable
-  protected SingleConnection createSingleConnection(String host, int port) {
-    return null;
-  }
-
-  protected boolean testWithClientParent() {
-    return true;
-  }
-
-  protected boolean testRedirects() {
-    return true;
-  }
-
-  protected boolean testCircularRedirects() {
-    return true;
-  }
-
-  // maximum number of redirects that http client follows before giving up
-  protected int maxRedirects() {
-    return 2;
-  }
-
-  protected boolean testReusedRequest() {
-    return true;
-  }
-
-  protected boolean testConnectionFailure() {
-    return true;
-  }
-
-  protected boolean testReadTimeout() {
-    return false;
-  }
-
-  protected boolean testRemoteConnection() {
-    return true;
-  }
-
-  protected boolean testHttps() {
-    return true;
-  }
-
-  protected boolean testCallback() {
-    return true;
-  }
-
-  protected boolean testCallbackWithParent() {
-    // FIXME: this hack is here because callback with parent is broken in play-ws when the stream()
-    // function is used.  There is no way to stop a test from a derived class hence the flag
-    return true;
-  }
-
-  protected boolean testCallbackWithImplicitParent() {
-    // depending on async behavior callback can be executed within
-    // parent span scope or outside of the scope, e.g. in reactor-netty or spring
-    // callback is correlated.
-    return false;
-  }
-
-  protected boolean testErrorWithCallback() {
-    return true;
-  }
-
-  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {}
-
   private int doRequest(String method, URI uri) throws Exception {
     return doRequest(method, uri, Collections.emptyMap());
   }
@@ -1209,12 +1082,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
     return httpClientResult;
   }
 
-  protected URI resolveAddress(String path) {
+  protected final URI resolveAddress(String path) {
     return URI.create("http://localhost:" + server.httpPort() + path);
-  }
-
-  final void setTesting(InstrumentationTestRunner testing, HttpClientTestServer server) {
-    this.testing = testing;
-    this.server = server;
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestOptions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestOptions.java
@@ -49,6 +49,10 @@ public abstract class HttpClientTestOptions {
 
   public abstract BiFunction<URI, Throwable, Throwable> getClientSpanErrorMapper();
 
+  /**
+   * The returned function should create either a single connection to the target uri or a http
+   * client which is guaranteed to use the same connection for all requests.
+   */
   public abstract BiFunction<String, Integer, SingleConnection> getSingleConnectionFactory();
 
   public abstract BiFunction<URI, String, String> getExpectedClientSpanNameMapper();
@@ -65,6 +69,7 @@ public abstract class HttpClientTestOptions {
 
   public abstract boolean getTestCircularRedirects();
 
+  /** Returns the maximum number of redirects that http client follows before giving up. */
   public abstract int getMaxRedirects();
 
   public abstract boolean getTestReusedRequest();
@@ -81,6 +86,9 @@ public abstract class HttpClientTestOptions {
 
   public abstract boolean getTestCallbackWithParent();
 
+  // depending on async behavior callback can be executed within
+  // parent span scope or outside of the scope, e.g. in reactor-netty or spring
+  // callback is correlated.
   public abstract boolean getTestCallbackWithImplicitParent();
 
   public abstract boolean getTestErrorWithCallback();


### PR DESCRIPTION
…s with `configure()`

Just an idea I had when I updated the retry tests