### PR TITLE
Fix instrumentation of Azure SDK EventHubs library

### DIFF
--- a/instrumentation/azure-core/azure-core-1.36/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureSdkInstrumentationModule.java
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureSdkInstrumentationModule.java
@@ -7,7 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.azurecore.v1_36;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
-import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
@@ -30,6 +30,11 @@ public class AzureSdkInstrumentationModule extends InstrumentationModule {
     helperResourceBuilder.register(
         "META-INF/services/com.azure.core.util.tracing.TracerProvider",
         "azure-core-1.36/META-INF/services/com.azure.core.util.tracing.TracerProvider");
+    // some azure sdks (e.g. EventHubs) are still looking up Tracer via service loader
+    // and not yet using the new TracerProvider
+    helperResourceBuilder.register(
+        "META-INF/services/com.azure.core.util.tracing.Tracer",
+        "azure-core-1.36/META-INF/services/com.azure.core.util.tracing.Tracer");
   }
 
   @Override
@@ -47,7 +52,9 @@ public class AzureSdkInstrumentationModule extends InstrumentationModule {
   public static class EmptyTypeInstrumentation implements TypeInstrumentation {
     @Override
     public ElementMatcher<TypeDescription> typeMatcher() {
-      return named("com.azure.core.util.tracing.TracerProvider");
+      return namedOneOf(
+          "com.azure.core.util.tracing.TracerProvider",
+          "com.azure.core.util.tracing.Tracer");
     }
 
     @Override

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/src/main/resources/azure-core-1.36/META-INF/services/com.azure.core.util.tracing.Tracer
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/src/main/resources/azure-core-1.36/META-INF/services/com.azure.core.util.tracing.Tracer
@@ -1,0 +1,1 @@
+io.opentelemetry.javaagent.instrumentation.azurecore.v1_36.shaded.com.azure.core.tracing.opentelemetry.OpenTelemetryTracer

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/src/test/java/AzureSdkTestOld.java
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/src/test/java/AzureSdkTestOld.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.azure.core.util.Context;
+import com.azure.core.util.tracing.Tracer;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+// some azure sdks (e.g. EventHubs) are still looking up Tracer via service loader
+// and not yet using the new TracerProvider
+class AzureSdkTestOld {
+
+  @RegisterExtension
+  public static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  @Test
+  void testHelperClassesInjected() {
+    com.azure.core.util.tracing.Tracer azTracer = createAzTracer();
+    assertThat(azTracer.isEnabled()).isTrue();
+
+    assertThat(azTracer.getClass().getName())
+        .isEqualTo(
+            "io.opentelemetry.javaagent.instrumentation.azurecore.v1_36.shaded"
+                + ".com.azure.core.tracing.opentelemetry.OpenTelemetryTracer");
+  }
+
+  @Test
+  void testSpan() {
+    com.azure.core.util.tracing.Tracer azTracer = createAzTracer();
+    Context context = azTracer.start("hello", Context.NONE);
+    azTracer.end(null, null, context);
+
+    testing.waitAndAssertTracesWithoutScopeVersionVerification(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("hello")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasStatus(StatusData.unset())
+                        .hasAttributesSatisfying(Attributes::isEmpty)));
+  }
+
+  private static com.azure.core.util.tracing.Tracer createAzTracer() {
+    Iterable<com.azure.core.util.tracing.Tracer> tracers = ServiceLoader.load(com.azure.core.util.tracing.Tracer.class);
+    Iterator<Tracer> it = tracers.iterator();
+    return it.hasNext() ? it.next() : null;
+  }
+}

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/src/test/java/AzureSdkTestOld.java
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/src/test/java/AzureSdkTestOld.java
@@ -52,7 +52,8 @@ class AzureSdkTestOld {
   }
 
   private static com.azure.core.util.tracing.Tracer createAzTracer() {
-    Iterable<com.azure.core.util.tracing.Tracer> tracers = ServiceLoader.load(com.azure.core.util.tracing.Tracer.class);
+    Iterable<com.azure.core.util.tracing.Tracer> tracers = ServiceLoader.load(
+        com.azure.core.util.tracing.Tracer.class);
     Iterator<Tracer> it = tracers.iterator();
     return it.hasNext() ? it.next() : null;
   }


### PR DESCRIPTION
cc @lmolkova @heyams

EventHubs is onboarded to new TracerProvider in https://github.com/Azure/azure-sdk-for-java/pull/33600

but current releases are using azure-core 1.36+ but are not using TracerProvider