### PR TITLE
Fix comment driven automation

### DIFF
--- a/.github/workflows/auto-update-otel-sdk.yml
+++ b/.github/workflows/auto-update-otel-sdk.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Use CLA approved github bot
         run: .github/scripts/use-cla-approved-github-bot.sh
 
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17.0.6
+
       - name: Update license report
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/comment-driven-pr-automation.yml
+++ b/.github/workflows/comment-driven-pr-automation.yml
@@ -73,6 +73,12 @@ jobs:
           env.COMMAND == 'update'
         run: .github/scripts/use-cla-approved-github-bot.sh
 
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17.0.6
+
       - name: Run command
         env:
           NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
We need to run all gradle tasks with jdk 17.
```
* What went wrong:
An exception occurred applying plugin request [id: 'otel.bom-conventions']
> Failed to apply plugin 'otel.bom-conventions'.
   > A problem occurred configuring project ':instrumentation-api-semconv'.
      > Could not determine the dependencies of null.
         > Could not resolve all task dependencies for configuration ':instrumentation-api-semconv:classpath'.
            > Could not resolve org.xbib.gradle.plugin:gradle-plugin-jflex:3.0.0.
              Required by:
                  project :instrumentation-api-semconv > org.xbib.gradle.plugin.jflex:org.xbib.gradle.plugin.jflex.gradle.plugin:3.0.0
               > No matching variant of org.xbib.gradle.plugin:gradle-plugin-jflex:3.0.0 was found. The consumer was configured to find a library for use during runtime, compatible with Java 11, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.1.1' but:
                   - Variant 'apiElements' capability org.xbib.gradle.plugin:gradle-plugin-jflex:3.0.0 declares a library, packaged as a jar, and its dependencies declared externally:
                       - Incompatible because this component declares a component for use during compile-time, compatible with Java 17 and the consumer needed a component for use during runtime, compatible with Java 11
                       - Other compatible attribute:
                           - Doesn't say anything about org.gradle.plugin.api-version (required '8.1.1')
                   - Variant 'javadocElements' capability org.xbib.gradle.plugin:gradle-plugin-jflex:3.0.0 declares a component for use during runtime, and its dependencies declared externally:
                       - Incompatible because this component declares documentation and the consumer needed a library
                       - Other compatible attributes:
                           - Doesn't say anything about its target Java version (required compatibility with Java 11)
                           - Doesn't say anything about its elements (required them packaged as a jar)
                           - Doesn't say anything about org.gradle.plugin.api-version (required '8.1.1')
                   - Variant 'runtimeElements' capability org.xbib.gradle.plugin:gradle-plugin-jflex:3.0.0 declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
                       - Incompatible because this component declares a component, compatible with Java 17 and the consumer needed a component, compatible with Java 11
                       - Other compatible attribute:
                           - Doesn't say anything about org.gradle.plugin.api-version (required '8.1.1')
                   - Variant 'sourcesElements' capability org.xbib.gradle.plugin:gradle-plugin-jflex:3.0.0 declares a component for use during runtime, and its dependencies declared externally:
                       - Incompatible because this component declares documentation and the consumer needed a library
                       - Other compatible attributes:
                           - Doesn't say anything about its target Java version (required compatibility with Java 11)
                           - Doesn't say anything about its elements (required them packaged as a jar)
                           - Doesn't say anything about org.gradle.plugin.api-version (required '8.1.1')
```