### PR TITLE
Remove `server.{address,port}` from HTTP server metrics

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsView.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsView.java
@@ -39,8 +39,6 @@ final class TemporaryMetricsView {
     view.add(HttpAttributes.HTTP_RESPONSE_STATUS_CODE);
     view.add(NetworkAttributes.NETWORK_PROTOCOL_NAME);
     view.add(NetworkAttributes.NETWORK_PROTOCOL_VERSION);
-    view.add(NetworkAttributes.SERVER_ADDRESS);
-    view.add(NetworkAttributes.SERVER_PORT);
     return view;
   }
 
@@ -54,6 +52,8 @@ final class TemporaryMetricsView {
     view.add(SemanticAttributes.NET_SOCK_PEER_ADDR);
     // stable semconv
     view.add(NetworkAttributes.SERVER_SOCKET_ADDRESS);
+    view.add(NetworkAttributes.SERVER_ADDRESS);
+    view.add(NetworkAttributes.SERVER_PORT);
     return view;
   }
 
@@ -83,8 +83,6 @@ final class TemporaryMetricsView {
     view.add(SemanticAttributes.NET_HOST_PORT);
     // stable semconv
     view.add(HttpAttributes.HTTP_REQUEST_METHOD);
-    view.add(NetworkAttributes.SERVER_ADDRESS);
-    view.add(NetworkAttributes.SERVER_PORT);
     view.add(UrlAttributes.URL_SCHEME);
     return view;
   }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsViewTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/TemporaryMetricsViewTest.java
@@ -174,9 +174,7 @@ class TemporaryMetricsViewTest {
             entry(SemanticAttributes.HTTP_ROUTE, "/somehost/high/{name}/{id}"),
             entry(UrlAttributes.URL_SCHEME, "https"),
             entry(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
-            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"),
-            entry(NetworkAttributes.SERVER_ADDRESS, "somehost"),
-            entry(NetworkAttributes.SERVER_PORT, 443L));
+            entry(NetworkAttributes.NETWORK_PROTOCOL_VERSION, "1.1"));
   }
 
   @Test
@@ -234,8 +232,6 @@ class TemporaryMetricsViewTest {
     assertThat(applyActiveRequestsView(attributes))
         .containsOnly(
             entry(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-            entry(UrlAttributes.URL_SCHEME, "https"),
-            entry(NetworkAttributes.SERVER_ADDRESS, "somehost"),
-            entry(NetworkAttributes.SERVER_PORT, 443L));
+            entry(UrlAttributes.URL_SCHEME, "https"));
   }
 }

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsStableSemconvTest.java
@@ -93,9 +93,7 @@ class HttpServerMetricsStableSemconvTest {
                                         .hasValue(1)
                                         .hasAttributesSatisfying(
                                             equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"),
-                                            equalTo(NetworkAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(NetworkAttributes.SERVER_PORT, 1234L))
+                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -118,9 +116,7 @@ class HttpServerMetricsStableSemconvTest {
                                         .hasValue(2)
                                         .hasAttributesSatisfying(
                                             equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"),
-                                            equalTo(NetworkAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(NetworkAttributes.SERVER_PORT, 1234L))
+                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -142,9 +138,7 @@ class HttpServerMetricsStableSemconvTest {
                                         .hasValue(1)
                                         .hasAttributesSatisfying(
                                             equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"),
-                                            equalTo(NetworkAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(NetworkAttributes.SERVER_PORT, 1234L))
+                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -167,9 +161,7 @@ class HttpServerMetricsStableSemconvTest {
                                                 NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
                                             equalTo(
                                                 NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"),
-                                            equalTo(NetworkAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(NetworkAttributes.SERVER_PORT, 1234L))
+                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -193,9 +185,7 @@ class HttpServerMetricsStableSemconvTest {
                                                 NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
                                             equalTo(
                                                 NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"),
-                                            equalTo(NetworkAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(NetworkAttributes.SERVER_PORT, 1234L))
+                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -218,9 +208,7 @@ class HttpServerMetricsStableSemconvTest {
                                                 NetworkAttributes.NETWORK_PROTOCOL_NAME, "http"),
                                             equalTo(
                                                 NetworkAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
-                                            equalTo(UrlAttributes.URL_SCHEME, "https"),
-                                            equalTo(NetworkAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(NetworkAttributes.SERVER_PORT, 1234L))
+                                            equalTo(UrlAttributes.URL_SCHEME, "https"))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -328,7 +316,6 @@ class HttpServerMetricsStableSemconvTest {
                                         .hasSum(0.100 /* seconds */)
                                         .hasAttributesSatisfying(
                                             equalTo(UrlAttributes.URL_SCHEME, "https"),
-                                            equalTo(NetworkAttributes.SERVER_ADDRESS, "host"),
                                             equalTo(
                                                 SemanticAttributes.HTTP_ROUTE, "/test/{id}")))));
   }


### PR DESCRIPTION
Implements https://github.com/open-telemetry/semantic-conventions/issues/108

Hopefully we'll be able to utilize https://github.com/open-telemetry/opentelemetry-specification/pull/3546 before 2.0 🤞 