### PR TITLE
Implement new stable network semantic conventions

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
@@ -87,6 +87,7 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
     internalNetworkExtractor =
         new InternalNetworkAttributesExtractor<>(
             netAttributesGetter,
+            HttpNetworkTransportFilter.INSTANCE,
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv());
     this.resendCountIncrementer = resendCountIncrementer;

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InternalNetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalNetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.url.internal.UrlAttributes;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
@@ -53,6 +54,7 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
   }
 
   private final InternalNetClientAttributesExtractor<REQUEST, RESPONSE> internalNetExtractor;
+  private final InternalNetworkAttributesExtractor<REQUEST, RESPONSE> internalNetworkExtractor;
   private final ToIntFunction<Context> resendCountIncrementer;
 
   HttpClientAttributesExtractor(
@@ -80,7 +82,13 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
         new InternalNetClientAttributesExtractor<>(
             netAttributesGetter,
             this::shouldCapturePeerPort,
-            new HttpNetNamePortGetter<>(httpAttributesGetter));
+            new HttpNetNamePortGetter<>(httpAttributesGetter),
+            SemconvStability.emitOldHttpSemconv());
+    internalNetworkExtractor =
+        new InternalNetworkAttributesExtractor<>(
+            netAttributesGetter,
+            SemconvStability.emitStableHttpSemconv(),
+            SemconvStability.emitOldHttpSemconv());
     this.resendCountIncrementer = resendCountIncrementer;
   }
 
@@ -121,6 +129,7 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
     super.onEnd(attributes, context, request, response, error);
 
     internalNetExtractor.onEnd(attributes, request, response);
