### PR TITLE
Upgrade playframework Gradle plugin to fix a build cache miss

### DIFF
--- a/smoke-tests/images/play/build.gradle.kts
+++ b/smoke-tests/images/play/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
   id("otel.spotless-conventions")
 
   id("com.google.cloud.tools.jib")
-  id("org.gradle.playframework") version "0.13"
+  id("org.gradle.playframework") version "0.14"
 }
 
 val playVer = "2.8.19"


### PR DESCRIPTION
This plugin upgrade fixes a build cache miss on `:smoke-tests:images:play:compileScala` due to volatile task inputs (Scala generated files containing timestamps and absolute paths)
See more details there: https://github.com/gradle/playframework/issues/109

![Screenshot 2023-06-29 at 10 51 59 AM](https://github.com/open-telemetry/opentelemetry-java-instrumentation/assets/10243934/33d35119-0e95-472c-a6f2-090934153424)
