### PR TITLE
Fix flaky rector netty test

### DIFF
--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/InstrumentationContexts.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/InstrumentationContexts.java
@@ -10,22 +10,18 @@ import static io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0.React
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientResend;
 import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.concurrent.LinkedBlockingQueue;
 import javax.annotation.Nullable;
 import reactor.netty.http.client.HttpClientRequest;
 import reactor.netty.http.client.HttpClientResponse;
 
 final class InstrumentationContexts {
 
-  private static final Logger logger = Logger.getLogger(InstrumentationContexts.class.getName());
-
   private volatile Context parentContext;
   // on retries, reactor-netty starts the next resend attempt before it ends the previous one (i.e.
-  // it calls the callback functions in that order); thus for a short moment there can be 2
+  // it calls the callback functions in that order); thus for a short moment there can be multiple
   // coexisting HTTP client spans
-  private final Queue<RequestAndContext> clientContexts = new ArrayBlockingQueue<>(2, true);
+  private final Queue<RequestAndContext> clientContexts = new LinkedBlockingQueue<>();
 
   void initialize(Context parentContext) {
     this.parentContext = HttpClientResend.initialize(parentContext);
@@ -47,13 +43,7 @@ final class InstrumentationContexts {
     Context context = null;
     if (instrumenter().shouldStart(parentContext, request)) {
       context = instrumenter().start(parentContext, request);
-      if (!clientContexts.offer(new RequestAndContext(request, context))) {
-        // should not ever happen in reality
-        String message =
-            "Could not instrument HTTP client request; not enough space in the request queue";
-        logger.log(Level.FINE, message);
-        instrumenter().end(context, request, null, new IllegalStateException(message));
-      }
+      clientContexts.offer(new RequestAndContext(request, context));
     }
     return context;
   }


### PR DESCRIPTION
https://ge.opentelemetry.io/s/tqskgtkgcnza6/tests/task/:instrumentation:reactor:reactor-netty:reactor-netty-1.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0.ReactorNettyHttpClientTest/circularRedirects()?expanded-stacktrace=WyIwIl0&page=eyJvdXRwdXQiOnsiMCI6MX19&top-execution=1
Apparently there can be more than 2 requests in flight.