### PR TITLE
Add EnvironmentResourceProvider

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -95,7 +95,7 @@ val DEPENDENCIES = listOf(
   "commons-lang:commons-lang:2.6",
   "commons-logging:commons-logging:1.2",
   "commons-validator:commons-validator:1.7",
-  // TODO(anuraaga): Skip 1.8 because of https://github.com/rohanpadhye/JQF/issues/172
+  // Skip 1.8 because of https://github.com/rohanpadhye/JQF/issues/172
   "edu.berkeley.cs.jqf:jqf-fuzz:1.7",
   "io.netty:netty:3.10.6.Final",
   "io.opentelemetry.contrib:opentelemetry-aws-xray-propagator:1.26.0-alpha",

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -95,6 +95,8 @@ val DEPENDENCIES = listOf(
   "commons-lang:commons-lang:2.6",
   "commons-logging:commons-logging:1.2",
   "commons-validator:commons-validator:1.7",
+  // TODO(anuraaga): Skip 1.8 because of https://github.com/rohanpadhye/JQF/issues/172
+  "edu.berkeley.cs.jqf:jqf-fuzz:1.7",
   "io.netty:netty:3.10.6.Final",
   "io.opentelemetry.contrib:opentelemetry-aws-xray-propagator:1.26.0-alpha",
   "io.opentelemetry.proto:opentelemetry-proto:0.19.0-alpha",

--- a/instrumentation/resources/library/README.md
+++ b/instrumentation/resources/library/README.md
@@ -5,6 +5,16 @@ common environments. Currently, the resources provide the following semantic con
 
 ## Populated attributes
 
+### Container
+
+Provider: `io.opentelemetry.instrumentation.resources.ContainerResource`
+
+Specification: <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/container.md>
+
+Implemented attributes:
+
+- `container.id`
+
 ### Environment
 
 Provider: `io.opentelemetry.instrumentation.resources.EnvironmentResourceProvider`
@@ -16,16 +26,6 @@ Parses environment variables / system properties in keys `otel.service.name` and
 Implemented attributes:
 
 - `service.name`, *
-
-### Container
-
-Provider: `io.opentelemetry.instrumentation.resources.ContainerResource`
-
-Specification: <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/container.md>
-
-Implemented attributes:
-
-- `container.id`
 
 ### Host
 

--- a/instrumentation/resources/library/README.md
+++ b/instrumentation/resources/library/README.md
@@ -5,6 +5,18 @@ common environments. Currently, the resources provide the following semantic con
 
 ## Populated attributes
 
+### Environment
+
+Provider: `io.opentelemetry.instrumentation.resources.EnvironmentResourceProvider`
+
+Specification: <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration>
+
+Parses environment variables / system properties in keys `otel.service.name` and `otel.resource.attributes` to construct resource.
+
+Implemented attributes:
+
+- `service.name`, *
+
 ### Container
 
 Provider: `io.opentelemetry.instrumentation.resources.ContainerResource`

--- a/instrumentation/resources/library/build.gradle.kts
+++ b/instrumentation/resources/library/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   testCompileOnly("com.google.auto.service:auto-service-annotations")
 
   testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testImplementation("edu.berkeley.cs.jqf:jqf-fuzz")
 }
 
 for (version in mrJarVersions) {

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/EnvironmentResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/EnvironmentResource.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.resources;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+public final class EnvironmentResource {
+
+  // Visible for testing
+  static final String ATTRIBUTE_PROPERTY = "otel.resource.attributes";
+  static final String SERVICE_NAME_PROPERTY = "otel.service.name";
+
+  private static final Resource INSTANCE =
+      buildResource(DefaultConfigProperties.create(Collections.emptyMap()));
+
+  /**
+   * Returns a new {@link Resource} from the environment. The resource contains attributes parsed
+   * from environment variables and system property keys {@code otel.resource.attributes} and {@code
+   * otel.service.name}.
+   *
+   * @return the resource
+   */
+  public static Resource get() {
+    return INSTANCE;
+  }
+
+  /**
+   * Create a new {@link Resource} from the environment by parsing the {@code config}. The resource
+   * contains attributes parsed from keys {@code otel.resource.attributes} and {@code
+   * otel.service.name}.
+   *
+   * @return the resource
+   */
+  public static Resource create(ConfigProperties configProperties) {
+    return buildResource(configProperties);
+  }
+
+  static Resource buildResource(ConfigProperties config) {
+    return Resource.create(getAttributes(config), ResourceAttributes.SCHEMA_URL);
+  }
+
+  // visible for testing
+  static Attributes getAttributes(ConfigProperties configProperties) {
+    AttributesBuilder resourceAttributes = Attributes.builder();
+    try {
+      for (Map.Entry<String, String> entry :
+          configProperties.getMap(ATTRIBUTE_PROPERTY).entrySet()) {
+        resourceAttributes.put(
+            entry.getKey(),
+            // Attributes specified via otel.resource.attributes follow the W3C Baggage spec and
+            // characters outside the baggage-octet range are percent encoded
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable
+            URLDecoder.decode(entry.getValue(), StandardCharsets.UTF_8.displayName()));
+      }
+    } catch (UnsupportedEncodingException e) {
+      // Should not happen since always using standard charset
+      throw new ConfigurationException("Unable to decode resource attributes.", e);
+    }
+    String serviceName = configProperties.getString(SERVICE_NAME_PROPERTY);
+    if (serviceName != null) {
+      resourceAttributes.put(ResourceAttributes.SERVICE_NAME, serviceName);
+    }
+    return resourceAttributes.build();
+  }
+
+  private EnvironmentResource() {}
+}

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/EnvironmentResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/EnvironmentResource.java
@@ -25,7 +25,7 @@ public final class EnvironmentResource {
   static final String SERVICE_NAME_PROPERTY = "otel.service.name";
 
   private static final Resource INSTANCE =
-      buildResource(DefaultConfigProperties.create(Collections.emptyMap()));
+      create(DefaultConfigProperties.create(Collections.emptyMap()));
 
   /**
    * Returns a new {@link Resource} from the environment. The resource contains attributes parsed
@@ -46,11 +46,7 @@ public final class EnvironmentResource {
    * @return the resource
    */
   public static Resource create(ConfigProperties configProperties) {
-    return buildResource(configProperties);
-  }
-
-  static Resource buildResource(ConfigProperties config) {
-    return Resource.create(getAttributes(config), ResourceAttributes.SCHEMA_URL);
+    return Resource.create(getAttributes(configProperties), ResourceAttributes.SCHEMA_URL);
   }
 
   // visible for testing

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/EnvironmentResourceProvider.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/EnvironmentResourceProvider.java
@@ -15,11 +15,13 @@ import io.opentelemetry.sdk.resources.Resource;
 public final class EnvironmentResourceProvider implements ResourceProvider {
   @Override
   public Resource createResource(ConfigProperties config) {
-    return EnvironmentResource.buildResource(config);
+    return EnvironmentResource.create(config);
   }
 
   @Override
   public int order() {
+    // A high order ensures that the environment resource takes precedent over the resources from
+    // other ResourceProviders
     return 10;
   }
 }

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/EnvironmentResourceProvider.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/EnvironmentResourceProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.resources;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+
+/** {@link ResourceProvider} for automatically configuring {@link EnvironmentResource}. */
+@AutoService(ResourceProvider.class)
+public final class EnvironmentResourceProvider implements ResourceProvider {
+  @Override
+  public Resource createResource(ConfigProperties config) {
+    return EnvironmentResource.buildResource(config);
+  }
+
+  @Override
+  public int order() {
+    return 10;
+  }
+}

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/EnvironmentResourceFuzzTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/EnvironmentResourceFuzzTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.resources;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Collections.singletonMap;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import edu.berkeley.cs.jqf.fuzz.junit.GuidedFuzzing;
+import edu.berkeley.cs.jqf.fuzz.random.NoGuidance;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.internal.PercentEscaper;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+@SuppressWarnings("SystemOut")
+class EnvironmentResourceFuzzTest {
+
+  @RunWith(JQF.class)
+  public static class TestCases {
+
+    private static final PercentEscaper escaper = PercentEscaper.create();
+
+    @Fuzz
+    public void getAttributesWithRandomValues(String value1, String value2) {
+      Attributes attributes =
+          EnvironmentResource.getAttributes(
+              DefaultConfigProperties.createForTest(
+                  singletonMap(
+                      EnvironmentResource.ATTRIBUTE_PROPERTY,
+                      "key1=" + escaper.escape(value1) + ",key2=" + escaper.escape(value2))));
+
+      assertThat(attributes).hasSize(2).containsEntry("key1", value1).containsEntry("key2", value2);
+    }
+  }
+
+  // driver methods to avoid having to use the vintage junit engine, and to enable increasing the
+  // number of iterations:
+
+  @Test
+  void getAttributesWithFuzzing() {
+    Result result =
+        GuidedFuzzing.run(
+            TestCases.class,
+            "getAttributesWithRandomValues",
+            new NoGuidance(10000, System.out),
+            System.out);
+    Assertions.assertThat(result.wasSuccessful()).isTrue();
+  }
+}

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/EnvironmentResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/EnvironmentResourceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.resources;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+
+import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentResourceTest {
+
+  @Test
+  void customConfigResource() {
+    Map<String, String> props = new HashMap<>();
+    props.put("otel.service.name", "test-service");
+    props.put("otel.resource.attributes", "food=cheesecake,drink=juice");
+
+    assertThat(EnvironmentResource.create(DefaultConfigProperties.create(props)))
+        .isEqualTo(
+            Resource.empty().toBuilder()
+                .put(ResourceAttributes.SERVICE_NAME, "test-service")
+                .put("food", "cheesecake")
+                .put("drink", "juice")
+                .setSchemaUrl(ResourceAttributes.SCHEMA_URL)
+                .build());
+  }
+
+  @Test
+  void resourceFromConfig_empty() {
+    Attributes attributes =
+        EnvironmentResource.getAttributes(DefaultConfigProperties.createForTest(emptyMap()));
+
+    assertThat(attributes).isEmpty();
+  }
+
+  @Test
+  void resourceFromConfig() {
+    Attributes attributes =
+        EnvironmentResource.getAttributes(
+            DefaultConfigProperties.createForTest(
+                singletonMap(
+                    EnvironmentResource.ATTRIBUTE_PROPERTY,
+                    "service.name=myService,appName=MyApp")));
+
+    assertThat(attributes)
+        .hasSize(2)
+        .containsEntry(ResourceAttributes.SERVICE_NAME, "myService")
+        .containsEntry("appName", "MyApp");
+  }
+
+  @Test
+  void serviceName() {
+    Attributes attributes =
+        EnvironmentResource.getAttributes(
+            DefaultConfigProperties.createForTest(
+                singletonMap(EnvironmentResource.SERVICE_NAME_PROPERTY, "myService")));
+
+    assertThat(attributes).hasSize(1).containsEntry(ResourceAttributes.SERVICE_NAME, "myService");
+  }
+
+  @Test
+  void resourceFromConfig_overrideServiceName() {
+    Attributes attributes =
+        EnvironmentResource.getAttributes(
+            DefaultConfigProperties.createForTest(
+                ImmutableMap.of(
+                    EnvironmentResource.ATTRIBUTE_PROPERTY,
+                    "service.name=myService,appName=MyApp",
+                    EnvironmentResource.SERVICE_NAME_PROPERTY,
+                    "ReallyMyService")));
+
+    assertThat(attributes)
+        .hasSize(2)
+        .containsEntry(ResourceAttributes.SERVICE_NAME, "ReallyMyService")
+        .containsEntry("appName", "MyApp");
+  }
+
+  @Test
+  void resourceFromConfig_emptyEnvVar() {
+    Attributes attributes =
+        EnvironmentResource.getAttributes(
+            DefaultConfigProperties.createForTest(
+                singletonMap(EnvironmentResource.ATTRIBUTE_PROPERTY, "")));
+
+    assertThat(attributes).isEmpty();
+  }
+}


### PR DESCRIPTION
An option that may nicely cleanup the problem discussed [here](https://github.com/open-telemetry/opentelemetry-java/pull/5467#discussion_r1200679542), where the autoconfigured resource from the environment is only accessible through via a roundabout API that instantiates an SDK.

This moves the environment resource logic to the `io.opentelemetry.instrumentation:opentelemetry-resources`, along side other resource providers. A `ResourceProvider` is provided, but you can also programatically access the environment resource via:
- `EnvironmentResource.get()` - access singleton resource which parses environment variables and system properties
- `EnvironmentResource.create(ConfigProperties)` - create an environment resource by parsing properties from `ConfigProperties`. Allows you to bring your own set of configuration overrides.

WDYT? 

cc @jkwatson 