### PR TITLE
Rework grpc cancelation propagation

### DIFF
--- a/instrumentation/grpc-1.6/javaagent/build.gradle.kts
+++ b/instrumentation/grpc-1.6/javaagent/build.gradle.kts
@@ -36,5 +36,11 @@ tasks {
     jvmArgs("-Dotel.javaagent.experimental.thread-propagation-debugger.enabled=false")
     jvmArgs("-Dotel.instrumentation.grpc.capture-metadata.client.request=some-client-key")
     jvmArgs("-Dotel.instrumentation.grpc.capture-metadata.server.request=some-server-key")
+
+    // exclude our grpc library instrumentation, the ContextStorageOverride contained within it
+    // breaks the tests
+    classpath = classpath.filter {
+      !it.absolutePath.contains("opentelemetry-grpc-1.6")
+    }
   }
 }

--- a/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcContextInstrumentation.java
+++ b/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcContextInstrumentation.java
@@ -36,14 +36,20 @@ public class GrpcContextInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class ContextBridgeAdvice {
 
-    @Advice.OnMethodEnter(skipOn = Advice.OnDefaultValue.class)
-    public static Object onEnter() {
-      return null;
+    @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class)
+    public static Context.Storage onEnter() {
+      return GrpcSingletons.getStorage();
     }
 
     @Advice.OnMethodExit
-    public static void onExit(@Advice.Return(readOnly = false) Context.Storage storage) {
-      storage = GrpcSingletons.STORAGE;
+    public static void onExit(
+        @Advice.Return(readOnly = false) Context.Storage storage,
+        @Advice.Enter Context.Storage ourStorage) {
+      if (ourStorage != null) {
+        storage = ourStorage;
+      } else {
+        storage = GrpcSingletons.setStorage(storage);
+      }
     }
   }
 }

