### PR TITLE
Lettuce instrumentation - optimization to avoid extra toString()

### DIFF
--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/lettuce/core/protocol/OtelCommandArgsUtil.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/lettuce/core/protocol/OtelCommandArgsUtil.java
@@ -5,6 +5,7 @@
 
 package io.lettuce.core.protocol;
 
+import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.protocol.CommandArgs.KeyArgument;
 import io.lettuce.core.protocol.CommandArgs.SingularArgument;
 import io.lettuce.core.protocol.CommandArgs.ValueArgument;
@@ -22,18 +23,26 @@ public final class OtelCommandArgsUtil {
    */
   public static List<String> getCommandArgs(CommandArgs<?, ?> commandArgs) {
     List<String> result = new ArrayList<>();
+    StringCodec stringCodec = new StringCodec();
+
     for (SingularArgument argument : commandArgs.singularArguments) {
-      String value = argument.toString();
-      if (argument instanceof KeyArgument && value.startsWith("key<") && value.endsWith(">")) {
-        value = value.substring("key<".length(), value.length() - 1);
-      } else if (argument instanceof ValueArgument
-          && value.startsWith("value<")
-          && value.endsWith(">")) {
-        value = value.substring("value<".length(), value.length() - 1);
-      }
+      String value = getArgValue(stringCodec, argument);
       result.add(value);
     }
     return result;
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static String getArgValue(StringCodec stringCodec, SingularArgument argument) {
+    if (argument instanceof KeyArgument) {
+      KeyArgument keyArg = (KeyArgument) argument;
+      return stringCodec.decodeValue(keyArg.codec.encodeValue(keyArg.key));
+    }
+    if (argument instanceof ValueArgument) {
+      ValueArgument valueArg = (ValueArgument) argument;
+      return stringCodec.decodeValue(valueArg.codec.encodeValue(valueArg.val));
+    }
+    return argument.toString();
   }
 
   private OtelCommandArgsUtil() {}


### PR DESCRIPTION
Relates to #8907

The instrumentation was calling `SingularArgument.toString()` for every argument. In the case of `KeyArgument` and `ValueArgument`, the implementations of `toString()` serve only to wrap the value in a string literal `key<...>` or `value<...>` (respectively), which we then parsed back out.

So this change doesn't call `toString()` in those two cases, instead jumping right to the contents (essentially inlining the important part of the `toString()` implementation from the lettuce source). This both bypasses the extra parsing/unwrapping but also eliminates a `String.format()` that generated it in the first place.

All other argument types still use the vanilla toString() approach.