### PR TITLE
(micrometer) don't add . to empty unit with prometheus naming conventions

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/PrometheusModeNamingConvention.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/PrometheusModeNamingConvention.java
@@ -20,7 +20,7 @@ enum PrometheusModeNamingConvention implements NamingConvention {
     if (type == Meter.Type.COUNTER
         || type == Meter.Type.DISTRIBUTION_SUMMARY
         || type == Meter.Type.GAUGE) {
-      if (baseUnit != null && !name.endsWith("." + baseUnit)) {
+      if (baseUnit != null && !baseUnit.equals("") && !name.endsWith("." + baseUnit)) {
         name = name + "." + baseUnit;
       }
     }

--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractPrometheusModeTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractPrometheusModeTest.java
@@ -34,7 +34,7 @@ public abstract class AbstractPrometheusModeTest {
         Counter.builder("testPrometheusCounter")
             .description("This is a test counter")
             .tags("tag", "value")
-            .baseUnit("items")
+            .baseUnit("")
             .register(Metrics.globalRegistry);
 
     // when
@@ -50,7 +50,7 @@ public abstract class AbstractPrometheusModeTest {
                     metric ->
                         assertThat(metric)
                             .hasDescription("This is a test counter")
-                            .hasUnit("items")
+                            .hasUnit("")
                             .hasDoubleSumSatisfying(
                                 sum ->
                                     sum.isMonotonic()


### PR DESCRIPTION
don't add . to empty unit with prometheus naming conventions