### PR TITLE
Allow overriding span name in spring web library instrumentation

### DIFF
--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/main/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebTelemetryBuilder.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientAttributesExtractorBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientExperimentalMetrics;
@@ -19,6 +20,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtr
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 
@@ -34,6 +37,10 @@ public final class SpringWebTelemetryBuilder {
           HttpClientAttributesExtractor.builder(
               SpringWebHttpAttributesGetter.INSTANCE, new SpringWebNetAttributesGetter());
   private boolean emitExperimentalHttpClientMetrics = false;
+
+  @Nullable
+  private Function<SpanNameExtractor<HttpRequest>, ? extends SpanNameExtractor<? super HttpRequest>>
+      spanNameExtractorTransformer;
 
   SpringWebTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
@@ -69,6 +76,15 @@ public final class SpringWebTelemetryBuilder {
   @CanIgnoreReturnValue
   public SpringWebTelemetryBuilder setCapturedResponseHeaders(List<String> responseHeaders) {
     httpAttributesExtractorBuilder.setCapturedResponseHeaders(responseHeaders);
+    return this;
+  }
+
+  /** Sets custom {@link SpanNameExtractor} via transform function. */
+  @CanIgnoreReturnValue
+  public SpringWebTelemetryBuilder setSpanNameExtractor(
+      Function<SpanNameExtractor<HttpRequest>, ? extends SpanNameExtractor<? super HttpRequest>>
+          spanNameExtractor) {
+    this.spanNameExtractorTransformer = spanNameExtractor;
     return this;
   }
 
@@ -111,11 +127,16 @@ public final class SpringWebTelemetryBuilder {
   public SpringWebTelemetry build() {
     SpringWebHttpAttributesGetter httpAttributeGetter = SpringWebHttpAttributesGetter.INSTANCE;
 
+    SpanNameExtractor<HttpRequest> originalSpanNameExtractor =
+        HttpSpanNameExtractor.create(httpAttributeGetter);
+    SpanNameExtractor<? super HttpRequest> spanNameExtractor = originalSpanNameExtractor;
+    if (spanNameExtractorTransformer != null) {
+      spanNameExtractor = spanNameExtractorTransformer.apply(originalSpanNameExtractor);
+    }
+
     InstrumenterBuilder<HttpRequest, ClientHttpResponse> builder =
         Instrumenter.<HttpRequest, ClientHttpResponse>builder(
-                openTelemetry,
-                INSTRUMENTATION_NAME,
-                HttpSpanNameExtractor.create(httpAttributeGetter))
+                openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributeGetter))
             .addAttributesExtractor(httpAttributesExtractorBuilder.build())
             .addAttributesExtractors(additionalExtractors)

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetryBuilder.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcTelemetryBuilder.java
@@ -9,6 +9,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteHolder;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesExtractorBuilder;
@@ -18,6 +19,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtr
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -33,6 +36,12 @@ public final class SpringWebMvcTelemetryBuilder {
       httpAttributesExtractorBuilder =
           HttpServerAttributesExtractor.builder(
               SpringWebMvcHttpAttributesGetter.INSTANCE, SpringWebMvcNetAttributesGetter.INSTANCE);
+
+  @Nullable
+  private Function<
+          SpanNameExtractor<HttpServletRequest>,
+          ? extends SpanNameExtractor<? super HttpServletRequest>>
+      spanNameExtractorTransformer;
 
   SpringWebMvcTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
@@ -71,6 +80,17 @@ public final class SpringWebMvcTelemetryBuilder {
     return this;
   }
 
+  /** Sets custom {@link SpanNameExtractor} via transform function. */
+  @CanIgnoreReturnValue
+  public SpringWebMvcTelemetryBuilder setSpanNameExtractor(
+      Function<
+              SpanNameExtractor<HttpServletRequest>,
+              ? extends SpanNameExtractor<? super HttpServletRequest>>
+          spanNameExtractor) {
+    this.spanNameExtractorTransformer = spanNameExtractor;
+    return this;
+  }
+
   /**
    * Configures the instrumentation to recognize an alternative set of HTTP request methods.
    *
@@ -98,11 +118,16 @@ public final class SpringWebMvcTelemetryBuilder {
     SpringWebMvcHttpAttributesGetter httpAttributesGetter =
         SpringWebMvcHttpAttributesGetter.INSTANCE;
 
+    SpanNameExtractor<HttpServletRequest> originalSpanNameExtractor =
+        HttpSpanNameExtractor.create(httpAttributesGetter);
+    SpanNameExtractor<? super HttpServletRequest> spanNameExtractor = originalSpanNameExtractor;
+    if (spanNameExtractorTransformer != null) {
+      spanNameExtractor = spanNameExtractorTransformer.apply(originalSpanNameExtractor);
+    }
+
     Instrumenter<HttpServletRequest, HttpServletResponse> instrumenter =
         Instrumenter.<HttpServletRequest, HttpServletResponse>builder(
-                openTelemetry,
-                INSTRUMENTATION_NAME,
-                HttpSpanNameExtractor.create(httpAttributesGetter))
+                openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
             .setSpanStatusExtractor(HttpSpanStatusExtractor.create(httpAttributesGetter))
             .addAttributesExtractor(httpAttributesExtractorBuilder.build())
             .addAttributesExtractors(additionalExtractors)


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8839
In `spring-webmvc` it is still possible that updating route overwrites the name from the span extractor.