### PR TITLE
Add comment

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,9 @@ pluginManagement {
 plugins {
   id("com.gradle.enterprise") version "3.13.4"
   id("com.gradle.common-custom-user-data-gradle-plugin") version "1.11"
+  // this is needed for auto provisioning toolchains when running locally, e.g.
+  // gradlew -PtestJavaVM=openj9 -PtestJavaVersion=17
+  // (github workflows install the required JVM before running the tests)
   id("org.gradle.toolchains.foojay-resolver-convention") version "0.6.0"
 }
 


### PR DESCRIPTION
Follow-up to #8915

@laurit do you think we need the foojay plugin under `gradle-plugins`?

https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/fce77cc0446876fa7184028952a251fcab1e3c66/gradle-plugins/settings.gradle.kts#L9