### PR TITLE
Allow opting-in to gRPC deadline and cancellation propagation with the agent

### DIFF
--- a/instrumentation/grpc-1.6/README.md
+++ b/instrumentation/grpc-1.6/README.md
@@ -1,5 +1,6 @@
 # Settings for the gRPC instrumentation
 
-| System property | Type | Default | Description |
-|---|---|---|---|
-| `otel.instrumentation.grpc.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes. |
+| System property | Type | Default | Description                                                  |
+|---|---|---|--------------------------------------------------------------|
+| `otel.instrumentation.grpc.experimental-span-attributes` | Boolean | `false` | Enable the capture of experimental span attributes.          |
+| `otel.instrumentation.grpc.propagate-grpc-deadline` | Boolean | `false` | Allow gRPC contexts to propagate cancellation and deadlines. |

--- a/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
+++ b/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
@@ -23,9 +23,14 @@ public final class GrpcSingletons {
 
   public static final ServerInterceptor SERVER_INTERCEPTOR;
 
-  public static final Context.Storage STORAGE = new ContextStorageBridge(false);
+  public static final Context.Storage STORAGE;
 
   static {
+    boolean propagateGrpcDeadline =
+        InstrumentationConfig.get()
+            .getBoolean("otel.instrumentation.grpc.propagate-grpc-deadline", false);
+    STORAGE = new ContextStorageBridge(propagateGrpcDeadline);
+
     boolean experimentalSpanAttributes =
         InstrumentationConfig.get()
             .getBoolean("otel.instrumentation.grpc.experimental-span-attributes", false);


### PR DESCRIPTION
This PR adds a system property to toggle propagation of gRPC deadlines and cancellation between contexts (defaults to false to preserve status quo behavior).  See https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8923 for an explanation of why this is useful.