### PR TITLE
Generate the Spring configuration metadata for the OTel autoconfiguration

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
@@ -50,6 +50,8 @@ dependencies {
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service-annotations")
 
+  annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:$springBootVersion")
+
   testLibrary("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
     exclude("org.junit.vintage", "junit-vintage-engine")
   }


### PR DESCRIPTION
This PR will generate the [Spring configuration metadata](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html#appendix.configuration-metadata.annotation-processor) for the OTel autoconfiguration.

Below is an extract of the generated `spring-configuration-metadata.json` file in  `META_INF`:

```json
    {
      "name": "otel.exporter.otlp.enabled",
      "type": "java.lang.Boolean",
      "sourceType": "io.opentelemetry.instrumentation.spring.autoconfigure.exporters.otlp.OtlpExporterProperties",
      "defaultValue": true
    },
    {
      "name": "otel.exporter.otlp.endpoint",
      "type": "java.lang.String",
      "sourceType": "io.opentelemetry.instrumentation.spring.autoconfigure.exporters.otlp.OtlpExporterProperties"
    },
    {
      "name": "otel.exporter.otlp.logs.enabled",
      "type": "java.lang.Boolean",
      "sourceType": "io.opentelemetry.instrumentation.spring.autoconfigure.exporters.otlp.OtlpExporterProperties$SignalProperties",
      "defaultValue": true
    }
```