### PR TITLE
Implement new stable server semantic conventions

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.FallbackNamePortGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InternalNetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalNetworkAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkTransportFilter;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import javax.annotation.Nullable;
@@ -29,6 +30,7 @@ public final class NetClientAttributesExtractor<REQUEST, RESPONSE>
 
   private final InternalNetClientAttributesExtractor<REQUEST, RESPONSE> internalExtractor;
   private final InternalNetworkAttributesExtractor<REQUEST, RESPONSE> internalNetworkExtractor;
+  private final InternalServerAttributesExtractor<REQUEST, RESPONSE> internalServerExtractor;
 
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       NetClientAttributesGetter<REQUEST, RESPONSE> getter) {
@@ -38,21 +40,26 @@ public final class NetClientAttributesExtractor<REQUEST, RESPONSE>
   private NetClientAttributesExtractor(NetClientAttributesGetter<REQUEST, RESPONSE> getter) {
     internalExtractor =
         new InternalNetClientAttributesExtractor<>(
-            getter,
-            (port, request) -> true,
-            FallbackNamePortGetter.noop(),
-            SemconvStability.emitOldHttpSemconv());
+            getter, FallbackNamePortGetter.noop(), SemconvStability.emitOldHttpSemconv());
     internalNetworkExtractor =
         new InternalNetworkAttributesExtractor<>(
             getter,
             NetworkTransportFilter.alwaysTrue(),
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv());
+    internalServerExtractor =
+        new InternalServerAttributesExtractor<>(
+            getter,
+            (port, request) -> true,
+            FallbackNamePortGetter.noop(),
+            SemconvStability.emitStableHttpSemconv(),
+            SemconvStability.emitOldHttpSemconv(),
+            InternalServerAttributesExtractor.Mode.PEER);
   }
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    internalExtractor.onStart(attributes, request);
+    internalServerExtractor.onStart(attributes, request);
   }
 
   @Override
