### PR TITLE
Only instrument the actual Spring `TaskScheduler` implementations

### DIFF
--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/TaskSchedulerInstrumentation.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/TaskSchedulerInstrumentation.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.scheduling.v3_1;
 
-import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -20,7 +19,10 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class TaskSchedulerInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return implementsInterface(named("org.springframework.scheduling.TaskScheduler"));
+    return namedOneOf(
+        "org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler",
+        "org.springframework.scheduling.concurrent.ConcurrentTaskScheduler",
+        "org.springframework.scheduling.commonj.TimerManagerTaskScheduler");
   }
 
   @Override

--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/TaskSchedulerInstrumentation.java
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/scheduling/v3_1/TaskSchedulerInstrumentation.java
@@ -19,6 +19,8 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class TaskSchedulerInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
+    // we're only instrumenting the "real" scheduler implementations, and skipping all the decorator
+    // impls
     return namedOneOf(
         "org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler",
         "org.springframework.scheduling.concurrent.ConcurrentTaskScheduler",


### PR DESCRIPTION
I think this might resolve #8661 -- assuming the user decorates the original `TaskScheduler` (I think they might be doing that).