### PR TITLE
Standardize on “Javaagent” instead of “Java agent”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@
 
 ## Version 1.25.1 (2023-04-27)
 
-- Fix apache pulsar instrumentation missing from the Java agent
+- Fix apache pulsar instrumentation missing from the Javaagent
   ([#8378](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8378))
 
 ## Version 1.25.0 (2023-04-13)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ java -version
 ./gradlew assemble
 ```
 
-and then you can find the java agent artifact at
+and then you can find the javaagent artifact at
 
 `javaagent/build/libs/opentelemetry-javaagent-<version>.jar`.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 ## About
 
-This project provides a Java agent JAR that can be attached to any Java 8+
+This project provides a Javaagent JAR that can be attached to any Java 8+
 application and dynamically injects bytecode to capture telemetry from a
 number of popular libraries and frameworks.
 You can export the telemetry data in a variety of formats.
@@ -53,7 +53,7 @@ or environment variables. The net result is the ability to gather telemetry
 data from a Java application without code changes.
 
 This repository also publishes standalone instrumentation for several libraries (and growing)
-that can be used if you prefer that over using the Java agent.
+that can be used if you prefer that over using the Javaagent.
 Please see the standalone library instrumentation column
 on [Supported Libraries](docs/supported-libraries.md#libraries--frameworks).
 if you are looking for documentation on using those.
@@ -74,7 +74,7 @@ java -javaagent:path/to/opentelemetry-javaagent.jar \
      -jar myapp.jar
 ```
 
-By default, the OpenTelemetry Java agent uses
+By default, the OpenTelemetry Javaagent uses
 [OTLP exporter](https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/otlp)
 configured to send data to
 [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md)

--- a/docs/agent-features.md
+++ b/docs/agent-features.md
@@ -1,6 +1,6 @@
-# OpenTelemetry Java Agent Features
+# OpenTelemetry Javaagent Features
 
-This lists out some of the features specific to java agents that OpenTelemetry Auto Instrumentation
+This lists out some of the features specific to javaagents that OpenTelemetry Auto Instrumentation
 provides.
 
 - Bundled exporters
@@ -24,7 +24,7 @@ provides.
 - [Safety mechanisms](./safety-mechanisms.md) to prevent application linkage errors
   - Collect all references from instrumentation to library and only apply instrumentation if they exist in application
   - Verify above at compile time
-  - Instrumentation tests that run the java agent in a near-production configuration
+  - Instrumentation tests that run the javaagent in a near-production configuration
   - Ability to run tests against a fixed version and the latest version of dependencies
   - Docker-based smoke tests to verify agent behavior across JVM runtimes, Java application servers
 - Ability to create custom distributions, agents with different components / configuration

--- a/docs/contributing/muzzle.md
+++ b/docs/contributing/muzzle.md
@@ -1,6 +1,6 @@
 # Muzzle
 
-Muzzle is a safety feature of the Java agent that prevents applying instrumentation when a mismatch
+Muzzle is a safety feature of the Javaagent that prevents applying instrumentation when a mismatch
 between the instrumentation code and the instrumented application code is detected.
 It ensures API compatibility between symbols (classes, methods, fields) on the application classpath
 and references to those symbols made by instrumentation advices defined in the agent.

--- a/docs/contributing/writing-instrumentation.md
+++ b/docs/contributing/writing-instrumentation.md
@@ -21,8 +21,8 @@ Some libraries will have no way of intercepting requests because they only expos
 and no interception hooks. For these libraries it is not possible to create library
 instrumentation.
 
-**Java agent instrumentation**: This is logic that is similar to library instrumentation, but instead
-of a user initializing classes themselves, a Java agent automatically initializes them during
+**Javaagent instrumentation**: This is logic that is similar to library instrumentation, but instead
+of a user initializing classes themselves, a Javaagent automatically initializes them during
 class loading by manipulating byte code. This allows a user to develop their apps without thinking
 about instrumentation and get it "for free". Often, the agent instrumentation will generate
 bytecode that is more or less identical to what a user would have written themselves in their app.
@@ -272,7 +272,7 @@ class LibraryYarpcTest extends AbstractYarpcTest implements LibraryTestTrait {
 }
 ```
 
-## Writing Java agent instrumentation
+## Writing Javaagent instrumentation
 
 Now that you have working and tested library instrumentation, implement the javaagent
 instrumentation so that the users of the agent do not have to modify their apps to enable telemetry
@@ -321,7 +321,7 @@ bytecode instrumentation as when the agent is run against a normal app, and mean
 instrumentation will be hidden inside the javaagent (loaded by the `AgentClassLoader`) and will not
 be directly accessible in your test code. Make sure not to use the classes from the javaagent
 instrumentation in your test code. If for some reason you need to write unit tests for the javaagent
-code, see [this section](#writing-java-agent-unit-tests).
+code, see [this section](#writing-javaagent-unit-tests).
 
 ## Additional considerations regarding instrumentations
 
@@ -383,7 +383,7 @@ All classes from the newly added bootstrap module will be loaded by the bootstra
 globally available within the JVM. **IMPORTANT: Note that you _cannot_ use any third-party libraries
 here, including the instrumented library - you can only use JDK and OpenTelemetry API classes.**
 
-## Writing Java agent unit tests
+## Writing Javaagent unit tests
 
 As mentioned before, tests in the `javaagent` module cannot access the javaagent instrumentation
 classes directly because of class loader separation - the javaagent classes are hidden and not

--- a/docs/logger-mdc-instrumentation.md
+++ b/docs/logger-mdc-instrumentation.md
@@ -8,7 +8,7 @@ The Mapped Diagnostic Context (MDC) is
 It contains thread-local contextual information which is later copied to each logging event captured
 by a logging library.
 
-The OTel Java agent injects several pieces of information about the current span into each logging
+The OTel Javaagent injects several pieces of information about the current span into each logging
 event's MDC copy:
 
 - `trace_id` - the current trace id

--- a/docs/misc/interop-design/interop-design.md
+++ b/docs/misc/interop-design/interop-design.md
@@ -4,7 +4,7 @@
 
 These two things must seamlessly interoperate:
 
-* Instrumentation provided by the Java agent
+* Instrumentation provided by the Javaagent
 * Instrumentation provided by the user app, using any 1.0+ version of the OpenTelemetry API
 
 ## Design
@@ -20,15 +20,15 @@ The rest of this section describes the components in the diagram above.
 using the OpenTelemetry API.
 
 **Versioned Bridge** - a bridge between the version of the OpenTelemetry API
-brought by the user app, and the (shaded) OpenTelemetry API used internally by the Java agent.
-The Java agent will rewrite io.opentelemetry.api.OpenTelemetry via bytecode instrumentation
+brought by the user app, and the (shaded) OpenTelemetry API used internally by the Javaagent.
+The Javaagent will rewrite io.opentelemetry.api.OpenTelemetry via bytecode instrumentation
 so that users will get the versioned bridge as their implementation of the OpenTelemetry API.
 In order to implement the OpenTelemetry API brought by the user app,
 the versioned bridge needs to be injected into the class loader where that OpenTelemetry API lives.
-The Java agent will inject an appropriate version of the bridge
+The Javaagent will inject an appropriate version of the bridge
 that supports the version of the OpenTelemetry API brought by the user.
-If the Java agent does not recognize the version of the OpenTelemetry API brought by the user app,
-then it will not inject one (e.g. running an old version of the Java agent with a new version
+If the Javaagent does not recognize the version of the OpenTelemetry API brought by the user app,
+then it will not inject one (e.g. running an old version of the Javaagent with a new version
 of OpenTelemetry API).
 
 **Bytecode Instrumentation** - bytecode instrumentation of well-known libraries.
@@ -73,7 +73,7 @@ This may lead us to apply the Versioned Bridge as bytecode instrumentation
 on the user-brought OpenTelemetry SDK, which is not as clean, but would avoid this issue.
 
 Users who have configured the underlying SDK / exporter could be surprised
-that the Java agent takes over, and their configuration work / exporter is not carried over.
+that the Javaagent takes over, and their configuration work / exporter is not carried over.
 
 ## Alternate Design 1
 
@@ -82,7 +82,7 @@ the bytecode instrumentation could use the OpenTelemetry API brought by the user
 
 ![Alternate Design 1](alt-design-1.png)
 
-The Java agent could check which version of the OpenTelemetry API was brought by the user,
+The Javaagent could check which version of the OpenTelemetry API was brought by the user,
 and only apply the bytecode instrumentation if it's compatible
 with that version of the OpenTelemetry API.
 

--- a/docs/safety-mechanisms.md
+++ b/docs/safety-mechanisms.md
@@ -1,7 +1,7 @@
-# OpenTelemetry Java Agent Safety Mechanisms
+# OpenTelemetry Javaagent Safety Mechanisms
 
 This document outlines the safety mechanisms we have in place to have confidence
-that the Java agent can be attached to a user's application with a very low chance of
+that the Javaagent can be attached to a user's application with a very low chance of
 affecting it negatively, for example introducing crashes.
 
 ## Instrumentation tests
@@ -53,7 +53,7 @@ potentially cause linkage errors.
 
 See more detail about the class loader separation [here](./contributing/javaagent-structure.md).
 
-The Java agent makes sure to include as little code as possible in the user app's class loader, and
+The Javaagent makes sure to include as little code as possible in the user app's class loader, and
 all code that is included is either unique to the agent itself or shaded in the agent build. This is
 because if the agent included classes that are also used by the user's app and there was a version
 mismatch, it could cause linkage crashes.

--- a/docs/supported-libraries.md
+++ b/docs/supported-libraries.md
@@ -135,7 +135,8 @@ These are the supported libraries and frameworks:
 | [Vibur DBCP](https://www.vibur.org/)                                                                                                        | 11.0+                         | [opentelemetry-vibur-dbcp-11.0](../instrumentation/vibur-dbcp-11.0/library)                                                                                                                                                                                                                                                                                                             | [Database Pool Metrics]                                                                |
 | [ZIO](https://zio.dev/)                                                                                                                     | 2.0.0+                        | N/A                                                                                                                                                                                                                                                                                                                                                                                     | Context propagation                                                                    |
 
-**[1]** Standalone library instrumentation refers to instrumentation that can be used without the Java agent.
+**[1]** Standalone library instrumentation refers to instrumentation that can be used without the
+Javaagent.
 
 **[2]** Provides `http.route`: Provides route-based span name for existing `SERVER` span. If applicable, provides `http.route` span and metric attribute on existing `SERVER` span and metrics.
 

--- a/examples/extension/README.md
+++ b/examples/extension/README.md
@@ -28,7 +28,9 @@ contain extension jars) for the `otel.javaagent.extensions` value.
 
 ## Embed extensions in the OpenTelemetry Agent
 
-To simplify deployment, you can embed extensions into the OpenTelemetry Java Agent to produce a single jar file. With an integrated extension, you no longer need the `-Dotel.javaagent.extensions` command line option.
+To simplify deployment, you can embed extensions into the OpenTelemetry Javaagent to produce a
+single jar file. With an integrated extension, you no longer need the `-Dotel.javaagent.extensions`
+command line option.
 
 For more information, see the `extendedAgent` task in [build.gradle](build.gradle).
 

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/CustomJodaModule.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/CustomJodaModule.java
@@ -22,7 +22,7 @@ import org.joda.time.format.DateTimeFormatter;
  *
  * <p>It enables parsing of {@link DateTime} which is used by some standard events. A custom module
  * was used as opposed to Jackson standard module for parsing Joda to avoid adding more libraries to
- * the Java Agent.
+ * the Javaagent.
  *
  * <p>Supporting custom POJOs using Joda is out of the scope of this class.
  */

--- a/instrumentation/jmx-metrics/javaagent/README.md
+++ b/instrumentation/jmx-metrics/javaagent/README.md
@@ -5,8 +5,12 @@ This subsystem provides a framework for collecting and reporting metrics provide
 local [MBeans](https://docs.oracle.com/javase/tutorial/jmx/mbeans/index.html)
 available within the instrumented application. The required MBeans and corresponding metrics can be described using a YAML configuration file. The individual metric configurations allow precise metric selection and identification.
 
-The selected JMX metrics are reported using the Java Agent internal SDK. This means that they share the configuration and metric exporter with other metrics collected by the agent and are controlled by the same properties, for example `otel.metric.export.interval` or `otel.metrics.exporter`.
-The Open Telemetry resource description for the metrics reported by JMX Metric Insight will be the same as for other metrics exported by the SDK, while the instrumentation scope will be `io.opentelemetry.jmx`.
+The selected JMX metrics are reported using the Javaagent internal SDK. This means that they share
+the configuration and metric exporter with other metrics collected by the agent and are controlled
+by the same properties, for example `otel.metric.export.interval` or `otel.metrics.exporter`.
+The Open Telemetry resource description for the metrics reported by JMX Metric Insight will be the
+same as for other metrics exported by the SDK, while the instrumentation scope will
+be `io.opentelemetry.jmx`.
 
 To control the time interval between MBean detection attempts, one can use the `otel.jmx.discovery.delay` property, which defines the number of milliseconds to elapse between the first and the next detection cycle. JMX Metric Insight may dynamically adjust the time interval between further attempts, but it guarantees that the MBean discovery will run perpetually.
 
@@ -129,7 +133,8 @@ Using the above rule, when running on HotSpot JVM for Java 11, the following com
 - {pool="CodeHeap 'non-nmethods'", type="NON_HEAP"}
 - {pool="G1 Survivor Space", type="HEAP"}
 
-**Note**: Heap and memory pool metrics above are given just as examples. The Java Agent already reports such metrics, no additional configuration is needed from the users.
+**Note**: Heap and memory pool metrics above are given just as examples. The Javaagent already
+reports such metrics, no additional configuration is needed from the users.
 
 ### Mapping multiple MBean attributes to the same metric
 

--- a/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/OpenTelemetryInstrumentation.java
+++ b/instrumentation/opentelemetry-api/opentelemetry-api-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetryapi/OpenTelemetryInstrumentation.java
@@ -74,7 +74,7 @@ public class OpenTelemetryInstrumentation implements TypeInstrumentation {
       Logger.getLogger(application.io.opentelemetry.api.GlobalOpenTelemetry.class.getName())
           .log(
               WARNING,
-              "You are currently using the OpenTelemetry Instrumentation Java Agent;"
+              "You are currently using the OpenTelemetry Instrumentation Javaagent;"
                   + " all GlobalOpenTelemetry.set calls are ignored - the agent provides"
                   + " the global OpenTelemetry object used by your application.",
               new Throwable());
@@ -89,7 +89,7 @@ public class OpenTelemetryInstrumentation implements TypeInstrumentation {
       Logger.getLogger(application.io.opentelemetry.api.GlobalOpenTelemetry.class.getName())
           .log(
               WARNING,
-              "You are currently using the OpenTelemetry Instrumentation Java Agent;"
+              "You are currently using the OpenTelemetry Instrumentation Javaagent;"
                   + " all GlobalOpenTelemetry.resetForTest calls are ignored - the agent provides"
                   + " the global OpenTelemetry object used by your application.",
               new Throwable());

--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -17,7 +17,7 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
 /**
- * Premain-Class for the OpenTelemetry Java agent.
+ * Premain-Class for the OpenTelemetry Javaagent.
  *
  * <p>The bootstrap process of the agent is somewhat complicated and care has to be taken to make
  * sure things do not get broken by accident.

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/AgentListener.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/AgentListener.java
@@ -11,8 +11,8 @@ import java.lang.instrument.Instrumentation;
 import net.bytebuddy.agent.builder.AgentBuilder;
 
 /**
- * {@link AgentListener} can be used to execute code after Java agent installation. It can be used
- * to install additional instrumentation that does not depend on bytecode injection, e.g. JMX
+ * {@link AgentListener} can be used to execute code after Javaagent installation. It can be used to
+ * install additional instrumentation that does not depend on bytecode injection, e.g. JMX
  * listeners. Can also be used to obtain the {@link AutoConfiguredOpenTelemetrySdk}.
  *
  * <p>This is a service provider interface that requires implementations to be registered in a

--- a/javaagent/README.md
+++ b/javaagent/README.md
@@ -1,1 +1,1 @@
-# Java Agent for Auto Instrumentation
+# Javaagent for Auto Instrumentation

--- a/smoke-tests/images/play/README.md
+++ b/smoke-tests/images/play/README.md
@@ -1,4 +1,4 @@
 # Play framework smoke test
 
-Play application used by smoke tests of OpenTelemetry java agent.
+Play application used by smoke tests of OpenTelemetry javaagent.
 Builds and publishes Docker image containing a trivial Play application.

--- a/smoke-tests/images/spring-boot/README.md
+++ b/smoke-tests/images/spring-boot/README.md
@@ -1,4 +1,4 @@
 # Spring Boot smoke test
 
-Spring Boot application used by smoke tests of OpenTelemetry java agent.
+Spring Boot application used by smoke tests of OpenTelemetry Javaagent.
 Builds and publishes Docker image containing a trivial Spring MVC application.


### PR DESCRIPTION
There are way more usages of “javaagent” within the project, so the inverse would be much more challenging.

I find the inconsistency confusing. The JVM calls it a `javaagent` so we should also.

Some minor word rewrapping snuck in because of my IDE settings.  If this is problematic, I can roll that back.