### PR TITLE
Document configuration options for logback appender library

### DIFF
--- a/instrumentation/logback/logback-appender-1.0/javaagent/README.md
+++ b/instrumentation/logback/logback-appender-1.0/javaagent/README.md
@@ -6,6 +6,6 @@
 | `otel.instrumentation.logback-appender.experimental.capture-code-attributes`           | Boolean | `false` | Enable the capture of [source code attributes]. Note that capturing source code attributes at logging sites might add a performance overhead. |
 | `otel.instrumentation.logback-appender.experimental.capture-marker-attribute`          | Boolean | `false` | Enable the capture of Logback markers as attributes.                                                                                          |
 | `otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes` | Boolean | `false` | Enable the capture of Logback key value pairs as attributes.                                                                                  |
-| `otel.instrumentation.logback-appender.experimental.capture-mdc-attributes`            | String  |         | List of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                                  |
+| `otel.instrumentation.logback-appender.experimental.capture-mdc-attributes`            | String  |         | Comma separated list of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                  |
 
 [source code attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#source-code-attributes

--- a/instrumentation/logback/logback-appender-1.0/library/README.md
+++ b/instrumentation/logback/logback-appender-1.0/library/README.md
@@ -80,3 +80,26 @@ public class Application {
   }
 }
 ```
+
+#### Settings for the Logback Appender
+
+Settings can be configured in `logback.xml`, for example:
+
+```xml
+<appender name="OpenTelemetry" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+  <captureExperimentalAttributes>true</captureExperimentalAttributes>
+  <captureMdcAttributes>*</captureMdcAttributes>
+</appender>
+```
+
+The available settings are:
+
+| XML Element                     | Type    | Default | Description                                                                                                                                   |
+| ------------------------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `captureExperimentalAttributes` | Boolean | `false` | Enable the capture of experimental span attributes `thread.name` and `thread.id`.                                                             |
+| `captureCodeAttributes`         | Boolean | `false` | Enable the capture of [source code attributes]. Note that capturing source code attributes at logging sites might add a performance overhead. |
+| `captureMarkerAttribute`        | Boolean | `false` | Enable the capture of Logback markers as attributes.                                                                                          |
+| `captureKeyValuePairAttributes` | Boolean | `false` | Enable the capture of Logback key value pairs as attributes.                                                                                  |
+| `captureMdcAttributes`          | String  |         | Comma separated list of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                  |
+
+[source code attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#source-code-attributes


### PR DESCRIPTION
Completes the logback task mentioned in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6947

For a quick link to the updated documentation: https://github.com/swar8080/opentelemetry-java-instrumentation/tree/logback-appender-configuration-documentation/instrumentation/logback/logback-appender-1.0/library