### PR TITLE
OTel Spring Boot starter: OpenTelemetry injection into the OTel Logack appenders

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-exporter-zipkin")
   compileOnly(project(":instrumentation-annotations"))
 
+  compileOnly("ch.qos.logback:logback-classic:1.3.0")
+  compileOnly("io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:1.28.0-alpha-SNAPSHOT")
+
   compileOnly(project(":instrumentation:resources:library"))
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service-annotations")

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/log/OtelLogbackAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/log/OtelLogbackAutoConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.autoconfigure.log;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender;
+import java.util.Iterator;
+import java.util.Optional;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+
+@ConditionalOnClass({OpenTelemetryAppender.class, LoggerContext.class})
+@AutoConfiguration
+public class OtelLogbackAutoConfiguration {
+
+  static class OtelInjectorForLogback implements BeanPostProcessor, Ordered {
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName)
+        throws BeansException {
+      if (bean instanceof OpenTelemetry) {
+        OpenTelemetry openTelemetry = (OpenTelemetry) bean;
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        Optional<OpenTelemetryAppender> potentialOtelAppender =
+            findOtelAppenderWithLogback(loggerContext);
+        if (potentialOtelAppender.isPresent()) {
+          OpenTelemetryAppender openTelemetryAppender = potentialOtelAppender.get();
+          openTelemetryAppender.setOpenTelemetry(openTelemetry);
+        }
+      }
+      return bean;
+    }
+
+    private static Optional<OpenTelemetryAppender> findOtelAppenderWithLogback(
+        LoggerContext loggerContext) {
+      for (Logger logger : loggerContext.getLoggerList()) {
+        Iterator<Appender<ILoggingEvent>> appenderIterator = logger.iteratorForAppenders();
+        while (appenderIterator.hasNext()) {
+          Appender<ILoggingEvent> appender = appenderIterator.next();
+          if (appender instanceof OpenTelemetryAppender) {
+            return Optional.of((OpenTelemetryAppender) appender);
+          }
+        }
+      }
+      return Optional.empty();
+    }
+
+    @Override
+    public int getOrder() {
+      return Ordered.LOWEST_PRECEDENCE - 1;
+    }
+  }
+
+  @Bean
+  public OtelInjectorForLogback otelPostProcessor() {
+    return new OtelInjectorForLogback();
+  }
+}

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -13,4 +13,5 @@ io.opentelemetry.instrumentation.spring.autoconfigure.kafka.KafkaInstrumentation
 io.opentelemetry.instrumentation.spring.autoconfigure.metrics.MicrometerShimAutoConfiguration,\
 io.opentelemetry.instrumentation.spring.autoconfigure.propagators.PropagationAutoConfiguration,\
 io.opentelemetry.instrumentation.spring.autoconfigure.resources.OtelResourceAutoConfiguration,\
-io.opentelemetry.instrumentation.spring.autoconfigure.webmvc.WebMvcFilterAutoConfiguration
+io.opentelemetry.instrumentation.spring.autoconfigure.webmvc.WebMvcFilterAutoConfiguration,\
+io.opentelemetry.instrumentation.spring.autoconfigure.log.OtelLogbackAutoConfiguration

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -13,3 +13,5 @@ io.opentelemetry.instrumentation.spring.autoconfigure.metrics.MicrometerShimAuto
 io.opentelemetry.instrumentation.spring.autoconfigure.propagators.PropagationAutoConfiguration
 io.opentelemetry.instrumentation.spring.autoconfigure.resources.OtelResourceAutoConfiguration
 io.opentelemetry.instrumentation.spring.autoconfigure.webmvc.WebMvcFilterAutoConfigurationSpring6
+io.opentelemetry.instrumentation.spring.autoconfigure.log.OtelLogbackAutoConfiguration
+


### PR DESCRIPTION

The purpose of this PR is to inject an OpenTelemetry instance into the OpenTelemetry Logback appender with the OpenTelemetry Spring Starter.