### PR TITLE
Make `server.socket.*` attributes on the HTTP server side opt-in

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
@@ -102,7 +102,8 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
             addressPortExtractor,
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv(),
-            InternalServerAttributesExtractor.Mode.PEER);
+            InternalServerAttributesExtractor.Mode.PEER,
+            /* captureServerSocketAttributes= */ true);
     this.resendCountIncrementer = resendCountIncrementer;
   }
 

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractor.java
@@ -80,13 +80,15 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
       NetServerAttributesGetter<REQUEST, RESPONSE> netAttributesGetter,
       List<String> capturedRequestHeaders,
       List<String> capturedResponseHeaders,
-      Set<String> knownMethods) {
+      Set<String> knownMethods,
+      boolean captureServerSocketAttributes) {
     this(
         httpAttributesGetter,
         netAttributesGetter,
         capturedRequestHeaders,
         capturedResponseHeaders,
         knownMethods,
+        captureServerSocketAttributes,
         HttpRouteHolder::getRoute);
   }
 
@@ -97,6 +99,7 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
       List<String> capturedRequestHeaders,
       List<String> capturedResponseHeaders,
       Set<String> knownMethods,
+      boolean captureServerSocketAttributes,
       Function<Context, String> httpRouteHolderGetter) {
     super(httpAttributesGetter, capturedRequestHeaders, capturedResponseHeaders, knownMethods);
     HttpNetAddressPortExtractor<REQUEST> addressPortExtractor =
@@ -123,7 +126,10 @@ public final class HttpServerAttributesExtractor<REQUEST, RESPONSE>
             addressPortExtractor,
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv(),
-            InternalServerAttributesExtractor.Mode.HOST);
+            InternalServerAttributesExtractor.Mode.HOST,
+            // we're not capturing these by default, since they're opt-in
+            // we'll add a configuration flag if someone happens to request them
+            /* captureServerSocketAttributes= */ false);
     internalClientExtractor =
         new InternalClientAttributesExtractor<>(
             netAttributesGetter,

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBuilder.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBuilder.java
@@ -22,6 +22,7 @@ public final class HttpServerAttributesExtractorBuilder<REQUEST, RESPONSE> {
   List<String> capturedRequestHeaders = emptyList();
   List<String> capturedResponseHeaders = emptyList();
   Set<String> knownMethods = HttpConstants.KNOWN_METHODS;
+  boolean captureServerSocketAttributes = false;
 
   HttpServerAttributesExtractorBuilder(
       HttpServerAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter,
@@ -90,6 +91,20 @@ public final class HttpServerAttributesExtractorBuilder<REQUEST, RESPONSE> {
   }
 
   /**
+   * Configures the extractor to capture the optional {@code server.socket.address} and {@code
+   * server.socket.port} attributes, which are not collected by default.
+   *
+   * @param captureServerSocketAttributes {@code true} if the extractor should collect the optional
+   *     {@code server.socket.address} and {@code server.socket.port} attributes.
+   */
+  @CanIgnoreReturnValue
+  public HttpServerAttributesExtractorBuilder<REQUEST, RESPONSE> setCaptureServerSocketAttributes(
+      boolean captureServerSocketAttributes) {
+    this.captureServerSocketAttributes = captureServerSocketAttributes;
+    return this;
+  }
+
+  /**
    * Returns a new {@link HttpServerAttributesExtractor} with the settings of this {@link
    * HttpServerAttributesExtractorBuilder}.
    */
@@ -99,6 +114,7 @@ public final class HttpServerAttributesExtractorBuilder<REQUEST, RESPONSE> {
         netAttributesGetter,
         capturedRequestHeaders,
         capturedResponseHeaders,
-        knownMethods);
+        knownMethods,
+        captureServerSocketAttributes);
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
@@ -53,7 +53,8 @@ public final class NetClientAttributesExtractor<REQUEST, RESPONSE>
             FallbackAddressPortExtractor.noop(),
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv(),
-            InternalServerAttributesExtractor.Mode.PEER);
+            InternalServerAttributesExtractor.Mode.PEER,
+            /* captureServerSocketAttributes= */ true);
   }
 
   @Override

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
@@ -52,7 +52,8 @@ public final class NetServerAttributesExtractor<REQUEST, RESPONSE>
             FallbackAddressPortExtractor.noop(),
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv(),
-            InternalServerAttributesExtractor.Mode.HOST);
+            InternalServerAttributesExtractor.Mode.HOST,
+            /* captureServerSocketAttributes= */ true);
     internalClientExtractor =
         new InternalClientAttributesExtractor<>(
             getter,

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractor.java
@@ -41,7 +41,8 @@ public final class ServerAttributesExtractor<REQUEST, RESPONSE>
             /* emitStableUrlAttributes= */ true,
             /* emitOldHttpAttributes= */ false,
             // this param does not matter when old semconv is off
-            InternalServerAttributesExtractor.Mode.HOST);
+            InternalServerAttributesExtractor.Mode.HOST,
+            /* captureServerSocketAttributes= */ true);
   }
 
   @Override

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalServerAttributesExtractor.java
@@ -26,6 +26,7 @@ public final class InternalServerAttributesExtractor<REQUEST, RESPONSE> {
   private final boolean emitStableUrlAttributes;
   private final boolean emitOldHttpAttributes;
   private final Mode oldSemconvMode;
+  private final boolean captureServerSocketAttributes;
 
   public InternalServerAttributesExtractor(
       ServerAttributesGetter<REQUEST, RESPONSE> getter,
@@ -33,13 +34,15 @@ public final class InternalServerAttributesExtractor<REQUEST, RESPONSE> {
       FallbackAddressPortExtractor<REQUEST> fallbackAddressPortExtractor,
       boolean emitStableUrlAttributes,
       boolean emitOldHttpAttributes,
-      Mode oldSemconvMode) {
+      Mode oldSemconvMode,
+      boolean captureServerSocketAttributes) {
     this.getter = getter;
     this.captureServerPortCondition = captureServerPortCondition;
     this.fallbackAddressPortExtractor = fallbackAddressPortExtractor;
     this.emitStableUrlAttributes = emitStableUrlAttributes;
     this.emitOldHttpAttributes = emitOldHttpAttributes;
     this.oldSemconvMode = oldSemconvMode;
+    this.captureServerSocketAttributes = captureServerSocketAttributes;
   }
 
   public void onStart(AttributesBuilder attributes, REQUEST request) {
@@ -69,7 +72,7 @@ public final class InternalServerAttributesExtractor<REQUEST, RESPONSE> {
 
     String serverSocketAddress = getter.getServerSocketAddress(request, response);
     if (serverSocketAddress != null && !serverSocketAddress.equals(serverAddressAndPort.address)) {
-      if (emitStableUrlAttributes) {
+      if (emitStableUrlAttributes && captureServerSocketAttributes) {
         internalSet(attributes, NetworkAttributes.SERVER_SOCKET_ADDRESS, serverSocketAddress);
       }
       if (emitOldHttpAttributes) {
@@ -81,7 +84,7 @@ public final class InternalServerAttributesExtractor<REQUEST, RESPONSE> {
     if (serverSocketPort != null
         && serverSocketPort > 0
         && !serverSocketPort.equals(serverAddressAndPort.port)) {
-      if (emitStableUrlAttributes) {
+      if (emitStableUrlAttributes && captureServerSocketAttributes) {
         internalSet(attributes, NetworkAttributes.SERVER_SOCKET_PORT, (long) serverSocketPort);
       }
       if (emitOldHttpAttributes) {
@@ -91,7 +94,7 @@ public final class InternalServerAttributesExtractor<REQUEST, RESPONSE> {
 
     String serverSocketDomain = getter.getServerSocketDomain(request, response);
     if (serverSocketDomain != null && !serverSocketDomain.equals(serverAddressAndPort.address)) {
-      if (emitStableUrlAttributes) {
+      if (emitStableUrlAttributes && captureServerSocketAttributes) {
         internalSet(attributes, NetworkAttributes.SERVER_SOCKET_DOMAIN, serverSocketDomain);
       }
       if (emitOldHttpAttributes && oldSemconvMode.socketDomain != null) {

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -164,6 +164,7 @@ class HttpServerAttributesExtractorTest {
             singletonList("Custom-Request-Header"),
             singletonList("Custom-Response-Header"),
             HttpConstants.KNOWN_METHODS,
+            false,
             routeFromContext);
 
     AttributesBuilder startAttributes = Attributes.builder();

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
@@ -158,6 +158,7 @@ class HttpServerAttributesExtractorBothSemconvTest {
             singletonList("Custom-Request-Header"),
             singletonList("Custom-Response-Header"),
             HttpConstants.KNOWN_METHODS,
+            false,
             routeFromContext);
 
     AttributesBuilder startAttributes = Attributes.builder();

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorStableSemconvTest.java
@@ -134,6 +134,21 @@ class HttpServerAttributesExtractorStableSemconvTest {
       String value = request.get("hostPort");
       return value == null ? null : Integer.parseInt(value);
     }
+
+    @Nullable
+    @Override
+    public String getServerSocketAddress(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      return request.get("serverSocketAddress");
+    }
+
+    @Nullable
+    @Override
+    public Integer getServerSocketPort(
+        Map<String, String> request, @Nullable Map<String, String> response) {
+      String value = request.get("serverSocketPort");
+      return value == null ? null : Integer.parseInt(value);
+    }
   }
 
   @Test
@@ -154,6 +169,8 @@ class HttpServerAttributesExtractorStableSemconvTest {
     request.put("type", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "2.0");
+    request.put("serverSocketAddress", "1.2.3.4");
+    request.put("serverSocketPort", "42");
 
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");
@@ -169,6 +186,7 @@ class HttpServerAttributesExtractorStableSemconvTest {
             singletonList("Custom-Request-Header"),
             singletonList("Custom-Response-Header"),
             HttpConstants.KNOWN_METHODS,
+            false,
             routeFromContext);
 
     AttributesBuilder startAttributes = Attributes.builder();


### PR DESCRIPTION
This is just the span attributes; for metric attributes I'm hoping that [my idea to use the advice API](https://github.com/open-telemetry/opentelemetry-specification/pull/3546#issuecomment-1594367578) catches on. 