### PR TITLE
Fix timeouts in reactor-netty-1.0 tests (🤞)

### DIFF
--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/build.gradle.kts
@@ -35,7 +35,10 @@ dependencies {
   testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
   testInstrumentation(project(":instrumentation:reactor:reactor-3.1:javaagent"))
 
-  testLibrary("io.projectreactor:reactor-test:3.1.0.RELEASE")
+  // using 3.4.3 to avoid the "Spec. Rule 1.3" issue in reactor-core during tests
+  // https://github.com/reactor/reactor-core/issues/2579
+  testLibrary("io.projectreactor:reactor-test:3.4.3")
+  testLibrary("io.projectreactor:reactor-core:3.4.3")
   testImplementation(project(":instrumentation-annotations"))
 
   latestDepTestLibrary("io.projectreactor:reactor-core:3.4.+")

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestServer.java
@@ -55,7 +55,7 @@ public final class HttpClientTestServer extends ServerExtension {
         .https(0)
         .tls(kmf)
         // not cleaning idle connections so eagerly helps minimize failures in HTTP client tests
-        .idleTimeout(Duration.ofSeconds(30))
+        .idleTimeout(Duration.ofSeconds(60))
         .service(
             "/success",
             (ctx, req) -> {


### PR DESCRIPTION
Lots of reactor-netty runs in CI have started timing out recently, I dug out the following error that's probably the underlying cause:

```
reactor.core.publisher.Sinks$EmissionException: Spec. Rule 1.3 - onSubscribe, onNext, onError and onComplete signaled to a Subscriber MUST be signaled serially. |  
-- | --
  | at reactor.core.publisher.InternalManySink.emitNext(InternalManySink.java:56) |  
  | at reactor.core.publisher.FluxRetryWhen$RetryWhenMainSubscriber.onError(FluxRetryWhen.java:191) |  
  | at io.opentelemetry.javaagent.shaded.instrumentation.reactor.v3_1.TracingSubscriber.lambda$onError$2(TracingSubscriber.java:74) |  
  | at io.opentelemetry.javaagent.shaded.instrumentation.reactor.v3_1.TracingSubscriber.withActiveSpan(TracingSubscriber.java:97) |  
  | at io.opentelemetry.javaagent.shaded.instrumentation.reactor.v3_1.TracingSubscriber.onError(TracingSubscriber.java:74) |  
  | at reactor.core.publisher.MonoCreate$DefaultMonoSink.error(MonoCreate.java:189) |  
  | at reactor.netty.http.client.HttpClientConnect$HttpObserver.onUncaughtException(HttpClientConnect.java:339) |  
  | at reactor.netty.ReactorNetty$CompositeConnectionObserver.onUncaughtException(ReactorNetty.java:605) |  
  | at reactor.netty.resources.DefaultPooledConnectionProvider$DisposableAcquire.onUncaughtException(DefaultPooledConnectionProvider.java:212) |  
  | at reactor.netty.resources.DefaultPooledConnectionProvider$PooledConnection.onUncaughtException(DefaultPooledConnectionProvider.java:473) |  
  | at reactor.netty.http.client.HttpClientOperations.afterInboundComplete(HttpClientOperations.java:298) |  
  | at reactor.netty.channel.ChannelOperations.terminate(ChannelOperations.java:455) |  
  | at reactor.netty.http.client.HttpClientOperations.onInboundNext(HttpClientOperations.java:664) |  
  | at reactor.netty.channel.ChannelOperationsHandler.channelRead(ChannelOperationsHandler.java:94) |  
  | at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) |  
  | at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) |  
  | at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) |  
  | at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436) |  
  | at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93) |  
  | at io.opentelemetry.javaagent.shaded.instrumentation.netty.v4_1.internal.client.HttpClientResponseTracingHandler.channelRead(HttpClientResponseTracingHandler.java:44)
```

This is _probably_ issue https://github.com/reactor/reactor-core/issues/2579 -- I don't know why it surfaced just now and not before, it's probably related to my recent refactoring.

Resolves #9045
