### PR TITLE
Remove okhttp debug output from smoke tests

### DIFF
--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
@@ -23,7 +23,11 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
     // while modern JVMs understand linux container memory limits, they do not understand windows
     // container memory limits yet, so we need to explicitly set max heap in order to prevent the
     // JVM from taking too much memory and hitting the windows container memory limit
-    environment.put(jvmArgsEnvVarName, "-Xmx512m -javaagent:/" + TARGET_AGENT_FILENAME);
+    environment.put(
+        jvmArgsEnvVarName,
+        "-Xmx512m -javaagent:/"
+            + TARGET_AGENT_FILENAME
+            + " -Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.okhttp3.internal.concurrent.TaskRunner=INFO");
     environment.put("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1");
     environment.put("OTEL_BSP_SCHEDULE_DELAY", "10ms");
     environment.put("OTEL_METRIC_EXPORT_INTERVAL", "1000");


### PR DESCRIPTION
Disables output like
```
App - STDERR: [otel.javaagent 2023-07-13 10:10:31:084 +0000] [OkHttp http://backend:8080/...] DEBUG okhttp3.internal.concurrent.TaskRunner - Q10001 scheduled after   0 µs: OkHttp ConnectionPool
App - STDERR: [otel.javaagent 2023-07-13 10:10:31:085 +0000] [OkHttp TaskRunner] DEBUG okhttp3.internal.concurrent.TaskRunner - Q10001 starting              : OkHttp ConnectionPool
App - STDERR: [otel.javaagent 2023-07-13 10:10:31:085 +0000] [OkHttp ConnectionPool] DEBUG okhttp3.internal.concurrent.TaskRunner - Q10001 run again after 300 s : OkHttp ConnectionPool
App - STDERR: [otel.javaagent 2023-07-13 10:10:31:086 +0000] [OkHttp TaskRunner] DEBUG okhttp3.internal.concurrent.TaskRunner - Q10001 finished run in 504 µs: OkHttp ConnectionPool
```
I guess we don't see these in regular tests because we are using in memory exporter. Maybe should disable this is agent conf?