### PR TITLE
Test vertx-web with version 4

### DIFF
--- a/instrumentation/vertx/vertx-web-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/build.gradle.kts
@@ -33,6 +33,17 @@ testing {
       }
     }
 
+    val version4Test by registering(JvmTestSuite::class) {
+      dependencies {
+        implementation(project(":instrumentation:vertx:vertx-web-3.0:testing"))
+
+        implementation("io.vertx:vertx-web:4.0.0")
+        implementation("io.vertx:vertx-jdbc-client:4.0.0")
+        implementation("io.vertx:vertx-codegen:4.0.0")
+        implementation("io.vertx:vertx-docgen:3.5.1")
+      }
+    }
+
     val latestDepTest by registering(JvmTestSuite::class) {
       dependencies {
         implementation(project(":instrumentation:vertx:vertx-web-3.0:testing"))

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/src/latestDepTest/java/server/VertxLatestWebServer.java
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/src/latestDepTest/java/server/VertxLatestWebServer.java
@@ -6,20 +6,9 @@
 package server;
 
 import io.vertx.core.Promise;
-import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.Router;
 
 public class VertxLatestWebServer extends AbstractVertxWebServer {
-
-  @Override
-  public void end(HttpServerResponse response) {
-    response.end();
-  }
-
-  @Override
-  public void end(HttpServerResponse response, String message) {
-    response.end(message);
-  }
 
   @Override
   public void start(Promise<Void> startPromise) {

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/src/latestDepTest/java/server/VertxLatestWebServer.java
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/src/latestDepTest/java/server/VertxLatestWebServer.java
@@ -5,16 +5,19 @@
 
 package server;
 
+import static server.VertxRouterBuddy.CONFIG_HTTP_SERVER_PORT;
+import static server.VertxRouterBuddy.buildRouter;
+
+import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.ext.web.Router;
 
-public class VertxLatestWebServer extends AbstractVertxWebServer {
+public class VertxLatestWebServer extends AbstractVerticle {
 
   @Override
   public void start(Promise<Void> startPromise) {
     int port = config().getInteger(CONFIG_HTTP_SERVER_PORT);
-    Router router = buildRouter();
-
+    Router router = buildRouter(vertx);
     vertx.createHttpServer().requestHandler(router).listen(port, it -> startPromise.complete());
   }
 }

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/src/version3Test/java/server/VertxWebServer.java
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/src/version3Test/java/server/VertxWebServer.java
@@ -5,16 +5,19 @@
 
 package server;
 
+import static server.VertxRouterBuddy.CONFIG_HTTP_SERVER_PORT;
+import static server.VertxRouterBuddy.buildRouter;
+
+import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.ext.web.Router;
 
-public class VertxWebServer extends AbstractVertxWebServer {
+public class VertxWebServer extends AbstractVerticle {
 
   @Override
   public void start(Future<Void> startFuture) {
     int port = config().getInteger(CONFIG_HTTP_SERVER_PORT);
-    Router router = buildRouter();
-
+    Router router = buildRouter(vertx);
     vertx
         .createHttpServer()
         .requestHandler(router::accept)

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/src/version3Test/java/server/VertxWebServer.java
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/src/version3Test/java/server/VertxWebServer.java
@@ -6,20 +6,9 @@
 package server;
 
 import io.vertx.core.Future;
-import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.Router;
 
 public class VertxWebServer extends AbstractVertxWebServer {
-
-  @Override
-  public void end(HttpServerResponse response) {
-    response.end();
-  }
-
-  @Override
-  public void end(HttpServerResponse response, String message) {
-    response.end(message);
-  }
 
   @Override
   public void start(Future<Void> startFuture) {

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/src/version4Test/groovy/server/VertxHttpServerTest.groovy
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/src/version4Test/groovy/server/VertxHttpServerTest.groovy
@@ -1,0 +1,16 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package server
+
+import io.vertx.core.AbstractVerticle
+
+class VertxHttpServerTest extends AbstractVertxHttpServerTest {
+
+  @Override
+  protected Class<? extends AbstractVerticle> verticle() {
+    return VertxWebServer
+  }
+}

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/src/version4Test/java/server/VertxWebServer.java
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/src/version4Test/java/server/VertxWebServer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package server;
+
+import static server.VertxRouterBuddy.CONFIG_HTTP_SERVER_PORT;
+import static server.VertxRouterBuddy.buildRouter;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.ext.web.Router;
+
+public class VertxWebServer extends AbstractVerticle {
+
+  @Override
+  public void start(Promise<Void> startFuture) {
+    int port = config().getInteger(CONFIG_HTTP_SERVER_PORT);
+    Router router = buildRouter(vertx);
+    vertx.createHttpServer().requestHandler(router).listen(port, it -> startFuture.complete());
+  }
+}

--- a/instrumentation/vertx/vertx-web-3.0/testing/src/main/groovy/server/AbstractVertxHttpServerTest.groovy
+++ b/instrumentation/vertx/vertx-web-3.0/testing/src/main/groovy/server/AbstractVertxHttpServerTest.groovy
@@ -27,7 +27,7 @@ abstract class AbstractVertxHttpServerTest extends HttpServerTest<Vertx> impleme
     CompletableFuture<Void> future = new CompletableFuture<>()
     server.deployVerticle(verticle().getName(),
       new DeploymentOptions()
-        .setConfig(new JsonObject().put(AbstractVertxWebServer.CONFIG_HTTP_SERVER_PORT, port))
+        .setConfig(new JsonObject().put(VertxRouterBuddy.CONFIG_HTTP_SERVER_PORT, port))
         .setInstances(3)) { res ->
       if (!res.succeeded()) {
         throw new IllegalStateException("Cannot deploy server Verticle", res.cause())

--- a/instrumentation/vertx/vertx-web-3.0/testing/src/main/java/server/AbstractVertxWebServer.java
+++ b/instrumentation/vertx/vertx-web-3.0/testing/src/main/java/server/AbstractVertxWebServer.java
@@ -17,16 +17,11 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import io.opentelemetry.instrumentation.test.base.HttpServerTest;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Handler;
-import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
 public abstract class AbstractVertxWebServer extends AbstractVerticle {
   public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port";
-
-  public abstract void end(HttpServerResponse response, String message);
-
-  public abstract void end(HttpServerResponse response);
 
   public Router buildRouter() {
     Router router = Router.router(vertx);
@@ -43,7 +38,7 @@ public abstract class AbstractVertxWebServer extends AbstractVerticle {
                 HttpServerTest.controller(
                     SUCCESS,
                     () -> {
-                      end(ctx.response().setStatusCode(SUCCESS.getStatus()), SUCCESS.getBody());
+                      ctx.response().setStatusCode(SUCCESS.getStatus()).end(SUCCESS.getBody());
                       return null;
                     });
               }
@@ -56,7 +51,7 @@ public abstract class AbstractVertxWebServer extends AbstractVerticle {
                     INDEXED_CHILD,
                     () -> {
                       INDEXED_CHILD.collectSpanAttributes(it -> ctx.request().getParam(it));
-                      end(ctx.response().setStatusCode(INDEXED_CHILD.getStatus()));
+                      ctx.response().setStatusCode(INDEXED_CHILD.getStatus()).end();
                       return null;
                     }));
     router
@@ -66,9 +61,9 @@ public abstract class AbstractVertxWebServer extends AbstractVerticle {
                 HttpServerTest.controller(
                     QUERY_PARAM,
                     () -> {
-                      end(
-                          ctx.response().setStatusCode(QUERY_PARAM.getStatus()),
-                          ctx.request().query());
+                      ctx.response()
+                          .setStatusCode(QUERY_PARAM.getStatus())
+                          .end(ctx.request().query());
                       return null;
                     }));
     router
@@ -78,10 +73,10 @@ public abstract class AbstractVertxWebServer extends AbstractVerticle {
                 HttpServerTest.controller(
                     REDIRECT,
                     () -> {
-                      end(
-                          ctx.response()
-                              .setStatusCode(REDIRECT.getStatus())
-                              .putHeader("location", REDIRECT.getBody()));
+                      ctx.response()
+                          .setStatusCode(REDIRECT.getStatus())
+                          .putHeader("location", REDIRECT.getBody())
+                          .end();
                       return null;
                     }));
     router
@@ -91,7 +86,7 @@ public abstract class AbstractVertxWebServer extends AbstractVerticle {
                 HttpServerTest.controller(
                     ERROR,
                     () -> {
-                      end(ctx.response().setStatusCode(ERROR.getStatus()), ERROR.getBody());
+                      ctx.response().setStatusCode(ERROR.getStatus()).end(ERROR.getBody());
                       return null;
                     }));
     router
@@ -110,9 +105,9 @@ public abstract class AbstractVertxWebServer extends AbstractVerticle {
                 HttpServerTest.controller(
                     PATH_PARAM,
                     () -> {
-                      end(
-                          ctx.response().setStatusCode(PATH_PARAM.getStatus()),
-                          ctx.request().getParam("id"));
+                      ctx.response()
+                          .setStatusCode(PATH_PARAM.getStatus())
+                          .end(ctx.request().getParam("id"));
                       return null;
                     }));
     router
@@ -122,12 +117,10 @@ public abstract class AbstractVertxWebServer extends AbstractVerticle {
                 HttpServerTest.controller(
                     CAPTURE_HEADERS,
                     () -> {
-                      end(
-                          ctx.response()
-                              .setStatusCode(CAPTURE_HEADERS.getStatus())
-                              .putHeader(
-                                  "X-Test-Response", ctx.request().getHeader("X-Test-Request")),
-                          CAPTURE_HEADERS.getBody());
+                      ctx.response()
+                          .setStatusCode(CAPTURE_HEADERS.getStatus())
+                          .putHeader("X-Test-Response", ctx.request().getHeader("X-Test-Request"))
+                          .end(CAPTURE_HEADERS.getBody());
                       return null;
                     }));
 

--- a/instrumentation/vertx/vertx-web-3.0/testing/src/main/java/server/VertxRouterBuddy.java
+++ b/instrumentation/vertx/vertx-web-3.0/testing/src/main/java/server/VertxRouterBuddy.java
@@ -15,15 +15,17 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
 import io.opentelemetry.instrumentation.test.base.HttpServerTest;
-import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
-public abstract class AbstractVertxWebServer extends AbstractVerticle {
+public final class VertxRouterBuddy {
   public static final String CONFIG_HTTP_SERVER_PORT = "http.server.port";
 
-  public Router buildRouter() {
+  private VertxRouterBuddy() {}
+
+  public static Router buildRouter(Vertx vertx) {
     Router router = Router.router(vertx);
 
     //noinspection Convert2Lambda


### PR DESCRIPTION
This is an attempt (that might fail!) to test vertx-web instrumentation with version 4.x.x. 

I had to make a few changes to the test code to get compatibility but it also made the class inheritance hierarchy simpler.

It isn't currently passing when running locally and I'm looking for some input/help.