### PR TITLE
Show test output

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -307,6 +307,7 @@ tasks.withType<Test>().configureEach {
 
   testLogging {
     exceptionFormat = TestExceptionFormat.FULL
+    showStandardStreams = true
   }
 }
 


### PR DESCRIPTION
Test output can be useful for debugging tests, for example the reason for the recent jms test failures only became evident when test output for these tests was enabled. On the other hand having too much output can also be disruptive, might need to download the full logs to get the build scan link when there is too much output. Lets see how it works out.