### PR TITLE
Micrometer bridge: interpret no SLO config as no buckets advice

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractDistributionSummaryTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractDistributionSummaryTest.java
@@ -12,17 +12,13 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attri
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Metrics;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.metrics.internal.aggregator.ExplicitBucketHistogramUtils;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public abstract class AbstractDistributionSummaryTest {
 
-  static final double[] DEFAULT_BUCKETS =
-      ExplicitBucketHistogramUtils.DEFAULT_HISTOGRAM_BUCKET_BOUNDARIES.stream()
-          .mapToDouble(d -> d)
-          .toArray();
+  static final double[] NO_BUCKETS = new double[0];
 
   protected abstract InstrumentationExtension testing();
 
@@ -65,7 +61,7 @@ public abstract class AbstractDistributionSummaryTest {
                                                 .hasSum(7)
                                                 .hasCount(3)
                                                 .hasAttributes(attributeEntry("tag", "value"))
-                                                .hasBucketBoundaries(DEFAULT_BUCKETS)))));
+                                                .hasBucketBoundaries(NO_BUCKETS)))));
     testing()
         .waitAndAssertMetrics(
             INSTRUMENTATION_NAME,

--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractTimerTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractTimerTest.java
@@ -15,7 +15,6 @@ import io.micrometer.core.instrument.Timer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.metrics.data.HistogramPointData;
-import io.opentelemetry.sdk.metrics.internal.aggregator.ExplicitBucketHistogramUtils;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.AbstractIterableAssert;
@@ -25,10 +24,7 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("PreferJavaTimeOverload")
 public abstract class AbstractTimerTest {
 
-  static final double[] DEFAULT_BUCKETS =
-      ExplicitBucketHistogramUtils.DEFAULT_HISTOGRAM_BUCKET_BOUNDARIES.stream()
-          .mapToDouble(d -> d)
-          .toArray();
+  static final double[] NO_BUCKETS = new double[0];
 
   protected abstract InstrumentationExtension testing();
 
@@ -63,7 +59,7 @@ public abstract class AbstractTimerTest {
                                                 .hasSum(42)
                                                 .hasCount(1)
                                                 .hasAttributes(attributeEntry("tag", "value"))
-                                                .hasBucketBoundaries(DEFAULT_BUCKETS)))));
+                                                .hasBucketBoundaries(NO_BUCKETS)))));
     testing()
         .waitAndAssertMetrics(
             INSTRUMENTATION_NAME,


### PR DESCRIPTION
Resolves #8841 (?)

cc @zeitlinger 

This implements my idea from the issue:

> By default Micrometer Timers have no buckets at all, unless you configure serviceLevelObjectives via the builder. Perhaps what we should do is preserve that behavior in the bridge as well -- and pass an empty bucket list if the user has not explicitly configured them via Micrometer API. At least it would be consistent with how "plain" Micrometer behaves.

