### PR TITLE
Fix jetty context leak

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ignore/GlobalIgnoredTypesConfigurer.java
@@ -170,5 +170,13 @@ public class GlobalIgnoredTypesConfigurer implements IgnoredTypesConfigurer {
 
     // Presto turned into trino, and so the package changed.
     builder.ignoreTaskClass("io.trino.jdbc.$internal.okhttp3.ConnectionPool$");
+
+    // ReservedThread is a Runnable that consumes tasks from a queue.
+    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8415
+    builder.ignoreTaskClass("org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread");
+
+    // Skip propagating context into truffle compiler.
+    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8415
+    builder.ignoreTaskClass("org.graalvm.compiler.truffle.runtime.CompilationTask");
   }
 }


### PR DESCRIPTION
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8415
I wasn't able to reproduce, it is unclear to me how context propagates into `ReservedThreadExecutor$ReservedThread` in the first place. Looking at  https://github.com/eclipse/jetty.project/blob/b45c405e4544384de066f814ed42ae3dceacdd49/jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java#L302 I'd say that we shouldn't propagate context there, it is reading tasks from a queue.