### PR TITLE
Cross test quarkus resteasy reactive with vertx-web instrumentation

### DIFF
--- a/instrumentation/quarkus-resteasy-reactive/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/quarkus/resteasy/reactive/OtelRequestContext.java
+++ b/instrumentation/quarkus-resteasy-reactive/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/quarkus/resteasy/reactive/OtelRequestContext.java
@@ -16,7 +16,7 @@ public final class OtelRequestContext {
     OtelRequestContext context = new OtelRequestContext();
     contextThreadLocal.set(context);
     ResteasyReactiveSpanName.INSTANCE.updateServerSpanName(
-        requestContext, HttpRouteSource.CONTROLLER);
+        requestContext, HttpRouteSource.NESTED_CONTROLLER);
     return context;
   }
 

--- a/instrumentation/quarkus-resteasy-reactive/quarkus2-testing/build.gradle.kts
+++ b/instrumentation/quarkus-resteasy-reactive/quarkus2-testing/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
   testInstrumentation(project(":instrumentation:quarkus-resteasy-reactive:javaagent"))
+  testInstrumentation(project(":instrumentation:vertx:vertx-web-3.0:javaagent"))
 
   testImplementation(project(":instrumentation:quarkus-resteasy-reactive:common-testing"))
   testImplementation("io.quarkus:quarkus-junit5")

--- a/instrumentation/quarkus-resteasy-reactive/quarkus3-testing/build.gradle.kts
+++ b/instrumentation/quarkus-resteasy-reactive/quarkus3-testing/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
   testInstrumentation(project(":instrumentation:quarkus-resteasy-reactive:javaagent"))
+  testInstrumentation(project(":instrumentation:vertx:vertx-web-3.0:javaagent"))
 
   testImplementation(project(":instrumentation:quarkus-resteasy-reactive:common-testing"))
   testImplementation("io.quarkus:quarkus-junit5")


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8873
Quarkus resteasy reactive needs to set route with `NESTED_CONTROLLER` because vert.x web instrumentation already sets the route with `CONTROLLER`