### PR TITLE
[minor cleanup] remove shell output from cgroup examples

### DIFF
--- a/instrumentation/resources/library/src/test/resources/docker_proc_self_mountinfo
+++ b/instrumentation/resources/library/src/test/resources/docker_proc_self_mountinfo
@@ -1,5 +1,3 @@
-473 456 254:1 /docker/containers/be522444b60caf2d3934b8b24b916a8a314f4b68d4595aa419874657e8d103f2/hostname /etc/hostname rw,relatime - ext4 /dev/vda1 rw
-root@be522444b60c:/# cat /proc/self/mountinfo
 456 375 0:143 / / rw,relatime master:175 - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/CBPR2ETR4Z3UMOOGIIRDVT2P27:/var/lib/docker/overlay2/l/46FCA2JFPCSNFGAR5TSYLLNHLK,upperdir=/var/lib/docker/overlay2/3ef3e5a1a87b4e220c1da9a7901654e945b0ef5398e1b67fccb42fdb7750829e/diff,workdir=/var/lib/docker/overlay2/3ef3e5a1a87b4e220c1da9a7901654e945b0ef5398e1b67fccb42fdb7750829e/work
 457 456 0:146 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
 466 456 0:147 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755

--- a/instrumentation/resources/library/src/test/resources/podman_proc_self_mountinfo
+++ b/instrumentation/resources/library/src/test/resources/podman_proc_self_mountinfo
@@ -1,5 +1,3 @@
-983 961 0:56 /containers/overlay-containers/2a33efc76e519c137fe6093179653788bed6162d4a15e5131c8e835c968afbe6/userdata/hostname /etc/hostname ro,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,size=783888k,nr_inodes=195972,mode=700,uid=2024,gid=2024,inode64
-[root@2a33efc76e51 /]# cat /proc/self/mountinfo
 961 812 0:58 / / ro,relatime - overlay overlay rw,lowerdir=/home/dracula/.local/share/containers/storage/overlay/l/4NB35A5Z4YGWDHXYEUZU4FN6BU,upperdir=/home/dracula/.local/share/containers/storage/overlay/a73044caca1b918335d1db6f0052d21d35045136f3aa86976dbad1ec96e2fdde/diff,workdir=/home/dracula/.local/share/containers/storage/overlay/a73044caca1b918335d1db6f0052d21d35045136f3aa86976dbad1ec96e2fdde/work,userxattr
 962 961 0:63 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs rw
 963 961 0:64 / /run rw,nosuid,nodev,relatime - tmpfs tmpfs rw,uid=2024,gid=2024,inode64


### PR DESCRIPTION
Hi !

I just noticed that the examples used for container ID parsing with cgroups v2 contain some extra lines that seem to come from a generous copy-paste.

The production and test code is not impacted by this, but there is no harm to fix this.