### PR TITLE
set cpu load unit to "{run_queue_item}"

### DIFF
--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/Cpu.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/java8/Cpu.java
@@ -89,7 +89,7 @@ public final class Cpu {
         meter
             .gaugeBuilder("process.runtime.jvm.system.cpu.load_1m")
             .setDescription("Average CPU load of the whole system for the last minute")
-            .setUnit("1")
+            .setUnit("{run_queue_item}")
             .buildWithCallback(
                 observableMeasurement -> {
                   double loadAverage = osBean.getSystemLoadAverage();

--- a/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/CpuTest.java
+++ b/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/src/test/java/io/opentelemetry/instrumentation/runtimemetrics/java8/CpuTest.java
@@ -45,7 +45,7 @@ class CpuTest {
                     assertThat(metricData)
                         .hasInstrumentationScope(EXPECTED_SCOPE)
                         .hasDescription("Average CPU load of the whole system for the last minute")
-                        .hasUnit("1")
+                        .hasUnit("{run_queue_item}")
                         .hasDoubleGaugeSatisfying(
                             gauge -> gauge.hasPointsSatisfying(point -> point.hasValue(2.2)))));
     testing.waitAndAssertMetrics(


### PR DESCRIPTION
set cpu load unit to "{run_queue_item}" to match https://github.com/open-telemetry/semantic-conventions/pull/95