### PR TITLE
Enable span sampling based on `thread.name` and `thread.id`

### DIFF
--- a/instrumentation-api/build.gradle.kts
+++ b/instrumentation-api/build.gradle.kts
@@ -14,6 +14,7 @@ group = "io.opentelemetry.instrumentation"
 dependencies {
   api("io.opentelemetry:opentelemetry-api")
   implementation("io.opentelemetry:opentelemetry-extension-incubator")
+  implementation("io.opentelemetry:opentelemetry-semconv")
 
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")

--- a/instrumentation-api/build.gradle.kts
+++ b/instrumentation-api/build.gradle.kts
@@ -14,7 +14,6 @@ group = "io.opentelemetry.instrumentation"
 dependencies {
   api("io.opentelemetry:opentelemetry-api")
   implementation("io.opentelemetry:opentelemetry-extension-incubator")
-  implementation("io.opentelemetry:opentelemetry-semconv")
 
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter;
 
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
@@ -21,9 +24,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
-
-import static io.opentelemetry.api.common.AttributeKey.longKey;
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 /**
  * The {@link Instrumenter} encapsulates the entire logic for gathering telemetry, from collecting

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.instrumenter;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
@@ -20,6 +21,9 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 /**
  * The {@link Instrumenter} encapsulates the entire logic for gathering telemetry, from collecting
@@ -42,6 +46,12 @@ import javax.annotation.Nullable;
  * the Instrumenter API</a> page.
  */
 public class Instrumenter<REQUEST, RESPONSE> {
+
+  /** Current &quot;managed&quot; thread ID (as opposed to OS thread ID). */
+  private static final AttributeKey<Long> THREAD_ID = longKey("thread.id");
+
+  /** Current thread name. */
+  private static final AttributeKey<String> THREAD_NAME = stringKey("thread.name");
 
   /**
    * Returns a new {@link InstrumenterBuilder}.
@@ -187,6 +197,11 @@ public class Instrumenter<REQUEST, RESPONSE> {
     }
 
     boolean localRoot = LocalRootSpan.isLocalRoot(context);
+
+    // add thread.name and thread.id attributes to every span
+    Thread currentThread = Thread.currentThread();
+    spanBuilder.setAttribute(THREAD_NAME, currentThread.getName());
+    spanBuilder.setAttribute(THREAD_ID, currentThread.getId());
 
     spanBuilder.setAllAttributes(attributes);
     Span span = spanBuilder.setParent(context).startSpan();

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -15,7 +15,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterAccess;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.SupportabilityMetrics;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +46,12 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
  * the Instrumenter API</a> page.
  */
 public class Instrumenter<REQUEST, RESPONSE> {
+
+  /** Current &quot;managed&quot; thread ID (as opposed to OS thread ID). */
+  private static final AttributeKey<Long> THREAD_ID = longKey("thread.id");
+
+  /** Current thread name. */
+  private static final AttributeKey<String> THREAD_NAME = stringKey("thread.name");
 
   /**
    * Returns a new {@link InstrumenterBuilder}.
@@ -195,8 +200,8 @@ public class Instrumenter<REQUEST, RESPONSE> {
 
     // add thread.name and thread.id attributes to every span
     Thread currentThread = Thread.currentThread();
-    spanBuilder.setAttribute(SemanticAttributes.THREAD_NAME, currentThread.getName());
-    spanBuilder.setAttribute(SemanticAttributes.THREAD_ID, currentThread.getId());
+    spanBuilder.setAttribute(THREAD_NAME, currentThread.getName());
+    spanBuilder.setAttribute(THREAD_ID, currentThread.getId());
 
     spanBuilder.setAllAttributes(attributes);
     Span span = spanBuilder.setParent(context).startSpan();

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -15,6 +15,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterAccess;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.SupportabilityMetrics;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -46,12 +47,6 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
  * the Instrumenter API</a> page.
  */
 public class Instrumenter<REQUEST, RESPONSE> {
-
-  /** Current &quot;managed&quot; thread ID (as opposed to OS thread ID). */
-  private static final AttributeKey<Long> THREAD_ID = longKey("thread.id");
-
-  /** Current thread name. */
-  private static final AttributeKey<String> THREAD_NAME = stringKey("thread.name");
 
   /**
    * Returns a new {@link InstrumenterBuilder}.
@@ -200,8 +195,8 @@ public class Instrumenter<REQUEST, RESPONSE> {
 
     // add thread.name and thread.id attributes to every span
     Thread currentThread = Thread.currentThread();
-    spanBuilder.setAttribute(THREAD_NAME, currentThread.getName());
-    spanBuilder.setAttribute(THREAD_ID, currentThread.getId());
+    spanBuilder.setAttribute(SemanticAttributes.THREAD_NAME, currentThread.getName());
+    spanBuilder.setAttribute(SemanticAttributes.THREAD_ID, currentThread.getId());
 
     spanBuilder.setAllAttributes(attributes);
     Span span = spanBuilder.setParent(context).startSpan();

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -213,8 +213,12 @@ class InstrumenterTest {
                                 equalTo(AttributeKey.stringKey("resp1"), "resp1_value"),
                                 equalTo(AttributeKey.stringKey("resp2"), "resp2_2_value"),
                                 equalTo(AttributeKey.stringKey("resp3"), "resp3_value"),
-                                equalTo(AttributeKey.stringKey("thread.name"), Thread.currentThread().getName()),
-                                equalTo(AttributeKey.longKey("thread.id"), Thread.currentThread().getId()))));
+                                equalTo(
+                                    AttributeKey.stringKey("thread.name"),
+                                    Thread.currentThread().getName()),
+                                equalTo(
+                                    AttributeKey.longKey("thread.id"),
+                                    Thread.currentThread().getId()))));
   }
 
   @Test
@@ -320,8 +324,12 @@ class InstrumenterTest {
                                 equalTo(AttributeKey.stringKey("resp1"), "resp1_value"),
                                 equalTo(AttributeKey.stringKey("resp2"), "resp2_2_value"),
                                 equalTo(AttributeKey.stringKey("resp3"), "resp3_value"),
-                                equalTo(AttributeKey.stringKey("thread.name"), Thread.currentThread().getName()),
-                                equalTo(AttributeKey.longKey("thread.id"), Thread.currentThread().getId()))));
+                                equalTo(
+                                    AttributeKey.stringKey("thread.name"),
+                                    Thread.currentThread().getName()),
+                                equalTo(
+                                    AttributeKey.longKey("thread.id"),
+                                    Thread.currentThread().getId()))));
   }
 
   @Test

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -212,7 +212,9 @@ class InstrumenterTest {
                                 equalTo(AttributeKey.stringKey("req3"), "req3_value"),
                                 equalTo(AttributeKey.stringKey("resp1"), "resp1_value"),
                                 equalTo(AttributeKey.stringKey("resp2"), "resp2_2_value"),
-                                equalTo(AttributeKey.stringKey("resp3"), "resp3_value"))));
+                                equalTo(AttributeKey.stringKey("resp3"), "resp3_value"),
+                                equalTo(AttributeKey.stringKey("thread.name"), Thread.currentThread().getName()),
+                                equalTo(AttributeKey.longKey("thread.id"), Thread.currentThread().getId()))));
   }
 
   @Test
@@ -317,7 +319,10 @@ class InstrumenterTest {
                                 equalTo(AttributeKey.stringKey("req3"), "req3_value"),
                                 equalTo(AttributeKey.stringKey("resp1"), "resp1_value"),
                                 equalTo(AttributeKey.stringKey("resp2"), "resp2_2_value"),
-                                equalTo(AttributeKey.stringKey("resp3"), "resp3_value"))));
+                                equalTo(AttributeKey.stringKey("resp3"), "resp3_value"),
+                                equalTo(AttributeKey.stringKey("thread.name"), Thread.currentThread().getName()),
+                                equalTo(AttributeKey.longKey("thread.id"), Thread.currentThread().getId()))));
+
   }
 
   @Test

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -322,7 +322,6 @@ class InstrumenterTest {
                                 equalTo(AttributeKey.stringKey("resp3"), "resp3_value"),
                                 equalTo(AttributeKey.stringKey("thread.name"), Thread.currentThread().getName()),
                                 equalTo(AttributeKey.longKey("thread.id"), Thread.currentThread().getId()))));
-
   }
 
   @Test


### PR DESCRIPTION
Fix https://github.com/microsoft/ApplicationInsights-Java/issues/3145

Propose `sampling_relevant`: https://github.com/open-telemetry/semantic-conventions/pull/213

In order to enable span sampling based on `thread.name` and `thread.id`, these two thread attributes need to be added before `Span.startSpan()`. 

This proposal doesn't cover the case of manual instrumentation.

Alternatively, a `ThreadDetailsAttributeExtractor` can be used to add thread attributes. That will require changes to all instrumentations to `addAttributesExtractor` when initializing the `Instrumenter`.

