### PR TITLE
Document configuration options for log4j2 appender library

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/README.md
@@ -1,10 +1,10 @@
 # Settings for the Log4j Appender instrumentation
 
-| System property                                                                    | Type    | Default | Description                                                                                           |
-| ---------------------------------------------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------- |
-| `otel.instrumentation.log4j-appender.experimental-log-attributes`                  | Boolean | `false` | Enable the capture of experimental span attributes `thread.name` and `thread.id`.                     |
-| `otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes`  | Boolean | `false` | Enable the capture of `MapMessage` attributes.                                                        |
-| `otel.instrumentation.log4j-appender.experimental.capture-marker-attribute`        | Boolean | `false` | Enable the capture of Log4j markers as attributes.                                                    |
-| `otel.instrumentation.log4j-appender.experimental.capture-context-data-attributes` | String  |         | List of context data attributes to capture. Use the wildcard character `*` to capture all attributes. |
+| System property                                                                    | Type    | Default | Description                                                                                                           |
+| ---------------------------------------------------------------------------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| `otel.instrumentation.log4j-appender.experimental-log-attributes`                  | Boolean | `false` | Enable the capture of experimental span attributes `thread.name` and `thread.id`.                                     |
+| `otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes`  | Boolean | `false` | Enable the capture of `MapMessage` attributes.                                                                        |
+| `otel.instrumentation.log4j-appender.experimental.capture-marker-attribute`        | Boolean | `false` | Enable the capture of Log4j markers as attributes.                                                                    |
+| `otel.instrumentation.log4j-appender.experimental.capture-context-data-attributes` | String  |         | Comma separated list of context data attributes to capture. Use the wildcard character `*` to capture all attributes. |
 
 [source code attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#source-code-attributes

--- a/instrumentation/log4j/log4j-appender-2.17/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/library/README.md
@@ -76,3 +76,28 @@ public class Application {
   }
 }
 ```
+
+#### Settings for the Log4j Appender
+
+Setting can be configured as XML attributes, for example:
+
+```xml
+<Appenders>
+  <OpenTelemetry name="OpenTelemetryAppender"
+      captureMapMessageAttributes="true"
+      captureMarkerAttribute="true"
+      captureContextDataAttributes="*"
+  />
+</Appenders>
+```
+
+The available settings are:
+
+| XML Attribute                   | Type    | Default | Description                                                                                                           |
+| ------------------------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| `captureExperimentalAttributes` | Boolean | `false` | Enable the capture of experimental span attributes `thread.name` and `thread.id`.                                     |
+| `captureMapMessageAttributes`   | Boolean | `false` | Enable the capture of `MapMessage` attributes.                                                                        |
+| `captureMarkerAttribute;`       | Boolean | `false` | Enable the capture of Log4j markers as attributes.                                                                    |
+| `captureContextDataAttributes`  | String  |         | Comma separated list of context data attributes to capture. Use the wildcard character `*` to capture all attributes. |
+
+[source code attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#source-code-attributes


### PR DESCRIPTION
Completes the log4j task mentioned in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/6947

Also clarifies that the setting for extracting attributes from `ThreadContext` takes a comma separated list of properties to extract