+    internalNetworkExtractor.onEnd(attributes, request, response);
 
     int resendCount = resendCountIncrementer.applyAsInt(context);
     if (resendCount > 0) {

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpNetworkTransportFilter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpNetworkTransportFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.http;
+
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkTransportFilter;
+import javax.annotation.Nullable;
+
+enum HttpNetworkTransportFilter implements NetworkTransportFilter {
+  INSTANCE;
+
+  @Override
+  public boolean shouldAddNetworkTransport(
+      @Nullable String protocolName,
+      @Nullable String protocolVersion,
+      @Nullable String proposedTransport) {
+    // tcp is the default transport for http/1* and http/2*, we're skipping it
+    if ("http".equals(protocolName)
+        && protocolVersion != null
+        && (protocolVersion.startsWith("1") || protocolVersion.startsWith("2"))
+        && "tcp".equals(proposedTransport)) {
+      return false;
+    }
+    // udp is the default transport for http/3*, we're skipping it
+    if ("http".equals(protocolName)
+        && protocolVersion != null
+        && protocolVersion.startsWith("3")
+        && "udp".equals(proposedTransport)) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -105,6 +105,7 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
     internalNetworkExtractor =
         new InternalNetworkAttributesExtractor<>(
             netAttributesGetter,
+            HttpNetworkTransportFilter.INSTANCE,
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv());
     this.httpRouteHolderGetter = httpRouteHolderGetter;

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBuilder.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBuilder.java
@@ -16,13 +16,13 @@ import java.util.List;
 public final class HttpServerAttributesExtractorBuilder<REQUEST, RESPONSE> {
 
   final HttpServerAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter;
-  final NetServerAttributesGetter<REQUEST> netAttributesGetter;
+  final NetServerAttributesGetter<REQUEST, RESPONSE> netAttributesGetter;
   List<String> capturedRequestHeaders = emptyList();
   List<String> capturedResponseHeaders = emptyList();
 
   HttpServerAttributesExtractorBuilder(
       HttpServerAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter,
-      NetServerAttributesGetter<REQUEST> netAttributesGetter) {
+      NetServerAttributesGetter<REQUEST, RESPONSE> netAttributesGetter) {
     this.httpAttributesGetter = httpAttributesGetter;
     this.netAttributesGetter = netAttributesGetter;
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetter.java
@@ -18,8 +18,8 @@ import javax.annotation.Nullable;
  *     NetServerAttributesGetter#getHostSocketAddress(Object)} methods instead.
  */
 @Deprecated
-public abstract class InetSocketAddressNetServerAttributesGetter<REQUEST>
-    implements NetServerAttributesGetter<REQUEST> {
+public abstract class InetSocketAddressNetServerAttributesGetter<REQUEST, RESPONSE>
+    implements NetServerAttributesGetter<REQUEST, RESPONSE> {
 
   @Nullable
   @Override

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressUtil.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressUtil.java
@@ -29,6 +29,19 @@ final class InetSocketAddressUtil {
   }
 
   @Nullable
+  static String getNetworkType(
+      @Nullable InetSocketAddress address, @Nullable InetSocketAddress otherAddress) {
+    if (address == null) {
+      address = otherAddress;
+    }
+    if (address == null) {
+      return null;
+    }
+    InetAddress remoteAddress = address.getAddress();
+    return remoteAddress instanceof Inet6Address ? "ipv6" : "ipv4";
+  }
+
+  @Nullable
   static String getHostName(@Nullable InetSocketAddress address) {
     if (address == null) {
       return null;

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.FallbackNamePortGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InternalNetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalNetworkAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkTransportFilter;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import javax.annotation.Nullable;
 
@@ -44,6 +45,7 @@ public final class NetClientAttributesExtractor<REQUEST, RESPONSE>
     internalNetworkExtractor =
         new InternalNetworkAttributesExtractor<>(
             getter,
+            NetworkTransportFilter.alwaysTrue(),
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv());
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.net;
 
+import io.opentelemetry.instrumentation.api.instrumenter.network.NetworkAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
@@ -16,7 +17,8 @@ import javax.annotation.Nullable;
  * library/framework. It will be used by the NetClientAttributesExtractor to obtain the various
  * network attributes in a type-generic way.
  */
-public interface NetClientAttributesGetter<REQUEST, RESPONSE> {
+public interface NetClientAttributesGetter<REQUEST, RESPONSE>
+    extends NetworkAttributesGetter<REQUEST, RESPONSE> {
 
   @Nullable
   default String getTransport(REQUEST request, @Nullable RESPONSE response) {
@@ -27,7 +29,11 @@ public interface NetClientAttributesGetter<REQUEST, RESPONSE> {
    * Returns the application protocol used.
    *
    * <p>Examples: `amqp`, `http`, `mqtt`.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getNetworkProtocolName(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default String getProtocolName(REQUEST request, @Nullable RESPONSE response) {
     return null;
@@ -37,10 +43,35 @@ public interface NetClientAttributesGetter<REQUEST, RESPONSE> {
    * Returns the version of the application protocol used.
    *
    * <p>Examples: `3.1.1`.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getNetworkProtocolVersion(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default String getProtocolVersion(REQUEST request, @Nullable RESPONSE response) {
     return null;
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getNetworkType(REQUEST request, @Nullable RESPONSE response) {
+    return InetSocketAddressUtil.getNetworkType(getPeerSocketAddress(request, response), null);
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getNetworkProtocolName(REQUEST request, @Nullable RESPONSE response) {
+    return getProtocolName(request, response);
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getNetworkProtocolVersion(REQUEST request, @Nullable RESPONSE response) {
+    return getProtocolVersion(request, response);
   }
 
   @Nullable

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.FallbackNamePortGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InternalNetServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalNetworkAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkTransportFilter;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import javax.annotation.Nullable;
 
@@ -40,6 +41,7 @@ public final class NetServerAttributesExtractor<REQUEST, RESPONSE>
     internalNetworkExtractor =
         new InternalNetworkAttributesExtractor<>(
             getter,
+            NetworkTransportFilter.alwaysTrue(),
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv());
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
@@ -10,6 +10,8 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.FallbackNamePortGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InternalNetServerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalNetworkAttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import javax.annotation.Nullable;
 
 /**
@@ -20,17 +22,26 @@ import javax.annotation.Nullable;
 public final class NetServerAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {
 
-  private final InternalNetServerAttributesExtractor<REQUEST> internalExtractor;
-
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
-      NetServerAttributesGetter<REQUEST> getter) {
+      NetServerAttributesGetter<REQUEST, RESPONSE> getter) {
     return new NetServerAttributesExtractor<>(getter);
   }
 
-  private NetServerAttributesExtractor(NetServerAttributesGetter<REQUEST> getter) {
+  private final InternalNetServerAttributesExtractor<REQUEST, RESPONSE> internalExtractor;
+  private final InternalNetworkAttributesExtractor<REQUEST, RESPONSE> internalNetworkExtractor;
+
+  private NetServerAttributesExtractor(NetServerAttributesGetter<REQUEST, RESPONSE> getter) {
     internalExtractor =
         new InternalNetServerAttributesExtractor<>(
-            getter, (integer, request) -> true, FallbackNamePortGetter.noop());
+            getter,
+            (integer, request) -> true,
+            FallbackNamePortGetter.noop(),
+            SemconvStability.emitOldHttpSemconv());
+    internalNetworkExtractor =
+        new InternalNetworkAttributesExtractor<>(
+            getter,
+            SemconvStability.emitStableHttpSemconv(),
+            SemconvStability.emitOldHttpSemconv());
   }
 
   @Override
@@ -44,5 +55,7 @@ public final class NetServerAttributesExtractor<REQUEST, RESPONSE>
       Context context,
       REQUEST request,
       @Nullable RESPONSE response,
-      @Nullable Throwable error) {}
+      @Nullable Throwable error) {
+    internalNetworkExtractor.onEnd(attributes, request, response);
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.net;
 
+import io.opentelemetry.instrumentation.api.instrumenter.network.NetworkAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
@@ -16,7 +17,8 @@ import javax.annotation.Nullable;
  * server library/framework. It will be used by the {@link NetServerAttributesExtractor} to obtain
  * the various network attributes in a type-generic way.
  */
-public interface NetServerAttributesGetter<REQUEST> {
+public interface NetServerAttributesGetter<REQUEST, RESPONSE>
+    extends NetworkAttributesGetter<REQUEST, RESPONSE> {
 
   @Nullable
   default String getTransport(REQUEST request) {
@@ -27,7 +29,11 @@ public interface NetServerAttributesGetter<REQUEST> {
    * Returns the application protocol used.
    *
    * <p>Examples: `amqp`, `http`, `mqtt`.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getNetworkProtocolName(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default String getProtocolName(REQUEST request) {
     return null;
@@ -37,10 +43,36 @@ public interface NetServerAttributesGetter<REQUEST> {
    * Returns the version of the application protocol used.
    *
    * <p>Examples: `3.1.1`.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getNetworkProtocolVersion(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default String getProtocolVersion(REQUEST request) {
     return null;
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getNetworkType(REQUEST request, @Nullable RESPONSE response) {
+    return InetSocketAddressUtil.getNetworkType(
+        getPeerSocketAddress(request), getHostSocketAddress(request));
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getNetworkProtocolName(REQUEST request, @Nullable RESPONSE response) {
+    return getProtocolName(request);
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getNetworkProtocolVersion(REQUEST request, @Nullable RESPONSE response) {
+    return getProtocolVersion(request);
   }
 
   @Nullable

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetServerAttributesExtractor.java
@@ -10,37 +10,35 @@ import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorU
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import java.util.Locale;
 import java.util.function.BiPredicate;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public final class InternalNetServerAttributesExtractor<REQUEST> {
+public final class InternalNetServerAttributesExtractor<REQUEST, RESPONSE> {
 
-  private final NetServerAttributesGetter<REQUEST> getter;
+  private final NetServerAttributesGetter<REQUEST, RESPONSE> getter;
   private final BiPredicate<Integer, REQUEST> captureHostPortCondition;
   private final FallbackNamePortGetter<REQUEST> fallbackNamePortGetter;
+  private final boolean emitOldHttpAttributes;
 
   public InternalNetServerAttributesExtractor(
-      NetServerAttributesGetter<REQUEST> getter,
+      NetServerAttributesGetter<REQUEST, RESPONSE> getter,
       BiPredicate<Integer, REQUEST> captureHostPortCondition,
-      FallbackNamePortGetter<REQUEST> fallbackNamePortGetter) {
+      FallbackNamePortGetter<REQUEST> fallbackNamePortGetter,
+      boolean emitOldHttpAttributes) {
     this.getter = getter;
     this.captureHostPortCondition = captureHostPortCondition;
     this.fallbackNamePortGetter = fallbackNamePortGetter;
+    this.emitOldHttpAttributes = emitOldHttpAttributes;
   }
 
   public void onStart(AttributesBuilder attributes, REQUEST request) {
 
-    internalSet(attributes, SemanticAttributes.NET_TRANSPORT, getter.getTransport(request));
-    String protocolName = getter.getProtocolName(request);
-    if (protocolName != null) {
-      internalSet(
-          attributes, NetAttributes.NET_PROTOCOL_NAME, protocolName.toLowerCase(Locale.ROOT));
+    if (emitOldHttpAttributes) {
+      internalSet(attributes, SemanticAttributes.NET_TRANSPORT, getter.getTransport(request));
     }
-    internalSet(attributes, NetAttributes.NET_PROTOCOL_VERSION, getter.getProtocolVersion(request));
 
     boolean setSockFamily = false;
 
@@ -79,7 +77,7 @@ public final class InternalNetServerAttributesExtractor<REQUEST> {
       }
     }
 
-    if (setSockFamily) {
+    if (emitOldHttpAttributes && setSockFamily) {
       String sockFamily = getter.getSockFamily(request);
       if (sockFamily != null && !SemanticAttributes.NetSockFamilyValues.INET.equals(sockFamily)) {
         internalSet(attributes, SemanticAttributes.NET_SOCK_FAMILY, sockFamily);

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/NetworkAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/NetworkAttributesExtractor.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalNetworkAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkTransportFilter;
 import javax.annotation.Nullable;
 
 /**
@@ -34,7 +35,10 @@ public final class NetworkAttributesExtractor<REQUEST, RESPONSE>
     // the NetworkAttributesExtractor will always emit new semconv
     internalExtractor =
         new InternalNetworkAttributesExtractor<>(
-            getter, /* emitStableUrlAttributes= */ true, /* emitOldHttpAttributes= */ false);
+            getter,
+            NetworkTransportFilter.alwaysTrue(),
+            /* emitStableUrlAttributes= */ true,
+            /* emitOldHttpAttributes= */ false);
   }
 
   @Override

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/NetworkAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/NetworkAttributesExtractor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalNetworkAttributesExtractor;
+import javax.annotation.Nullable;
+
+/**
+ * Extractor of <a
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/main/specification/trace/semantic_conventions/span-general.md#network-attributes">network
+ * attributes</a>.
+ */
+public final class NetworkAttributesExtractor<REQUEST, RESPONSE>
+    implements AttributesExtractor<REQUEST, RESPONSE> {
+
+  /**
+   * Returns a new {@link NetworkAttributesExtractor} that will use the passed {@link
+   * NetworkAttributesGetter}.
+   */
+  public static <REQUEST, RESPONSE> NetworkAttributesExtractor<REQUEST, RESPONSE> create(
+      NetworkAttributesGetter<REQUEST, RESPONSE> getter) {
+    return new NetworkAttributesExtractor<>(getter);
+  }
+
+  private final InternalNetworkAttributesExtractor<REQUEST, RESPONSE> internalExtractor;
+
+  NetworkAttributesExtractor(NetworkAttributesGetter<REQUEST, RESPONSE> getter) {
+    // the NetworkAttributesExtractor will always emit new semconv
+    internalExtractor =
+        new InternalNetworkAttributesExtractor<>(
+            getter, /* emitStableUrlAttributes= */ true, /* emitOldHttpAttributes= */ false);
+  }
+
+  @Override
+  public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {}
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
+    internalExtractor.onEnd(attributes, request, response);
+  }
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/NetworkAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/NetworkAttributesGetter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network;
+
+import javax.annotation.Nullable;
+
+/**
+ * An interface for getting network attributes.
+ *
+ * <p>Instrumentation authors will create implementations of this interface for their specific
+ * library/framework. It will be used by the {@link NetworkAttributesExtractor} (or other convention
+ * specific extractors) to obtain the various network attributes in a type-generic way.
+ */
+public interface NetworkAttributesGetter<REQUEST, RESPONSE> {
+
+  /**
+   * Returns the <a href="https://osi-model.com/transport-layer/">OSI Transport Layer</a> or <a
+   * href="https://en.wikipedia.org/wiki/Inter-process_communication">Inter-process Communication
+   * method</a>.
+   *
+   * <p>Examples: {@code tcp}, {@code udp}
+   */
+  @Nullable
+  default String getNetworkTransport(REQUEST request, @Nullable RESPONSE response) {
+    return null;
+  }
+
+  /**
+   * Returns the <a href="https://osi-model.com/network-layer/">OSI Network Layer</a> or non-OSI
+   * equivalent.
+   *
+   * <p>Examples: {@code ipv4}, {@code ipv6}
+   */
+  @Nullable
+  default String getNetworkType(REQUEST request, @Nullable RESPONSE response) {
+    return null;
+  }
+
+  /**
+   * Returns the <a href="https://osi-model.com/application-layer/">OSI Application Layer</a> or
+   * non-OSI equivalent.
+   *
+   * <p>Examples: {@code ampq}, {@code http}, {@code mqtt}
+   */
+  @Nullable
+  default String getNetworkProtocolName(REQUEST request, @Nullable RESPONSE response) {
+    return null;
+  }
+
+  /**
+   * Returns the version of the application layer protocol used.
+   *
+   * <p>Examples: {@code 3.1.1}
+   */
+  @Nullable
+  default String getNetworkProtocolVersion(REQUEST request, @Nullable RESPONSE response) {
+    return null;
+  }
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalNetworkAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalNetworkAttributesExtractor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
+import io.opentelemetry.instrumentation.api.instrumenter.network.NetworkAttributesGetter;
+import java.util.Locale;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class InternalNetworkAttributesExtractor<REQUEST, RESPONSE> {
+
+  private final NetworkAttributesGetter<REQUEST, RESPONSE> getter;
+  private final boolean emitStableUrlAttributes;
+  private final boolean emitOldHttpAttributes;
+
+  public InternalNetworkAttributesExtractor(
+      NetworkAttributesGetter<REQUEST, RESPONSE> getter,
+      boolean emitStableUrlAttributes,
+      boolean emitOldHttpAttributes) {
+    this.getter = getter;
+    this.emitStableUrlAttributes = emitStableUrlAttributes;
+    this.emitOldHttpAttributes = emitOldHttpAttributes;
+  }
+
+  public void onEnd(AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {
+    String protocolName = lowercase(getter.getNetworkProtocolName(request, response));
+    String protocolVersion = lowercase(getter.getNetworkProtocolVersion(request, response));
+
+    if (emitStableUrlAttributes) {
+      internalSet(
+          attributes,
+          NetworkAttributes.NETWORK_TRANSPORT,
+          lowercase(getter.getNetworkTransport(request, response)));
+      internalSet(
+          attributes,
+          NetworkAttributes.NETWORK_TYPE,
+          lowercase(getter.getNetworkType(request, response)));
+      internalSet(attributes, NetworkAttributes.NETWORK_PROTOCOL_NAME, protocolName);
+      internalSet(attributes, NetworkAttributes.NETWORK_PROTOCOL_VERSION, protocolVersion);
+    }
+    if (emitOldHttpAttributes) {
+      // net.transport and net.sock.family are not 1:1 convertible with network.transport and
+      // network.type; they must be handled separately in the old net.* extractors
+      internalSet(attributes, NetAttributes.NET_PROTOCOL_NAME, protocolName);
+      internalSet(attributes, NetAttributes.NET_PROTOCOL_VERSION, protocolVersion);
+    }
+  }
+
+  @Nullable
+  private static String lowercase(@Nullable String str) {
+    return str == null ? null : str.toLowerCase(Locale.ROOT);
+  }
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalNetworkAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalNetworkAttributesExtractor.java
@@ -20,14 +20,17 @@ import javax.annotation.Nullable;
 public final class InternalNetworkAttributesExtractor<REQUEST, RESPONSE> {
 
   private final NetworkAttributesGetter<REQUEST, RESPONSE> getter;
+  private final NetworkTransportFilter networkTransportFilter;
   private final boolean emitStableUrlAttributes;
   private final boolean emitOldHttpAttributes;
 
   public InternalNetworkAttributesExtractor(
       NetworkAttributesGetter<REQUEST, RESPONSE> getter,
+      NetworkTransportFilter networkTransportFilter,
       boolean emitStableUrlAttributes,
       boolean emitOldHttpAttributes) {
     this.getter = getter;
+    this.networkTransportFilter = networkTransportFilter;
     this.emitStableUrlAttributes = emitStableUrlAttributes;
     this.emitOldHttpAttributes = emitOldHttpAttributes;
   }
@@ -37,10 +40,11 @@ public final class InternalNetworkAttributesExtractor<REQUEST, RESPONSE> {
     String protocolVersion = lowercase(getter.getNetworkProtocolVersion(request, response));
 
     if (emitStableUrlAttributes) {
-      internalSet(
-          attributes,
-          NetworkAttributes.NETWORK_TRANSPORT,
-          lowercase(getter.getNetworkTransport(request, response)));
+      String transport = lowercase(getter.getNetworkTransport(request, response));
+      if (networkTransportFilter.shouldAddNetworkTransport(
+          protocolName, protocolVersion, transport)) {
+        internalSet(attributes, NetworkAttributes.NETWORK_TRANSPORT, transport);
+      }
       internalSet(
           attributes,
           NetworkAttributes.NETWORK_TYPE,

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/NetworkAttributes.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/NetworkAttributes.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network.internal;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class NetworkAttributes {
+
+  // FIXME: remove this class and replace its usages with SemanticAttributes once schema 1.20 is
+  // released
+
+  public static final AttributeKey<String> NETWORK_TRANSPORT = stringKey("network.transport");
+
+  public static final AttributeKey<String> NETWORK_TYPE = stringKey("network.type");
+
+  public static final AttributeKey<String> NETWORK_PROTOCOL_NAME =
+      stringKey("network.protocol.name");
+
+  public static final AttributeKey<String> NETWORK_PROTOCOL_VERSION =
+      stringKey("network.protocol.version");
+
+  private NetworkAttributes() {}
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/NetworkTransportFilter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/NetworkTransportFilter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network.internal;
+
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+@FunctionalInterface
+public interface NetworkTransportFilter {
+
+  boolean shouldAddNetworkTransport(
+      @Nullable String protocolName,
+      @Nullable String protocolVersion,
+      @Nullable String proposedTransport);
+
+  static NetworkTransportFilter alwaysTrue() {
+    return (protocolName, protocolVersion, proposedTransport) -> true;
+  }
+}

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -73,14 +73,28 @@ class HttpClientAttributesExtractorTest {
 
     @Nullable
     @Override
-    public String getProtocolName(
+    public String getNetworkTransport(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("transport");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkType(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("type");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolName(
         Map<String, String> request, @Nullable Map<String, String> response) {
       return request.get("protocolName");
     }
 
     @Nullable
     @Override
-    public String getProtocolVersion(
+    public String getNetworkProtocolVersion(
         Map<String, String> request, @Nullable Map<String, String> response) {
       return request.get("protocolVersion");
     }
@@ -107,6 +121,8 @@ class HttpClientAttributesExtractorTest {
     request.put("header.content-length", "10");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.custom-request-header", "123,456");
+    request.put("transport", "tcp");
+    request.put("type", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "1.1");
     request.put("peerName", "github.com");

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -87,17 +87,33 @@ class HttpServerAttributesExtractorTest {
   }
 
   static class TestNetServerAttributesGetter
-      implements NetServerAttributesGetter<Map<String, Object>> {
+      implements NetServerAttributesGetter<Map<String, Object>, Map<String, Object>> {
 
     @Nullable
     @Override
-    public String getProtocolName(Map<String, Object> request) {
+    public String getNetworkTransport(
+        Map<String, Object> request, @Nullable Map<String, Object> response) {
+      return (String) request.get("transport");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkType(
+        Map<String, Object> request, @Nullable Map<String, Object> response) {
+      return (String) request.get("type");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolName(
+        Map<String, Object> request, Map<String, Object> response) {
       return (String) request.get("protocolName");
     }
 
     @Nullable
     @Override
-    public String getProtocolVersion(Map<String, Object> request) {
+    public String getNetworkProtocolVersion(
+        Map<String, Object> request, Map<String, Object> response) {
       return (String) request.get("protocolVersion");
     }
 
@@ -128,6 +144,8 @@ class HttpServerAttributesExtractorTest {
     request.put("header.host", "github.com");
     request.put("header.forwarded", "for=1.1.1.1;proto=https");
     request.put("header.custom-request-header", "123,456");
+    request.put("transport", "tcp");
+    request.put("type", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "2.0");
 
@@ -151,8 +169,6 @@ class HttpServerAttributesExtractorTest {
     assertThat(startAttributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_HOST_NAME, "github.com"),
-            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
-            entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_SCHEME, "https"),
             entry(SemanticAttributes.HTTP_TARGET, "/repositories/1?details=true"),
@@ -167,6 +183,8 @@ class HttpServerAttributesExtractorTest {
     extractor.onEnd(endAttributes, Context.root(), request, response, null);
     assertThat(endAttributes.build())
         .containsOnly(
+            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
             entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{repoId}"),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(SemanticAttributes.HTTP_STATUS_CODE, 202L),

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
@@ -21,7 +21,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class InetSocketAddressNetServerAttributesGetterTest {
 
-  static class TestNetServerAttributesGetter implements NetServerAttributesGetter<Addresses> {
+  static class TestNetServerAttributesGetter
+      implements NetServerAttributesGetter<Addresses, Addresses> {
 
     @Override
     public String getHostName(Addresses request) {

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/network/NetworkAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/network/NetworkAttributesExtractorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class NetworkAttributesExtractorTest {
+
+  static class TestNetworkAttributesGetter
+      implements NetworkAttributesGetter<Map<String, String>, Void> {
+
+    @Nullable
+    @Override
+    public String getNetworkTransport(Map<String, String> request, @Nullable Void response) {
+      return request.get("transport");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkType(Map<String, String> request, @Nullable Void response) {
+      return request.get("type");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolName(Map<String, String> request, @Nullable Void response) {
+      return request.get("protocolName");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolVersion(Map<String, String> request, @Nullable Void response) {
+      return request.get("protocolVersion");
+    }
+  }
+
+  @Test
+  void allAttributes() {
+    Map<String, String> request = new HashMap<>();
+    request.put("transport", "TcP");
+    request.put("type", "IPv4");
+    request.put("protocolName", "Http");
+    request.put("protocolVersion", "1.1");
+
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        NetworkAttributesExtractor.create(new TestNetworkAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build()).isEmpty();
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, null, null);
+    assertThat(endAttributes.build())
+        .containsOnly(
+            entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+            entry(NetworkAttributes.NETWORK_TYPE, "ipv4"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"));
+  }
+
+  @Test
+  void noAttributes() {
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        NetworkAttributesExtractor.create(new TestNetworkAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), emptyMap());
+    assertThat(startAttributes.build()).isEmpty();
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), emptyMap(), null, null);
+    assertThat(endAttributes.build()).isEmpty();
+  }
+}

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
@@ -18,6 +18,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkAttributes;
 import io.opentelemetry.instrumentation.api.instrumenter.url.internal.UrlAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
@@ -67,14 +68,28 @@ class HttpClientAttributesExtractorBothSemconvTest {
 
     @Nullable
     @Override
-    public String getProtocolName(
+    public String getNetworkTransport(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("transport");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkType(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("type");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolName(
         Map<String, String> request, @Nullable Map<String, String> response) {
       return request.get("protocolName");
     }
 
     @Nullable
     @Override
-    public String getProtocolVersion(
+    public String getNetworkProtocolVersion(
         Map<String, String> request, @Nullable Map<String, String> response) {
       return request.get("protocolVersion");
     }
@@ -101,6 +116,8 @@ class HttpClientAttributesExtractorBothSemconvTest {
     request.put("header.content-length", "10");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.custom-request-header", "123,456");
+    request.put("transport", "tcp");
+    request.put("type", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "1.1");
     request.put("peerName", "github.com");
@@ -151,6 +168,10 @@ class HttpClientAttributesExtractorBothSemconvTest {
                 AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
                 asList("654", "321")),
             entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
-            entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"));
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"),
+            entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+            entry(NetworkAttributes.NETWORK_TYPE, "ipv4"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"));
   }
 }

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
@@ -116,7 +116,7 @@ class HttpClientAttributesExtractorBothSemconvTest {
     request.put("header.content-length", "10");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.custom-request-header", "123,456");
-    request.put("transport", "tcp");
+    request.put("transport", "udp");
     request.put("type", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "1.1");
@@ -169,7 +169,7 @@ class HttpClientAttributesExtractorBothSemconvTest {
                 asList("654", "321")),
             entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
             entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"),
-            entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+            entry(NetworkAttributes.NETWORK_TRANSPORT, "udp"),
             entry(NetworkAttributes.NETWORK_TYPE, "ipv4"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"));

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
@@ -138,7 +138,7 @@ class HttpServerAttributesExtractorBothSemconvTest {
     request.put("header.host", "github.com");
     request.put("header.forwarded", "for=1.1.1.1;proto=https");
     request.put("header.custom-request-header", "123,456");
-    request.put("transport", "tcp");
+    request.put("transport", "udp");
     request.put("type", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "2.0");
@@ -183,7 +183,7 @@ class HttpServerAttributesExtractorBothSemconvTest {
         .containsOnly(
             entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
             entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
-            entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+            entry(NetworkAttributes.NETWORK_TRANSPORT, "udp"),
             entry(NetworkAttributes.NETWORK_TYPE, "ipv4"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
@@ -17,6 +17,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkAttributes;
 import io.opentelemetry.instrumentation.api.instrumenter.url.internal.UrlAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
@@ -80,17 +81,33 @@ class HttpServerAttributesExtractorBothSemconvTest {
   }
 
   static class TestNetServerAttributesGetter
-      implements NetServerAttributesGetter<Map<String, Object>> {
+      implements NetServerAttributesGetter<Map<String, Object>, Map<String, Object>> {
 
     @Nullable
     @Override
-    public String getProtocolName(Map<String, Object> request) {
+    public String getNetworkTransport(
+        Map<String, Object> request, @Nullable Map<String, Object> response) {
+      return (String) request.get("transport");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkType(
+        Map<String, Object> request, @Nullable Map<String, Object> response) {
+      return (String) request.get("type");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolName(
+        Map<String, Object> request, Map<String, Object> response) {
       return (String) request.get("protocolName");
     }
 
     @Nullable
     @Override
-    public String getProtocolVersion(Map<String, Object> request) {
+    public String getNetworkProtocolVersion(
+        Map<String, Object> request, Map<String, Object> response) {
       return (String) request.get("protocolVersion");
     }
 
@@ -121,6 +138,8 @@ class HttpServerAttributesExtractorBothSemconvTest {
     request.put("header.host", "github.com");
     request.put("header.forwarded", "for=1.1.1.1;proto=https");
     request.put("header.custom-request-header", "123,456");
+    request.put("transport", "tcp");
+    request.put("type", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "2.0");
 
@@ -144,8 +163,6 @@ class HttpServerAttributesExtractorBothSemconvTest {
     assertThat(startAttributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_HOST_NAME, "github.com"),
-            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
-            entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_SCHEME, "http"),
@@ -164,6 +181,12 @@ class HttpServerAttributesExtractorBothSemconvTest {
     extractor.onEnd(endAttributes, Context.root(), request, response, null);
     assertThat(endAttributes.build())
         .containsOnly(
+            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "2.0"),
+            entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+            entry(NetworkAttributes.NETWORK_TYPE, "ipv4"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
             entry(SemanticAttributes.HTTP_ROUTE, "/repositories/{repoId}"),
             entry(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH, 10L),
             entry(HttpAttributes.HTTP_REQUEST_BODY_SIZE, 10L),

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorBothSemconvTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.api.instrumenter.net;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
-import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.api.common.Attributes;
@@ -15,14 +14,14 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class NetClientAttributesExtractorTest {
+class NetClientAttributesExtractorBothSemconvTest {
 
   static class TestNetClientAttributesGetter
       implements NetClientAttributesGetter<Map<String, String>, Map<String, String>> {
@@ -132,144 +131,13 @@ class NetClientAttributesExtractorTest {
             entry(SemanticAttributes.NET_TRANSPORT, IP_TCP),
             entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
             entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"),
+            entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+            entry(NetworkAttributes.NETWORK_TYPE, "ipv6"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
             entry(SemanticAttributes.NET_SOCK_FAMILY, "inet6"),
             entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"),
             entry(SemanticAttributes.NET_SOCK_PEER_NAME, "proxy.opentelemetry.io"),
             entry(SemanticAttributes.NET_SOCK_PEER_PORT, 123L));
-  }
-
-  @Test
-  void empty() {
-    // given
-    Context context = Context.root();
-
-    // when
-    AttributesBuilder startAttributes = Attributes.builder();
-    extractor.onStart(startAttributes, context, emptyMap());
-
-    AttributesBuilder endAttributes = Attributes.builder();
-    extractor.onEnd(endAttributes, context, emptyMap(), emptyMap(), null);
-
-    // then
-    assertThat(startAttributes.build()).isEmpty();
-    assertThat(endAttributes.build()).isEmpty();
-  }
-
-  @Test
-  @DisplayName("does not set any net.sock.* attributes when net.peer.name = net.sock.peer.addr")
-  void doesNotSetDuplicates1() {
-    // given
-    Map<String, String> map = new HashMap<>();
-    map.put("netTransport", IP_TCP);
-    map.put("peerName", "1:2:3:4::");
-    map.put("peerPort", "42");
-    map.put("sockFamily", "inet6");
-    map.put("sockPeerAddr", "1:2:3:4::");
-    map.put("sockPeerName", "proxy.opentelemetry.io");
-    map.put("sockPeerPort", "123");
-
-    Context context = Context.root();
-
-    // when
-    AttributesBuilder startAttributes = Attributes.builder();
-    extractor.onStart(startAttributes, context, map);
-
-    AttributesBuilder endAttributes = Attributes.builder();
-    extractor.onEnd(endAttributes, context, map, map, null);
-
-    // then
-    assertThat(startAttributes.build())
-        .containsOnly(
-            entry(SemanticAttributes.NET_PEER_NAME, "1:2:3:4::"),
-            entry(SemanticAttributes.NET_PEER_PORT, 42L));
-
-    assertThat(endAttributes.build()).containsOnly(entry(SemanticAttributes.NET_TRANSPORT, IP_TCP));
-  }
-
-  @Test
-  @DisplayName(
-      "does not set net.sock.* attributes when they duplicate related net.peer.* attributes")
-  void doesNotSetDuplicates2() {
-    // given
-    Map<String, String> map = new HashMap<>();
-    map.put("netTransport", IP_TCP);
-    map.put("peerName", "opentelemetry.io");
-    map.put("peerPort", "42");
-    map.put("sockFamily", "inet6");
-    map.put("sockPeerAddr", "1:2:3:4::");
-    map.put("sockPeerName", "opentelemetry.io");
-    map.put("sockPeerPort", "42");
-
-    Context context = Context.root();
-
-    // when
-    AttributesBuilder startAttributes = Attributes.builder();
-    extractor.onStart(startAttributes, context, map);
-
-    AttributesBuilder endAttributes = Attributes.builder();
-    extractor.onEnd(endAttributes, context, map, map, null);
-
-    // then
-    assertThat(startAttributes.build())
-        .containsOnly(
-            entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"),
-            entry(SemanticAttributes.NET_PEER_PORT, 42L));
-
-    assertThat(endAttributes.build())
-        .containsOnly(
-            entry(SemanticAttributes.NET_TRANSPORT, IP_TCP),
-            entry(SemanticAttributes.NET_SOCK_FAMILY, "inet6"),
-            entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"));
-  }
-
-  @Test
-  void doesNotSetNegativePortValues() {
-    // given
-    Map<String, String> map = new HashMap<>();
-    map.put("peerName", "opentelemetry.io");
-    map.put("peerPort", "-12");
-    map.put("sockPeerAddr", "1:2:3:4::");
-    map.put("sockPeerPort", "-42");
-
-    Context context = Context.root();
-
-    // when
-    AttributesBuilder startAttributes = Attributes.builder();
-    extractor.onStart(startAttributes, context, map);
-
-    AttributesBuilder endAttributes = Attributes.builder();
-    extractor.onEnd(endAttributes, context, map, map, null);
-
-    // then
-    assertThat(startAttributes.build())
-        .containsOnly(entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"));
-
-    assertThat(endAttributes.build())
-        .containsOnly(entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"));
-  }
-
-  @Test
-  void doesNotSetSockFamilyInet() {
-    // given
-    Map<String, String> map = new HashMap<>();
-    map.put("peerName", "opentelemetry.io");
-    map.put("sockPeerAddr", "1.2.3.4");
-    map.put("sockFamily", SemanticAttributes.NetSockFamilyValues.INET);
-
-    Context context = Context.root();
-
-    // when
-    AttributesBuilder startAttributes = Attributes.builder();
-    extractor.onStart(startAttributes, context, map);
-
-    AttributesBuilder endAttributes = Attributes.builder();
-    extractor.onEnd(endAttributes, context, map, map, null);
-
-    // then
-    assertThat(startAttributes.build())
-        .containsOnly(entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"));
-
-    assertThat(endAttributes.build())
-        .containsOnly(entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1.2.3.4"));
   }
 }

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
@@ -8,8 +8,10 @@ package io.opentelemetry.instrumentation.api.instrumenter.http;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -24,8 +26,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.ToIntFunction;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 class HttpClientAttributesExtractorStableSemconvTest {
 
@@ -51,7 +59,8 @@ class HttpClientAttributesExtractorStableSemconvTest {
     @Override
     public Integer getHttpResponseStatusCode(
         Map<String, String> request, Map<String, String> response, @Nullable Throwable error) {
-      return Integer.parseInt(response.get("statusCode"));
+      String value = response.get("statusCode");
+      return value == null ? null : Integer.parseInt(value);
     }
 
     @Override
@@ -102,8 +111,8 @@ class HttpClientAttributesExtractorStableSemconvTest {
     @Nullable
     @Override
     public Integer getPeerPort(Map<String, String> request) {
-      String statusCode = request.get("peerPort");
-      return statusCode == null ? null : Integer.parseInt(statusCode);
+      String value = request.get("peerPort");
+      return value == null ? null : Integer.parseInt(value);
     }
   }
 
@@ -115,7 +124,7 @@ class HttpClientAttributesExtractorStableSemconvTest {
     request.put("header.content-length", "10");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.custom-request-header", "123,456");
-    request.put("transport", "tcp");
+    request.put("transport", "udp");
     request.put("type", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "1.1");
@@ -161,9 +170,53 @@ class HttpClientAttributesExtractorStableSemconvTest {
             entry(
                 AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
                 asList("654", "321")),
-            entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+            entry(NetworkAttributes.NETWORK_TRANSPORT, "udp"),
             entry(NetworkAttributes.NETWORK_TYPE, "ipv4"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"));
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(NetworkTransportAndProtocolProvider.class)
+  void skipNetworkTransportIfDefaultForProtocol(
+      String observedProtocolName,
+      String observedProtocolVersion,
+      String observedTransport,
+      @Nullable String extractedTransport) {
+    Map<String, String> request = new HashMap<>();
+    request.put("protocolName", observedProtocolName);
+    request.put("protocolVersion", observedProtocolVersion);
+    request.put("transport", observedTransport);
+
+    AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+        HttpClientAttributesExtractor.create(
+            new TestHttpClientAttributesGetter(), new TestNetClientAttributesGetter());
+
+    AttributesBuilder attributes = Attributes.builder();
+    extractor.onStart(attributes, Context.root(), request);
+    extractor.onEnd(attributes, Context.root(), request, emptyMap(), null);
+
+    if (extractedTransport != null) {
+      assertThat(attributes.build())
+          .containsEntry(NetworkAttributes.NETWORK_TRANSPORT, extractedTransport);
+    } else {
+      assertThat(attributes.build()).doesNotContainKey(NetworkAttributes.NETWORK_TRANSPORT);
+    }
+  }
+
+  static final class NetworkTransportAndProtocolProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          arguments("http", "1.0", "tcp", null),
+          arguments("http", "1.1", "tcp", null),
+          arguments("http", "2.0", "tcp", null),
+          arguments("http", "3.0", "udp", null),
+          arguments("http", "1.1", "udp", "udp"),
+          arguments("ftp", "2.0", "tcp", "tcp"),
+          arguments("http", "3.0", "tcp", "tcp"),
+          arguments("http", "42", "tcp", "tcp"));
+    }
   }
 }

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
@@ -17,7 +17,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
-import io.opentelemetry.instrumentation.api.instrumenter.net.internal.NetAttributes;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkAttributes;
 import io.opentelemetry.instrumentation.api.instrumenter.url.internal.UrlAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
@@ -67,14 +67,28 @@ class HttpClientAttributesExtractorStableSemconvTest {
 
     @Nullable
     @Override
-    public String getProtocolName(
+    public String getNetworkTransport(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("transport");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkType(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("type");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolName(
         Map<String, String> request, @Nullable Map<String, String> response) {
       return request.get("protocolName");
     }
 
     @Nullable
     @Override
-    public String getProtocolVersion(
+    public String getNetworkProtocolVersion(
         Map<String, String> request, @Nullable Map<String, String> response) {
       return request.get("protocolVersion");
     }
@@ -101,6 +115,8 @@ class HttpClientAttributesExtractorStableSemconvTest {
     request.put("header.content-length", "10");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.custom-request-header", "123,456");
+    request.put("transport", "tcp");
+    request.put("type", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "1.1");
     request.put("peerName", "github.com");
@@ -145,7 +161,9 @@ class HttpClientAttributesExtractorStableSemconvTest {
             entry(
                 AttributeKey.stringArrayKey("http.response.header.custom_response_header"),
                 asList("654", "321")),
-            entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
-            entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"));
+            entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+            entry(NetworkAttributes.NETWORK_TYPE, "ipv4"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"));
   }
 }

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorStableSemconvTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.net;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class NetClientAttributesExtractorStableSemconvTest {
+
+  static class TestNetClientAttributesGetter
+      implements NetClientAttributesGetter<Map<String, String>, Map<String, String>> {
+
+    @Override
+    public String getTransport(Map<String, String> request, Map<String, String> response) {
+      return response.get("netTransport");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkTransport(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("transport");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkType(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("type");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolName(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("protocolName");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolVersion(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("protocolVersion");
+    }
+
+    @Override
+    public String getPeerName(Map<String, String> request) {
+      return request.get("peerName");
+    }
+
+    @Override
+    public Integer getPeerPort(Map<String, String> request) {
+      String peerPort = request.get("peerPort");
+      return peerPort == null ? null : Integer.valueOf(peerPort);
+    }
+
+    @Override
+    public String getSockFamily(Map<String, String> request, Map<String, String> response) {
+      return response.get("sockFamily");
+    }
+
+    @Override
+    public String getSockPeerAddr(Map<String, String> request, Map<String, String> response) {
+      return response.get("sockPeerAddr");
+    }
+
+    @Override
+    public String getSockPeerName(Map<String, String> request, Map<String, String> response) {
+      return response.get("sockPeerName");
+    }
+
+    @Override
+    public Integer getSockPeerPort(Map<String, String> request, Map<String, String> response) {
+      String sockPeerPort = response.get("sockPeerPort");
+      return sockPeerPort == null ? null : Integer.valueOf(sockPeerPort);
+    }
+  }
+
+  private final AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
+      NetClientAttributesExtractor.create(new TestNetClientAttributesGetter());
+
+  @Test
+  void normal() {
+    // given
+    Map<String, String> map = new HashMap<>();
+    map.put("netTransport", IP_TCP);
+    map.put("transport", "tcp");
+    map.put("type", "ipv6");
+    map.put("protocolName", "http");
+    map.put("protocolVersion", "1.1");
+    map.put("peerName", "opentelemetry.io");
+    map.put("peerPort", "42");
+    map.put("sockFamily", "inet6");
+    map.put("sockPeerAddr", "1:2:3:4::");
+    map.put("sockPeerName", "proxy.opentelemetry.io");
+    map.put("sockPeerPort", "123");
+
+    Context context = Context.root();
+
+    // when
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, context, map);
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, context, map, map, null);
+
+    // then
+    assertThat(startAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"),
+            entry(SemanticAttributes.NET_PEER_PORT, 42L));
+
+    assertThat(endAttributes.build())
+        .containsOnly(
+            entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+            entry(NetworkAttributes.NETWORK_TYPE, "ipv6"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
+            entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"),
+            entry(SemanticAttributes.NET_SOCK_PEER_NAME, "proxy.opentelemetry.io"),
+            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 123L));
+  }
+}

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorStableSemconvTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.net;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_TCP;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class NetServerAttributesExtractorStableSemconvTest {
+
+  static class TestNetServerAttributesGetter
+      implements NetServerAttributesGetter<Map<String, String>, Void> {
+
+    @Override
+    public String getTransport(Map<String, String> request) {
+      return request.get("netTransport");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkTransport(Map<String, String> request, @Nullable Void response) {
+      return request.get("transport");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkType(Map<String, String> request, @Nullable Void response) {
+      return request.get("type");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolName(Map<String, String> request, Void response) {
+      return request.get("protocolName");
+    }
+
+    @Nullable
+    @Override
+    public String getNetworkProtocolVersion(Map<String, String> request, Void response) {
+      return request.get("protocolVersion");
+    }
+
+    @Nullable
+    @Override
+    public String getHostName(Map<String, String> request) {
+      return request.get("hostName");
+    }
+
+    @Nullable
+    @Override
+    public Integer getHostPort(Map<String, String> request) {
+      String hostPort = request.get("hostPort");
+      return hostPort == null ? null : Integer.valueOf(hostPort);
+    }
+
+    @Nullable
+    @Override
+    public String getSockFamily(Map<String, String> request) {
+      return request.get("sockFamily");
+    }
+
+    @Override
+    public String getSockPeerAddr(Map<String, String> request) {
+      return request.get("sockPeerAddr");
+    }
+
+    @Override
+    public Integer getSockPeerPort(Map<String, String> request) {
+      String sockPeerPort = request.get("sockPeerPort");
+      return sockPeerPort == null ? null : Integer.valueOf(sockPeerPort);
+    }
+
+    @Nullable
+    @Override
+    public String getSockHostAddr(Map<String, String> request) {
+      return request.get("sockHostAddr");
+    }
+
+    @Nullable
+    @Override
+    public Integer getSockHostPort(Map<String, String> request) {
+      String sockHostPort = request.get("sockHostPort");
+      return sockHostPort == null ? null : Integer.valueOf(sockHostPort);
+    }
+  }
+
+  AttributesExtractor<Map<String, String>, Void> extractor =
+      NetServerAttributesExtractor.create(new TestNetServerAttributesGetter());
+
+  @Test
+  void normal() {
+    // given
+    Map<String, String> map = new HashMap<>();
+    map.put("netTransport", IP_TCP);
+    map.put("transport", "tcp");
+    map.put("type", "ipv6");
+    map.put("protocolName", "http");
+    map.put("protocolVersion", "1.1");
+    map.put("hostName", "opentelemetry.io");
+    map.put("hostPort", "80");
+    map.put("sockFamily", "inet6");
+    map.put("sockPeerAddr", "1:2:3:4::");
+    map.put("sockPeerPort", "42");
+    map.put("sockHostAddr", "4:3:2:1::");
+    map.put("sockHostPort", "8080");
+
+    Context context = Context.root();
+
+    // when
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, context, map);
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, context, map, null, null);
+
+    // then
+    assertThat(startAttributes.build())
+        .containsOnly(
+            entry(SemanticAttributes.NET_HOST_NAME, "opentelemetry.io"),
+            entry(SemanticAttributes.NET_HOST_PORT, 80L),
+            entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"),
+            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 42L),
+            entry(SemanticAttributes.NET_SOCK_HOST_ADDR, "4:3:2:1::"),
+            entry(SemanticAttributes.NET_SOCK_HOST_PORT, 8080L));
+
+    assertThat(endAttributes.build())
+        .containsOnly(
+            entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
+            entry(NetworkAttributes.NETWORK_TYPE, "ipv6"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
+            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"));
+  }
+}

--- a/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
+++ b/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
@@ -95,13 +95,13 @@ public class InstrumenterBenchmark {
 
     @Nullable
     @Override
-    public String getProtocolName(Void unused, @Nullable Void unused2) {
+    public String getNetworkProtocolName(Void unused, @Nullable Void unused2) {
       return "http";
     }
 
     @Nullable
     @Override
-    public String getProtocolVersion(Void unused, @Nullable Void unused2) {
+    public String getNetworkProtocolVersion(Void unused, @Nullable Void unused2) {
       return "2.0";
     }
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpNetAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpNetAttributesGetter.java
@@ -15,13 +15,15 @@ class AkkaHttpNetAttributesGetter implements NetClientAttributesGetter<HttpReque
 
   @Nullable
   @Override
-  public String getProtocolName(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
+  public String getNetworkProtocolName(
+      HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
     return AkkaHttpUtil.protocolName(httpRequest);
   }
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
+  public String getNetworkProtocolVersion(
+      HttpRequest httpRequest, @Nullable HttpResponse httpResponse) {
     return AkkaHttpUtil.protocolVersion(httpRequest);
   }
 

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaNetServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaNetServerAttributesGetter.java
@@ -7,11 +7,11 @@ package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
 
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
+import akka.http.scaladsl.model.Uri;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.akkahttp.AkkaHttpUtil;
 import javax.annotation.Nullable;
 
-// TODO (trask) capture net attributes?
 class AkkaNetServerAttributesGetter
     implements NetServerAttributesGetter<HttpRequest, HttpResponse> {
 
@@ -31,12 +31,12 @@ class AkkaNetServerAttributesGetter
   @Nullable
   @Override
   public String getHostName(HttpRequest request) {
-    return null;
+    Uri.Host host = request.uri().authority().host();
+    return host.isEmpty() ? null : host.address();
   }
 
-  @Nullable
   @Override
   public Integer getHostPort(HttpRequest request) {
-    return null;
+    return request.uri().authority().port();
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaNetServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaNetServerAttributesGetter.java
@@ -6,22 +6,25 @@
 package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
 
 import akka.http.scaladsl.model.HttpRequest;
+import akka.http.scaladsl.model.HttpResponse;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.akkahttp.AkkaHttpUtil;
 import javax.annotation.Nullable;
 
 // TODO (trask) capture net attributes?
-class AkkaNetServerAttributesGetter implements NetServerAttributesGetter<HttpRequest> {
+class AkkaNetServerAttributesGetter
+    implements NetServerAttributesGetter<HttpRequest, HttpResponse> {
 
   @Nullable
   @Override
-  public String getProtocolName(HttpRequest request) {
+  public String getNetworkProtocolName(HttpRequest request, @Nullable HttpResponse httpResponse) {
     return AkkaHttpUtil.protocolName(request);
   }
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpRequest request) {
+  public String getNetworkProtocolVersion(
+      HttpRequest request, @Nullable HttpResponse httpResponse) {
     return AkkaHttpUtil.protocolVersion(request);
   }
 

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetServerAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetServerAttributesGetter.java
@@ -9,13 +9,14 @@ import io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboRequest;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
+import org.apache.dubbo.rpc.Result;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
 public final class DubboNetServerAttributesGetter
-    implements NetServerAttributesGetter<DubboRequest> {
+    implements NetServerAttributesGetter<DubboRequest, Result> {
 
   @Nullable
   @Override

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesGetter.java
@@ -14,12 +14,13 @@ final class ApacheHttpAsyncClientNetAttributesGetter
     implements NetClientAttributesGetter<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
-  public String getProtocolName(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String getNetworkProtocolName(
+      ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getProtocolName();
   }
 
   @Override
-  public String getProtocolVersion(
+  public String getNetworkProtocolVersion(
       ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getProtocolVersion();
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesGetter.java
@@ -15,13 +15,13 @@ final class ApacheHttpClientNetAttributesGetter
     implements NetClientAttributesGetter<HttpMethod, HttpMethod> {
 
   @Override
-  public String getProtocolName(HttpMethod request, @Nullable HttpMethod response) {
+  public String getNetworkProtocolName(HttpMethod request, @Nullable HttpMethod response) {
     return "http";
   }
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpMethod request, @Nullable HttpMethod response) {
+  public String getNetworkProtocolVersion(HttpMethod request, @Nullable HttpMethod response) {
     if (request instanceof HttpMethodBase) {
       return ((HttpMethodBase) request).isHttp11() ? "1.1" : "1.0";
     }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientNetAttributesGetter.java
@@ -13,12 +13,13 @@ final class ApacheHttpClientNetAttributesGetter
     implements NetClientAttributesGetter<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
-  public String getProtocolName(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String getNetworkProtocolName(
+      ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getProtocolName();
   }
 
   @Override
-  public String getProtocolVersion(
+  public String getNetworkProtocolVersion(
       ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getProtocolVersion();
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesGetter.java
@@ -14,12 +14,13 @@ final class ApacheHttpClientNetAttributesGetter
     implements NetClientAttributesGetter<ApacheHttpClientRequest, HttpResponse> {
 
   @Override
-  public String getProtocolName(ApacheHttpClientRequest request, @Nullable HttpResponse response) {
+  public String getNetworkProtocolName(
+      ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getProtocolName();
   }
 
   @Override
-  public String getProtocolVersion(
+  public String getNetworkProtocolVersion(
       ApacheHttpClientRequest request, @Nullable HttpResponse response) {
     return request.getProtocolVersion();
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
@@ -16,7 +16,7 @@ final class ApacheHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolName(HttpRequest request, @Nullable HttpResponse response) {
+  public String getNetworkProtocolName(HttpRequest request, @Nullable HttpResponse response) {
     ProtocolVersion protocolVersion = getVersion(request, response);
     if (protocolVersion == null) {
       return null;
@@ -26,7 +26,7 @@ final class ApacheHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpRequest request, @Nullable HttpResponse response) {
+  public String getNetworkProtocolVersion(HttpRequest request, @Nullable HttpResponse response) {
     ProtocolVersion protocolVersion = getVersion(request, response);
     if (protocolVersion == null) {
       return null;

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
@@ -7,20 +7,22 @@ package io.opentelemetry.instrumentation.armeria.v1_3;
 
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.logging.RequestLog;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-final class ArmeriaNetServerAttributesGetter implements NetServerAttributesGetter<RequestContext> {
+final class ArmeriaNetServerAttributesGetter
+    implements NetServerAttributesGetter<RequestContext, RequestLog> {
 
   @Override
-  public String getProtocolName(RequestContext ctx) {
+  public String getNetworkProtocolName(RequestContext ctx, @Nullable RequestLog requestLog) {
     return "http";
   }
 
   @Override
-  public String getProtocolVersion(RequestContext ctx) {
+  public String getNetworkProtocolVersion(RequestContext ctx, @Nullable RequestLog requestLog) {
     SessionProtocol protocol = ctx.sessionProtocol();
     return protocol.isMultiplex() ? "2.0" : "1.1";
   }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetClientAttributesGetter.java
@@ -22,12 +22,12 @@ public final class ArmeriaNetClientAttributesGetter
     implements NetClientAttributesGetter<RequestContext, RequestLog> {
 
   @Override
-  public String getProtocolName(RequestContext ctx, @Nullable RequestLog requestLog) {
+  public String getNetworkProtocolName(RequestContext ctx, @Nullable RequestLog requestLog) {
     return "http";
   }
 
   @Override
-  public String getProtocolVersion(RequestContext ctx, @Nullable RequestLog requestLog) {
+  public String getNetworkProtocolVersion(RequestContext ctx, @Nullable RequestLog requestLog) {
     SessionProtocol protocol = ctx.sessionProtocol();
     return protocol.isMultiplex() ? "2.0" : "1.1";
   }

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientNetAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientNetAttributesGetter.java
@@ -15,13 +15,13 @@ final class AsyncHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolName(Request request, @Nullable Response response) {
+  public String getNetworkProtocolName(Request request, @Nullable Response response) {
     return null;
   }
 
   @Nullable
   @Override
-  public String getProtocolVersion(Request request, @Nullable Response response) {
+  public String getNetworkProtocolVersion(Request request, @Nullable Response response) {
     return null;
   }
 

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesGetter.java
@@ -18,7 +18,7 @@ final class AsyncHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolName(RequestContext request, @Nullable Response response) {
+  public String getNetworkProtocolName(RequestContext request, @Nullable Response response) {
     HttpVersion httpVersion = getHttpVersion(request);
     if (httpVersion == null) {
       return null;
@@ -28,7 +28,7 @@ final class AsyncHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolVersion(RequestContext request, @Nullable Response response) {
+  public String getNetworkProtocolVersion(RequestContext request, @Nullable Response response) {
     HttpVersion httpVersion = getHttpVersion(request);
     if (httpVersion == null) {
       return null;

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkNetAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkNetAttributesGetter.java
@@ -17,7 +17,7 @@ class AwsSdkNetAttributesGetter implements NetClientAttributesGetter<Request<?>,
 
   @Nullable
   @Override
-  public String getProtocolName(Request<?> request, @Nullable Response<?> response) {
+  public String getNetworkProtocolName(Request<?> request, @Nullable Response<?> response) {
     ProtocolVersion protocolVersion = getProtocolVersion(response);
     if (protocolVersion == null) {
       return null;
@@ -27,7 +27,7 @@ class AwsSdkNetAttributesGetter implements NetClientAttributesGetter<Request<?>,
 
   @Nullable
   @Override
-  public String getProtocolVersion(Request<?> request, @Nullable Response<?> response) {
+  public String getNetworkProtocolVersion(Request<?> request, @Nullable Response<?> response) {
     ProtocolVersion protocolVersion = getProtocolVersion(response);
     if (protocolVersion == null) {
       return null;

--- a/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
@@ -24,7 +24,8 @@ final class GrizzlyNetAttributesGetter
     Transport transport = request.getConnection().getTransport();
     if (transport instanceof TCPNIOTransport) {
       return IP_TCP;
-    } else if (transport instanceof UDPNIOTransport) {
+    }
+    if (transport instanceof UDPNIOTransport) {
       return IP_UDP;
     }
     return null;

--- a/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
@@ -12,10 +12,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributes
 import javax.annotation.Nullable;
 import org.glassfish.grizzly.Transport;
 import org.glassfish.grizzly.http.HttpRequestPacket;
+import org.glassfish.grizzly.http.HttpResponsePacket;
 import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
 import org.glassfish.grizzly.nio.transport.UDPNIOTransport;
 
-final class GrizzlyNetAttributesGetter implements NetServerAttributesGetter<HttpRequestPacket> {
+final class GrizzlyNetAttributesGetter
+    implements NetServerAttributesGetter<HttpRequestPacket, HttpResponsePacket> {
 
   @Override
   public String getTransport(HttpRequestPacket request) {
@@ -30,7 +32,21 @@ final class GrizzlyNetAttributesGetter implements NetServerAttributesGetter<Http
 
   @Nullable
   @Override
-  public String getProtocolName(HttpRequestPacket request) {
+  public String getNetworkTransport(
+      HttpRequestPacket request, @Nullable HttpResponsePacket response) {
+    Transport transport = request.getConnection().getTransport();
+    if (transport instanceof TCPNIOTransport) {
+      return "tcp";
+    } else if (transport instanceof UDPNIOTransport) {
+      return "udp";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getNetworkProtocolName(
+      HttpRequestPacket request, @Nullable HttpResponsePacket response) {
     String protocol = request.getProtocolString();
     if (protocol.startsWith("HTTP/")) {
       return "http";
@@ -40,7 +56,8 @@ final class GrizzlyNetAttributesGetter implements NetServerAttributesGetter<Http
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpRequestPacket request) {
+  public String getNetworkProtocolVersion(
+      HttpRequestPacket request, @Nullable HttpResponsePacket response) {
     String protocol = request.getProtocolString();
     if (protocol.startsWith("HTTP/")) {
       return protocol.substring("HTTP/".length());

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetServerAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetServerAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6.internal;
 
+import io.grpc.Status;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcRequest;
 import java.net.InetSocketAddress;
@@ -15,7 +16,8 @@ import javax.annotation.Nullable;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public final class GrpcNetServerAttributesGetter implements NetServerAttributesGetter<GrpcRequest> {
+public final class GrpcNetServerAttributesGetter
+    implements NetServerAttributesGetter<GrpcRequest, Status> {
 
   @Nullable
   @Override

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlNetAttributesGetter.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlNetAttributesGetter.java
@@ -13,14 +13,14 @@ class HttpUrlNetAttributesGetter implements NetClientAttributesGetter<HttpURLCon
 
   @Nullable
   @Override
-  public String getProtocolName(HttpURLConnection connection, @Nullable Integer integer) {
+  public String getNetworkProtocolName(HttpURLConnection connection, @Nullable Integer integer) {
     // HttpURLConnection hardcodes the protocol name&version
     return "http";
   }
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpURLConnection connection, @Nullable Integer integer) {
+  public String getNetworkProtocolVersion(HttpURLConnection connection, @Nullable Integer integer) {
     // HttpURLConnection hardcodes the protocol name&version
     return "1.1";
   }

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/JavaHttpClientNetAttributesGetter.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/JavaHttpClientNetAttributesGetter.java
@@ -20,13 +20,13 @@ public class JavaHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolName(HttpRequest request, @Nullable HttpResponse<?> response) {
+  public String getNetworkProtocolName(HttpRequest request, @Nullable HttpResponse<?> response) {
     return "http";
   }
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpRequest request, @Nullable HttpResponse<?> response) {
+  public String getNetworkProtocolVersion(HttpRequest request, @Nullable HttpResponse<?> response) {
     HttpClient.Version version;
     if (response != null) {
       version = response.version();

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClientNetAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClientNetAttributesGetter.java
@@ -20,13 +20,13 @@ public class JettyHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolName(Request request, @Nullable Response response) {
+  public String getNetworkProtocolName(Request request, @Nullable Response response) {
     return "http";
   }
 
   @Nullable
   @Override
-  public String getProtocolVersion(Request request, @Nullable Response response) {
+  public String getNetworkProtocolVersion(Request request, @Nullable Response response) {
     HttpVersion httpVersion = null;
     if (response != null) {
       httpVersion = response.getVersion();

--- a/instrumentation/jodd-http-4.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpNetAttributesGetter.java
+++ b/instrumentation/jodd-http-4.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpNetAttributesGetter.java
@@ -14,13 +14,13 @@ final class JoddHttpNetAttributesGetter
     implements NetClientAttributesGetter<HttpRequest, HttpResponse> {
 
   @Override
-  public String getProtocolName(HttpRequest request, @Nullable HttpResponse response) {
+  public String getNetworkProtocolName(HttpRequest request, @Nullable HttpResponse response) {
     return "http";
   }
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpRequest request, @Nullable HttpResponse response) {
+  public String getNetworkProtocolVersion(HttpRequest request, @Nullable HttpResponse response) {
     String httpVersion = request.httpVersion();
     if (httpVersion == null && response != null) {
       httpVersion = response.httpVersion();

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorNetServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorNetServerAttributesGetter.kt
@@ -6,15 +6,16 @@
 package io.opentelemetry.instrumentation.ktor.v1_0
 
 import io.ktor.request.*
+import io.ktor.response.*
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter
 import io.opentelemetry.instrumentation.ktor.isIpAddress
 
-internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<ApplicationRequest> {
+internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<ApplicationRequest, ApplicationResponse> {
 
-  override fun getProtocolName(request: ApplicationRequest): String? =
+  override fun getNetworkProtocolName(request: ApplicationRequest, response: ApplicationResponse?): String? =
     if (request.httpVersion.startsWith("HTTP/")) "http" else null
 
-  override fun getProtocolVersion(request: ApplicationRequest): String? =
+  override fun getNetworkProtocolVersion(request: ApplicationRequest, response: ApplicationResponse?): String? =
     if (request.httpVersion.startsWith("HTTP/")) request.httpVersion.substring("HTTP/".length) else null
 
   override fun getSockPeerAddr(request: ApplicationRequest): String? {

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorNetClientAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorNetClientAttributesGetter.kt
@@ -11,10 +11,10 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributes
 
 internal object KtorNetClientAttributesGetter : NetClientAttributesGetter<HttpRequestData, HttpResponse> {
 
-  override fun getProtocolName(request: HttpRequestData?, response: HttpResponse?): String? =
+  override fun getNetworkProtocolName(request: HttpRequestData?, response: HttpResponse?): String? =
     response?.version?.name
 
-  override fun getProtocolVersion(request: HttpRequestData?, response: HttpResponse?): String? {
+  override fun getNetworkProtocolVersion(request: HttpRequestData?, response: HttpResponse?): String? {
     val version = response?.version ?: return null
     return "${version.major}.${version.minor}"
   }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorNetServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorNetServerAttributesGetter.kt
@@ -6,15 +6,16 @@
 package io.opentelemetry.instrumentation.ktor.v2_0.server
 
 import io.ktor.server.request.*
+import io.ktor.server.response.*
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter
 import io.opentelemetry.instrumentation.ktor.isIpAddress
 
-internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<ApplicationRequest> {
+internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<ApplicationRequest, ApplicationResponse> {
 
-  override fun getProtocolName(request: ApplicationRequest): String? =
+  override fun getNetworkProtocolName(request: ApplicationRequest, response: ApplicationResponse?): String? =
     if (request.httpVersion.startsWith("HTTP/")) "http" else null
 
-  override fun getProtocolVersion(request: ApplicationRequest): String? =
+  override fun getNetworkProtocolVersion(request: ApplicationRequest, response: ApplicationResponse?): String? =
     if (request.httpVersion.startsWith("HTTP/")) request.httpVersion.substring("HTTP/".length) else null
 
   override fun getHostName(request: ApplicationRequest): String {

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
@@ -9,11 +9,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributes
 import javax.annotation.Nullable;
 
 public class LibertyDispatcherNetAttributesGetter
-    implements NetServerAttributesGetter<LibertyRequest> {
+    implements NetServerAttributesGetter<LibertyRequest, LibertyResponse> {
 
   @Nullable
   @Override
-  public String getProtocolName(LibertyRequest request) {
+  public String getNetworkProtocolName(
+      LibertyRequest request, @Nullable LibertyResponse libertyResponse) {
     String protocol = request.getProtocol();
     if (protocol != null && protocol.startsWith("HTTP/")) {
       return "http";
@@ -23,7 +24,8 @@ public class LibertyDispatcherNetAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolVersion(LibertyRequest request) {
+  public String getNetworkProtocolVersion(
+      LibertyRequest request, @Nullable LibertyResponse libertyResponse) {
     String protocol = request.getProtocol();
     if (protocol != null && protocol.startsWith("HTTP/")) {
       return protocol.substring("HTTP/".length());

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectNetAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectNetAttributesGetter.java
@@ -24,6 +24,11 @@ final class NettyConnectNetAttributesGetter
     return channel instanceof DatagramChannel ? IP_UDP : IP_TCP;
   }
 
+  @Override
+  public String getNetworkTransport(NettyConnectionRequest request, @Nullable Channel channel) {
+    return channel instanceof DatagramChannel ? "udp" : "tcp";
+  }
+
   @Nullable
   @Override
   public String getPeerName(NettyConnectionRequest request) {

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectNetAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectNetAttributesGetter.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTr
 
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.netty.common.internal.NettyConnectionRequest;
+import io.opentelemetry.javaagent.instrumentation.netty.v3_8.util.ChannelUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
@@ -26,7 +27,7 @@ final class NettyConnectNetAttributesGetter
 
   @Override
   public String getNetworkTransport(NettyConnectionRequest request, @Nullable Channel channel) {
-    return channel instanceof DatagramChannel ? "udp" : "tcp";
+    return ChannelUtil.getNetworkTransport(channel);
   }
 
   @Nullable

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyNetClientAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyNetClientAttributesGetter.java
@@ -27,13 +27,19 @@ final class NettyNetClientAttributesGetter
   }
 
   @Override
-  public String getProtocolName(
+  public String getNetworkTransport(
+      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
+    return requestAndChannel.channel() instanceof DatagramChannel ? "udp" : "tcp";
+  }
+
+  @Override
+  public String getNetworkProtocolName(
       HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse httpResponse) {
     return requestAndChannel.request().getProtocolVersion().getProtocolName();
   }
 
   @Override
-  public String getProtocolVersion(
+  public String getNetworkProtocolVersion(
       HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse httpResponse) {
     HttpVersion version = requestAndChannel.request().getProtocolVersion();
     return version.getMajorVersion() + "." + version.getMinorVersion();

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyNetClientAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyNetClientAttributesGetter.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTr
 
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.netty.v3_8.HttpRequestAndChannel;
+import io.opentelemetry.javaagent.instrumentation.netty.v3_8.util.ChannelUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
@@ -29,7 +30,7 @@ final class NettyNetClientAttributesGetter
   @Override
   public String getNetworkTransport(
       HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
-    return requestAndChannel.channel() instanceof DatagramChannel ? "udp" : "tcp";
+    return ChannelUtil.getNetworkTransport(requestAndChannel.channel());
   }
 
   @Override

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTr
 
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.netty.v3_8.HttpRequestAndChannel;
+import io.opentelemetry.javaagent.instrumentation.netty.v3_8.util.ChannelUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
@@ -28,7 +29,7 @@ final class NettyNetServerAttributesGetter
   @Override
   public String getNetworkTransport(
       HttpRequestAndChannel requestAndChannel, HttpResponse response) {
-    return requestAndChannel.channel() instanceof DatagramChannel ? "udp" : "tcp";
+    return ChannelUtil.getNetworkTransport(requestAndChannel.channel());
   }
 
   @Override

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
@@ -14,10 +14,11 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 import org.jboss.netty.channel.socket.DatagramChannel;
+import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 
 final class NettyNetServerAttributesGetter
-    implements NetServerAttributesGetter<HttpRequestAndChannel> {
+    implements NetServerAttributesGetter<HttpRequestAndChannel, HttpResponse> {
 
   @Override
   public String getTransport(HttpRequestAndChannel requestAndChannel) {
@@ -25,12 +26,20 @@ final class NettyNetServerAttributesGetter
   }
 
   @Override
-  public String getProtocolName(HttpRequestAndChannel requestAndChannel) {
+  public String getNetworkTransport(
+      HttpRequestAndChannel requestAndChannel, HttpResponse response) {
+    return requestAndChannel.channel() instanceof DatagramChannel ? "udp" : "tcp";
+  }
+
+  @Override
+  public String getNetworkProtocolName(
+      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     return requestAndChannel.request().getProtocolVersion().getProtocolName();
   }
 
   @Override
-  public String getProtocolVersion(HttpRequestAndChannel requestAndChannel) {
+  public String getNetworkProtocolVersion(
+      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     HttpVersion version = requestAndChannel.request().getProtocolVersion();
     return version.getMajorVersion() + "." + version.getMinorVersion();
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/util/ChannelUtil.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/util/ChannelUtil.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.netty.v3_8.util;
+
+import javax.annotation.Nullable;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.socket.DatagramChannel;
+
+public final class ChannelUtil {
+
+  public static String getNetworkTransport(@Nullable Channel channel) {
+    if (channel == null) {
+      return null;
+    }
+    return channel instanceof DatagramChannel ? "udp" : "tcp";
+  }
+
+  private ChannelUtil() {}
+}

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/ChannelUtil.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/ChannelUtil.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.netty.v4.common.internal;
+
+import io.netty.channel.Channel;
+import io.netty.channel.socket.DatagramChannel;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class ChannelUtil {
+
+  public static String getNetworkTransport(@Nullable Channel channel) {
+    if (channel == null) {
+      return null;
+    }
+    return channel instanceof DatagramChannel ? "udp" : "tcp";
+  }
+
+  private ChannelUtil() {}
+}

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectNetAttributesGetter.java
@@ -24,6 +24,11 @@ final class NettyConnectNetAttributesGetter
     return channel instanceof DatagramChannel ? IP_UDP : IP_TCP;
   }
 
+  @Override
+  public String getNetworkTransport(NettyConnectionRequest request, @Nullable Channel channel) {
+    return channel instanceof DatagramChannel ? "udp" : "tcp";
+  }
+
   @Nullable
   @Override
   public String getPeerName(NettyConnectionRequest request) {

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectNetAttributesGetter.java
@@ -12,6 +12,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.socket.DatagramChannel;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.netty.common.internal.NettyConnectionRequest;
+import io.opentelemetry.instrumentation.netty.v4.common.internal.ChannelUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
@@ -26,7 +27,7 @@ final class NettyConnectNetAttributesGetter
 
   @Override
   public String getNetworkTransport(NettyConnectionRequest request, @Nullable Channel channel) {
-    return channel instanceof DatagramChannel ? "udp" : "tcp";
+    return ChannelUtil.getNetworkTransport(channel);
   }
 
   @Nullable

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyNetClientAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyNetClientAttributesGetter.java
@@ -13,6 +13,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
+import io.opentelemetry.instrumentation.netty.v4.common.internal.ChannelUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
@@ -29,7 +30,7 @@ final class NettyNetClientAttributesGetter
   @Override
   public String getNetworkTransport(
       HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
-    return requestAndChannel.channel() instanceof DatagramChannel ? "udp" : "tcp";
+    return ChannelUtil.getNetworkTransport(requestAndChannel.channel());
   }
 
   @Override

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyNetClientAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyNetClientAttributesGetter.java
@@ -27,13 +27,19 @@ final class NettyNetClientAttributesGetter
   }
 
   @Override
-  public String getProtocolName(
+  public String getNetworkTransport(
+      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
+    return requestAndChannel.channel() instanceof DatagramChannel ? "udp" : "tcp";
+  }
+
+  @Override
+  public String getNetworkProtocolName(
       HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     return requestAndChannel.request().getProtocolVersion().protocolName();
   }
 
   @Override
-  public String getProtocolVersion(
+  public String getNetworkProtocolVersion(
       HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     HttpVersion version = requestAndChannel.request().getProtocolVersion();
     return version.majorVersion() + "." + version.minorVersion();

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
@@ -21,6 +21,11 @@ final class NettySslNetAttributesGetter
     return request.channel() instanceof DatagramChannel ? IP_UDP : IP_TCP;
   }
 
+  @Override
+  public String getNetworkTransport(NettySslRequest request, @Nullable Void unused) {
+    return request.channel() instanceof DatagramChannel ? "udp" : "tcp";
+  }
+
   @Nullable
   @Override
   public String getPeerName(NettySslRequest nettySslRequest) {

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTr
 
 import io.netty.channel.socket.DatagramChannel;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.netty.v4.common.internal.ChannelUtil;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
@@ -23,7 +24,7 @@ final class NettySslNetAttributesGetter
 
   @Override
   public String getNetworkTransport(NettySslRequest request, @Nullable Void unused) {
-    return request.channel() instanceof DatagramChannel ? "udp" : "tcp";
+    return ChannelUtil.getNetworkTransport(request.channel());
   }
 
   @Nullable

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTr
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_UDP;
 
 import io.netty.channel.socket.DatagramChannel;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
@@ -17,7 +18,7 @@ import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
 final class NettyNetServerAttributesGetter
-    implements NetServerAttributesGetter<HttpRequestAndChannel> {
+    implements NetServerAttributesGetter<HttpRequestAndChannel, HttpResponse> {
 
   @Override
   public String getTransport(HttpRequestAndChannel requestAndChannel) {
@@ -25,12 +26,20 @@ final class NettyNetServerAttributesGetter
   }
 
   @Override
-  public String getProtocolName(HttpRequestAndChannel requestAndChannel) {
+  public String getNetworkTransport(
+      HttpRequestAndChannel requestAndChannel, HttpResponse response) {
+    return requestAndChannel.channel() instanceof DatagramChannel ? "udp" : "tcp";
+  }
+
+  @Override
+  public String getNetworkProtocolName(
+      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     return requestAndChannel.request().getProtocolVersion().protocolName();
   }
 
   @Override
-  public String getProtocolVersion(HttpRequestAndChannel requestAndChannel) {
+  public String getNetworkProtocolVersion(
+      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     HttpVersion version = requestAndChannel.request().getProtocolVersion();
     return version.majorVersion() + "." + version.minorVersion();
   }

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
@@ -13,6 +13,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
+import io.opentelemetry.instrumentation.netty.v4.common.internal.ChannelUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
@@ -28,7 +29,7 @@ final class NettyNetServerAttributesGetter
   @Override
   public String getNetworkTransport(
       HttpRequestAndChannel requestAndChannel, HttpResponse response) {
-    return requestAndChannel.channel() instanceof DatagramChannel ? "udp" : "tcp";
+    return ChannelUtil.getNetworkTransport(requestAndChannel.channel());
   }
 
   @Override

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2NetAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2NetAttributesGetter.java
@@ -15,7 +15,7 @@ public final class OkHttp2NetAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolName(Request request, @Nullable Response response) {
+  public String getNetworkProtocolName(Request request, @Nullable Response response) {
     if (response == null) {
       return null;
     }
@@ -32,7 +32,7 @@ public final class OkHttp2NetAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolVersion(Request request, @Nullable Response response) {
+  public String getNetworkProtocolVersion(Request request, @Nullable Response response) {
     if (response == null) {
       return null;
     }

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpNetAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpNetAttributesGetter.java
@@ -19,7 +19,7 @@ public enum OkHttpNetAttributesGetter implements NetClientAttributesGetter<Reque
 
   @Nullable
   @Override
-  public String getProtocolName(Request request, @Nullable Response response) {
+  public String getNetworkProtocolName(Request request, @Nullable Response response) {
     if (response == null) {
       return null;
     }
@@ -36,7 +36,7 @@ public enum OkHttpNetAttributesGetter implements NetClientAttributesGetter<Reque
 
   @Nullable
   @Override
-  public String getProtocolVersion(Request request, @Nullable Response response) {
+  public String getNetworkProtocolVersion(Request request, @Nullable Response response) {
     if (response == null) {
       return null;
     }

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockNetServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockNetServerAttributesGetter.java
@@ -9,7 +9,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributes
 import javax.annotation.Nullable;
 
 // only needed so that HttpServerAttributesExtractor can be added to the HTTP server instrumenter
-enum MockNetServerAttributesGetter implements NetServerAttributesGetter<String> {
+enum MockNetServerAttributesGetter implements NetServerAttributesGetter<String, Void> {
   INSTANCE;
 
   @Nullable

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackNetServerAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackNetServerAttributesGetter.java
@@ -9,17 +9,19 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributes
 import javax.annotation.Nullable;
 import ratpack.handling.Context;
 import ratpack.http.Request;
+import ratpack.http.Response;
 import ratpack.server.PublicAddress;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public final class RatpackNetServerAttributesGetter implements NetServerAttributesGetter<Request> {
+public final class RatpackNetServerAttributesGetter
+    implements NetServerAttributesGetter<Request, Response> {
 
   @Nullable
   @Override
-  public String getProtocolName(Request request) {
+  public String getNetworkProtocolName(Request request, @Nullable Response response) {
     String protocol = request.getProtocol();
     if (protocol.startsWith("HTTP/")) {
       return "http";
@@ -29,7 +31,7 @@ public final class RatpackNetServerAttributesGetter implements NetServerAttribut
 
   @Nullable
   @Override
-  public String getProtocolVersion(Request request) {
+  public String getNetworkProtocolVersion(Request request, @Nullable Response response) {
     String protocol = request.getProtocol();
     if (protocol.startsWith("HTTP/")) {
       return protocol.substring("HTTP/".length());

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyNetClientAttributesGetter.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyNetClientAttributesGetter.java
@@ -19,7 +19,8 @@ final class ReactorNettyNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolName(HttpClientConfig request, @Nullable HttpClientResponse response) {
+  public String getNetworkProtocolName(
+      HttpClientConfig request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }
@@ -28,7 +29,7 @@ final class ReactorNettyNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String getProtocolVersion(
+  public String getNetworkProtocolVersion(
       HttpClientConfig request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletNetAttributesGetter.java
@@ -10,12 +10,13 @@ import com.noelios.restlet.http.HttpRequest;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import javax.annotation.Nullable;
 import org.restlet.data.Request;
+import org.restlet.data.Response;
 
-final class RestletNetAttributesGetter implements NetServerAttributesGetter<Request> {
+final class RestletNetAttributesGetter implements NetServerAttributesGetter<Request, Response> {
 
   @Nullable
   @Override
-  public String getProtocolName(Request request) {
+  public String getNetworkProtocolName(Request request, @Nullable Response response) {
     String protocol = getProtocolString(request);
     if (protocol.startsWith("HTTP/")) {
       return "http";
@@ -25,7 +26,7 @@ final class RestletNetAttributesGetter implements NetServerAttributesGetter<Requ
 
   @Nullable
   @Override
-  public String getProtocolVersion(Request request) {
+  public String getNetworkProtocolVersion(Request request, @Nullable Response response) {
     String protocol = getProtocolString(request);
     if (protocol.startsWith("HTTP/")) {
       return protocol.substring("HTTP/".length());

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletNetAttributesGetter.java
@@ -12,12 +12,14 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import javax.annotation.Nullable;
 import org.restlet.Request;
+import org.restlet.Response;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public final class RestletNetAttributesGetter implements NetServerAttributesGetter<Request> {
+public final class RestletNetAttributesGetter
+    implements NetServerAttributesGetter<Request, Response> {
 
   private static final Class<?> HTTP_REQUEST_CLASS;
   private static final MethodHandle GET_HTTP_CALL;
@@ -79,13 +81,13 @@ public final class RestletNetAttributesGetter implements NetServerAttributesGett
 
   @Nullable
   @Override
-  public String getProtocolName(Request request) {
+  public String getNetworkProtocolName(Request request, @Nullable Response response) {
     return request.getProtocol().getSchemeName();
   }
 
   @Nullable
   @Override
-  public String getProtocolVersion(Request request) {
+  public String getNetworkProtocolVersion(Request request, @Nullable Response response) {
     return request.getProtocol().getVersion();
   }
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesGetter.java
@@ -9,7 +9,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributes
 import javax.annotation.Nullable;
 
 public class ServletNetAttributesGetter<REQUEST, RESPONSE>
-    implements NetServerAttributesGetter<ServletRequestContext<REQUEST>> {
+    implements NetServerAttributesGetter<
+        ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>> {
 
   private final ServletAccessor<REQUEST, RESPONSE> accessor;
 
@@ -19,7 +20,9 @@ public class ServletNetAttributesGetter<REQUEST, RESPONSE>
 
   @Nullable
   @Override
-  public String getProtocolName(ServletRequestContext<REQUEST> requestContext) {
+  public String getNetworkProtocolName(
+      ServletRequestContext<REQUEST> requestContext,
+      @Nullable ServletResponseContext<RESPONSE> responseContext) {
     String protocol = accessor.getRequestProtocol(requestContext.request());
     if (protocol != null && protocol.startsWith("HTTP/")) {
       return "http";
@@ -29,7 +32,9 @@ public class ServletNetAttributesGetter<REQUEST, RESPONSE>
 
   @Nullable
   @Override
-  public String getProtocolVersion(ServletRequestContext<REQUEST> requestContext) {
+  public String getNetworkProtocolVersion(
+      ServletRequestContext<REQUEST> requestContext,
+      @Nullable ServletResponseContext<RESPONSE> responseContext) {
     String protocol = accessor.getRequestProtocol(requestContext.request());
     if (protocol != null && protocol.startsWith("HTTP/")) {
       return protocol.substring("HTTP/".length());

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerNetAttributesGetter.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 import org.springframework.web.server.ServerWebExchange;
 
 final class WebfluxServerNetAttributesGetter
-    implements NetServerAttributesGetter<ServerWebExchange> {
+    implements NetServerAttributesGetter<ServerWebExchange, ServerWebExchange> {
 
   @Nullable
   @Override

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcNetAttributesGetter.java
@@ -8,13 +8,16 @@ package io.opentelemetry.instrumentation.spring.webmvc.v5_3;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
-enum SpringWebMvcNetAttributesGetter implements NetServerAttributesGetter<HttpServletRequest> {
+enum SpringWebMvcNetAttributesGetter
+    implements NetServerAttributesGetter<HttpServletRequest, HttpServletResponse> {
   INSTANCE;
 
   @Nullable
   @Override
-  public String getProtocolName(HttpServletRequest request) {
+  public String getNetworkProtocolName(
+      HttpServletRequest request, @Nullable HttpServletResponse response) {
     String protocol = request.getProtocol();
     if (protocol != null && protocol.startsWith("HTTP/")) {
       return "http";
@@ -24,7 +27,8 @@ enum SpringWebMvcNetAttributesGetter implements NetServerAttributesGetter<HttpSe
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpServletRequest request) {
+  public String getNetworkProtocolVersion(
+      HttpServletRequest request, @Nullable HttpServletResponse response) {
     String protocol = request.getProtocol();
     if (protocol != null && protocol.startsWith("HTTP/")) {
       return protocol.substring("HTTP/".length());

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcNetAttributesGetter.java
@@ -7,14 +7,17 @@ package io.opentelemetry.instrumentation.spring.webmvc.v6_0;
 
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import javax.annotation.Nullable;
 
-enum SpringWebMvcNetAttributesGetter implements NetServerAttributesGetter<HttpServletRequest> {
+enum SpringWebMvcNetAttributesGetter
+    implements NetServerAttributesGetter<HttpServletRequest, HttpServletResponse> {
   INSTANCE;
 
   @Nullable
   @Override
-  public String getProtocolName(HttpServletRequest request) {
+  public String getNetworkProtocolName(
+      HttpServletRequest request, @Nullable HttpServletResponse response) {
     String protocol = request.getProtocol();
     if (protocol != null && protocol.startsWith("HTTP/")) {
       return "http";
@@ -24,7 +27,8 @@ enum SpringWebMvcNetAttributesGetter implements NetServerAttributesGetter<HttpSe
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpServletRequest request) {
+  public String getNetworkProtocolVersion(
+      HttpServletRequest request, @Nullable HttpServletResponse response) {
     String protocol = request.getProtocol();
     if (protocol != null && protocol.startsWith("HTTP/")) {
       return protocol.substring("HTTP/".length());

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesGetter.java
@@ -11,12 +11,13 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributes
 import javax.annotation.Nullable;
 import org.apache.coyote.ActionCode;
 import org.apache.coyote.Request;
+import org.apache.coyote.Response;
 
-public class TomcatNetAttributesGetter implements NetServerAttributesGetter<Request> {
+public class TomcatNetAttributesGetter implements NetServerAttributesGetter<Request, Response> {
 
   @Nullable
   @Override
-  public String getProtocolName(Request request) {
+  public String getNetworkProtocolName(Request request, @Nullable Response response) {
     String protocol = messageBytesToString(request.protocol());
     if (protocol != null && protocol.startsWith("HTTP/")) {
       return "http";
@@ -26,7 +27,7 @@ public class TomcatNetAttributesGetter implements NetServerAttributesGetter<Requ
 
   @Nullable
   @Override
-  public String getProtocolVersion(Request request) {
+  public String getNetworkProtocolVersion(Request request, @Nullable Response response) {
     String protocol = messageBytesToString(request.protocol());
     if (protocol != null && protocol.startsWith("HTTP/")) {
       return protocol.substring("HTTP/".length());

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
@@ -10,11 +10,13 @@ import io.undertow.server.HttpServerExchange;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
-public class UndertowNetAttributesGetter implements NetServerAttributesGetter<HttpServerExchange> {
+public class UndertowNetAttributesGetter
+    implements NetServerAttributesGetter<HttpServerExchange, HttpServerExchange> {
 
   @Nullable
   @Override
-  public String getProtocolName(HttpServerExchange exchange) {
+  public String getNetworkProtocolName(
+      HttpServerExchange exchange, @Nullable HttpServerExchange unused) {
     String protocol = exchange.getProtocol().toString();
     if (protocol.startsWith("HTTP/")) {
       return "http";
@@ -24,7 +26,8 @@ public class UndertowNetAttributesGetter implements NetServerAttributesGetter<Ht
 
   @Nullable
   @Override
-  public String getProtocolVersion(HttpServerExchange exchange) {
+  public String getNetworkProtocolVersion(
+      HttpServerExchange exchange, @Nullable HttpServerExchange unused) {
     String protocol = exchange.getProtocol().toString();
     if (protocol.startsWith("HTTP/")) {
       return protocol.substring("HTTP/".length());

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4NetAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4NetAttributesGetter.java
@@ -16,13 +16,14 @@ final class Vertx4NetAttributesGetter
     implements NetClientAttributesGetter<HttpClientRequest, HttpClientResponse> {
 
   @Override
-  public String getProtocolName(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getNetworkProtocolName(
+      HttpClientRequest request, @Nullable HttpClientResponse response) {
     return "http";
   }
 
   @Nullable
   @Override
-  public String getProtocolVersion(
+  public String getNetworkProtocolVersion(
       HttpClientRequest request, @Nullable HttpClientResponse response) {
     HttpVersion version = request.version();
     if (version == null) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
@@ -182,7 +182,7 @@ final class TestInstrumenters {
     }
   }
 
-  private enum NetServerGetter implements NetServerAttributesGetter<String> {
+  private enum NetServerGetter implements NetServerAttributesGetter<String, Void> {
     INSTANCE;
 
     @Nullable


### PR DESCRIPTION
Next part of the new stable HTTP semantic conventions; this PR introduces the `network.*` attributes.