### PR TITLE
Fix rocketmq latest dep test

### DIFF
--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/javaagent/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/javaagent/build.gradle.kts
@@ -25,4 +25,8 @@ tasks.withType<Test>().configureEach {
   jvmArgs("-Dotel.instrumentation.rocketmq-client.experimental-span-attributes=true")
 
   systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
+
+  // required on jdk17
+  jvmArgs("--add-opens=java.base/sun.nio.ch=ALL-UNNAMED")
+  jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
 }

--- a/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client/rocketmq-client-4.8/library/build.gradle.kts
@@ -15,4 +15,7 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
   systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
+  // required on jdk17
+  jvmArgs("--add-opens=java.base/sun.nio.ch=ALL-UNNAMED")
+  jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8753
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8754
`createTopic` attempts to create the topic and then waits until the topic is ready. The problem is that the attempt to create the topic can fail because it is called too early (exceptions from the create are suppressed) and the topic ready check will eventually time out.