### PR TITLE
Change context propagation debug failures from error to warn

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/ContextPropagationDebug.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/ContextPropagationDebug.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.internal;
 
-import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
@@ -75,10 +75,10 @@ public final class ContextPropagationDebug {
 
     Context current = Context.current();
     if (current != Context.root()) {
-      logger.severe("Unexpected non-root current context found when extracting remote context!");
+      logger.warning("Unexpected non-root current context found when extracting remote context!");
       Span currentSpan = Span.fromContextOrNull(current);
       if (currentSpan != null) {
-        logger.log(SEVERE, "It contains this span: {0}", currentSpan);
+        logger.log(WARNING, "It contains this span: {0}", currentSpan);
       }
 
       debugContextPropagation(current);
@@ -125,7 +125,7 @@ public final class ContextPropagationDebug {
           sb.append("\nwhich was propagated from:");
         }
       }
-      logger.log(SEVERE, "a context leak was detected. it was propagated from: {0}", sb);
+      logger.log(WARNING, "a context leak was detected. it was propagated from: {0}", sb);
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8536
As having unexpected non-root context doesn't always mean something will break or that there was a context leak it feels better to log a warning instead of an error.