--- a/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
+++ b/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
 import io.opentelemetry.instrumentation.grpc.v1_6.internal.ContextStorageBridge;
 import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 // Holds singleton references.
 public final class GrpcSingletons {
@@ -23,7 +24,7 @@ public final class GrpcSingletons {
 
   public static final ServerInterceptor SERVER_INTERCEPTOR;
 
-  public static final Context.Storage STORAGE = new ContextStorageBridge(false);
+  private static final AtomicReference<Context.Storage> STORAGE_REFERENCE = new AtomicReference<>();
 
   static {
     boolean experimentalSpanAttributes =
@@ -46,6 +47,15 @@ public final class GrpcSingletons {
 
     CLIENT_INTERCEPTOR = telemetry.newClientInterceptor();
     SERVER_INTERCEPTOR = telemetry.newServerInterceptor();
+  }
+
+  public static Context.Storage getStorage() {
+    return STORAGE_REFERENCE.get();
+  }
+
+  public static Context.Storage setStorage(Context.Storage storage) {
+    STORAGE_REFERENCE.compareAndSet(null, new ContextStorageBridge(storage));
+    return getStorage();
   }
 
   private GrpcSingletons() {}

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/ContextStorageBridge.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/ContextStorageBridge.java
@@ -28,11 +28,24 @@ public final class ContextStorageBridge extends Context.Storage {
   private static final Context.Key<io.opentelemetry.context.Context> OTEL_CONTEXT =
       Context.key("otel-context");
   private static final Context.Key<Scope> OTEL_SCOPE = Context.key("otel-scope");
+  // context attached to original context store
+  private static final Context.Key<Context> ORIGINAL_CONTEXT = Context.key("original-context");
+  // context that should be restored in original context store on detach
+  private static final Context.Key<Context> ORIGINAL_TO_RESTORE =
+      Context.key("original-to-restore");
 
   private final boolean propagateGrpcDeadline;
+  // original context storage that would have been used when running without agent
+  private final Context.Storage originalStorage;
 
   public ContextStorageBridge(boolean propagateGrpcDeadline) {
     this.propagateGrpcDeadline = propagateGrpcDeadline;
+    this.originalStorage = null;
+  }
+
+  public ContextStorageBridge(Context.Storage originalStorage) {
+    propagateGrpcDeadline = false;
+    this.originalStorage = originalStorage;
   }
 
   @Override
@@ -45,7 +58,9 @@ public final class ContextStorageBridge extends Context.Storage {
     }
 
     if (current == toAttach) {
-      return current.withValue(OTEL_SCOPE, Scope.noop());
+      Context result = current.withValue(OTEL_SCOPE, Scope.noop());
+      result = attachOriginalContextStorage(result);
+      return result;
     }
 
     io.opentelemetry.context.Context base = OTEL_CONTEXT.get(toAttach);
@@ -64,11 +79,28 @@ public final class ContextStorageBridge extends Context.Storage {
     }
 
     Scope scope = newOtelContext.makeCurrent();
-    return current.withValue(OTEL_SCOPE, scope);
+    Context result = current.withValue(OTEL_SCOPE, scope);
+    result = attachOriginalContextStorage(result);
+    return result;
+  }
+
+  private Context attachOriginalContextStorage(Context context) {
+    Context result = context;
+    if (originalStorage != null) {
+      Context originalToRestore = originalStorage.doAttach(result);
+      result = result.withValues(ORIGINAL_CONTEXT, result, ORIGINAL_TO_RESTORE, originalToRestore);
+    }
+    return result;
   }
 
   @Override
   public void detach(Context toDetach, Context toRestore) {
+    if (originalStorage != null) {
+      Context originalContext = ORIGINAL_CONTEXT.get(toRestore);
+      Context originalToRestore = ORIGINAL_TO_RESTORE.get(toRestore);
+      originalStorage.detach(originalContext, originalToRestore);
+    }
+
     Scope scope = OTEL_SCOPE.get(toRestore);
     if (scope == null) {
       logger.log(
@@ -93,17 +125,18 @@ public final class ContextStorageBridge extends Context.Storage {
       // create a new context referring to the current OTel context to reflect the current stack.
       // The previous context is unaffected and will continue to live in its own stack.
 
-      if (!propagateGrpcDeadline) {
-        // Because we are propagating gRPC context via OpenTelemetry here, we may also propagate a
-        // deadline where it
-        // wasn't present before. Notably, this could happen with no user intention when using the
-        // javaagent which will
-        // add OpenTelemetry propagation automatically, and cause that code to fail with a deadline
-        // cancellation. While
-        // ideally we could propagate deadline as well as gRPC intended, we cannot have existing
-        // code fail because it
-        // added the javaagent and choose to fork here.
-        current = current.fork();
+      if (!propagateGrpcDeadline && originalStorage != null) {
+        Context originalCurrent = originalStorage.current();
+        // check whether grpc context would have propagated without otel context
+        if (originalCurrent == null) {
+          // Because we are propagating gRPC context via OpenTelemetry here, we may also propagate a
+          // deadline where it wasn't present before. Notably, this could happen with no user
+          // intention when using the javaagent which will add OpenTelemetry propagation
+          // automatically, and cause that code to fail with a deadline cancellation. While ideally
+          // we could propagate deadline as well as gRPC intended, we cannot have existing code fail
+          // because it added the javaagent and choose to fork here.
+          current = current.fork();
+        }
       }
 
       return current.withValue(OTEL_CONTEXT, otelContext);

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/ContextStorageBridge.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/ContextStorageBridge.java
@@ -128,7 +128,7 @@ public final class ContextStorageBridge extends Context.Storage {
       if (!propagateGrpcDeadline && originalStorage != null) {
         Context originalCurrent = originalStorage.current();
         // check whether grpc context would have propagated without otel context
-        if (originalCurrent == null) {
+        if (originalCurrent == null || originalCurrent == Context.ROOT) {
           // Because we are propagating gRPC context via OpenTelemetry here, we may also propagate a
           // deadline where it wasn't present before. Notably, this could happen with no user
           // intention when using the javaagent which will add OpenTelemetry propagation


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8923
When running with the agent we switch grpc context storage to use opentelemetry context. As described in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4169#issuecomment-1064878066 this strategy works too well, context propagation sometimes happens when originally context was not propagated. This has the side effect of also propagating deadlines to calls that previously didn't have them. This is corrected in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5543 Unfortunately this has the side effect that now deadlines and cancellations aren't sometimes propagated when they are with the original context store implementation. https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8924 introduces a flag that allows users to decide whether cancelation and deadlines should propagate. Such flags aren't ideal because users need to figure out what works for them. This pr explores an alternative strategy where, instead of completely replacing the original context storage, we'll track propagation through both otel context and the original context storage. When we discover that context was propagated through otel, but not with the original context storage, we'll fork the grpc context to break cancellation propagation. Hopefully this way deadlines and cancellation are propagated only when they are propagated without the agent. This pr can coexist with the flag introduced in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8924