### PR TITLE
Remove unused guava dependency in testing-common

### DIFF
--- a/testing-common/build.gradle.kts
+++ b/testing-common/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
   api("org.assertj:assertj-core")
   // Needs to be api dependency due to Spock restriction.
   api("org.awaitility:awaitility")
-  api("com.google.guava:guava")
   api("org.mockito:mockito-core")
   api("org.slf4j:slf4j-api")
 


### PR DESCRIPTION
I couldn't find any usages, but it's possible I missed something. Let's find out!