### PR TITLE
Handle kafka METRIC_REPORTER_CLASSES_CONFIG being set to a List

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
@@ -71,6 +71,7 @@ public final class KafkaSingletons {
 
   @SuppressWarnings("unchecked")
   public static void enhanceConfig(Map<? super String, Object> config) {
+    // skip enhancing configuration when metrics are disabled or when we have already enhanced it
     if (!METRICS_ENABLED
         || config.get(OpenTelemetryMetricsReporter.CONFIG_KEY_OPENTELEMETRY_INSTRUMENTATION_NAME)
             != null) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
@@ -16,8 +16,9 @@ import io.opentelemetry.instrumentation.kafka.internal.OpenTelemetrySupplier;
 import io.opentelemetry.javaagent.bootstrap.internal.DeprecatedConfigProperties;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
@@ -33,10 +34,6 @@ public final class KafkaSingletons {
   private static final boolean METRICS_ENABLED =
       InstrumentationConfig.get()
           .getBoolean("otel.instrumentation.kafka.metric-reporter.enabled", true);
-
-  private static final Pattern METRIC_REPORTER_PRESENT_PATTERN =
-      Pattern.compile(
-          "(^|,)" + Pattern.quote(OpenTelemetryMetricsReporter.class.getName()) + "($|,)");
 
   private static final Instrumenter<KafkaProducerRequest, RecordMetadata> PRODUCER_INSTRUMENTER;
   private static final Instrumenter<KafkaReceiveRequest, Void> CONSUMER_RECEIVE_INSTRUMENTER;
@@ -72,21 +69,27 @@ public final class KafkaSingletons {
     return CONSUMER_PROCESS_INSTRUMENTER;
   }
 
+  @SuppressWarnings("unchecked")
   public static void enhanceConfig(Map<? super String, Object> config) {
-    if (!METRICS_ENABLED) {
+    if (!METRICS_ENABLED
+        || config.get(OpenTelemetryMetricsReporter.CONFIG_KEY_OPENTELEMETRY_INSTRUMENTATION_NAME)
+            != null) {
       return;
     }
     config.merge(
         CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
         OpenTelemetryMetricsReporter.class.getName(),
         (class1, class2) -> {
-          if (class1 instanceof String) {
+          // class1 is either a class name or List of class names or classes
+          if (class1 instanceof List) {
+            List<Object> result = new ArrayList<>();
+            result.addAll((List<Object>) class1);
+            result.add(class2);
+            return result;
+          } else if (class1 instanceof String) {
             String className1 = (String) class1;
             if (className1.isEmpty()) {
               return class2;
-            }
-            if (METRIC_REPORTER_PRESENT_PATTERN.matcher(className1).find()) {
-              return class1;
             }
           }
           return class1 + "," + class2;

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/OpenTelemetryMetricsReporterTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/OpenTelemetryMetricsReporterTest.java
@@ -10,6 +10,7 @@ import static java.util.Collections.emptyMap;
 import io.opentelemetry.instrumentation.kafka.internal.AbstractOpenTelemetryMetricsReporterTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import java.util.Collections;
 import java.util.Map;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -46,6 +47,36 @@ class OpenTelemetryMetricsReporterTest extends AbstractOpenTelemetryMetricsRepor
 
     Map<String, Object> producerConfig = producerConfig();
     producerConfig.put(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, "");
+    new KafkaProducer<>(producerConfig).close();
+  }
+
+  @Test
+  void classListMetricsReporter() {
+    Map<String, Object> consumerConfig = consumerConfig();
+    consumerConfig.put(
+        CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
+        Collections.singletonList(TestMetricsReporter.class));
+    new KafkaConsumer<>(consumerConfig).close();
+
+    Map<String, Object> producerConfig = producerConfig();
+    producerConfig.put(
+        CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
+        Collections.singletonList(TestMetricsReporter.class));
+    new KafkaProducer<>(producerConfig).close();
+  }
+
+  @Test
+  void stringListMetricsReporter() {
+    Map<String, Object> consumerConfig = consumerConfig();
+    consumerConfig.put(
+        CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
+        Collections.singletonList(TestMetricsReporter.class.getName()));
+    new KafkaConsumer<>(consumerConfig).close();
+
+    Map<String, Object> producerConfig = producerConfig();
+    producerConfig.put(
+        CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
+        Collections.singletonList(TestMetricsReporter.class.getName()));
     new KafkaProducer<>(producerConfig).close();
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9143
For `METRIC_REPORTER_CLASSES_CONFIG` valid values seem to be a comma separated string with class names, list of classes and list of class names. Instead of checking with regex whether our metrics reporter has been added we'll now check whether instrumentation name has been added to config and is so skip enhancing. Duplicate enhancement happens because we do it in the constructors of producer/consumer and due to constructor chaining it may be called multiple times.