### PR TITLE
Rename common HTTP configuration settings

### DIFF
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/CommonConfig.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/CommonConfig.java
@@ -33,14 +33,27 @@ public final class CommonConfig {
   CommonConfig(InstrumentationConfig config) {
     peerServiceMapping =
         config.getMap("otel.instrumentation.common.peer-service-mapping", emptyMap());
+    // TODO (mateusz): remove the old config names in 2.0
     clientRequestHeaders =
-        config.getList("otel.instrumentation.http.capture-headers.client.request", emptyList());
+        config.getList(
+            "otel.instrumentation.http.client.capture-request-headers",
+            config.getList(
+                "otel.instrumentation.http.capture-headers.client.request", emptyList()));
     clientResponseHeaders =
-        config.getList("otel.instrumentation.http.capture-headers.client.response", emptyList());
+        config.getList(
+            "otel.instrumentation.http.client.capture-response-headers",
+            config.getList(
+                "otel.instrumentation.http.capture-headers.client.response", emptyList()));
     serverRequestHeaders =
-        config.getList("otel.instrumentation.http.capture-headers.server.request", emptyList());
+        config.getList(
+            "otel.instrumentation.http.server.capture-request-headers",
+            config.getList(
+                "otel.instrumentation.http.capture-headers.server.request", emptyList()));
     serverResponseHeaders =
-        config.getList("otel.instrumentation.http.capture-headers.server.response", emptyList());
+        config.getList(
+            "otel.instrumentation.http.server.capture-response-headers",
+            config.getList(
+                "otel.instrumentation.http.capture-headers.server.response", emptyList()));
     statementSanitizationEnabled =
         config.getBoolean("otel.instrumentation.common.db-statement-sanitizer.enabled", true);
   }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/CommonConfig.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/CommonConfig.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.bootstrap.internal;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 import java.util.List;
@@ -33,27 +32,29 @@ public final class CommonConfig {
   CommonConfig(InstrumentationConfig config) {
     peerServiceMapping =
         config.getMap("otel.instrumentation.common.peer-service-mapping", emptyMap());
+
     // TODO (mateusz): remove the old config names in 2.0
     clientRequestHeaders =
-        config.getList(
-            "otel.instrumentation.http.client.capture-request-headers",
-            config.getList(
-                "otel.instrumentation.http.capture-headers.client.request", emptyList()));
+        DeprecatedConfigProperties.getList(
+            config,
+            "otel.instrumentation.http.capture-headers.client.request",
+            "otel.instrumentation.http.client.capture-request-headers");
     clientResponseHeaders =
-        config.getList(
-            "otel.instrumentation.http.client.capture-response-headers",
-            config.getList(
-                "otel.instrumentation.http.capture-headers.client.response", emptyList()));
+        DeprecatedConfigProperties.getList(
+            config,
+            "otel.instrumentation.http.capture-headers.client.response",
+            "otel.instrumentation.http.client.capture-response-headers");
     serverRequestHeaders =
-        config.getList(
-            "otel.instrumentation.http.server.capture-request-headers",
-            config.getList(
-                "otel.instrumentation.http.capture-headers.server.request", emptyList()));
+        DeprecatedConfigProperties.getList(
+            config,
+            "otel.instrumentation.http.capture-headers.server.request",
+            "otel.instrumentation.http.server.capture-request-headers");
     serverResponseHeaders =
-        config.getList(
-            "otel.instrumentation.http.server.capture-response-headers",
-            config.getList(
-                "otel.instrumentation.http.capture-headers.server.response", emptyList()));
+        DeprecatedConfigProperties.getList(
+            config,
+            "otel.instrumentation.http.capture-headers.server.response",
+            "otel.instrumentation.http.server.capture-response-headers");
+
     statementSanitizationEnabled =
         config.getBoolean("otel.instrumentation.common.db-statement-sanitizer.enabled", true);
   }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/DeprecatedConfigProperties.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/DeprecatedConfigProperties.java
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.javaagent.bootstrap.internal;
 
+import static java.util.Collections.emptyList;
 import static java.util.logging.Level.WARNING;
 
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
@@ -22,14 +24,26 @@ public final class DeprecatedConfigProperties {
       String deprecatedPropertyName,
       String newPropertyName,
       boolean defaultValue) {
+    warnIfUsed(config, deprecatedPropertyName, newPropertyName);
+    boolean value = config.getBoolean(deprecatedPropertyName, defaultValue);
+    return config.getBoolean(newPropertyName, value);
+  }
+
+  public static List<String> getList(
+      InstrumentationConfig config, String deprecatedPropertyName, String newPropertyName) {
+    warnIfUsed(config, deprecatedPropertyName, newPropertyName);
+    List<String> value = config.getList(deprecatedPropertyName, emptyList());
+    return config.getList(newPropertyName, value);
+  }
+
+  private static void warnIfUsed(
+      InstrumentationConfig config, String deprecatedPropertyName, String newPropertyName) {
     if (config.getString(deprecatedPropertyName) != null) {
       logger.log(
           WARNING,
           "Deprecated property \"{0}\" was used; use the \"{1}\" property instead",
           new Object[] {deprecatedPropertyName, newPropertyName});
     }
-    boolean value = config.getBoolean(deprecatedPropertyName, defaultValue);
-    return config.getBoolean(newPropertyName, value);
   }
 
   private DeprecatedConfigProperties() {}

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/http/CapturedHttpHeadersTestConfigSupplier.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/http/CapturedHttpHeadersTestConfigSupplier.java
@@ -22,10 +22,10 @@ public class CapturedHttpHeadersTestConfigSupplier implements AutoConfigurationC
 
   private static Map<String, String> getTestProperties() {
     Map<String, String> testConfig = new HashMap<>();
-    testConfig.put("otel.instrumentation.http.capture-headers.client.request", "X-Test-Request");
-    testConfig.put("otel.instrumentation.http.capture-headers.client.response", "X-Test-Response");
-    testConfig.put("otel.instrumentation.http.capture-headers.server.request", "X-Test-Request");
-    testConfig.put("otel.instrumentation.http.capture-headers.server.response", "X-Test-Response");
+    testConfig.put("otel.instrumentation.http.client.capture-request-headers", "X-Test-Request");
+    testConfig.put("otel.instrumentation.http.client.capture-response-headers", "X-Test-Response");
+    testConfig.put("otel.instrumentation.http.server.capture-request-headers", "X-Test-Request");
+    testConfig.put("otel.instrumentation.http.server.capture-response-headers", "X-Test-Response");
     return testConfig;
   }
 }


### PR DESCRIPTION
Split off from #8747

I think it makes sense to introduce that rename either way; since I'm planning to introduce things like `otel.instrumentation.http.client.capture-experimental-metrics` or `otel.instrumentation.http.server.captured-request-methods`