### PR TITLE
Fix the build on OpenJ9

### DIFF
--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/AlternateUrlSchemeProviderTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/AlternateUrlSchemeProviderTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -36,14 +36,14 @@ class AlternateUrlSchemeProviderTest {
 
   @Test
   void noHeaders() {
-    when(getter.getHttpRequestHeader(eq(REQUEST), any())).thenReturn(emptyList());
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(eq(REQUEST), any());
     assertThat(underTest.apply(REQUEST)).isNull();
   }
 
   @ParameterizedTest
   @ArgumentsSource(ForwardedHeaderValues.class)
   void parseForwardedHeader(String headerValue, String expectedScheme) {
-    when(getter.getHttpRequestHeader(REQUEST, "forwarded")).thenReturn(singletonList(headerValue));
+    doReturn(singletonList(headerValue)).when(getter).getHttpRequestHeader(REQUEST, "forwarded");
     assertThat(underTest.apply(REQUEST)).isEqualTo(expectedScheme);
   }
 
@@ -71,9 +71,10 @@ class AlternateUrlSchemeProviderTest {
   @ParameterizedTest
   @ArgumentsSource(ForwardedProtoHeaderValues.class)
   void parseForwardedProtoHeader(String headerValue, String expectedScheme) {
-    when(getter.getHttpRequestHeader(REQUEST, "forwarded")).thenReturn(emptyList());
-    when(getter.getHttpRequestHeader(REQUEST, "x-forwarded-proto"))
-        .thenReturn(singletonList(headerValue));
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "forwarded");
+    doReturn(singletonList(headerValue))
+        .when(getter)
+        .getHttpRequestHeader(REQUEST, "x-forwarded-proto");
     assertThat(underTest.apply(REQUEST)).isEqualTo(expectedScheme);
   }
 


### PR DESCRIPTION
Fixes #9085
Fixes #9086

```
    org.mockito.exceptions.misusing.PotentialStubbingProblem: 
    Strict stubbing argument mismatch. Please check:
     - this invocation of 'getHttpRequestHeader' method:
        getter.getHttpRequestHeader(
        "request",
        "x-forwarded-proto"
    );
        -> at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     - has following stubbing(s) with different arguments:
        1. getter.getHttpRequestHeader(
        "request",
        "forwarded"
    );
          -> at io.opentelemetry.instrumentation.api.instrumenter.http.AlternateUrlSchemeProviderTest.parseForwardedProtoHeader(AlternateUrlSchemeProviderTest.java:74)
    Typically, stubbing argument mismatch indicates user mistake when writing tests.
    Mockito fails early so that you can debug potential problem easily.
    However, there are legit scenarios when this exception generates false negative signal:
      - stubbing the same method multiple times using 'given().will()' or 'when().then()' API
        Please use 'will().given()' or 'doReturn().when()' API for stubbing.
      - stubbed method is intentionally invoked with different arguments by code under test
        Please use default or 'silent' JUnit Rule (equivalent of Strictness.LENIENT).
    For more information see javadoc for PotentialStubbingProblem class.
        at app//io.opentelemetry.instrumentation.api.instrumenter.http.AlternateUrlSchemeProviderTest.parseForwardedProtoHeader(AlternateUrlSchemeProviderTest.java:75)
```

I suspect there's a weird OpenJ9 caveat at play here; let's just start with implementing the suggestion given by mockito and see if it works.