### PR TITLE
Fix flaky ratpack test

### DIFF
--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackServerTest.groovy
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/groovy/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackServerTest.groovy
@@ -46,19 +46,20 @@ class RatpackServerTest extends Specification {
       }
     }
 
-    when:
-    app.test { httpClient -> "hi-foo" == httpClient.get("foo").body.text }
+    expect:
+    app.test { httpClient ->
+      assert "hi-foo" == httpClient.get("foo").body.text
 
-    then:
-    new PollingConditions().eventually {
-      def spanData = spanExporter.finishedSpanItems.find { it.name == "GET /foo" }
-      def attributes = spanData.attributes.asMap()
+      new PollingConditions().eventually {
+        def spanData = spanExporter.finishedSpanItems.find { it.name == "GET /foo" }
+        def attributes = spanData.attributes.asMap()
 
-      spanData.kind == SpanKind.SERVER
-      attributes[SemanticAttributes.HTTP_ROUTE] == "/foo"
-      attributes[SemanticAttributes.HTTP_TARGET] == "/foo"
-      attributes[SemanticAttributes.HTTP_METHOD] == "GET"
-      attributes[SemanticAttributes.HTTP_STATUS_CODE] == 200L
+        spanData.kind == SpanKind.SERVER
+        attributes[SemanticAttributes.HTTP_ROUTE] == "/foo"
+        attributes[SemanticAttributes.HTTP_TARGET] == "/foo"
+        attributes[SemanticAttributes.HTTP_METHOD] == "GET"
+        attributes[SemanticAttributes.HTTP_STATUS_CODE] == 200L
+      }
     }
   }
 
@@ -81,7 +82,7 @@ class RatpackServerTest extends Specification {
     }
 
     app.test { httpClient ->
-      "hi-foo" == httpClient.get("foo").body.text
+      assert "hi-foo" == httpClient.get("foo").body.text
 
       new PollingConditions().eventually {
         def spanData = spanExporter.finishedSpanItems.find { it.name == "GET /foo" }
@@ -130,8 +131,9 @@ class RatpackServerTest extends Specification {
     }
 
     app.test { httpClient ->
-      "hi-foo" == httpClient.get("foo").body.text
-      "hi-bar" == httpClient.get("bar").body.text
+      assert "hi-foo" == httpClient.get("foo").body.text
+      assert "hi-bar" == httpClient.get("bar").body.text
+
       new PollingConditions().eventually {
         def spanData = spanExporter.finishedSpanItems.find { it.name == "GET /foo" }
         def spanDataChild = spanExporter.finishedSpanItems.find { it.name == "a-span" }


### PR DESCRIPTION
https://ge.opentelemetry.io/s/kcg53l5v4msgw/tests/:instrumentation:ratpack:ratpack-1.7:library:test/io.opentelemetry.instrumentation.ratpack.v1_7.server.RatpackServerTest/add%20span%20on%20handlers?expanded-stacktrace=WyIwIiwiMC0xIl0&top-execution=1
Apparently it is possible that the server is stopped before we have completed the span. Moving the `PollingConditions().eventually` inside `app.test` should ensure that the server can't be stopped before we have ended the span.