### PR TITLE
Add action to keep CloudFoundry repo branch current

### DIFF
--- a/.github/workflows/release-update-cloudfoundry-index.yml
+++ b/.github/workflows/release-update-cloudfoundry-index.yml
@@ -15,8 +15,6 @@ jobs:
 
   update-cloudfoundry-index-yml:
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.create-github-release.outputs.version }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-update-cloudfoundry-index.yml
+++ b/.github/workflows/release-update-cloudfoundry-index.yml
@@ -1,0 +1,37 @@
+# This action updates the CloudFoundry java-buildpack release index after each release.
+# See https://github.com/cloudfoundry/java-buildpack/blob/main/docs/extending-repositories.md
+# Prerequisite: the repo must have a branch named "cloudfoundry".
+
+name: Update cloudfoundry release index
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+
+  update-cloudfoundry-index-yml:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.create-github-release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: 'cloudfoundry'
+
+      - run: sudo apt-get install jq python3-pip
+      - run: pip install yq
+
+      - run: |
+          wget https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/maven-metadata.xml
+          xq -r .metadata.versioning.versions.version[] maven-metadata.xml | sed -E 's/(.*)/\1: https:\/\/repo1.maven.org\/maven2\/io\/opentelemetry\/javaagent\/opentelemetry-javaagent\/\1\/opentelemetry-javaagent-\1.jar/' > index.yml
+
+      - run: |
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+          git add index.yml
+          git commit -m "Updated index.yml"
+          git push

--- a/.github/workflows/release-update-cloudfoundry-index.yml
+++ b/.github/workflows/release-update-cloudfoundry-index.yml
@@ -4,8 +4,8 @@
 
 name: Update cloudfoundry release index
 on:
-  release:
-    types: [published]
+  schedule:
+    - cron: '25 4 * * *' # Daily at 4:25 AM UTC
   workflow_dispatch:
 
 permissions:
@@ -31,5 +31,5 @@ jobs:
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
           git add index.yml
-          git commit -m "Updated index.yml"
+          git diff-index --quiet --cached HEAD || git commit -m "Updated index.yml"
           git push

--- a/.github/workflows/release-update-cloudfoundry-index.yml
+++ b/.github/workflows/release-update-cloudfoundry-index.yml
@@ -5,7 +5,7 @@
 name: Update cloudfoundry release index
 on:
   release:
-    types: [released]
+    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-update-cloudfoundry-index.yml
+++ b/.github/workflows/release-update-cloudfoundry-index.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
 
@@ -20,16 +21,31 @@ jobs:
         with:
           ref: 'cloudfoundry'
 
+      - name: create working branch
+        run: git checkout -b cloudfoundry-${{ github.run_number }}-${{ github.run_attempt }}
+
       - run: sudo apt-get install jq python3-pip
       - run: pip install yq
 
-      - run: |
+      - name: update index.yml
+        run: |
           wget https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/maven-metadata.xml
           xq -r .metadata.versioning.versions.version[] maven-metadata.xml | sed -E 's/(.*)/\1: https:\/\/repo1.maven.org\/maven2\/io\/opentelemetry\/javaagent\/opentelemetry-javaagent\/\1\/opentelemetry-javaagent-\1.jar/' > index.yml
 
-      - run: |
+      - name: display changes
+        run: git diff
+
+      - name: create pr with repo changes
+        run: |
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
           git add index.yml
-          git diff-index --quiet --cached HEAD || git commit -m "Updated index.yml"
-          git push
+          if git diff-index --quiet --cached HEAD ; then
+            echo "index.yml already current"
+            exit 0
+          fi
+          git commit -m "Updated index.yml"
+          git push --set-upstream origin cloudfoundry-${{ github.run_number }}-${{ github.run_attempt }}
+          gh pr create -B cloudfoundry -H cloudfoundry-${{ github.run_number }}-${{ github.run_attempt }} --title 'Release updates for Cloudfoundry Repo' --body '[Created by Github action]'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-update-cloudfoundry-index.yml
+++ b/.github/workflows/release-update-cloudfoundry-index.yml
@@ -35,10 +35,11 @@ jobs:
       - name: display changes
         run: git diff
 
+      - name: Use CLA approved github bot
+        run: .github/scripts/use-cla-approved-github-bot.sh
+
       - name: create pr with repo changes
         run: |
-          git config user.name ${{ github.actor }}
-          git config user.email ${{ github.actor }}@users.noreply.github.com
           git add index.yml
           if git diff-index --quiet --cached HEAD ; then
             echo "index.yml already current"
@@ -46,6 +47,10 @@ jobs:
           fi
           git commit -m "Updated index.yml"
           git push --set-upstream origin cloudfoundry-${{ github.run_number }}-${{ github.run_attempt }}
-          gh pr create -B cloudfoundry -H cloudfoundry-${{ github.run_number }}-${{ github.run_attempt }} --title 'Release updates for Cloudfoundry Repo' --body '[Created by Github action]'
+          gh pr create --base cloudfoundry \
+            --head cloudfoundry-${{ github.run_number }}-${{ github.run_attempt }} \
+            --title 'Release updates for Cloudfoundry Repo' \
+            --body '[Created by Github action]'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
CloudFoundry’s `java-buildpack` needs a list of available releases. This action should run every day. It can also be triggered manually with the push of a button. If there are new versions added to maven central, it will be reflected.

The resulting index.yml file has a line like this for each version in maven:
```
1.26.0: https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/1.26.0/opentelemetry-javaagent-1.26.0.jar
1.27.0: https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/1.27.0/opentelemetry-javaagent-1.27.0.jar
```

(This is a prerequisite for adding otel javaagent support to the buildpack.)