### PR TITLE
Update the JDBC driver documentation

### DIFF
--- a/instrumentation/jdbc/library/README.md
+++ b/instrumentation/jdbc/library/README.md
@@ -67,8 +67,4 @@ public class DataSourceConfig {
 
 1. Activate tracing for JDBC connections by setting `jdbc:otel:` prefix to the JDBC URL, e.g. `jdbc:otel:h2:mem:test`.
 
-2. Set the driver class to `io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver` and initialize the driver with:
-
-  ```java
-  Class.forName("io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver");
-  ```
+2. Set the driver class to `io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver`.


### PR DESCRIPTION
From JDBC 4.0 (Java SE 6), the driver can be auto-registered from a `java.sql.Driver` file contained in the `META-INF.services` folder. [This file is provided by the `opentelemetry-jdbc` library](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jdbc/library/src/main/resources/META-INF/services/java.sql.Driver). OpenTelemetry libraries are supposed to work from Java 8. So, the `Class.forName` mention could be removed from the documentation.