### PR TITLE
Rename `http.*.duration` to `http.*.request.duration`

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetrics.java
@@ -44,9 +44,13 @@ public final class HttpClientMetrics implements OperationListener {
   private final DoubleHistogram duration;
 
   private HttpClientMetrics(Meter meter) {
+    String durationInstrumentName =
+        HttpMetricsUtil.emitNewSemconvMetrics
+            ? "http.client.request.duration"
+            : "http.client.duration";
     duration =
         createDurationHistogram(
-            meter, "http.client.duration", "The duration of the outbound HTTP request");
+            meter, durationInstrumentName, "The duration of the outbound HTTP request");
   }
 
   @Override

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetrics.java
@@ -58,9 +58,13 @@ public final class HttpServerMetrics implements OperationListener {
             .setUnit("{requests}")
             .setDescription("The number of concurrent HTTP requests that are currently in-flight")
             .build();
+    String durationInstrumentName =
+        HttpMetricsUtil.emitNewSemconvMetrics
+            ? "http.server.request.duration"
+            : "http.server.duration";
     duration =
         createDurationHistogram(
-            meter, "http.server.duration", "The duration of the inbound HTTP request");
+            meter, durationInstrumentName, "The duration of the inbound HTTP request");
     requestSize =
         meter
             .histogramBuilder("http.server.request.size")

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsStableSemconvTest.java
@@ -82,7 +82,7 @@ class HttpClientMetricsStableSemconvTest {
         .satisfiesExactlyInAnyOrder(
             metric ->
                 assertThat(metric)
-                    .hasName("http.client.duration")
+                    .hasName("http.client.request.duration")
                     .hasUnit("s")
                     .hasHistogramSatisfying(
                         histogram ->
@@ -114,7 +114,7 @@ class HttpClientMetricsStableSemconvTest {
         .satisfiesExactlyInAnyOrder(
             metric ->
                 assertThat(metric)
-                    .hasName("http.client.duration")
+                    .hasName("http.client.request.duration")
                     .hasHistogramSatisfying(
                         histogram ->
                             histogram.hasPointsSatisfying(

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerMetricsStableSemconvTest.java
@@ -146,7 +146,7 @@ class HttpServerMetricsStableSemconvTest {
                                                     .hasSpanId(spanContext1.getSpanId())))),
             metric ->
                 assertThat(metric)
-                    .hasName("http.server.duration")
+                    .hasName("http.server.request.duration")
                     .hasUnit("s")
                     .hasHistogramSatisfying(
                         histogram ->
@@ -235,7 +235,7 @@ class HttpServerMetricsStableSemconvTest {
                                                     .hasSpanId(spanContext2.getSpanId())))),
             metric ->
                 assertThat(metric)
-                    .hasName("http.server.duration")
+                    .hasName("http.server.request.duration")
                     .hasHistogramSatisfying(
                         histogram ->
                             histogram.hasPointsSatisfying(
@@ -306,7 +306,7 @@ class HttpServerMetricsStableSemconvTest {
         .anySatisfy(
             metric ->
                 assertThat(metric)
-                    .hasName("http.server.duration")
+                    .hasName("http.server.request.duration")
                     .hasUnit("s")
                     .hasHistogramSatisfying(
                         histogram ->


### PR DESCRIPTION
Implements https://github.com/open-telemetry/semantic-conventions/pull/224