### PR TITLE
Fix flaky tomcat access log test

### DIFF
--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -151,6 +152,22 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
       "</html>"
     response.contentUtf8() == result
     response.headers().contentLength() == result.length()
+
+    def expectedRoute = expectedHttpRoute(HTML_SERVLET_OUTPUT_STREAM)
+    assertTraces(1) {
+      trace(0, 2) {
+        span(0) {
+          name "GET" + (expectedRoute != null ? " " + expectedRoute : "")
+          kind SpanKind.SERVER
+          hasNoParent()
+        }
+        span(1) {
+          name "controller"
+          kind SpanKind.INTERNAL
+          childOf span(0)
+        }
+      }
+    }
   }
 
   def "snippet injection with PrintWriter"() {
@@ -175,5 +192,21 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
 
     response.contentUtf8() == result
     response.headers().contentLength() == result.length()
+
+    def expectedRoute = expectedHttpRoute(HTML_PRINT_WRITER)
+    assertTraces(1) {
+      trace(0, 2) {
+        span(0) {
+          name "GET" + (expectedRoute != null ? " " + expectedRoute : "")
+          kind SpanKind.SERVER
+          hasNoParent()
+        }
+        span(1) {
+          name "controller"
+          kind SpanKind.INTERNAL
+          childOf span(0)
+        }
+      }
+    }
   }
 }

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3Test.groovy
@@ -101,6 +101,7 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
 
   def setup() {
     accessLogValue.loggedIds.clear()
+    accessLogValue.disable()
   }
 
   @Override
@@ -122,6 +123,8 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
   }
 
   def "access log has ids for #count requests"() {
+    accessLogValue.enable()
+
     given:
     def request = request(SUCCESS, method)
 
@@ -162,6 +165,8 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
   def "access log has ids for error request"() {
     setup:
     assumeTrue(testError())
+    accessLogValue.enable()
+
     def request = request(ERROR, method)
     def response = client.execute(request).aggregate().join()
 
@@ -246,12 +251,25 @@ class ErrorHandlerValve extends ErrorReportValve {
 
 class TestAccessLogValve extends ValveBase implements AccessLog {
   final List<Tuple2<String, String>> loggedIds = []
+  volatile boolean enabled = false
 
   TestAccessLogValve() {
     super(true)
   }
 
+  void disable() {
+    enabled = false
+  }
+
+  void enable() {
+    enabled = true
+  }
+
   void log(Request request, Response response, long time) {
+    if (!enabled) {
+      return
+    }
+
     synchronized (loggedIds) {
       loggedIds.add(new Tuple2(request.getAttribute("trace_id"),
         request.getAttribute("span_id")))

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.test.AgentTestTrait
 import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
@@ -151,6 +152,22 @@ abstract class AbstractServlet5Test<SERVER, CONTEXT> extends HttpServerTest<SERV
       "</html>"
     response.contentUtf8() == result
     response.headers().contentLength() == result.length()
+
+    def expectedRoute = expectedHttpRoute(HTML_SERVLET_OUTPUT_STREAM)
+    assertTraces(1) {
+      trace(0, 2) {
+        span(0) {
+          name "GET" + (expectedRoute != null ? " " + expectedRoute : "")
+          kind SpanKind.SERVER
+          hasNoParent()
+        }
+        span(1) {
+          name "controller"
+          kind SpanKind.INTERNAL
+          childOf span(0)
+        }
+      }
+    }
   }
 
   def "snippet injection with PrintWriter"() {
@@ -175,5 +192,21 @@ abstract class AbstractServlet5Test<SERVER, CONTEXT> extends HttpServerTest<SERV
 
     response.contentUtf8() == result
     response.headers().contentLength() == result.length()
+
+    def expectedRoute = expectedHttpRoute(HTML_PRINT_WRITER)
+    assertTraces(1) {
+      trace(0, 2) {
+        span(0) {
+          name "GET" + (expectedRoute != null ? " " + expectedRoute : "")
+          kind SpanKind.SERVER
+          hasNoParent()
+        }
+        span(1) {
+          name "controller"
+          kind SpanKind.INTERNAL
+          childOf span(0)
+        }
+      }
+    }
   }
 }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5Test.groovy
@@ -101,6 +101,7 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
 
   def setup() {
     accessLogValue.loggedIds.clear()
+    accessLogValue.disable()
   }
 
   @Override
@@ -122,6 +123,8 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
   }
 
   def "access log has ids for #count requests"() {
+    accessLogValue.enable()
+
     given:
     def request = request(SUCCESS, method)
 
@@ -162,6 +165,8 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
   def "access log has ids for error request"() {
     setup:
     assumeTrue(testError())
+    accessLogValue.enable()
+
     def request = request(ERROR, method)
     def response = client.execute(request).aggregate().join()
 
@@ -246,12 +251,24 @@ class ErrorHandlerValve extends ErrorReportValve {
 
 class TestAccessLogValve extends ValveBase implements AccessLog {
   final List<Tuple2<String, String>> loggedIds = []
+  volatile boolean enabled = false
 
   TestAccessLogValve() {
     super(true)
   }
 
+  void disable() {
+    enabled = false
+  }
+
+  void enable() {
+    enabled = true
+  }
+
   void log(Request request, Response response, long time) {
+    if (!enabled) {
+      return
+    }
     synchronized (loggedIds) {
       loggedIds.add(new Tuple2(request.getAttribute("trace_id"),
         request.getAttribute("span_id")))


### PR DESCRIPTION
https://ge.opentelemetry.io/s/52shpx4drfmks/tests/:instrumentation:servlet:servlet-5.0:javaagent:test/TomcatServlet5TestInclude/access%20log%20has%20ids%20for%201%20requests?expanded-stacktrace=WyIwIl0&top-execution=1
I think access log test fails with 2 access log entries instead of the expected 1 because the snippet injection test that runs before it finishes before access log entry was written. This PR also adds asserting spans to snippet injection test, I initially thought that they this would help, but it didn't.