### PR TITLE
Stop gradle daemon before codeql analysis

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         with:
           # skipping build cache is needed so that all modules will be analyzed
-          arguments: assemble -x javadoc --no-build-cache
+          arguments: assemble -x javadoc --no-build-cache --no-daemon
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8597
After increasing gradle heap size codeql analysis fails with `The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.` Hopefully the analysis process needs more memory and stopping the gradle daemon when it has done its thing is enough to fix it.