### PR TITLE
Add debg output to test async servlet

### DIFF
--- a/smoke-tests/images/servlet/servlet-3.0/src/main/java/io/opentelemetry/smoketest/matrix/AsyncGreetingServlet.java
+++ b/smoke-tests/images/servlet/servlet-3.0/src/main/java/io/opentelemetry/smoketest/matrix/AsyncGreetingServlet.java
@@ -10,10 +10,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.servlet.AsyncContext;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+@SuppressWarnings("SystemOut")
 public class AsyncGreetingServlet extends GreetingServlet {
   private static final long serialVersionUID = 1L;
 
@@ -21,7 +21,8 @@ public class AsyncGreetingServlet extends GreetingServlet {
   private static final ExecutorService executor = Executors.newFixedThreadPool(2);
 
   @Override
-  public void init() throws ServletException {
+  public void init() {
+    System.err.println("init AsyncGreetingServlet");
     executor.submit(
         new Runnable() {
           @Override
@@ -29,6 +30,7 @@ public class AsyncGreetingServlet extends GreetingServlet {
             try {
               while (true) {
                 AsyncContext ac = jobQueue.take();
+                System.err.println("got async request from queue");
                 executor.submit(() -> handleRequest(ac));
               }
             } catch (InterruptedException e) {
@@ -40,16 +42,21 @@ public class AsyncGreetingServlet extends GreetingServlet {
 
   @Override
   public void destroy() {
+    System.err.println("destroy AsyncGreetingServlet");
     executor.shutdownNow();
   }
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+    System.err.println("start async request");
     AsyncContext ac = req.startAsync(req, resp);
+    System.err.println("add async request to queue");
     jobQueue.add(ac);
+    System.err.println("async request added to queue");
   }
 
   private static void handleRequest(AsyncContext ac) {
+    System.err.println("dispatch async request");
     ac.dispatch("/greeting");
   }
 }


### PR DESCRIPTION
Async servlet smoke test occasionally timeouts on payara. https://ge.opentelemetry.io/s/d6qax4sbl7ykk/tests/:smoke-tests:test/io.opentelemetry.smoketest.Payara6Jdk17Openj9/6.2023.4%20async%20smoke%20test%20on%20JDK%2017-openj9?top-execution=1 Hopefully added output will help to narrow where the request gets stuck.