@@ -64,5 +71,6 @@ public final class NetClientAttributesExtractor<REQUEST, RESPONSE>
       @Nullable Throwable error) {
     internalExtractor.onEnd(attributes, request, response);
     internalNetworkExtractor.onEnd(attributes, request, response);
+    internalServerExtractor.onEnd(attributes, request, response);
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesGetter.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.net;
 
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InetSocketAddressUtil;
 import io.opentelemetry.instrumentation.api.instrumenter.network.NetworkAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
@@ -18,7 +20,7 @@ import javax.annotation.Nullable;
  * network attributes in a type-generic way.
  */
 public interface NetClientAttributesGetter<REQUEST, RESPONSE>
-    extends NetworkAttributesGetter<REQUEST, RESPONSE> {
+    extends NetworkAttributesGetter<REQUEST, RESPONSE>, ServerAttributesGetter<REQUEST, RESPONSE> {
 
   @Nullable
   default String getTransport(REQUEST request, @Nullable RESPONSE response) {
@@ -74,11 +76,43 @@ public interface NetClientAttributesGetter<REQUEST, RESPONSE>
     return getProtocolVersion(request, response);
   }
 
+  /**
+   * Returns the logical peer name.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerAddress(Object)} instead.
+   */
+  @Deprecated
   @Nullable
-  String getPeerName(REQUEST request);
+  default String getPeerName(REQUEST request) {
+    return null;
+  }
 
+  /**
+   * Returns the logical peer port.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerPort(Object)} instead.
+   */
+  @Deprecated
   @Nullable
-  Integer getPeerPort(REQUEST request);
+  default Integer getPeerPort(REQUEST request) {
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getServerAddress(REQUEST request) {
+    return getPeerName(request);
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default Integer getServerPort(REQUEST request) {
+    return getPeerPort(request);
+  }
 
   /**
    * Returns an {@link InetSocketAddress} object representing the peer socket address.
@@ -86,10 +120,22 @@ public interface NetClientAttributesGetter<REQUEST, RESPONSE>
    * <p>Implementing this method is equivalent to implementing all four of {@link
    * #getSockFamily(Object, Object)}, {@link #getSockPeerAddr(Object, Object)}, {@link
    * #getSockPeerName(Object, Object)} and {@link #getSockPeerPort(Object, Object)}.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerInetSocketAddress(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default InetSocketAddress getPeerSocketAddress(REQUEST request, @Nullable RESPONSE response) {
     return null;
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default InetSocketAddress getServerInetSocketAddress(
+      REQUEST request, @Nullable RESPONSE response) {
+    return getPeerSocketAddress(request, response);
   }
 
   /**
@@ -107,7 +153,7 @@ public interface NetClientAttributesGetter<REQUEST, RESPONSE>
    */
   @Nullable
   default String getSockFamily(REQUEST request, @Nullable RESPONSE response) {
-    return InetSocketAddressUtil.getSockFamily(getPeerSocketAddress(request, response), null);
+    return InetSocketAddressUtil.getSockFamily(getServerInetSocketAddress(request, response), null);
   }
 
   /**
@@ -121,10 +167,14 @@ public interface NetClientAttributesGetter<REQUEST, RESPONSE>
    * simply return {@code null}. If the instrumented library does not expose {@link
    * InetSocketAddress} in its API, you might want to implement this method instead of {@link
    * #getPeerSocketAddress(Object, Object)}.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerSocketAddress(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default String getSockPeerAddr(REQUEST request, @Nullable RESPONSE response) {
-    return InetSocketAddressUtil.getHostAddress(getPeerSocketAddress(request, response));
+    return InetSocketAddressUtil.getIpAddress(getServerInetSocketAddress(request, response));
   }
 
   /**
@@ -137,10 +187,14 @@ public interface NetClientAttributesGetter<REQUEST, RESPONSE>
    * simply return {@code null}. If the instrumented library does not expose {@link
    * InetSocketAddress} in its API, you might want to implement this method instead of {@link
    * #getPeerSocketAddress(Object, Object)}.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerSocketDomain(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default String getSockPeerName(REQUEST request, @Nullable RESPONSE response) {
-    return InetSocketAddressUtil.getHostName(getPeerSocketAddress(request, response));
+    return InetSocketAddressUtil.getDomainName(getServerInetSocketAddress(request, response));
   }
 
   /**
@@ -153,9 +207,34 @@ public interface NetClientAttributesGetter<REQUEST, RESPONSE>
    * simply return {@code null}. If the instrumented library does not expose {@link
    * InetSocketAddress} in its API, you might want to implement this method instead of {@link
    * #getPeerSocketAddress(Object, Object)}.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerSocketPort(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default Integer getSockPeerPort(REQUEST request, @Nullable RESPONSE response) {
-    return InetSocketAddressUtil.getPort(getPeerSocketAddress(request, response));
+    return InetSocketAddressUtil.getPort(getServerInetSocketAddress(request, response));
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getServerSocketDomain(REQUEST request, @Nullable RESPONSE response) {
+    return getSockPeerName(request, response);
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getServerSocketAddress(REQUEST request, @Nullable RESPONSE response) {
+    return getSockPeerAddr(request, response);
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default Integer getServerSocketPort(REQUEST request, @Nullable RESPONSE response) {
+    return getSockPeerPort(request, response);
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesGetter.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.net;
 
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InetSocketAddressUtil;
 import io.opentelemetry.instrumentation.api.instrumenter.network.NetworkAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
@@ -18,7 +20,7 @@ import javax.annotation.Nullable;
  * the various network attributes in a type-generic way.
  */
 public interface NetServerAttributesGetter<REQUEST, RESPONSE>
-    extends NetworkAttributesGetter<REQUEST, RESPONSE> {
+    extends NetworkAttributesGetter<REQUEST, RESPONSE>, ServerAttributesGetter<REQUEST, RESPONSE> {
 
   @Nullable
   default String getTransport(REQUEST request) {
@@ -58,7 +60,7 @@ public interface NetServerAttributesGetter<REQUEST, RESPONSE>
   @Override
   default String getNetworkType(REQUEST request, @Nullable RESPONSE response) {
     return InetSocketAddressUtil.getNetworkType(
-        getPeerSocketAddress(request), getHostSocketAddress(request));
+        getPeerSocketAddress(request), getServerInetSocketAddress(request, null));
   }
 
   /** {@inheritDoc} */
@@ -75,11 +77,43 @@ public interface NetServerAttributesGetter<REQUEST, RESPONSE>
     return getProtocolVersion(request);
   }
 
+  /**
+   * Returns the logical host name.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerAddress(Object)} instead.
+   */
+  @Deprecated
   @Nullable
-  String getHostName(REQUEST request);
+  default String getHostName(REQUEST request) {
+    return null;
+  }
 
+  /**
+   * Returns the logical host port.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerPort(Object)} instead.
+   */
+  @Deprecated
   @Nullable
-  Integer getHostPort(REQUEST request);
+  default Integer getHostPort(REQUEST request) {
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getServerAddress(REQUEST request) {
+    return getHostName(request);
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default Integer getServerPort(REQUEST request) {
+    return getHostPort(request);
+  }
 
   /**
    * Returns the protocol <a
@@ -97,7 +131,7 @@ public interface NetServerAttributesGetter<REQUEST, RESPONSE>
   @Nullable
   default String getSockFamily(REQUEST request) {
     return InetSocketAddressUtil.getSockFamily(
-        getPeerSocketAddress(request), getHostSocketAddress(request));
+        getPeerSocketAddress(request), getServerInetSocketAddress(request, null));
   }
 
   /**
@@ -124,7 +158,7 @@ public interface NetServerAttributesGetter<REQUEST, RESPONSE>
    */
   @Nullable
   default String getSockPeerAddr(REQUEST request) {
-    return InetSocketAddressUtil.getHostAddress(getPeerSocketAddress(request));
+    return InetSocketAddressUtil.getIpAddress(getPeerSocketAddress(request));
   }
 
   /**
@@ -147,10 +181,22 @@ public interface NetServerAttributesGetter<REQUEST, RESPONSE>
    *
    * <p>Implementing this method is equivalent to implementing all three of {@link
    * #getSockFamily(Object)}, {@link #getSockHostAddr(Object)} and {@link #getSockHostPort(Object)}.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerInetSocketAddress(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default InetSocketAddress getHostSocketAddress(REQUEST request) {
     return null;
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default InetSocketAddress getServerInetSocketAddress(
+      REQUEST request, @Nullable RESPONSE response) {
+    return getHostSocketAddress(request);
   }
 
   /**
@@ -162,10 +208,14 @@ public interface NetServerAttributesGetter<REQUEST, RESPONSE>
    * #getHostSocketAddress(Object)} method. If this method is not implemented, it will simply return
    * {@code null}. If the instrumented library does not expose {@link InetSocketAddress} in its API,
    * you might want to implement this method instead of {@link #getHostSocketAddress(Object)}.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerSocketAddress(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default String getSockHostAddr(REQUEST request) {
-    return InetSocketAddressUtil.getHostAddress(getHostSocketAddress(request));
+    return InetSocketAddressUtil.getIpAddress(getServerInetSocketAddress(request, null));
   }
 
   /**
@@ -177,9 +227,27 @@ public interface NetServerAttributesGetter<REQUEST, RESPONSE>
    * #getHostSocketAddress(Object)} method. If this method is not implemented, it will simply return
    * {@code null}. If the instrumented library does not expose {@link InetSocketAddress} in its API,
    * you might want to implement this method instead of {@link #getHostSocketAddress(Object)}.
+   *
+   * @deprecated This method is deprecated and will be removed in the following release. Implement
+   *     {@link #getServerSocketPort(Object, Object)} instead.
    */
+  @Deprecated
   @Nullable
   default Integer getSockHostPort(REQUEST request) {
-    return InetSocketAddressUtil.getPort(getHostSocketAddress(request));
+    return InetSocketAddressUtil.getPort(getServerInetSocketAddress(request, null));
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default String getServerSocketAddress(REQUEST request, @Nullable RESPONSE response) {
+    return getSockHostAddr(request);
+  }
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  default Integer getServerSocketPort(REQUEST request, @Nullable RESPONSE response) {
+    return getSockHostPort(request);
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractor.java
@@ -57,11 +57,11 @@ public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
       return;
     }
 
-    String peerName = attributesGetter.getPeerName(request);
-    String peerService = mapToPeerService(peerName);
+    String serverAddress = attributesGetter.getServerAddress(request);
+    String peerService = mapToPeerService(serverAddress);
     if (peerService == null) {
-      String sockPeerName = attributesGetter.getSockPeerName(request, response);
-      peerService = mapToPeerService(sockPeerName);
+      String serverSocketDomain = attributesGetter.getServerSocketDomain(request, response);
+      peerService = mapToPeerService(serverSocketDomain);
     }
     if (peerService != null) {
       attributes.put(SemanticAttributes.PEER_SERVICE, peerService);
@@ -69,7 +69,7 @@ public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
   }
 
   @Nullable
-  private String mapToPeerService(String endpoint) {
+  private String mapToPeerService(@Nullable String endpoint) {
     if (endpoint == null) {
       return null;
     }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InetSocketAddressUtil.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InetSocketAddressUtil.java
@@ -3,17 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.instrumentation.api.instrumenter.net;
+package io.opentelemetry.instrumentation.api.instrumenter.net.internal;
 
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
-final class InetSocketAddressUtil {
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class InetSocketAddressUtil {
 
   @Nullable
-  static String getSockFamily(
+  public static String getSockFamily(
       @Nullable InetSocketAddress address, @Nullable InetSocketAddress otherAddress) {
     if (address == null) {
       address = otherAddress;
@@ -29,7 +33,7 @@ final class InetSocketAddressUtil {
   }
 
   @Nullable
-  static String getNetworkType(
+  public static String getNetworkType(
       @Nullable InetSocketAddress address, @Nullable InetSocketAddress otherAddress) {
     if (address == null) {
       address = otherAddress;
@@ -42,7 +46,7 @@ final class InetSocketAddressUtil {
   }
 
   @Nullable
-  static String getHostName(@Nullable InetSocketAddress address) {
+  public static String getDomainName(@Nullable InetSocketAddress address) {
     if (address == null) {
       return null;
     }
@@ -50,7 +54,7 @@ final class InetSocketAddressUtil {
   }
 
   @Nullable
-  static String getHostAddress(@Nullable InetSocketAddress address) {
+  public static String getIpAddress(@Nullable InetSocketAddress address) {
     if (address == null) {
       return null;
     }
@@ -62,7 +66,7 @@ final class InetSocketAddressUtil {
   }
 
   @Nullable
-  static Integer getPort(@Nullable InetSocketAddress address) {
+  public static Integer getPort(@Nullable InetSocketAddress address) {
     if (address == null) {
       return null;
     }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetClientAttributesExtractor.java
@@ -10,7 +10,6 @@ import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorU
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import java.util.function.BiPredicate;
 import javax.annotation.Nullable;
 
 /**
@@ -20,32 +19,16 @@ import javax.annotation.Nullable;
 public final class InternalNetClientAttributesExtractor<REQUEST, RESPONSE> {
 
   private final NetClientAttributesGetter<REQUEST, RESPONSE> getter;
-  private final BiPredicate<Integer, REQUEST> capturePeerPortCondition;
   private final FallbackNamePortGetter<REQUEST> fallbackNamePortGetter;
   private final boolean emitOldHttpAttributes;
 
   public InternalNetClientAttributesExtractor(
       NetClientAttributesGetter<REQUEST, RESPONSE> getter,
-      BiPredicate<Integer, REQUEST> capturePeerPortCondition,
       FallbackNamePortGetter<REQUEST> fallbackNamePortGetter,
       boolean emitOldHttpAttributes) {
     this.getter = getter;
-    this.capturePeerPortCondition = capturePeerPortCondition;
     this.fallbackNamePortGetter = fallbackNamePortGetter;
     this.emitOldHttpAttributes = emitOldHttpAttributes;
-  }
-
-  public void onStart(AttributesBuilder attributes, REQUEST request) {
-    String peerName = extractPeerName(request);
-
-    if (peerName != null) {
-      internalSet(attributes, SemanticAttributes.NET_PEER_NAME, peerName);
-
-      Integer peerPort = extractPeerPort(request);
-      if (peerPort != null && peerPort > 0 && capturePeerPortCondition.test(peerPort, request)) {
-        internalSet(attributes, SemanticAttributes.NET_PEER_PORT, (long) peerPort);
-      }
-    }
   }
 
   public void onEnd(AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {
@@ -53,47 +36,23 @@ public final class InternalNetClientAttributesExtractor<REQUEST, RESPONSE> {
     if (emitOldHttpAttributes) {
       internalSet(
           attributes, SemanticAttributes.NET_TRANSPORT, getter.getTransport(request, response));
-    }
 
-    String peerName = extractPeerName(request);
-
-    String sockPeerAddr = getter.getSockPeerAddr(request, response);
-    if (sockPeerAddr != null && !sockPeerAddr.equals(peerName)) {
-      internalSet(attributes, SemanticAttributes.NET_SOCK_PEER_ADDR, sockPeerAddr);
-
-      Integer peerPort = extractPeerPort(request);
-      Integer sockPeerPort = getter.getSockPeerPort(request, response);
-      if (sockPeerPort != null && sockPeerPort > 0 && !sockPeerPort.equals(peerPort)) {
-        internalSet(attributes, SemanticAttributes.NET_SOCK_PEER_PORT, (long) sockPeerPort);
-      }
-
-      if (emitOldHttpAttributes) {
+      String peerName = extractPeerName(request);
+      String sockPeerAddr = getter.getServerSocketAddress(request, response);
+      if (sockPeerAddr != null && !sockPeerAddr.equals(peerName)) {
         String sockFamily = getter.getSockFamily(request, response);
         if (sockFamily != null && !SemanticAttributes.NetSockFamilyValues.INET.equals(sockFamily)) {
           internalSet(attributes, SemanticAttributes.NET_SOCK_FAMILY, sockFamily);
         }
       }
-
-      String sockPeerName = getter.getSockPeerName(request, response);
-      if (sockPeerName != null && !sockPeerName.equals(peerName)) {
-        internalSet(attributes, SemanticAttributes.NET_SOCK_PEER_NAME, sockPeerName);
-      }
     }
   }
 
   private String extractPeerName(REQUEST request) {
-    String peerName = getter.getPeerName(request);
+    String peerName = getter.getServerAddress(request);
     if (peerName == null) {
       peerName = fallbackNamePortGetter.name(request);
     }
     return peerName;
-  }
-
-  private Integer extractPeerPort(REQUEST request) {
-    Integer peerPort = getter.getPeerPort(request);
-    if (peerPort == null) {
-      peerPort = fallbackNamePortGetter.port(request);
-    }
-    return peerPort;
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractor.java
@@ -31,7 +31,7 @@ public final class ServerAttributesExtractor<REQUEST, RESPONSE>
 
   private final InternalServerAttributesExtractor<REQUEST, RESPONSE> internalExtractor;
 
-  public ServerAttributesExtractor(ServerAttributesGetter<REQUEST, RESPONSE> getter) {
+  ServerAttributesExtractor(ServerAttributesGetter<REQUEST, RESPONSE> getter) {
     // the ServerAttributesExtractor will always emit new semconv
     internalExtractor =
         new InternalServerAttributesExtractor<>(

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.FallbackNamePortGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalServerAttributesExtractor;
+import javax.annotation.Nullable;
+
+/**
+ * Extractor of <a
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/main/specification/trace/semantic_conventions/span-general.md#server-attributes">server
+ * attributes</a>.
+ */
+public final class ServerAttributesExtractor<REQUEST, RESPONSE>
+    implements AttributesExtractor<REQUEST, RESPONSE> {
+
+  /**
+   * Returns a new {@link ServerAttributesExtractor} that will use the passed {@link
+   * ServerAttributesGetter}.
+   */
+  public static <REQUEST, RESPONSE> ServerAttributesExtractor<REQUEST, RESPONSE> create(
+      ServerAttributesGetter<REQUEST, RESPONSE> getter) {
+    return new ServerAttributesExtractor<>(getter);
+  }
+
+  private final InternalServerAttributesExtractor<REQUEST, RESPONSE> internalExtractor;
+
+  public ServerAttributesExtractor(ServerAttributesGetter<REQUEST, RESPONSE> getter) {
+    // the ServerAttributesExtractor will always emit new semconv
+    internalExtractor =
+        new InternalServerAttributesExtractor<>(
+            getter,
+            (port, request) -> true,
+            FallbackNamePortGetter.noop(),
+            /* emitStableUrlAttributes= */ true,
+            /* emitOldHttpAttributes= */ false,
+            // this param does not matter when old semconv is off
+            InternalServerAttributesExtractor.Mode.HOST);
+  }
+
+  @Override
+  public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
+    internalExtractor.onStart(attributes, request);
+  }
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error) {
+    internalExtractor.onEnd(attributes, request, response);
+  }
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesGetter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network;
+
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InetSocketAddressUtil;
+import java.net.InetSocketAddress;
+import javax.annotation.Nullable;
+
+/**
+ * An interface for getting attributes describing a network server.
+ *
+ * <p>Instrumentation authors will create implementations of this interface for their specific
+ * library/framework. It will be used by the {@link ServerAttributesExtractor} (or other convention
+ * specific extractors) to obtain the various server attributes in a type-generic way.
+ */
+public interface ServerAttributesGetter<REQUEST, RESPONSE> {
+
+  /**
+   * Return the logical server hostname that matches server FQDN if available, and IP or socket
+   * address if FQDN is not known.
+   *
+   * <p>Examples: {@code example.com}
+   */
+  @Nullable
+  String getServerAddress(REQUEST request);
+
+  /**
+   * Return the logical server port number.
+   *
+   * <p>Examples: {@code 80}, {@code 8080}, {@code 443}
+   */
+  @Nullable
+  Integer getServerPort(REQUEST request);
+
+  /**
+   * Returns an {@link InetSocketAddress} object representing the server socket address.
+   *
+   * <p>Implementing this method is equivalent to implementing all three of {@link
+   * #getServerSocketDomain(Object, Object)}, {@link #getServerSocketAddress(Object, Object)} and
+   * {@link #getServerSocketPort(Object, Object)}.
+   */
+  @Nullable
+  default InetSocketAddress getServerInetSocketAddress(
+      REQUEST request, @Nullable RESPONSE response) {
+    return null;
+  }
+
+  /**
+   * Return the domain name of an immediate peer.
+   *
+   * <p>Examples: {@code proxy.example.com}
+   *
+   * <p>By default, this method attempts to retrieve the server domain name using the {@link
+   * #getServerInetSocketAddress(Object, Object)} method. If this method is not implemented, it will
+   * simply return {@code null}. If the instrumented library does not expose {@link
+   * InetSocketAddress} in its API, you might want to implement this method instead of {@link
+   * #getServerInetSocketAddress(Object, Object)}.
+   */
+  @Nullable
+  default String getServerSocketDomain(REQUEST request, @Nullable RESPONSE response) {
+    return InetSocketAddressUtil.getDomainName(getServerInetSocketAddress(request, response));
+  }
+
+  /**
+   * Return the physical server IP address or Unix socket address.
+   *
+   * <p>Examples: {@code 10.5.3.2}
+   *
+   * <p>By default, this method attempts to retrieve the server address using the {@link
+   * #getServerInetSocketAddress(Object, Object)} method. If this method is not implemented, it will
+   * simply return {@code null}. If the instrumented library does not expose {@link
+   * InetSocketAddress} in its API, you might want to implement this method instead of {@link
+   * #getServerInetSocketAddress(Object, Object)}.
+   */
+  @Nullable
+  default String getServerSocketAddress(REQUEST request, @Nullable RESPONSE response) {
+    return InetSocketAddressUtil.getIpAddress(getServerInetSocketAddress(request, response));
+  }
+
+  /**
+   * Return the physical server port.
+   *
+   * <p>Examples: {@code 16456}
+   *
+   * <p>By default, this method attempts to retrieve the server port using the {@link
+   * #getServerInetSocketAddress(Object, Object)} method. If this method is not implemented, it will
+   * simply return {@code null}. If the instrumented library does not expose {@link
+   * InetSocketAddress} in its API, you might want to implement this method instead of {@link
+   * #getServerInetSocketAddress(Object, Object)}.
+   */
+  @Nullable
+  default Integer getServerSocketPort(REQUEST request, @Nullable RESPONSE response) {
+    return InetSocketAddressUtil.getPort(getServerInetSocketAddress(request, response));
+  }
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalServerAttributesExtractor.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.net.internal.FallbackNamePortGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.function.BiPredicate;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class InternalServerAttributesExtractor<REQUEST, RESPONSE> {
+
+  private final ServerAttributesGetter<REQUEST, RESPONSE> getter;
+  private final BiPredicate<Integer, REQUEST> captureServerPortCondition;
+  private final FallbackNamePortGetter<REQUEST> fallbackNamePortGetter;
+  private final boolean emitStableUrlAttributes;
+  private final boolean emitOldHttpAttributes;
+  private final Mode oldSemconvMode;
+
+  public InternalServerAttributesExtractor(
+      ServerAttributesGetter<REQUEST, RESPONSE> getter,
+      BiPredicate<Integer, REQUEST> captureServerPortCondition,
+      FallbackNamePortGetter<REQUEST> fallbackNamePortGetter,
+      boolean emitStableUrlAttributes,
+      boolean emitOldHttpAttributes,
+      Mode oldSemconvMode) {
+    this.getter = getter;
+    this.captureServerPortCondition = captureServerPortCondition;
+    this.fallbackNamePortGetter = fallbackNamePortGetter;
+    this.emitStableUrlAttributes = emitStableUrlAttributes;
+    this.emitOldHttpAttributes = emitOldHttpAttributes;
+    this.oldSemconvMode = oldSemconvMode;
+  }
+
+  public void onStart(AttributesBuilder attributes, REQUEST request) {
+    String serverAddress = extractServerAddress(request);
+
+    if (serverAddress != null) {
+      if (emitStableUrlAttributes) {
+        internalSet(attributes, NetworkAttributes.SERVER_ADDRESS, serverAddress);
+      }
+      if (emitOldHttpAttributes) {
+        internalSet(attributes, oldSemconvMode.address, serverAddress);
+      }
+
+      Integer serverPort = extractServerPort(request);
+      if (serverPort != null
+          && serverPort > 0
+          && captureServerPortCondition.test(serverPort, request)) {
+        if (emitStableUrlAttributes) {
+          internalSet(attributes, NetworkAttributes.SERVER_PORT, (long) serverPort);
+        }
+        if (emitOldHttpAttributes) {
+          internalSet(attributes, oldSemconvMode.port, (long) serverPort);
+        }
+      }
+    }
+  }
+
+  public void onEnd(AttributesBuilder attributes, REQUEST request, @Nullable RESPONSE response) {
+    String serverAddress = extractServerAddress(request);
+
+    String serverSocketAddress = getter.getServerSocketAddress(request, response);
+    if (serverSocketAddress != null && !serverSocketAddress.equals(serverAddress)) {
+      if (emitStableUrlAttributes) {
+        internalSet(attributes, NetworkAttributes.SERVER_SOCKET_ADDRESS, serverSocketAddress);
+      }
+      if (emitOldHttpAttributes) {
+        internalSet(attributes, oldSemconvMode.socketAddress, serverSocketAddress);
+      }
+
+      Integer serverPort = extractServerPort(request);
+      Integer serverSocketPort = getter.getServerSocketPort(request, response);
+      if (serverSocketPort != null
+          && serverSocketPort > 0
+          && !serverSocketPort.equals(serverPort)) {
+        if (emitStableUrlAttributes) {
+          internalSet(attributes, NetworkAttributes.SERVER_SOCKET_PORT, (long) serverSocketPort);
+        }
+        if (emitOldHttpAttributes) {
+          internalSet(attributes, oldSemconvMode.socketPort, (long) serverSocketPort);
+        }
+      }
+
+      String serverSocketDomain = getter.getServerSocketDomain(request, response);
+      if (serverSocketDomain != null && !serverSocketDomain.equals(serverAddress)) {
+        if (emitStableUrlAttributes) {
+          internalSet(attributes, NetworkAttributes.SERVER_SOCKET_DOMAIN, serverSocketDomain);
+        }
+        if (emitOldHttpAttributes && oldSemconvMode.socketDomain != null) {
+          internalSet(attributes, oldSemconvMode.socketDomain, serverSocketDomain);
+        }
+      }
+    }
+  }
+
+  private String extractServerAddress(REQUEST request) {
+    String serverAddress = getter.getServerAddress(request);
+    if (serverAddress == null) {
+      serverAddress = fallbackNamePortGetter.name(request);
+    }
+    return serverAddress;
+  }
+
+  private Integer extractServerPort(REQUEST request) {
+    Integer serverPort = getter.getServerPort(request);
+    if (serverPort == null) {
+      serverPort = fallbackNamePortGetter.port(request);
+    }
+    return serverPort;
+  }
+
+  /**
+   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+   * any time.
+   */
+  @SuppressWarnings("ImmutableEnumChecker")
+  public enum Mode {
+    PEER(
+        SemanticAttributes.NET_PEER_NAME,
+        SemanticAttributes.NET_PEER_PORT,
+        SemanticAttributes.NET_SOCK_PEER_NAME,
+        SemanticAttributes.NET_SOCK_PEER_ADDR,
+        SemanticAttributes.NET_SOCK_PEER_PORT),
+    HOST(
+        SemanticAttributes.NET_HOST_NAME,
+        SemanticAttributes.NET_HOST_PORT,
+        // the old semconv does not have an attribute for this
+        null,
+        SemanticAttributes.NET_SOCK_HOST_ADDR,
+        SemanticAttributes.NET_SOCK_HOST_PORT);
+
+    final AttributeKey<String> address;
+    final AttributeKey<Long> port;
+    @Nullable final AttributeKey<String> socketDomain;
+    final AttributeKey<String> socketAddress;
+    final AttributeKey<Long> socketPort;
+
+    Mode(
+        AttributeKey<String> address,
+        AttributeKey<Long> port,
+        AttributeKey<String> socketDomain,
+        AttributeKey<String> socketAddress,
+        AttributeKey<Long> socketPort) {
+      this.address = address;
+      this.port = port;
+      this.socketDomain = socketDomain;
+      this.socketAddress = socketAddress;
+      this.socketPort = socketPort;
+    }
+  }
+}

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/NetworkAttributes.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/NetworkAttributes.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.network.internal;
 
+import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -27,6 +28,17 @@ public final class NetworkAttributes {
 
   public static final AttributeKey<String> NETWORK_PROTOCOL_VERSION =
       stringKey("network.protocol.version");
+
+  public static final AttributeKey<String> SERVER_ADDRESS = stringKey("server.address");
+
+  public static final AttributeKey<Long> SERVER_PORT = longKey("server.port");
+
+  public static final AttributeKey<String> SERVER_SOCKET_DOMAIN = stringKey("server.socket.domain");
+
+  public static final AttributeKey<String> SERVER_SOCKET_ADDRESS =
+      stringKey("server.socket.address");
+
+  public static final AttributeKey<Long> SERVER_SOCKET_PORT = longKey("server.socket.port");
 
   private NetworkAttributes() {}
 }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -101,13 +101,13 @@ class HttpClientAttributesExtractorTest {
 
     @Nullable
     @Override
-    public String getPeerName(Map<String, String> request) {
+    public String getServerAddress(Map<String, String> request) {
       return request.get("peerName");
     }
 
     @Nullable
     @Override
-    public Integer getPeerPort(Map<String, String> request) {
+    public Integer getServerPort(Map<String, String> request) {
       String statusCode = request.get("peerPort");
       return statusCode == null ? null : Integer.parseInt(statusCode);
     }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -119,13 +119,13 @@ class HttpServerAttributesExtractorTest {
 
     @Nullable
     @Override
-    public String getHostName(Map<String, Object> request) {
+    public String getServerAddress(Map<String, Object> request) {
       return (String) request.get("hostName");
     }
 
     @Nullable
     @Override
-    public Integer getHostPort(Map<String, Object> request) {
+    public Integer getServerPort(Map<String, Object> request) {
       return (Integer) request.get("hostPort");
     }
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetterTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetterTest.java
@@ -25,19 +25,19 @@ class InetSocketAddressNetClientAttributesGetterTest {
       implements NetClientAttributesGetter<InetSocketAddress, InetSocketAddress> {
 
     @Override
-    public String getPeerName(InetSocketAddress request) {
+    public String getServerAddress(InetSocketAddress request) {
       // net.peer.name and net.peer.port are tested in NetClientAttributesExtractorTest
       return null;
     }
 
     @Override
-    public Integer getPeerPort(InetSocketAddress request) {
+    public Integer getServerPort(InetSocketAddress request) {
       // net.peer.name and net.peer.port are tested in NetClientAttributesExtractorTest
       return null;
     }
 
     @Override
-    public InetSocketAddress getPeerSocketAddress(
+    public InetSocketAddress getServerInetSocketAddress(
         InetSocketAddress request, InetSocketAddress response) {
       return response;
     }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetServerAttributesGetterTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.instrumenter.net;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -25,13 +26,13 @@ class InetSocketAddressNetServerAttributesGetterTest {
       implements NetServerAttributesGetter<Addresses, Addresses> {
 
     @Override
-    public String getHostName(Addresses request) {
+    public String getServerAddress(Addresses request) {
       // net.host.name and net.host.port are tested in NetClientAttributesExtractorTest
       return null;
     }
 
     @Override
-    public Integer getHostPort(Addresses request) {
+    public Integer getServerPort(Addresses request) {
       // net.host.name and net.host.port are tested in NetClientAttributesExtractorTest
       return null;
     }
@@ -42,7 +43,7 @@ class InetSocketAddressNetServerAttributesGetterTest {
     }
 
     @Override
-    public InetSocketAddress getHostSocketAddress(Addresses request) {
+    public InetSocketAddress getServerInetSocketAddress(Addresses request, Addresses response) {
       return request.host;
     }
   }
@@ -82,12 +83,14 @@ class InetSocketAddressNetServerAttributesGetterTest {
     }
     builder.put(SemanticAttributes.NET_SOCK_PEER_ADDR, request.peer.getAddress().getHostAddress());
     builder.put(SemanticAttributes.NET_SOCK_PEER_PORT, 123L);
-    builder.put(SemanticAttributes.NET_SOCK_HOST_ADDR, request.host.getAddress().getHostAddress());
-    builder.put(SemanticAttributes.NET_SOCK_HOST_PORT, 456L);
 
     assertThat(startAttributes.build()).isEqualTo(builder.build());
 
-    assertThat(endAttributes.build()).isEmpty();
+    assertThat(endAttributes.build())
+        .containsOnly(
+            entry(
+                SemanticAttributes.NET_SOCK_HOST_ADDR, request.host.getAddress().getHostAddress()),
+            entry(SemanticAttributes.NET_SOCK_HOST_PORT, 456L));
   }
 
   @Test

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorTest.java
@@ -61,12 +61,12 @@ class NetClientAttributesExtractorTest {
     }
 
     @Override
-    public String getPeerName(Map<String, String> request) {
+    public String getServerAddress(Map<String, String> request) {
       return request.get("peerName");
     }
 
     @Override
-    public Integer getPeerPort(Map<String, String> request) {
+    public Integer getServerPort(Map<String, String> request) {
       String peerPort = request.get("peerPort");
       return peerPort == null ? null : Integer.valueOf(peerPort);
     }
@@ -77,17 +77,18 @@ class NetClientAttributesExtractorTest {
     }
 
     @Override
-    public String getSockPeerAddr(Map<String, String> request, Map<String, String> response) {
-      return response.get("sockPeerAddr");
-    }
-
-    @Override
-    public String getSockPeerName(Map<String, String> request, Map<String, String> response) {
+    public String getServerSocketDomain(Map<String, String> request, Map<String, String> response) {
       return response.get("sockPeerName");
     }
 
     @Override
-    public Integer getSockPeerPort(Map<String, String> request, Map<String, String> response) {
+    public String getServerSocketAddress(
+        Map<String, String> request, Map<String, String> response) {
+      return response.get("sockPeerAddr");
+    }
+
+    @Override
+    public Integer getServerSocketPort(Map<String, String> request, Map<String, String> response) {
       String sockPeerPort = response.get("sockPeerPort");
       return sockPeerPort == null ? null : Integer.valueOf(sockPeerPort);
     }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorTest.java
@@ -58,13 +58,13 @@ class NetServerAttributesExtractorTest {
 
     @Nullable
     @Override
-    public String getHostName(Map<String, String> request) {
+    public String getServerAddress(Map<String, String> request) {
       return request.get("hostName");
     }
 
     @Nullable
     @Override
-    public Integer getHostPort(Map<String, String> request) {
+    public Integer getServerPort(Map<String, String> request) {
       String hostPort = request.get("hostPort");
       return hostPort == null ? null : Integer.valueOf(hostPort);
     }
@@ -88,13 +88,13 @@ class NetServerAttributesExtractorTest {
 
     @Nullable
     @Override
-    public String getSockHostAddr(Map<String, String> request) {
+    public String getServerSocketAddress(Map<String, String> request, Void response) {
       return request.get("sockHostAddr");
     }
 
     @Nullable
     @Override
-    public Integer getSockHostPort(Map<String, String> request) {
+    public Integer getServerSocketPort(Map<String, String> request, Void response) {
       String sockHostPort = request.get("sockHostPort");
       return sockHostPort == null ? null : Integer.valueOf(sockHostPort);
     }
@@ -137,14 +137,14 @@ class NetServerAttributesExtractorTest {
             entry(SemanticAttributes.NET_HOST_PORT, 80L),
             entry(SemanticAttributes.NET_SOCK_FAMILY, "inet6"),
             entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"),
-            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 42L),
-            entry(SemanticAttributes.NET_SOCK_HOST_ADDR, "4:3:2:1::"),
-            entry(SemanticAttributes.NET_SOCK_HOST_PORT, 8080L));
+            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 42L));
 
     assertThat(endAttributes.build())
         .containsOnly(
             entry(NetAttributes.NET_PROTOCOL_NAME, "http"),
-            entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"));
+            entry(NetAttributes.NET_PROTOCOL_VERSION, "1.1"),
+            entry(SemanticAttributes.NET_SOCK_HOST_ADDR, "4:3:2:1::"),
+            entry(SemanticAttributes.NET_SOCK_HOST_PORT, 8080L));
   }
 
   @Test
@@ -224,10 +224,10 @@ class NetServerAttributesExtractorTest {
             entry(SemanticAttributes.NET_TRANSPORT, IP_TCP),
             entry(SemanticAttributes.NET_HOST_NAME, "opentelemetry.io"),
             entry(SemanticAttributes.NET_HOST_PORT, 80L),
-            entry(SemanticAttributes.NET_SOCK_FAMILY, "inet6"),
-            entry(SemanticAttributes.NET_SOCK_HOST_ADDR, "4:3:2:1::"));
+            entry(SemanticAttributes.NET_SOCK_FAMILY, "inet6"));
 
-    assertThat(endAttributes.build()).isEmpty();
+    assertThat(endAttributes.build())
+        .containsOnly(entry(SemanticAttributes.NET_SOCK_HOST_ADDR, "4:3:2:1::"));
   }
 
   @Test
@@ -254,10 +254,10 @@ class NetServerAttributesExtractorTest {
     assertThat(startAttributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_HOST_NAME, "opentelemetry.io"),
-            entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"),
-            entry(SemanticAttributes.NET_SOCK_HOST_ADDR, "4:3:2:1::"));
+            entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"));
 
-    assertThat(endAttributes.build()).isEmpty();
+    assertThat(endAttributes.build())
+        .containsOnly(entry(SemanticAttributes.NET_SOCK_HOST_ADDR, "4:3:2:1::"));
   }
 
   @Test

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractorTest.java
@@ -56,7 +56,7 @@ class PeerServiceAttributesExtractorTest {
     PeerServiceAttributesExtractor<String, String> underTest =
         new PeerServiceAttributesExtractor<>(netAttributesExtractor, peerServiceMapping);
 
-    when(netAttributesExtractor.getPeerName(any())).thenReturn("example2.com");
+    when(netAttributesExtractor.getServerAddress(any())).thenReturn("example2.com");
 
     Context context = Context.root();
 
@@ -81,7 +81,7 @@ class PeerServiceAttributesExtractorTest {
     PeerServiceAttributesExtractor<String, String> underTest =
         new PeerServiceAttributesExtractor<>(netAttributesExtractor, peerServiceMapping);
 
-    when(netAttributesExtractor.getPeerName(any())).thenReturn("example.com");
+    when(netAttributesExtractor.getServerAddress(any())).thenReturn("example.com");
 
     Context context = Context.root();
 
@@ -95,7 +95,7 @@ class PeerServiceAttributesExtractorTest {
     assertThat(startAttributes.build()).isEmpty();
     assertThat(endAttributes.build())
         .containsOnly(entry(SemanticAttributes.PEER_SERVICE, "myService"));
-    verify(netAttributesExtractor, never()).getSockPeerName(any(), any());
+    verify(netAttributesExtractor, never()).getServerSocketDomain(any(), any());
   }
 
   @Test
@@ -108,7 +108,7 @@ class PeerServiceAttributesExtractorTest {
     PeerServiceAttributesExtractor<String, String> underTest =
         new PeerServiceAttributesExtractor<>(netAttributesExtractor, peerServiceMapping);
 
-    when(netAttributesExtractor.getSockPeerName(any(), any())).thenReturn("example.com");
+    when(netAttributesExtractor.getServerSocketDomain(any(), any())).thenReturn("example.com");
 
     Context context = Context.root();
 

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractorInetSocketAddressTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractorInetSocketAddressTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkAttributes;
+import java.net.InetSocketAddress;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class ServerAttributesExtractorInetSocketAddressTest {
+
+  static class TestServerAttributesGetter
+      implements ServerAttributesGetter<InetSocketAddress, Void> {
+
+    @Nullable
+    @Override
+    public String getServerAddress(InetSocketAddress request) {
+      // covered in ServerAttributesExtractorTest
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Integer getServerPort(InetSocketAddress request) {
+      // covered in ServerAttributesExtractorTest
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public InetSocketAddress getServerInetSocketAddress(
+        InetSocketAddress request, @Nullable Void unused) {
+      return request;
+    }
+  }
+
+  @Test
+  void fullAddress() {
+    InetSocketAddress address = new InetSocketAddress("api.github.com", 456);
+    assertThat(address.getAddress().getHostAddress()).isNotNull();
+
+    AttributesExtractor<InetSocketAddress, Void> extractor =
+        ServerAttributesExtractor.create(new TestServerAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), address);
+    assertThat(startAttributes.build()).isEmpty();
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), address, null, null);
+    assertThat(endAttributes.build())
+        .containsOnly(
+            entry(NetworkAttributes.SERVER_SOCKET_DOMAIN, "api.github.com"),
+            entry(NetworkAttributes.SERVER_SOCKET_ADDRESS, address.getAddress().getHostAddress()),
+            entry(NetworkAttributes.SERVER_SOCKET_PORT, 456L));
+  }
+
+  @Test
+  void noAttributes() {
+    AttributesExtractor<InetSocketAddress, Void> extractor =
+        ServerAttributesExtractor.create(new TestServerAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), null);
+    assertThat(startAttributes.build()).isEmpty();
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), null, null, null);
+    assertThat(endAttributes.build()).isEmpty();
+  }
+}

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.instrumenter.network;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class ServerAttributesExtractorTest {
+
+  static class TestServerAttributesGetter
+      implements ServerAttributesGetter<Map<String, String>, Void> {
+
+    @Nullable
+    @Override
+    public String getServerAddress(Map<String, String> request) {
+      return request.get("address");
+    }
+
+    @Nullable
+    @Override
+    public Integer getServerPort(Map<String, String> request) {
+      String port = request.get("port");
+      return port == null ? null : Integer.parseInt(port);
+    }
+
+    @Nullable
+    @Override
+    public String getServerSocketDomain(Map<String, String> request, @Nullable Void unused) {
+      return request.get("socketDomain");
+    }
+
+    @Nullable
+    @Override
+    public String getServerSocketAddress(Map<String, String> request, @Nullable Void unused) {
+      return request.get("socketAddress");
+    }
+
+    @Nullable
+    @Override
+    public Integer getServerSocketPort(Map<String, String> request, @Nullable Void unused) {
+      String port = request.get("socketPort");
+      return port == null ? null : Integer.parseInt(port);
+    }
+  }
+
+  @Test
+  void allAttributes() {
+    Map<String, String> request = new HashMap<>();
+    request.put("address", "opentelemetry.io");
+    request.put("port", "80");
+    request.put("socketDomain", "proxy.opentelemetry.io");
+    request.put("socketAddress", "1.2.3.4");
+    request.put("socketPort", "8080");
+
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        ServerAttributesExtractor.create(new TestServerAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build())
+        .containsOnly(
+            entry(NetworkAttributes.SERVER_ADDRESS, "opentelemetry.io"),
+            entry(NetworkAttributes.SERVER_PORT, 80L));
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, null, null);
+    assertThat(endAttributes.build())
+        .containsOnly(
+            entry(NetworkAttributes.SERVER_SOCKET_DOMAIN, "proxy.opentelemetry.io"),
+            entry(NetworkAttributes.SERVER_SOCKET_ADDRESS, "1.2.3.4"),
+            entry(NetworkAttributes.SERVER_SOCKET_PORT, 8080L));
+  }
+
+  @Test
+  void noAttributes() {
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        ServerAttributesExtractor.create(new TestServerAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), emptyMap());
+    assertThat(startAttributes.build()).isEmpty();
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), emptyMap(), null, null);
+    assertThat(endAttributes.build()).isEmpty();
+  }
+
+  @Test
+  void doesNotSetNegativePortValues() {
+    Map<String, String> request = new HashMap<>();
+    request.put("address", "opentelemetry.io");
+    request.put("port", "-12");
+    request.put("socketAddress", "1.2.3.4");
+    request.put("socketPort", "-42");
+
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        ServerAttributesExtractor.create(new TestServerAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build())
+        .containsOnly(entry(NetworkAttributes.SERVER_ADDRESS, "opentelemetry.io"));
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, null, null);
+    assertThat(endAttributes.build())
+        .containsOnly(entry(NetworkAttributes.SERVER_SOCKET_ADDRESS, "1.2.3.4"));
+  }
+
+  // TODO: add more test cases around duplicate data once
+  // https://github.com/open-telemetry/semantic-conventions/issues/85 clears up
+}

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
@@ -96,13 +96,13 @@ class HttpClientAttributesExtractorBothSemconvTest {
 
     @Nullable
     @Override
-    public String getPeerName(Map<String, String> request) {
+    public String getServerAddress(Map<String, String> request) {
       return request.get("peerName");
     }
 
     @Nullable
     @Override
-    public Integer getPeerPort(Map<String, String> request) {
+    public Integer getServerPort(Map<String, String> request) {
       String statusCode = request.get("peerPort");
       return statusCode == null ? null : Integer.parseInt(statusCode);
     }
@@ -151,7 +151,9 @@ class HttpClientAttributesExtractorBothSemconvTest {
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")),
             entry(SemanticAttributes.NET_PEER_NAME, "github.com"),
-            entry(SemanticAttributes.NET_PEER_PORT, 123L));
+            entry(SemanticAttributes.NET_PEER_PORT, 123L),
+            entry(NetworkAttributes.SERVER_ADDRESS, "github.com"),
+            entry(NetworkAttributes.SERVER_PORT, 123L));
 
     AttributesBuilder endAttributes = Attributes.builder();
     extractor.onEnd(endAttributes, Context.root(), request, response, null);

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
@@ -113,13 +113,13 @@ class HttpServerAttributesExtractorBothSemconvTest {
 
     @Nullable
     @Override
-    public String getHostName(Map<String, Object> request) {
+    public String getServerAddress(Map<String, Object> request) {
       return (String) request.get("hostName");
     }
 
     @Nullable
     @Override
-    public Integer getHostPort(Map<String, Object> request) {
+    public Integer getServerPort(Map<String, Object> request) {
       return (Integer) request.get("hostPort");
     }
   }
@@ -163,6 +163,7 @@ class HttpServerAttributesExtractorBothSemconvTest {
     assertThat(startAttributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_HOST_NAME, "github.com"),
+            entry(NetworkAttributes.SERVER_ADDRESS, "github.com"),
             entry(SemanticAttributes.HTTP_METHOD, "POST"),
             entry(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
             entry(SemanticAttributes.HTTP_SCHEME, "http"),

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorBothSemconvTest.java
@@ -60,12 +60,12 @@ class NetClientAttributesExtractorBothSemconvTest {
     }
 
     @Override
-    public String getPeerName(Map<String, String> request) {
+    public String getServerAddress(Map<String, String> request) {
       return request.get("peerName");
     }
 
     @Override
-    public Integer getPeerPort(Map<String, String> request) {
+    public Integer getServerPort(Map<String, String> request) {
       String peerPort = request.get("peerPort");
       return peerPort == null ? null : Integer.valueOf(peerPort);
     }
@@ -76,17 +76,18 @@ class NetClientAttributesExtractorBothSemconvTest {
     }
 
     @Override
-    public String getSockPeerAddr(Map<String, String> request, Map<String, String> response) {
-      return response.get("sockPeerAddr");
-    }
-
-    @Override
-    public String getSockPeerName(Map<String, String> request, Map<String, String> response) {
+    public String getServerSocketDomain(Map<String, String> request, Map<String, String> response) {
       return response.get("sockPeerName");
     }
 
     @Override
-    public Integer getSockPeerPort(Map<String, String> request, Map<String, String> response) {
+    public String getServerSocketAddress(
+        Map<String, String> request, Map<String, String> response) {
+      return response.get("sockPeerAddr");
+    }
+
+    @Override
+    public Integer getServerSocketPort(Map<String, String> request, Map<String, String> response) {
       String sockPeerPort = response.get("sockPeerPort");
       return sockPeerPort == null ? null : Integer.valueOf(sockPeerPort);
     }
@@ -124,7 +125,9 @@ class NetClientAttributesExtractorBothSemconvTest {
     assertThat(startAttributes.build())
         .containsOnly(
             entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"),
-            entry(SemanticAttributes.NET_PEER_PORT, 42L));
+            entry(SemanticAttributes.NET_PEER_PORT, 42L),
+            entry(NetworkAttributes.SERVER_ADDRESS, "opentelemetry.io"),
+            entry(NetworkAttributes.SERVER_PORT, 42L));
 
     assertThat(endAttributes.build())
         .containsOnly(
@@ -138,6 +141,9 @@ class NetClientAttributesExtractorBothSemconvTest {
             entry(SemanticAttributes.NET_SOCK_FAMILY, "inet6"),
             entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"),
             entry(SemanticAttributes.NET_SOCK_PEER_NAME, "proxy.opentelemetry.io"),
-            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 123L));
+            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 123L),
+            entry(NetworkAttributes.SERVER_SOCKET_DOMAIN, "proxy.opentelemetry.io"),
+            entry(NetworkAttributes.SERVER_SOCKET_ADDRESS, "1:2:3:4::"),
+            entry(NetworkAttributes.SERVER_SOCKET_PORT, 123L));
   }
 }

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorBothSemconvTest.java
@@ -57,13 +57,13 @@ class NetServerAttributesExtractorBothSemconvTest {
 
     @Nullable
     @Override
-    public String getHostName(Map<String, String> request) {
+    public String getServerAddress(Map<String, String> request) {
       return request.get("hostName");
     }
 
     @Nullable
     @Override
-    public Integer getHostPort(Map<String, String> request) {
+    public Integer getServerPort(Map<String, String> request) {
       String hostPort = request.get("hostPort");
       return hostPort == null ? null : Integer.valueOf(hostPort);
     }
@@ -87,13 +87,13 @@ class NetServerAttributesExtractorBothSemconvTest {
 
     @Nullable
     @Override
-    public String getSockHostAddr(Map<String, String> request) {
+    public String getServerSocketAddress(Map<String, String> request, Void response) {
       return request.get("sockHostAddr");
     }
 
     @Nullable
     @Override
-    public Integer getSockHostPort(Map<String, String> request) {
+    public Integer getServerSocketPort(Map<String, String> request, Void response) {
       String sockHostPort = request.get("sockHostPort");
       return sockHostPort == null ? null : Integer.valueOf(sockHostPort);
     }
@@ -134,14 +134,18 @@ class NetServerAttributesExtractorBothSemconvTest {
             entry(SemanticAttributes.NET_TRANSPORT, IP_TCP),
             entry(SemanticAttributes.NET_HOST_NAME, "opentelemetry.io"),
             entry(SemanticAttributes.NET_HOST_PORT, 80L),
+            entry(NetworkAttributes.SERVER_ADDRESS, "opentelemetry.io"),
+            entry(NetworkAttributes.SERVER_PORT, 80L),
             entry(SemanticAttributes.NET_SOCK_FAMILY, "inet6"),
             entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"),
-            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 42L),
-            entry(SemanticAttributes.NET_SOCK_HOST_ADDR, "4:3:2:1::"),
-            entry(SemanticAttributes.NET_SOCK_HOST_PORT, 8080L));
+            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 42L));
 
     assertThat(endAttributes.build())
         .containsOnly(
+            entry(SemanticAttributes.NET_SOCK_HOST_ADDR, "4:3:2:1::"),
+            entry(SemanticAttributes.NET_SOCK_HOST_PORT, 8080L),
+            entry(NetworkAttributes.SERVER_SOCKET_ADDRESS, "4:3:2:1::"),
+            entry(NetworkAttributes.SERVER_SOCKET_PORT, 8080L),
             entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
             entry(NetworkAttributes.NETWORK_TYPE, "ipv6"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
@@ -104,13 +104,13 @@ class HttpClientAttributesExtractorStableSemconvTest {
 
     @Nullable
     @Override
-    public String getPeerName(Map<String, String> request) {
+    public String getServerAddress(Map<String, String> request) {
       return request.get("peerName");
     }
 
     @Nullable
     @Override
-    public Integer getPeerPort(Map<String, String> request) {
+    public Integer getServerPort(Map<String, String> request) {
       String value = request.get("peerPort");
       return value == null ? null : Integer.parseInt(value);
     }
@@ -156,8 +156,8 @@ class HttpClientAttributesExtractorStableSemconvTest {
             entry(
                 AttributeKey.stringArrayKey("http.request.header.custom_request_header"),
                 asList("123", "456")),
-            entry(SemanticAttributes.NET_PEER_NAME, "github.com"),
-            entry(SemanticAttributes.NET_PEER_PORT, 123L));
+            entry(NetworkAttributes.SERVER_ADDRESS, "github.com"),
+            entry(NetworkAttributes.SERVER_PORT, 123L));
 
     AttributesBuilder endAttributes = Attributes.builder();
     extractor.onEnd(endAttributes, Context.root(), request, response, null);

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorStableSemconvTest.java
@@ -121,13 +121,13 @@ class HttpServerAttributesExtractorStableSemconvTest {
 
     @Nullable
     @Override
-    public String getHostName(Map<String, Object> request) {
+    public String getServerAddress(Map<String, Object> request) {
       return (String) request.get("hostName");
     }
 
     @Nullable
     @Override
-    public Integer getHostPort(Map<String, Object> request) {
+    public Integer getServerPort(Map<String, Object> request) {
       return (Integer) request.get("hostPort");
     }
   }
@@ -170,7 +170,7 @@ class HttpServerAttributesExtractorStableSemconvTest {
     extractor.onStart(startAttributes, Context.root(), request);
     assertThat(startAttributes.build())
         .containsOnly(
-            entry(SemanticAttributes.NET_HOST_NAME, "github.com"),
+            entry(NetworkAttributes.SERVER_ADDRESS, "github.com"),
             entry(HttpAttributes.HTTP_REQUEST_METHOD, "POST"),
             entry(UrlAttributes.URL_SCHEME, "http"),
             entry(UrlAttributes.URL_PATH, "/repositories/1"),

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorStableSemconvTest.java
@@ -14,7 +14,6 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.NetworkAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -59,12 +58,12 @@ class NetClientAttributesExtractorStableSemconvTest {
     }
 
     @Override
-    public String getPeerName(Map<String, String> request) {
+    public String getServerAddress(Map<String, String> request) {
       return request.get("peerName");
     }
 
     @Override
-    public Integer getPeerPort(Map<String, String> request) {
+    public Integer getServerPort(Map<String, String> request) {
       String peerPort = request.get("peerPort");
       return peerPort == null ? null : Integer.valueOf(peerPort);
     }
@@ -75,17 +74,18 @@ class NetClientAttributesExtractorStableSemconvTest {
     }
 
     @Override
-    public String getSockPeerAddr(Map<String, String> request, Map<String, String> response) {
-      return response.get("sockPeerAddr");
-    }
-
-    @Override
-    public String getSockPeerName(Map<String, String> request, Map<String, String> response) {
+    public String getServerSocketDomain(Map<String, String> request, Map<String, String> response) {
       return response.get("sockPeerName");
     }
 
     @Override
-    public Integer getSockPeerPort(Map<String, String> request, Map<String, String> response) {
+    public String getServerSocketAddress(
+        Map<String, String> request, Map<String, String> response) {
+      return response.get("sockPeerAddr");
+    }
+
+    @Override
+    public Integer getServerSocketPort(Map<String, String> request, Map<String, String> response) {
       String sockPeerPort = response.get("sockPeerPort");
       return sockPeerPort == null ? null : Integer.valueOf(sockPeerPort);
     }
@@ -122,8 +122,8 @@ class NetClientAttributesExtractorStableSemconvTest {
     // then
     assertThat(startAttributes.build())
         .containsOnly(
-            entry(SemanticAttributes.NET_PEER_NAME, "opentelemetry.io"),
-            entry(SemanticAttributes.NET_PEER_PORT, 42L));
+            entry(NetworkAttributes.SERVER_ADDRESS, "opentelemetry.io"),
+            entry(NetworkAttributes.SERVER_PORT, 42L));
 
     assertThat(endAttributes.build())
         .containsOnly(
@@ -131,8 +131,8 @@ class NetClientAttributesExtractorStableSemconvTest {
             entry(NetworkAttributes.NETWORK_TYPE, "ipv6"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-            entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"),
-            entry(SemanticAttributes.NET_SOCK_PEER_NAME, "proxy.opentelemetry.io"),
-            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 123L));
+            entry(NetworkAttributes.SERVER_SOCKET_DOMAIN, "proxy.opentelemetry.io"),
+            entry(NetworkAttributes.SERVER_SOCKET_ADDRESS, "1:2:3:4::"),
+            entry(NetworkAttributes.SERVER_SOCKET_PORT, 123L));
   }
 }

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractorStableSemconvTest.java
@@ -56,13 +56,13 @@ class NetServerAttributesExtractorStableSemconvTest {
 
     @Nullable
     @Override
-    public String getHostName(Map<String, String> request) {
+    public String getServerAddress(Map<String, String> request) {
       return request.get("hostName");
     }
 
     @Nullable
     @Override
-    public Integer getHostPort(Map<String, String> request) {
+    public Integer getServerPort(Map<String, String> request) {
       String hostPort = request.get("hostPort");
       return hostPort == null ? null : Integer.valueOf(hostPort);
     }
@@ -86,13 +86,13 @@ class NetServerAttributesExtractorStableSemconvTest {
 
     @Nullable
     @Override
-    public String getSockHostAddr(Map<String, String> request) {
+    public String getServerSocketAddress(Map<String, String> request, Void response) {
       return request.get("sockHostAddr");
     }
 
     @Nullable
     @Override
-    public Integer getSockHostPort(Map<String, String> request) {
+    public Integer getServerSocketPort(Map<String, String> request, Void response) {
       String sockHostPort = request.get("sockHostPort");
       return sockHostPort == null ? null : Integer.valueOf(sockHostPort);
     }
@@ -130,18 +130,18 @@ class NetServerAttributesExtractorStableSemconvTest {
     // then
     assertThat(startAttributes.build())
         .containsOnly(
-            entry(SemanticAttributes.NET_HOST_NAME, "opentelemetry.io"),
-            entry(SemanticAttributes.NET_HOST_PORT, 80L),
+            entry(NetworkAttributes.SERVER_ADDRESS, "opentelemetry.io"),
+            entry(NetworkAttributes.SERVER_PORT, 80L),
             entry(SemanticAttributes.NET_SOCK_PEER_ADDR, "1:2:3:4::"),
-            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 42L),
-            entry(SemanticAttributes.NET_SOCK_HOST_ADDR, "4:3:2:1::"),
-            entry(SemanticAttributes.NET_SOCK_HOST_PORT, 8080L));
+            entry(SemanticAttributes.NET_SOCK_PEER_PORT, 42L));
 
     assertThat(endAttributes.build())
         .containsOnly(
             entry(NetworkAttributes.NETWORK_TRANSPORT, "tcp"),
             entry(NetworkAttributes.NETWORK_TYPE, "ipv6"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
-            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"));
+            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
+            entry(NetworkAttributes.SERVER_SOCKET_ADDRESS, "4:3:2:1::"),
+            entry(NetworkAttributes.SERVER_SOCKET_PORT, 8080L));
   }
 }

--- a/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
+++ b/instrumentation-api/src/jmh/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterBenchmark.java
@@ -107,19 +107,19 @@ public class InstrumenterBenchmark {
 
     @Nullable
     @Override
-    public String getPeerName(Void request) {
+    public String getServerAddress(Void request) {
       return null;
     }
 
     @Nullable
     @Override
-    public Integer getPeerPort(Void request) {
+    public Integer getServerPort(Void request) {
       return null;
     }
 
     @Nullable
     @Override
-    public InetSocketAddress getPeerSocketAddress(Void request, @Nullable Void response) {
+    public InetSocketAddress getServerInetSocketAddress(Void request, @Nullable Void response) {
       return PEER_ADDRESS;
     }
   }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpNetAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/client/AkkaHttpNetAttributesGetter.java
@@ -28,12 +28,12 @@ class AkkaHttpNetAttributesGetter implements NetClientAttributesGetter<HttpReque
   }
 
   @Override
-  public String getPeerName(HttpRequest httpRequest) {
+  public String getServerAddress(HttpRequest httpRequest) {
     return httpRequest.uri().authority().host().address();
   }
 
   @Override
-  public Integer getPeerPort(HttpRequest httpRequest) {
+  public Integer getServerPort(HttpRequest httpRequest) {
     return httpRequest.uri().authority().port();
   }
 }

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaNetServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaNetServerAttributesGetter.java
@@ -30,13 +30,13 @@ class AkkaNetServerAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(HttpRequest request) {
+  public String getServerAddress(HttpRequest request) {
     Uri.Host host = request.uri().authority().host();
     return host.isEmpty() ? null : host.address();
   }
 
   @Override
-  public Integer getHostPort(HttpRequest request) {
+  public Integer getServerPort(HttpRequest request) {
     return request.uri().authority().port();
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetClientAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetClientAttributesGetter.java
@@ -20,18 +20,19 @@ public final class DubboNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(DubboRequest request) {
+  public String getServerAddress(DubboRequest request) {
     return request.url().getHost();
   }
 
   @Override
-  public Integer getPeerPort(DubboRequest request) {
+  public Integer getServerPort(DubboRequest request) {
     return request.url().getPort();
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(DubboRequest request, @Nullable Result response) {
+  public InetSocketAddress getServerInetSocketAddress(
+      DubboRequest request, @Nullable Result response) {
     return request.remoteAddress();
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetServerAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboNetServerAttributesGetter.java
@@ -20,13 +20,13 @@ public final class DubboNetServerAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(DubboRequest request) {
+  public String getServerAddress(DubboRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(DubboRequest request) {
+  public Integer getServerPort(DubboRequest request) {
     return null;
   }
 
@@ -38,7 +38,8 @@ public final class DubboNetServerAttributesGetter
 
   @Nullable
   @Override
-  public InetSocketAddress getHostSocketAddress(DubboRequest request) {
+  public InetSocketAddress getServerInetSocketAddress(
+      DubboRequest request, @Nullable Result result) {
     return request.localAddress();
   }
 }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesGetter.java
@@ -27,19 +27,19 @@ final class ApacheHttpAsyncClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(ApacheHttpClientRequest request) {
-    return request.getPeerName();
+  public String getServerAddress(ApacheHttpClientRequest request) {
+    return request.getServerAddress();
   }
 
   @Override
-  public Integer getPeerPort(ApacheHttpClientRequest request) {
-    return request.getPeerPort();
+  public Integer getServerPort(ApacheHttpClientRequest request) {
+    return request.getServerPort();
   }
 
   @Nullable
   @Override
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return request.peerSocketAddress();
+    return request.serverSocketAddress();
   }
 }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientNetAttributesGetter.java
@@ -40,6 +40,6 @@ final class ApacheHttpAsyncClientNetAttributesGetter
   @Override
   public InetSocketAddress getServerInetSocketAddress(
       ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return request.serverSocketAddress();
+    return request.getServerSocketAddress();
   }
 }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
@@ -78,11 +78,11 @@ public final class ApacheHttpClientRequest {
     return protocolVersion.getMajor() + "." + protocolVersion.getMinor();
   }
 
-  public String getPeerName() {
+  public String getServerAddress() {
     return uri != null ? uri.getHost() : null;
   }
 
-  public Integer getPeerPort() {
+  public Integer getServerPort() {
     if (uri == null) {
       return null;
     }
@@ -136,7 +136,7 @@ public final class ApacheHttpClientRequest {
   }
 
   @Nullable
-  public InetSocketAddress peerSocketAddress() {
+  public InetSocketAddress serverSocketAddress() {
     if (target == null) {
       return null;
     }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/ApacheHttpClientRequest.java
@@ -136,7 +136,7 @@ public final class ApacheHttpClientRequest {
   }
 
   @Nullable
-  public InetSocketAddress serverSocketAddress() {
+  public InetSocketAddress getServerSocketAddress() {
     if (target == null) {
       return null;
     }

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v2_0/ApacheHttpClientNetAttributesGetter.java
@@ -30,14 +30,14 @@ final class ApacheHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(HttpMethod request) {
+  public String getServerAddress(HttpMethod request) {
     HostConfiguration hostConfiguration = request.getHostConfiguration();
     return hostConfiguration != null ? hostConfiguration.getHost() : null;
   }
 
   @Override
   @Nullable
-  public Integer getPeerPort(HttpMethod request) {
+  public Integer getServerPort(HttpMethod request) {
     HostConfiguration hostConfiguration = request.getHostConfiguration();
     return hostConfiguration != null ? hostConfiguration.getPort() : null;
   }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientNetAttributesGetter.java
@@ -26,12 +26,12 @@ final class ApacheHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(ApacheHttpClientRequest request) {
-    return request.getPeerName();
+  public String getServerAddress(ApacheHttpClientRequest request) {
+    return request.getServerAddress();
   }
 
   @Override
-  public Integer getPeerPort(ApacheHttpClientRequest request) {
-    return request.getPeerPort();
+  public Integer getServerPort(ApacheHttpClientRequest request) {
+    return request.getServerPort();
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v4_0/ApacheHttpClientRequest.java
@@ -81,12 +81,12 @@ public final class ApacheHttpClientRequest {
   }
 
   @Nullable
-  public String getPeerName() {
+  public String getServerAddress() {
     return uri == null ? null : uri.getHost();
   }
 
   @Nullable
-  public Integer getPeerPort() {
+  public Integer getServerPort() {
     return uri == null ? null : uri.getPort();
   }
 

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesGetter.java
@@ -41,6 +41,6 @@ final class ApacheHttpClientNetAttributesGetter
   @Override
   public InetSocketAddress getServerInetSocketAddress(
       ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return request.serverSocketAddress();
+    return request.getServerSocketAddress();
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientNetAttributesGetter.java
@@ -27,20 +27,20 @@ final class ApacheHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(ApacheHttpClientRequest request) {
-    return request.getPeerName();
+  public String getServerAddress(ApacheHttpClientRequest request) {
+    return request.getServerAddress();
   }
 
   @Override
   @Nullable
-  public Integer getPeerPort(ApacheHttpClientRequest request) {
-    return request.getPeerPort();
+  public Integer getServerPort(ApacheHttpClientRequest request) {
+    return request.getServerPort();
   }
 
   @Nullable
   @Override
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       ApacheHttpClientRequest request, @Nullable HttpResponse response) {
-    return request.peerSocketAddress();
+    return request.serverSocketAddress();
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
@@ -85,12 +85,12 @@ public final class ApacheHttpClientRequest {
   }
 
   @Nullable
-  public String getPeerName() {
+  public String getServerAddress() {
     return uri == null ? null : uri.getHost();
   }
 
   @Nullable
-  public Integer getPeerPort() {
+  public Integer getServerPort() {
     return uri == null ? null : uri.getPort();
   }
 
@@ -123,7 +123,7 @@ public final class ApacheHttpClientRequest {
   }
 
   @Nullable
-  public InetSocketAddress peerSocketAddress() {
+  public InetSocketAddress serverSocketAddress() {
     if (target == null) {
       return null;
     }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/main/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientRequest.java
@@ -123,7 +123,7 @@ public final class ApacheHttpClientRequest {
   }
 
   @Nullable
-  public InetSocketAddress serverSocketAddress() {
+  public InetSocketAddress getServerSocketAddress() {
     if (target == null) {
       return null;
     }

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpclient/v5_0/ApacheHttpClientNetAttributesGetter.java
@@ -36,12 +36,12 @@ final class ApacheHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(HttpRequest request) {
+  public String getServerAddress(HttpRequest request) {
     return request.getAuthority().getHostName();
   }
 
   @Override
-  public Integer getPeerPort(HttpRequest request) {
+  public Integer getServerPort(HttpRequest request) {
     return request.getAuthority().getPort();
   }
 

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaNetServerAttributesGetter.java
@@ -29,13 +29,13 @@ final class ArmeriaNetServerAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(RequestContext ctx) {
+  public String getServerAddress(RequestContext ctx) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(RequestContext ctx) {
+  public Integer getServerPort(RequestContext ctx) {
     return null;
   }
 
@@ -51,7 +51,8 @@ final class ArmeriaNetServerAttributesGetter
 
   @Nullable
   @Override
-  public InetSocketAddress getHostSocketAddress(RequestContext ctx) {
+  public InetSocketAddress getServerInetSocketAddress(
+      RequestContext ctx, @Nullable RequestLog log) {
     SocketAddress address = ctx.localAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetClientAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaNetClientAttributesGetter.java
@@ -34,7 +34,7 @@ public final class ArmeriaNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(RequestContext ctx) {
+  public String getServerAddress(RequestContext ctx) {
     HttpRequest request = request(ctx);
     String authority = request.authority();
     if (authority == null) {
@@ -46,7 +46,7 @@ public final class ArmeriaNetClientAttributesGetter
 
   @Nullable
   @Override
-  public Integer getPeerPort(RequestContext ctx) {
+  public Integer getServerPort(RequestContext ctx) {
     HttpRequest request = request(ctx);
     String authority = request.authority();
     if (authority == null) {
@@ -65,7 +65,7 @@ public final class ArmeriaNetClientAttributesGetter
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       RequestContext ctx, @Nullable RequestLog requestLog) {
     SocketAddress address = ctx.remoteAddress();
     if (address instanceof InetSocketAddress) {

--- a/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientNetAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-1.9/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v1_9/AsyncHttpClientNetAttributesGetter.java
@@ -26,12 +26,12 @@ final class AsyncHttpClientNetAttributesGetter
   }
 
   @Override
-  public String getPeerName(Request request) {
+  public String getServerAddress(Request request) {
     return request.getUri().getHost();
   }
 
   @Override
-  public Integer getPeerPort(Request request) {
+  public Integer getServerPort(Request request) {
     return request.getUri().getPort();
   }
 }

--- a/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesGetter.java
+++ b/instrumentation/async-http-client/async-http-client-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/asynchttpclient/v2_0/AsyncHttpClientNetAttributesGetter.java
@@ -51,18 +51,18 @@ final class AsyncHttpClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(RequestContext request) {
+  public String getServerAddress(RequestContext request) {
     return request.getRequest().getUri().getHost();
   }
 
   @Override
-  public Integer getPeerPort(RequestContext request) {
+  public Integer getServerPort(RequestContext request) {
     return request.getRequest().getUri().getPort();
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       RequestContext request, @Nullable Response response) {
     if (response != null && response.getRemoteAddress() instanceof InetSocketAddress) {
       return (InetSocketAddress) response.getRemoteAddress();

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkNetAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkNetAttributesGetter.java
@@ -53,12 +53,12 @@ class AwsSdkNetAttributesGetter implements NetClientAttributesGetter<Request<?>,
 
   @Override
   @Nullable
-  public String getPeerName(Request<?> request) {
+  public String getServerAddress(Request<?> request) {
     return request.getEndpoint().getHost();
   }
 
   @Override
-  public Integer getPeerPort(Request<?> request) {
+  public Integer getServerPort(Request<?> request) {
     return request.getEndpoint().getPort();
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkNetAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkNetAttributesGetter.java
@@ -16,14 +16,14 @@ class AwsSdkNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(ExecutionAttributes request) {
+  public String getServerAddress(ExecutionAttributes request) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     return httpRequest.host();
   }
 
   @Override
-  public Integer getPeerPort(ExecutionAttributes request) {
+  public Integer getServerPort(ExecutionAttributes request) {
     SdkHttpRequest httpRequest =
         request.getAttribute(TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE);
     return httpRequest.port();

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetAttributesGetter.java
@@ -15,19 +15,19 @@ final class CassandraNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(CassandraRequest request) {
+  public String getServerAddress(CassandraRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(CassandraRequest request) {
+  public Integer getServerPort(CassandraRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
     return executionInfo == null ? null : executionInfo.getQueriedHost().getSocketAddress();
   }

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetAttributesGetter.java
@@ -17,19 +17,19 @@ final class CassandraNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(CassandraRequest request) {
+  public String getServerAddress(CassandraRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(CassandraRequest request) {
+  public Integer getServerPort(CassandraRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
     if (executionInfo == null) {
       return null;

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraNetAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraNetAttributesGetter.java
@@ -17,19 +17,19 @@ final class CassandraNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(CassandraRequest request) {
+  public String getServerAddress(CassandraRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(CassandraRequest request) {
+  public Integer getServerPort(CassandraRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
     if (executionInfo == null) {
       return null;

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseNetAttributesGetter.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseNetAttributesGetter.java
@@ -15,19 +15,19 @@ public class CouchbaseNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(CouchbaseRequestInfo couchbaseRequest) {
+  public String getServerAddress(CouchbaseRequestInfo couchbaseRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(CouchbaseRequestInfo couchbaseRequest) {
+  public Integer getServerPort(CouchbaseRequestInfo couchbaseRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       CouchbaseRequestInfo couchbaseRequest, @Nullable Void unused) {
     SocketAddress peerAddress = couchbaseRequest.getPeerAddress();
     if (peerAddress instanceof InetSocketAddress) {

--- a/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestNetResponseAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/ElasticsearchRestNetResponseAttributesGetter.java
@@ -15,13 +15,13 @@ final class ElasticsearchRestNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(ElasticsearchRestRequest request) {
+  public String getServerAddress(ElasticsearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public Integer getPeerPort(ElasticsearchRestRequest request) {
+  public Integer getServerPort(ElasticsearchRestRequest request) {
     return null;
   }
 
@@ -37,7 +37,8 @@ final class ElasticsearchRestNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String getSockPeerAddr(ElasticsearchRestRequest request, @Nullable Response response) {
+  public String getServerSocketAddress(
+      ElasticsearchRestRequest request, @Nullable Response response) {
     if (response != null && response.getHost().getAddress() != null) {
       return response.getHost().getAddress().getHostAddress();
     }

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportNetAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportNetAttributesGetter.java
@@ -16,19 +16,19 @@ public class Elasticsearch6TransportNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(ElasticTransportRequest request) {
+  public String getServerAddress(ElasticTransportRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(ElasticTransportRequest request) {
+  public Integer getServerPort(ElasticTransportRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       ElasticTransportRequest request, @Nullable ActionResponse response) {
     if (response != null && response.remoteAddress() != null) {
       return response.remoteAddress().address();

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticTransportNetResponseAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticTransportNetResponseAttributesGetter.java
@@ -14,19 +14,19 @@ public class ElasticTransportNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(ElasticTransportRequest request) {
+  public String getServerAddress(ElasticTransportRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public Integer getPeerPort(ElasticTransportRequest request) {
+  public Integer getServerPort(ElasticTransportRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public String getSockPeerAddr(
+  public String getServerSocketAddress(
       ElasticTransportRequest request, @Nullable ActionResponse response) {
     if (response != null && response.remoteAddress() != null) {
       return response.remoteAddress().getAddress();
@@ -36,7 +36,7 @@ public class ElasticTransportNetResponseAttributesGetter
 
   @Nullable
   @Override
-  public String getSockPeerName(
+  public String getServerSocketDomain(
       ElasticTransportRequest request, @Nullable ActionResponse response) {
     if (response != null && response.remoteAddress() != null) {
       return response.remoteAddress().getHost();
@@ -46,7 +46,7 @@ public class ElasticTransportNetResponseAttributesGetter
 
   @Nullable
   @Override
-  public Integer getSockPeerPort(
+  public Integer getServerSocketPort(
       ElasticTransportRequest request, @Nullable ActionResponse response) {
     if (response != null && response.remoteAddress() != null) {
       return response.remoteAddress().getPort();

--- a/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientNetAttributesGetter.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/GoogleHttpClientNetAttributesGetter.java
@@ -15,12 +15,12 @@ final class GoogleHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(HttpRequest request) {
+  public String getServerAddress(HttpRequest request) {
     return request.getUrl().getHost();
   }
 
   @Override
-  public Integer getPeerPort(HttpRequest request) {
+  public Integer getServerPort(HttpRequest request) {
     return request.getUrl().getPort();
   }
 }

--- a/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyNetAttributesGetter.java
@@ -68,12 +68,12 @@ final class GrizzlyNetAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(HttpRequestPacket request) {
+  public String getServerAddress(HttpRequestPacket request) {
     return request.getLocalHost();
   }
 
   @Override
-  public Integer getHostPort(HttpRequestPacket request) {
+  public Integer getServerPort(HttpRequestPacket request) {
     return request.getServerPort();
   }
 
@@ -90,12 +90,12 @@ final class GrizzlyNetAttributesGetter
 
   @Nullable
   @Override
-  public String getSockHostAddr(HttpRequestPacket request) {
+  public String getServerSocketAddress(HttpRequestPacket request, HttpResponsePacket response) {
     return request.getLocalAddress();
   }
 
   @Override
-  public Integer getSockHostPort(HttpRequestPacket request) {
+  public Integer getServerSocketPort(HttpRequestPacket request, HttpResponsePacket response) {
     return request.getLocalPort();
   }
 }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetClientAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetClientAttributesGetter.java
@@ -21,18 +21,19 @@ public final class GrpcNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(GrpcRequest grpcRequest) {
+  public String getServerAddress(GrpcRequest grpcRequest) {
     return grpcRequest.getLogicalHost();
   }
 
   @Override
-  public Integer getPeerPort(GrpcRequest grpcRequest) {
+  public Integer getServerPort(GrpcRequest grpcRequest) {
     return grpcRequest.getLogicalPort();
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(GrpcRequest request, @Nullable Status response) {
+  public InetSocketAddress getServerInetSocketAddress(
+      GrpcRequest request, @Nullable Status response) {
     SocketAddress address = request.getPeerSocketAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetServerAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcNetServerAttributesGetter.java
@@ -21,12 +21,12 @@ public final class GrpcNetServerAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(GrpcRequest grpcRequest) {
+  public String getServerAddress(GrpcRequest grpcRequest) {
     return grpcRequest.getLogicalHost();
   }
 
   @Override
-  public Integer getHostPort(GrpcRequest grpcRequest) {
+  public Integer getServerPort(GrpcRequest grpcRequest) {
     return grpcRequest.getLogicalPort();
   }
 
@@ -42,7 +42,8 @@ public final class GrpcNetServerAttributesGetter
 
   @Nullable
   @Override
-  public InetSocketAddress getHostSocketAddress(GrpcRequest grpcRequest) {
+  public InetSocketAddress getServerInetSocketAddress(
+      GrpcRequest grpcRequest, @Nullable Status status) {
     // TODO: later version introduces TRANSPORT_ATTR_LOCAL_ADDR, might be a good idea to use it
     return null;
   }

--- a/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlNetAttributesGetter.java
+++ b/instrumentation/http-url-connection/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlNetAttributesGetter.java
@@ -26,12 +26,12 @@ class HttpUrlNetAttributesGetter implements NetClientAttributesGetter<HttpURLCon
   }
 
   @Override
-  public String getPeerName(HttpURLConnection connection) {
+  public String getServerAddress(HttpURLConnection connection) {
     return connection.getURL().getHost();
   }
 
   @Override
-  public Integer getPeerPort(HttpURLConnection connection) {
+  public Integer getServerPort(HttpURLConnection connection) {
     return connection.getURL().getPort();
   }
 }

--- a/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/JavaHttpClientNetAttributesGetter.java
+++ b/instrumentation/java-http-client/library/src/main/java/io/opentelemetry/instrumentation/httpclient/internal/JavaHttpClientNetAttributesGetter.java
@@ -47,13 +47,13 @@ public class JavaHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(HttpRequest request) {
+  public String getServerAddress(HttpRequest request) {
     return request.uri().getHost();
   }
 
   @Override
   @Nullable
-  public Integer getPeerPort(HttpRequest request) {
+  public Integer getServerPort(HttpRequest request) {
     return request.uri().getPort();
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientNetAttributesGetter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrsclient/v1_1/JaxRsClientNetAttributesGetter.java
@@ -15,12 +15,12 @@ final class JaxRsClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(ClientRequest request) {
+  public String getServerAddress(ClientRequest request) {
     return request.getURI().getHost();
   }
 
   @Override
-  public Integer getPeerPort(ClientRequest request) {
+  public Integer getServerPort(ClientRequest request) {
     return request.getURI().getPort();
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcNetAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcNetAttributesGetter.java
@@ -16,13 +16,13 @@ public final class JdbcNetAttributesGetter implements NetClientAttributesGetter<
 
   @Nullable
   @Override
-  public String getPeerName(DbRequest request) {
+  public String getServerAddress(DbRequest request) {
     return request.getDbInfo().getHost();
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(DbRequest request) {
+  public Integer getServerPort(DbRequest request) {
     return request.getDbInfo().getPort();
   }
 }

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetAttributesGetter.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetAttributesGetter.java
@@ -10,12 +10,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributes
 final class JedisNetAttributesGetter implements NetClientAttributesGetter<JedisRequest, Void> {
 
   @Override
-  public String getPeerName(JedisRequest request) {
+  public String getServerAddress(JedisRequest request) {
     return request.getConnection().getHost();
   }
 
   @Override
-  public Integer getPeerPort(JedisRequest request) {
+  public Integer getServerPort(JedisRequest request) {
     return request.getConnection().getPort();
   }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetAttributesGetter.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetAttributesGetter.java
@@ -14,18 +14,19 @@ final class JedisNetAttributesGetter implements NetClientAttributesGetter<JedisR
 
   @Nullable
   @Override
-  public String getPeerName(JedisRequest jedisRequest) {
+  public String getServerAddress(JedisRequest jedisRequest) {
     return jedisRequest.getConnection().getHost();
   }
 
   @Override
-  public Integer getPeerPort(JedisRequest jedisRequest) {
+  public Integer getServerPort(JedisRequest jedisRequest) {
     return jedisRequest.getConnection().getPort();
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(JedisRequest jedisRequest, @Nullable Void unused) {
+  public InetSocketAddress getServerInetSocketAddress(
+      JedisRequest jedisRequest, @Nullable Void unused) {
     Socket socket = jedisRequest.getConnection().getSocket();
     if (socket != null && socket.getRemoteSocketAddress() instanceof InetSocketAddress) {
       return (InetSocketAddress) socket.getRemoteSocketAddress();

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisNetAttributesGetter.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisNetAttributesGetter.java
@@ -14,19 +14,20 @@ final class JedisNetAttributesGetter implements NetClientAttributesGetter<JedisR
 
   @Nullable
   @Override
-  public String getPeerName(JedisRequest jedisRequest) {
+  public String getServerAddress(JedisRequest jedisRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(JedisRequest jedisRequest) {
+  public Integer getServerPort(JedisRequest jedisRequest) {
     return null;
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(JedisRequest jedisRequest, @Nullable Void unused) {
+  public InetSocketAddress getServerInetSocketAddress(
+      JedisRequest jedisRequest, @Nullable Void unused) {
     SocketAddress socketAddress = jedisRequest.getRemoteSocketAddress();
     if (socketAddress instanceof InetSocketAddress) {
       return (InetSocketAddress) socketAddress;

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClientNetAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyHttpClientNetAttributesGetter.java
@@ -46,13 +46,13 @@ public class JettyHttpClientNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(Request request) {
+  public String getServerAddress(Request request) {
     return request.getHost();
   }
 
   @Override
   @Nullable
-  public Integer getPeerPort(Request request) {
+  public Integer getServerPort(Request request) {
     return request.getPort();
   }
 }

--- a/instrumentation/jodd-http-4.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpNetAttributesGetter.java
+++ b/instrumentation/jodd-http-4.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpNetAttributesGetter.java
@@ -35,12 +35,12 @@ final class JoddHttpNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(HttpRequest request) {
+  public String getServerAddress(HttpRequest request) {
     return request.host();
   }
 
   @Override
-  public Integer getPeerPort(HttpRequest request) {
+  public Integer getServerPort(HttpRequest request) {
     return request.port();
   }
 }

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorNetServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorNetServerAttributesGetter.kt
@@ -26,11 +26,11 @@ internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<Applica
     return null
   }
 
-  override fun getHostName(request: ApplicationRequest): String {
+  override fun getServerAddress(request: ApplicationRequest): String {
     return request.local.host
   }
 
-  override fun getHostPort(request: ApplicationRequest): Int {
+  override fun getServerPort(request: ApplicationRequest): Int {
     return request.local.port
   }
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorNetClientAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/client/KtorNetClientAttributesGetter.kt
@@ -19,7 +19,7 @@ internal object KtorNetClientAttributesGetter : NetClientAttributesGetter<HttpRe
     return "${version.major}.${version.minor}"
   }
 
-  override fun getPeerName(request: HttpRequestData) = request.url.host
+  override fun getServerAddress(request: HttpRequestData) = request.url.host
 
-  override fun getPeerPort(request: HttpRequestData) = request.url.port
+  override fun getServerPort(request: HttpRequestData) = request.url.port
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorNetServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorNetServerAttributesGetter.kt
@@ -18,11 +18,11 @@ internal class KtorNetServerAttributesGetter : NetServerAttributesGetter<Applica
   override fun getNetworkProtocolVersion(request: ApplicationRequest, response: ApplicationResponse?): String? =
     if (request.httpVersion.startsWith("HTTP/")) request.httpVersion.substring("HTTP/".length) else null
 
-  override fun getHostName(request: ApplicationRequest): String {
+  override fun getServerAddress(request: ApplicationRequest): String {
     return request.local.host
   }
 
-  override fun getHostPort(request: ApplicationRequest): Int {
+  override fun getServerPort(request: ApplicationRequest): Int {
     return request.local.port
   }
 

--- a/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesNetAttributesGetter.java
+++ b/instrumentation/kubernetes-client-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kubernetesclient/KubernetesNetAttributesGetter.java
@@ -12,12 +12,12 @@ import okhttp3.Request;
 class KubernetesNetAttributesGetter implements NetClientAttributesGetter<Request, ApiResponse<?>> {
 
   @Override
-  public String getPeerName(Request request) {
+  public String getServerAddress(Request request) {
     return request.url().host();
   }
 
   @Override
-  public Integer getPeerPort(Request request) {
+  public Integer getServerPort(Request request) {
     return request.url().port();
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetAttributesGetter.java
@@ -11,12 +11,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributes
 final class LettuceConnectNetAttributesGetter implements NetClientAttributesGetter<RedisURI, Void> {
 
   @Override
-  public String getPeerName(RedisURI redisUri) {
+  public String getServerAddress(RedisURI redisUri) {
     return redisUri.getHost();
   }
 
   @Override
-  public Integer getPeerPort(RedisURI redisUri) {
+  public Integer getServerPort(RedisURI redisUri) {
     return redisUri.getPort();
   }
 }

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetAttributesGetter.java
@@ -11,12 +11,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributes
 final class LettuceConnectNetAttributesGetter implements NetClientAttributesGetter<RedisURI, Void> {
 
   @Override
-  public String getPeerName(RedisURI redisUri) {
+  public String getServerAddress(RedisURI redisUri) {
     return redisUri.getHost();
   }
 
   @Override
-  public Integer getPeerPort(RedisURI redisUri) {
+  public Integer getServerPort(RedisURI redisUri) {
     return redisUri.getPort();
   }
 }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceNetAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceNetAttributesGetter.java
@@ -15,19 +15,19 @@ final class LettuceNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(OpenTelemetryEndpoint openTelemetryEndpoint) {
+  public String getServerAddress(OpenTelemetryEndpoint openTelemetryEndpoint) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(OpenTelemetryEndpoint openTelemetryEndpoint) {
+  public Integer getServerPort(OpenTelemetryEndpoint openTelemetryEndpoint) {
     return null;
   }
 
   @Nullable
   @Override
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       OpenTelemetryEndpoint openTelemetryEndpoint, @Nullable Void unused) {
     return openTelemetryEndpoint.address;
   }

--- a/instrumentation/liberty/compile-stub/src/main/java/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
+++ b/instrumentation/liberty/compile-stub/src/main/java/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
@@ -6,12 +6,21 @@
 package com.ibm.ws.http.channel.internal.inbound;
 
 import com.ibm.wsspi.http.channel.HttpRequestMessage;
+import java.net.InetAddress;
 
 // https://github.com/OpenLiberty/open-liberty/blob/master/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
 @SuppressWarnings("OtelInternalJavadoc")
 public class HttpInboundServiceContextImpl {
 
   public HttpRequestMessage getRequest() {
+    throw new UnsupportedOperationException();
+  }
+
+  public InetAddress getLocalAddr() {
+    throw new UnsupportedOperationException();
+  }
+
+  public int getLocalPort() {
     throw new UnsupportedOperationException();
   }
 }

--- a/instrumentation/liberty/compile-stub/src/main/java/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/instrumentation/liberty/compile-stub/src/main/java/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -19,14 +19,6 @@ public class HttpDispatcherLink {
     throw new UnsupportedOperationException();
   }
 
-  public String getLocalHostAddress() {
-    throw new UnsupportedOperationException();
-  }
-
-  public int getLocalPort() {
-    throw new UnsupportedOperationException();
-  }
-
   public HttpResponse getResponse() {
     throw new UnsupportedOperationException();
   }

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherLinkInstrumentation.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherLinkInstrumentation.java
@@ -58,7 +58,9 @@ public class LibertyDispatcherLinkInstrumentation implements TypeInstrumentation
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
       Context parentContext = Java8BytecodeBridge.currentContext();
-      request = new LibertyRequest(httpDispatcherLink, isc.getRequest());
+      request =
+          new LibertyRequest(
+              httpDispatcherLink, isc.getRequest(), isc.getLocalAddr(), isc.getLocalPort());
       if (!instrumenter().shouldStart(parentContext, request)) {
         return;
       }

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
@@ -35,12 +35,12 @@ public class LibertyDispatcherNetAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(LibertyRequest request) {
+  public String getServerAddress(LibertyRequest request) {
     return request.request().getURLHost();
   }
 
   @Override
-  public Integer getHostPort(LibertyRequest request) {
+  public Integer getServerPort(LibertyRequest request) {
     return request.request().getURLPort();
   }
 
@@ -57,13 +57,13 @@ public class LibertyDispatcherNetAttributesGetter
 
   @Nullable
   @Override
-  public String getSockHostAddr(LibertyRequest request) {
+  public String getServerSocketAddress(LibertyRequest request, LibertyResponse response) {
     return request.dispatcher().getLocalHostAddress();
   }
 
   @Nullable
   @Override
-  public Integer getSockHostPort(LibertyRequest request) {
+  public Integer getServerSocketPort(LibertyRequest request, LibertyResponse response) {
     return request.dispatcher().getLocalPort();
   }
 }

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherNetAttributesGetter.java
@@ -58,12 +58,12 @@ public class LibertyDispatcherNetAttributesGetter
   @Nullable
   @Override
   public String getServerSocketAddress(LibertyRequest request, LibertyResponse response) {
-    return request.dispatcher().getLocalHostAddress();
+    return request.getServerSocketAddress();
   }
 
   @Nullable
   @Override
   public Integer getServerSocketPort(LibertyRequest request, LibertyResponse response) {
-    return request.dispatcher().getLocalPort();
+    return request.getServerSocketPort();
   }
 }

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.liberty.dispatcher;
 import com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink;
 import com.ibm.wsspi.genericbnf.HeaderField;
 import com.ibm.wsspi.http.channel.HttpRequestMessage;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -15,11 +16,18 @@ import java.util.List;
 public class LibertyRequest {
   private final HttpDispatcherLink httpDispatcherLink;
   private final HttpRequestMessage httpRequestMessage;
+  private final String serverSocketAddress;
+  private final int serverSocketPort;
 
   public LibertyRequest(
-      HttpDispatcherLink httpDispatcherLink, HttpRequestMessage httpRequestMessage) {
+      HttpDispatcherLink httpDispatcherLink,
+      HttpRequestMessage httpRequestMessage,
+      InetAddress serverInetAddress,
+      int serverSocketPort) {
     this.httpDispatcherLink = httpDispatcherLink;
     this.httpRequestMessage = httpRequestMessage;
+    this.serverSocketAddress = serverInetAddress.getHostAddress();
+    this.serverSocketPort = serverSocketPort;
   }
 
   public String getMethod() {
@@ -61,6 +69,14 @@ public class LibertyRequest {
 
   public String getProtocol() {
     return httpRequestMessage.getVersion();
+  }
+
+  public String getServerSocketAddress() {
+    return serverSocketAddress;
+  }
+
+  public int getServerSocketPort() {
+    return serverSocketPort;
   }
 
   public HttpDispatcherLink dispatcher() {

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoNetAttributesGetter.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoNetAttributesGetter.java
@@ -13,7 +13,7 @@ class MongoNetAttributesGetter implements NetClientAttributesGetter<CommandStart
 
   @Nullable
   @Override
-  public String getPeerName(CommandStartedEvent event) {
+  public String getServerAddress(CommandStartedEvent event) {
     if (event.getConnectionDescription() != null
         && event.getConnectionDescription().getServerAddress() != null) {
       return event.getConnectionDescription().getServerAddress().getHost();
@@ -23,7 +23,7 @@ class MongoNetAttributesGetter implements NetClientAttributesGetter<CommandStart
 
   @Nullable
   @Override
-  public Integer getPeerPort(CommandStartedEvent event) {
+  public Integer getServerPort(CommandStartedEvent event) {
     if (event.getConnectionDescription() != null
         && event.getConnectionDescription().getServerAddress() != null) {
       return event.getConnectionDescription().getServerAddress().getPort();

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectNetAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyConnectNetAttributesGetter.java
@@ -32,7 +32,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(NettyConnectionRequest request) {
+  public String getServerAddress(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getHostString();
@@ -42,7 +42,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public Integer getPeerPort(NettyConnectionRequest request) {
+  public Integer getServerPort(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getPort();
@@ -52,7 +52,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       NettyConnectionRequest request, @Nullable Channel channel) {
     if (channel == null) {
       return null;

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyNetClientAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/NettyNetClientAttributesGetter.java
@@ -48,19 +48,19 @@ final class NettyNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(HttpRequestAndChannel requestAndChannel) {
+  public String getServerAddress(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(HttpRequestAndChannel requestAndChannel) {
+  public Integer getServerPort(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     SocketAddress address = requestAndChannel.channel().getRemoteAddress();
     if (address instanceof InetSocketAddress) {

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyNetServerAttributesGetter.java
@@ -47,13 +47,13 @@ final class NettyNetServerAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(HttpRequestAndChannel requestAndChannel) {
+  public String getServerAddress(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(HttpRequestAndChannel requestAndChannel) {
+  public Integer getServerPort(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
@@ -69,7 +69,8 @@ final class NettyNetServerAttributesGetter
 
   @Nullable
   @Override
-  public InetSocketAddress getHostSocketAddress(HttpRequestAndChannel requestAndChannel) {
+  public InetSocketAddress getServerInetSocketAddress(
+      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     SocketAddress address = requestAndChannel.channel().getLocalAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyConnectNetAttributesGetter.java
@@ -32,7 +32,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(NettyConnectionRequest request) {
+  public String getServerAddress(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getHostString();
@@ -42,7 +42,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public Integer getPeerPort(NettyConnectionRequest request) {
+  public Integer getServerPort(NettyConnectionRequest request) {
     SocketAddress requestedAddress = request.remoteAddressOnStart();
     if (requestedAddress instanceof InetSocketAddress) {
       return ((InetSocketAddress) requestedAddress).getPort();
@@ -52,7 +52,7 @@ final class NettyConnectNetAttributesGetter
 
   @Nullable
   @Override
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       NettyConnectionRequest request, @Nullable Channel channel) {
     if (channel == null) {
       return null;

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyNetClientAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyNetClientAttributesGetter.java
@@ -48,19 +48,19 @@ final class NettyNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(HttpRequestAndChannel requestAndChannel) {
+  public String getServerAddress(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(HttpRequestAndChannel requestAndChannel) {
+  public Integer getServerPort(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     SocketAddress address = requestAndChannel.remoteAddress();
     if (address instanceof InetSocketAddress) {

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
@@ -29,19 +29,20 @@ final class NettySslNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(NettySslRequest nettySslRequest) {
+  public String getServerAddress(NettySslRequest nettySslRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(NettySslRequest nettySslRequest) {
+  public Integer getServerPort(NettySslRequest nettySslRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public InetSocketAddress getPeerSocketAddress(NettySslRequest request, @Nullable Void unused) {
+  public InetSocketAddress getServerInetSocketAddress(
+      NettySslRequest request, @Nullable Void unused) {
     if (request.remoteAddress() instanceof InetSocketAddress) {
       return (InetSocketAddress) request.remoteAddress();
     }

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyNetServerAttributesGetter.java
@@ -47,13 +47,13 @@ final class NettyNetServerAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(HttpRequestAndChannel requestAndChannel) {
+  public String getServerAddress(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(HttpRequestAndChannel requestAndChannel) {
+  public Integer getServerPort(HttpRequestAndChannel requestAndChannel) {
     return null;
   }
 
@@ -69,7 +69,8 @@ final class NettyNetServerAttributesGetter
 
   @Nullable
   @Override
-  public InetSocketAddress getHostSocketAddress(HttpRequestAndChannel requestAndChannel) {
+  public InetSocketAddress getServerInetSocketAddress(
+      HttpRequestAndChannel requestAndChannel, @Nullable HttpResponse response) {
     SocketAddress address = requestAndChannel.channel().localAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;

--- a/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2NetAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v2_2/OkHttp2NetAttributesGetter.java
@@ -51,12 +51,12 @@ public final class OkHttp2NetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(Request request) {
+  public String getServerAddress(Request request) {
     return request.url().getHost();
   }
 
   @Override
-  public Integer getPeerPort(Request request) {
+  public Integer getServerPort(Request request) {
     return request.url().getPort();
   }
 }

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpNetAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpNetAttributesGetter.java
@@ -55,12 +55,12 @@ public enum OkHttpNetAttributesGetter implements NetClientAttributesGetter<Reque
 
   @Override
   @Nullable
-  public String getPeerName(Request request) {
+  public String getServerAddress(Request request) {
     return request.url().host();
   }
 
   @Override
-  public Integer getPeerPort(Request request) {
+  public Integer getServerPort(Request request) {
     return request.url().port();
   }
 }

--- a/instrumentation/opensearch/opensearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/OpenSearchRestNetResponseAttributesGetter.java
+++ b/instrumentation/opensearch/opensearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/OpenSearchRestNetResponseAttributesGetter.java
@@ -15,13 +15,13 @@ final class OpenSearchRestNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(OpenSearchRestRequest request) {
+  public String getServerAddress(OpenSearchRestRequest request) {
     return null;
   }
 
   @Override
   @Nullable
-  public Integer getPeerPort(OpenSearchRestRequest request) {
+  public Integer getServerPort(OpenSearchRestRequest request) {
     return null;
   }
 
@@ -37,7 +37,7 @@ final class OpenSearchRestNetResponseAttributesGetter
 
   @Override
   @Nullable
-  public String getSockPeerAddr(OpenSearchRestRequest request, @Nullable Response response) {
+  public String getServerSocketAddress(OpenSearchRestRequest request, @Nullable Response response) {
     if (response != null && response.getHost().getAddress() != null) {
       return response.getHost().getAddress().getHostAddress();
     }

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockNetServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockNetServerAttributesGetter.java
@@ -14,13 +14,13 @@ enum MockNetServerAttributesGetter implements NetServerAttributesGetter<String, 
 
   @Nullable
   @Override
-  public String getHostName(String s) {
+  public String getServerAddress(String s) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(String s) {
+  public Integer getServerPort(String s) {
     return null;
   }
 }

--- a/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientNetAttributesGetter.java
+++ b/instrumentation/play/play-ws/play-ws-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/playws/PlayWsClientNetAttributesGetter.java
@@ -16,18 +16,19 @@ final class PlayWsClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(Request request) {
+  public String getServerAddress(Request request) {
     return request.getUri().getHost();
   }
 
   @Override
-  public Integer getPeerPort(Request request) {
+  public Integer getServerPort(Request request) {
     return request.getUri().getPort();
   }
 
   @Override
   @Nullable
-  public InetSocketAddress getPeerSocketAddress(Request request, @Nullable Response response) {
+  public InetSocketAddress getServerInetSocketAddress(
+      Request request, @Nullable Response response) {
     if (response != null && response.getRemoteAddress() instanceof InetSocketAddress) {
       return (InetSocketAddress) response.getRemoteAddress();
     }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarNetClientAttributesGetter.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarNetClientAttributesGetter.java
@@ -18,13 +18,13 @@ public final class PulsarNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(BasePulsarRequest request) {
+  public String getServerAddress(BasePulsarRequest request) {
     return request.getUrlData() != null ? request.getUrlData().getHost() : null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(BasePulsarRequest request) {
+  public Integer getServerPort(BasePulsarRequest request) {
     return request.getUrlData() != null ? request.getUrlData().getPort() : null;
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcNetAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcNetAttributesGetter.java
@@ -17,13 +17,13 @@ public enum R2dbcNetAttributesGetter implements NetClientAttributesGetter<DbExec
 
   @Nullable
   @Override
-  public String getPeerName(DbExecution request) {
+  public String getServerAddress(DbExecution request) {
     return request.getHost();
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(DbExecution request) {
+  public Integer getServerPort(DbExecution request) {
     return request.getPort();
   }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelNetAttributesGetter.java
@@ -14,24 +14,24 @@ public class RabbitChannelNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(ChannelAndMethod channelAndMethod) {
+  public String getServerAddress(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(ChannelAndMethod channelAndMethod) {
+  public Integer getServerPort(ChannelAndMethod channelAndMethod) {
     return null;
   }
 
   @Nullable
   @Override
-  public String getSockPeerAddr(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+  public String getServerSocketAddress(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
     return channelAndMethod.getChannel().getConnection().getAddress().getHostAddress();
   }
 
   @Override
-  public Integer getSockPeerPort(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+  public Integer getServerSocketPort(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
     return channelAndMethod.getChannel().getConnection().getPort();
   }
 

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitReceiveNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitReceiveNetAttributesGetter.java
@@ -15,25 +15,25 @@ public class RabbitReceiveNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(ReceiveRequest request) {
+  public String getServerAddress(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(ReceiveRequest request) {
+  public Integer getServerPort(ReceiveRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String getSockPeerAddr(ReceiveRequest request, @Nullable GetResponse response) {
+  public String getServerSocketAddress(ReceiveRequest request, @Nullable GetResponse response) {
     return request.getConnection().getAddress().getHostAddress();
   }
 
   @Nullable
   @Override
-  public Integer getSockPeerPort(ReceiveRequest request, @Nullable GetResponse response) {
+  public Integer getServerSocketPort(ReceiveRequest request, @Nullable GetResponse response) {
     return request.getConnection().getPort();
   }
 

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackNetClientAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackNetClientAttributesGetter.java
@@ -19,12 +19,12 @@ public final class RatpackNetClientAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(RequestSpec request) {
+  public String getServerAddress(RequestSpec request) {
     return request.getUri().getHost();
   }
 
   @Override
-  public Integer getPeerPort(RequestSpec request) {
+  public Integer getServerPort(RequestSpec request) {
     return request.getUri().getPort();
   }
 }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackNetServerAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackNetServerAttributesGetter.java
@@ -41,14 +41,14 @@ public final class RatpackNetServerAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(Request request) {
+  public String getServerAddress(Request request) {
     PublicAddress publicAddress = getPublicAddress(request);
     return publicAddress == null ? null : publicAddress.get().getHost();
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(Request request) {
+  public Integer getServerPort(Request request) {
     PublicAddress publicAddress = getPublicAddress(request);
     return publicAddress == null ? null : publicAddress.get().getPort();
   }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyNetClientAttributesGetter.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/ReactorNettyNetClientAttributesGetter.java
@@ -40,19 +40,19 @@ final class ReactorNettyNetClientAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(HttpClientConfig request) {
+  public String getServerAddress(HttpClientConfig request) {
     return getHost(request);
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(HttpClientConfig request) {
+  public Integer getServerPort(HttpClientConfig request) {
     return getPort(request);
   }
 
   @Nullable
   @Override
-  public InetSocketAddress getPeerSocketAddress(
+  public InetSocketAddress getServerInetSocketAddress(
       HttpClientConfig request, @Nullable HttpClientResponse response) {
 
     // we're making use of the fact that HttpClientOperations is both a Connection and an

--- a/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonNetAttributesGetter.java
+++ b/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonNetAttributesGetter.java
@@ -14,18 +14,19 @@ final class RedissonNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(RedissonRequest redissonRequest) {
+  public String getServerAddress(RedissonRequest redissonRequest) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(RedissonRequest redissonRequest) {
+  public Integer getServerPort(RedissonRequest redissonRequest) {
     return null;
   }
 
   @Override
-  public InetSocketAddress getPeerSocketAddress(RedissonRequest request, @Nullable Void unused) {
+  public InetSocketAddress getServerInetSocketAddress(
+      RedissonRequest request, @Nullable Void unused) {
     return request.getAddress();
   }
 }

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletNetAttributesGetter.java
@@ -40,14 +40,14 @@ final class RestletNetAttributesGetter implements NetServerAttributesGetter<Requ
 
   @Nullable
   @Override
-  public String getHostName(Request request) {
+  public String getServerAddress(Request request) {
     HttpCall call = httpCall(request);
     return call == null ? null : call.getHostDomain();
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(Request request) {
+  public Integer getServerPort(Request request) {
     HttpCall call = httpCall(request);
     return call == null ? null : call.getServerPort();
   }
@@ -65,7 +65,7 @@ final class RestletNetAttributesGetter implements NetServerAttributesGetter<Requ
 
   @Nullable
   @Override
-  public String getSockHostAddr(Request request) {
+  public String getServerSocketAddress(Request request, @Nullable Response response) {
     HttpCall call = httpCall(request);
     return call == null ? null : call.getServerAddress();
   }

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletNetAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletNetAttributesGetter.java
@@ -93,7 +93,7 @@ public final class RestletNetAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(Request request) {
+  public String getServerAddress(Request request) {
     if (GET_HOST_DOMAIN == null) {
       return null;
     }
@@ -110,7 +110,7 @@ public final class RestletNetAttributesGetter
 
   @Nullable
   @Override
-  public Integer getHostPort(Request request) {
+  public Integer getServerPort(Request request) {
     if (GET_SERVER_PORT == null) {
       return null;
     }
@@ -138,7 +138,7 @@ public final class RestletNetAttributesGetter
 
   @Nullable
   @Override
-  public String getSockHostAddr(Request request) {
+  public String getServerSocketAddress(Request request, @Nullable Response response) {
     if (GET_SERVER_ADDRESS == null) {
       return null;
     }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletNetAttributesGetter.java
@@ -44,13 +44,13 @@ public class ServletNetAttributesGetter<REQUEST, RESPONSE>
 
   @Nullable
   @Override
-  public String getHostName(ServletRequestContext<REQUEST> requestContext) {
+  public String getServerAddress(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestServerName(requestContext.request());
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(ServletRequestContext<REQUEST> requestContext) {
+  public Integer getServerPort(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestServerPort(requestContext.request());
   }
 
@@ -68,13 +68,17 @@ public class ServletNetAttributesGetter<REQUEST, RESPONSE>
 
   @Nullable
   @Override
-  public String getSockHostAddr(ServletRequestContext<REQUEST> requestContext) {
+  public String getServerSocketAddress(
+      ServletRequestContext<REQUEST> requestContext,
+      @Nullable ServletResponseContext<RESPONSE> response) {
     return accessor.getRequestLocalAddr(requestContext.request());
   }
 
   @Nullable
   @Override
-  public Integer getSockHostPort(ServletRequestContext<REQUEST> requestContext) {
+  public Integer getServerSocketPort(
+      ServletRequestContext<REQUEST> requestContext,
+      @Nullable ServletResponseContext<RESPONSE> response) {
     return accessor.getRequestLocalPort(requestContext.request());
   }
 }

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebNetAttributesGetter.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebNetAttributesGetter.java
@@ -15,12 +15,12 @@ final class SpringWebNetAttributesGetter
 
   @Override
   @Nullable
-  public String getPeerName(HttpRequest httpRequest) {
+  public String getServerAddress(HttpRequest httpRequest) {
     return httpRequest.getURI().getHost();
   }
 
   @Override
-  public Integer getPeerPort(HttpRequest httpRequest) {
+  public Integer getServerPort(HttpRequest httpRequest) {
     return httpRequest.getURI().getPort();
   }
 }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerNetAttributesGetter.java
@@ -15,13 +15,13 @@ final class WebfluxServerNetAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(ServerWebExchange request) {
+  public String getServerAddress(ServerWebExchange request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(ServerWebExchange request) {
+  public Integer getServerPort(ServerWebExchange request) {
     int port = request.getRequest().getURI().getPort();
     return port == -1 ? null : port;
   }
@@ -34,7 +34,8 @@ final class WebfluxServerNetAttributesGetter
 
   @Nullable
   @Override
-  public InetSocketAddress getHostSocketAddress(ServerWebExchange request) {
+  public InetSocketAddress getServerInetSocketAddress(
+      ServerWebExchange request, ServerWebExchange response) {
     return request.getRequest().getLocalAddress();
   }
 }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/internal/WebClientNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/internal/WebClientNetAttributesGetter.java
@@ -19,12 +19,12 @@ public final class WebClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(ClientRequest request) {
+  public String getServerAddress(ClientRequest request) {
     return request.url().getHost();
   }
 
   @Override
-  public Integer getPeerPort(ClientRequest request) {
+  public Integer getServerPort(ClientRequest request) {
     return request.url().getPort();
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcNetAttributesGetter.java
@@ -38,12 +38,12 @@ enum SpringWebMvcNetAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(HttpServletRequest request) {
+  public String getServerAddress(HttpServletRequest request) {
     return request.getServerName();
   }
 
   @Override
-  public Integer getHostPort(HttpServletRequest request) {
+  public Integer getServerPort(HttpServletRequest request) {
     return request.getServerPort();
   }
 
@@ -60,12 +60,14 @@ enum SpringWebMvcNetAttributesGetter
 
   @Nullable
   @Override
-  public String getSockHostAddr(HttpServletRequest request) {
+  public String getServerSocketAddress(
+      HttpServletRequest request, @Nullable HttpServletResponse response) {
     return request.getLocalAddr();
   }
 
   @Override
-  public Integer getSockHostPort(HttpServletRequest request) {
+  public Integer getServerSocketPort(
+      HttpServletRequest request, @Nullable HttpServletResponse respo) {
     return request.getLocalPort();
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcNetAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcNetAttributesGetter.java
@@ -38,12 +38,12 @@ enum SpringWebMvcNetAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(HttpServletRequest request) {
+  public String getServerAddress(HttpServletRequest request) {
     return request.getServerName();
   }
 
   @Override
-  public Integer getHostPort(HttpServletRequest request) {
+  public Integer getServerPort(HttpServletRequest request) {
     return request.getServerPort();
   }
 
@@ -60,12 +60,14 @@ enum SpringWebMvcNetAttributesGetter
 
   @Nullable
   @Override
-  public String getSockHostAddr(HttpServletRequest request) {
+  public String getServerSocketAddress(
+      HttpServletRequest request, @Nullable HttpServletResponse response) {
     return request.getLocalAddr();
   }
 
   @Override
-  public Integer getSockHostPort(HttpServletRequest request) {
+  public Integer getServerSocketPort(
+      HttpServletRequest request, @Nullable HttpServletResponse response) {
     return request.getLocalPort();
   }
 }

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatNetAttributesGetter.java
@@ -37,12 +37,12 @@ public class TomcatNetAttributesGetter implements NetServerAttributesGetter<Requ
 
   @Nullable
   @Override
-  public String getHostName(Request request) {
+  public String getServerAddress(Request request) {
     return messageBytesToString(request.serverName());
   }
 
   @Override
-  public Integer getHostPort(Request request) {
+  public Integer getServerPort(Request request) {
     return request.getServerPort();
   }
 
@@ -62,14 +62,14 @@ public class TomcatNetAttributesGetter implements NetServerAttributesGetter<Requ
 
   @Nullable
   @Override
-  public String getSockHostAddr(Request request) {
+  public String getServerSocketAddress(Request request, @Nullable Response response) {
     request.action(ActionCode.REQ_LOCAL_ADDR_ATTRIBUTE, request);
     return messageBytesToString(request.localAddr());
   }
 
   @Nullable
   @Override
-  public Integer getSockHostPort(Request request) {
+  public Integer getServerSocketPort(Request request, @Nullable Response response) {
     request.action(ActionCode.REQ_LOCALPORT_ATTRIBUTE, request);
     return request.getLocalPort();
   }

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowNetAttributesGetter.java
@@ -37,13 +37,13 @@ public class UndertowNetAttributesGetter
 
   @Nullable
   @Override
-  public String getHostName(HttpServerExchange exchange) {
+  public String getServerAddress(HttpServerExchange exchange) {
     return exchange.getHostName();
   }
 
   @Nullable
   @Override
-  public Integer getHostPort(HttpServerExchange exchange) {
+  public Integer getServerPort(HttpServerExchange exchange) {
     return exchange.getHostPort();
   }
 
@@ -55,7 +55,8 @@ public class UndertowNetAttributesGetter
 
   @Nullable
   @Override
-  public InetSocketAddress getHostSocketAddress(HttpServerExchange exchange) {
+  public InetSocketAddress getServerInetSocketAddress(
+      HttpServerExchange exchange, @Nullable HttpServerExchange unused) {
     return exchange.getConnection().getLocalAddress(InetSocketAddress.class);
   }
 }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3NetAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3NetAttributesGetter.java
@@ -17,18 +17,19 @@ enum Vertx3NetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(HttpClientRequest request) {
+  public String getServerAddress(HttpClientRequest request) {
     return null;
   }
 
   @Override
-  public Integer getPeerPort(HttpClientRequest request) {
+  public Integer getServerPort(HttpClientRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String getSockPeerName(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getServerSocketDomain(
+      HttpClientRequest request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }
@@ -38,7 +39,8 @@ enum Vertx3NetAttributesGetter
 
   @Nullable
   @Override
-  public Integer getSockPeerPort(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public Integer getServerSocketPort(
+      HttpClientRequest request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4NetAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/client/Vertx4NetAttributesGetter.java
@@ -42,18 +42,19 @@ final class Vertx4NetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(HttpClientRequest request) {
+  public String getServerAddress(HttpClientRequest request) {
     return request.getHost();
   }
 
   @Override
-  public Integer getPeerPort(HttpClientRequest request) {
+  public Integer getServerPort(HttpClientRequest request) {
     return request.getPort();
   }
 
   @Nullable
   @Override
-  public String getSockPeerAddr(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getServerSocketAddress(
+      HttpClientRequest request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }
@@ -63,7 +64,8 @@ final class Vertx4NetAttributesGetter
 
   @Nullable
   @Override
-  public String getSockPeerName(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public String getServerSocketDomain(
+      HttpClientRequest request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }
@@ -73,7 +75,8 @@ final class Vertx4NetAttributesGetter
 
   @Nullable
   @Override
-  public Integer getSockPeerPort(HttpClientRequest request, @Nullable HttpClientResponse response) {
+  public Integer getServerSocketPort(
+      HttpClientRequest request, @Nullable HttpClientResponse response) {
     if (response == null) {
       return null;
     }

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientNetAttributesGetter.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientNetAttributesGetter.java
@@ -20,13 +20,13 @@ public enum VertxSqlClientNetAttributesGetter
 
   @Nullable
   @Override
-  public String getPeerName(VertxSqlClientRequest request) {
+  public String getServerAddress(VertxSqlClientRequest request) {
     return request.getHost();
   }
 
   @Nullable
   @Override
-  public Integer getPeerPort(VertxSqlClientRequest request) {
+  public Integer getServerPort(VertxSqlClientRequest request) {
     return request.getPort();
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
@@ -187,13 +187,13 @@ final class TestInstrumenters {
 
     @Nullable
     @Override
-    public String getHostName(String unused) {
+    public String getServerAddress(String unused) {
       return null;
     }
 
     @Nullable
     @Override
-    public Integer getHostPort(String unused) {
+    public Integer getServerPort(String unused) {
       return null;
     }
   }


### PR DESCRIPTION
This PR builds on top of  #8616

It does not include resolving the questions raised in https://github.com/open-telemetry/semantic-conventions/issues/85 -- for now I simply copied the old behavior. I'll fix all that and introduce opt-in attributes in a separate PR.