### PR TITLE
End netty client span when channel is closed

### DIFF
--- a/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AbstractChannelHandlerContextInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/AbstractChannelHandlerContextInstrumentation.java
@@ -47,6 +47,9 @@ public class AbstractChannelHandlerContextInstrumentation implements TypeInstrum
     public static void onEnter(
         @Advice.This ChannelHandlerContext ctx, @Advice.Argument(0) Throwable throwable) {
 
+      // we can't rely on exception handling in HttpClientTracingHandler because it can't catch
+      // exceptions from handlers that run after it, for example ratpack has ReadTimeoutHandler
+      // (trigger ReadTimeoutException) after HttpClientCodec (or handler is inserted after it)
       Attribute<Context> contextAttr = ctx.channel().attr(AttributeKeys.CLIENT_CONTEXT);
       Context clientContext = contextAttr.get();
       if (clientContext != null) {

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientResponseTracingHandler.java
@@ -26,7 +26,7 @@ import io.opentelemetry.instrumentation.netty.v4_1.internal.AttributeKeys;
  */
 public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapter {
 
-  private static final AttributeKey<HttpResponse> HTTP_CLIENT_RESPONSE =
+  static final AttributeKey<HttpResponse> HTTP_CLIENT_RESPONSE =
       AttributeKey.valueOf(HttpClientResponseTracingHandler.class, "http-client-response");
 
   private final Instrumenter<HttpRequestAndChannel, HttpResponse> instrumenter;

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientTracingHandler.java
@@ -5,10 +5,18 @@
 
 package io.opentelemetry.instrumentation.netty.v4_1.internal.client;
 
+import static io.opentelemetry.instrumentation.netty.v4_1.internal.client.HttpClientRequestTracingHandler.HTTP_CLIENT_REQUEST;
+import static io.opentelemetry.instrumentation.netty.v4_1.internal.client.HttpClientResponseTracingHandler.HTTP_CLIENT_RESPONSE;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.CombinedChannelDuplexHandler;
 import io.netty.handler.codec.http.HttpResponse;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
+import io.opentelemetry.instrumentation.netty.v4_1.internal.AttributeKeys;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -17,10 +25,52 @@ import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 public class HttpClientTracingHandler
     extends CombinedChannelDuplexHandler<
         HttpClientResponseTracingHandler, HttpClientRequestTracingHandler> {
+  private final Instrumenter<HttpRequestAndChannel, HttpResponse> instrumenter;
 
   public HttpClientTracingHandler(Instrumenter<HttpRequestAndChannel, HttpResponse> instrumenter) {
     super(
         new HttpClientResponseTracingHandler(instrumenter),
         new HttpClientRequestTracingHandler(instrumenter));
+    this.instrumenter = instrumenter;
+  }
+
+  @Override
+  public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    Context context = ctx.channel().attr(AttributeKeys.CLIENT_CONTEXT).getAndSet(null);
+    HttpRequestAndChannel request = ctx.channel().attr(HTTP_CLIENT_REQUEST).getAndSet(null);
+    HttpResponse response = ctx.channel().attr(HTTP_CLIENT_RESPONSE).getAndSet(null);
+    Context parentContext = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_CONTEXT).getAndSet(null);
+    if (context != null && request != null) {
+      instrumenter.end(context, request, response, null);
+    }
+
+    if (parentContext != null) {
+      try (Scope ignored = parentContext.makeCurrent()) {
+        super.close(ctx, promise);
+      }
+    } else {
+      super.close(ctx, promise);
+    }
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    // javaagent inserts exception handling in AbstractChannelHandlerContextInstrumentation that
+    // runs before this code
+    Context context = ctx.channel().attr(AttributeKeys.CLIENT_CONTEXT).getAndSet(null);
+    HttpRequestAndChannel request = ctx.channel().attr(HTTP_CLIENT_REQUEST).getAndSet(null);
+    HttpResponse response = ctx.channel().attr(HTTP_CLIENT_RESPONSE).getAndSet(null);
+    Context parentContext = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_CONTEXT).getAndSet(null);
+    if (context != null && request != null) {
+      instrumenter.end(context, request, response, cause);
+    }
+
+    if (parentContext != null) {
+      try (Scope ignored = parentContext.makeCurrent()) {
+        super.exceptionCaught(ctx, cause);
+      }
+    } else {
+      super.exceptionCaught(ctx, cause);
+    }
   }
 }

--- a/instrumentation/netty/netty-4.1/library/src/test/java/io/opentelemetry/instrumentation/netty/v4_1/Netty41ClientTest.java
+++ b/instrumentation/netty/netty-4.1/library/src/test/java/io/opentelemetry/instrumentation/netty/v4_1/Netty41ClientTest.java
@@ -52,6 +52,5 @@ public class Netty41ClientTest extends AbstractNetty41ClientTest {
     optionsBuilder.disableTestWithClientParent();
     optionsBuilder.disableTestConnectionFailure();
     optionsBuilder.disableTestRemoteConnection();
-    optionsBuilder.disableTestReadTimeout();
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8598
Should we set the span status to `ERROR` when it is ended because the channel was closed?