### PR TITLE
Increase timeout for aws client timeout and retry errors not captured…

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test_before_1_11_106/groovy/Aws0ClientTest.groovy
@@ -234,8 +234,8 @@ class Aws0ClientTest extends AgentInstrumentationSpecification {
   def "timeout and retry errors not captured"() {
     setup:
     // One retry so two requests.
-    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(500)))
-    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(500)))
+    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(5000)))
+    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(5000)))
     AmazonS3Client client = new AmazonS3Client(new ClientConfiguration()
       .withRequestTimeout(50 /* ms */)
       .withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(1)))

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2ClientTest.groovy
@@ -506,8 +506,8 @@ abstract class AbstractAws2ClientTest extends InstrumentationSpecification {
   def "timeout and retry errors not captured"() {
     setup:
     // One retry so two requests.
-    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(500)))
-    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(500)))
+    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(5000)))
+    server.enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(5000)))
     def client = S3Client.builder()
       .overrideConfiguration(createOverrideConfigurationBuilder()
         .retryPolicy(RetryPolicy.builder().numRetries(1).build())


### PR DESCRIPTION
… test
https://ge.opentelemetry.io/s/s6s7v762gvoda/tests/:instrumentation:aws-sdk:aws-sdk-2.2:javaagent:test/Aws2ClientTest/timeout%20and%20retry%20errors%20not%20captured?top-execution=1
Same change was made in `AbstractAws1ClientTest` a while ago 