### PR TITLE
Fix flaky spring rabbit test

### DIFF
--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/groovy/ContextPropagationTest.groovy
@@ -91,7 +91,12 @@ class ContextPropagationTest extends AgentInstrumentationSpecification {
     then:
     assertTraces(2) {
       trace(0, 5) {
-        spans.subList(2, 4).sort {
+        spans.subList(2, 5).sort {
+          // sort "consumer" span after "testQueue process" spans
+          if (it.name == "consumer") {
+            return 2
+          }
+          // order "testQueue process" spans
           def destination = it.attributes.get(SemanticAttributes.MESSAGING_DESTINATION_NAME)
           return destination == "<default>" ? 0 : 1
         }


### PR DESCRIPTION
https://ge.opentelemetry.io/s/jbvn72btwhnf4/tests/:instrumentation:spring:spring-rabbit-1.0:javaagent:test/ContextPropagationTest/should%20propagate%20context%20to%20consumer,%20test%20headers:%20true?top-execution=1
I have attempted to fix this before by sorting the 2 `testQueue process` spans when they appeared in wrong order, but that didn't work because the second `testQueue process` has a child span named `consumer`. If the order of `testQueue process` is swapped then the `consumer` span is moved between them.