### PR TITLE
Disable flaky async http client read timeout tests

### DIFF
--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/build.gradle.kts
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/build.gradle.kts
@@ -24,4 +24,6 @@ tasks.withType<Test>().configureEach {
   // required on jdk17
   jvmArgs("--add-exports=java.base/sun.security.util=ALL-UNNAMED")
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+
+  systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
 }

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/test/groovy/AsyncHttpClientTest.groovy
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/test/groovy/AsyncHttpClientTest.groovy
@@ -67,6 +67,12 @@ class AsyncHttpClientTest extends HttpClientTest<Request> implements AgentTestTr
   }
 
   @Override
+  boolean testReadTimeout() {
+    // disable read timeout test for non latest because it is flaky wih 1.9.0
+    Boolean.getBoolean("testLatestDeps")
+  }
+
+  @Override
   SingleConnection createSingleConnection(String host, int port) {
     // AsyncHttpClient does not support HTTP 1.1 pipelining nor waiting for connection pool slots to
     // free up (it immediately throws "Too many connections" IOException). Therefore making a single

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/test/groovy/AsyncHttpClientTest.groovy
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/test/groovy/AsyncHttpClientTest.groovy
@@ -68,7 +68,7 @@ class AsyncHttpClientTest extends HttpClientTest<Request> implements AgentTestTr
 
   @Override
   boolean testReadTimeout() {
-    // disable read timeout test for non latest because it is flaky wih 1.9.0
+    // disable read timeout test for non latest because it is flaky with 1.9.0
     Boolean.getBoolean("testLatestDeps")
   }
 


### PR DESCRIPTION
https://ge.opentelemetry.io/scans/tests?search.buildOutcome=success&search.relativeStartTime=P28D&search.tags=CI&search.timeZoneId=Europe/Tallinn&tests.container=AsyncHttpClientTest&tests.sortField=FLAKY&tests.test=read%20timed%20out&tests.unstableOnly=true
Looks like a bug in async http client 1.9.0. I think this test was disabled before https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8530