### PR TITLE
Deprecate `NetClientAttributesExtractor`

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractor.java
@@ -10,7 +10,6 @@ import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorU
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InternalNetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalNetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalServerAttributesExtractor;
@@ -52,7 +51,9 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
   @Deprecated
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       HttpClientAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter,
-      NetClientAttributesGetter<REQUEST, RESPONSE> netAttributesGetter) {
+      io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter<
+              REQUEST, RESPONSE>
+          netAttributesGetter) {
     return builder(httpAttributesGetter, netAttributesGetter).build();
   }
 
@@ -76,7 +77,9 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
   @Deprecated
   public static <REQUEST, RESPONSE> HttpClientAttributesExtractorBuilder<REQUEST, RESPONSE> builder(
       HttpClientAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter,
-      NetClientAttributesGetter<REQUEST, RESPONSE> netAttributesGetter) {
+      io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter<
+              REQUEST, RESPONSE>
+          netAttributesGetter) {
     return new HttpClientAttributesExtractorBuilder<>(httpAttributesGetter, netAttributesGetter);
   }
 

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBuilder.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBuilder.java
@@ -10,7 +10,6 @@ import static java.util.Collections.emptyList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.internal.InternalNetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalNetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalServerAttributesExtractor;
@@ -26,7 +25,12 @@ import java.util.function.ToIntFunction;
 public final class HttpClientAttributesExtractorBuilder<REQUEST, RESPONSE> {
 
   final HttpClientAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter;
-  final NetClientAttributesGetter<REQUEST, RESPONSE> netAttributesGetter;
+
+  @SuppressWarnings("deprecation") // using the net extractor for the old->stable semconv story
+  final io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter<
+          REQUEST, RESPONSE>
+      netAttributesGetter;
+
   final HttpAddressPortExtractor<REQUEST> addressPortExtractor;
   List<String> capturedRequestHeaders = emptyList();
   List<String> capturedResponseHeaders = emptyList();
@@ -35,7 +39,10 @@ public final class HttpClientAttributesExtractorBuilder<REQUEST, RESPONSE> {
 
   HttpClientAttributesExtractorBuilder(
       HttpClientAttributesGetter<REQUEST, RESPONSE> httpAttributesGetter,
-      NetClientAttributesGetter<REQUEST, RESPONSE> netAttributesGetter) {
+      @SuppressWarnings("deprecation") // using the net extractor for the old->stable semconv story
+          io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter<
+                  REQUEST, RESPONSE>
+              netAttributesGetter) {
     this.httpAttributesGetter = httpAttributesGetter;
     this.netAttributesGetter = netAttributesGetter;
     addressPortExtractor = new HttpAddressPortExtractor<>(httpAttributesGetter);

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesGetter.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.network.NetworkAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import javax.annotation.Nullable;
@@ -17,9 +16,13 @@ import javax.annotation.Nullable;
  * library/framework. It will be used by the {@link HttpClientAttributesExtractor} to obtain the
  * various HTTP client attributes in a type-generic way.
  */
+@SuppressWarnings(
+    "deprecation") // implementing the NetClientAttributesGetter for the old->stable semconv story;
+// will be removed in 2.0
 public interface HttpClientAttributesGetter<REQUEST, RESPONSE>
     extends HttpCommonAttributesGetter<REQUEST, RESPONSE>,
-        NetClientAttributesGetter<REQUEST, RESPONSE>,
+        io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter<
+            REQUEST, RESPONSE>,
         NetworkAttributesGetter<REQUEST, RESPONSE>,
         ServerAttributesGetter<REQUEST, RESPONSE> {
 

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractor.java
@@ -23,7 +23,11 @@ import javax.annotation.Nullable;
  *
  * <p>This class delegates to a type-specific {@link NetClientAttributesGetter} for individual
  * attribute extraction from request/response objects.
+ *
+ * @deprecated Make sure that your instrumentation uses the extractors from the {@code ...network}
+ *     package instead. This class will be removed in the 2.0 release.
  */
+@Deprecated
 public final class NetClientAttributesExtractor<REQUEST, RESPONSE>
     implements AttributesExtractor<REQUEST, RESPONSE> {
 

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesGetter.java
@@ -18,7 +18,11 @@ import javax.annotation.Nullable;
  * <p>Instrumentation authors will create implementations of this interface for their specific
  * library/framework. It will be used by the NetClientAttributesExtractor to obtain the various
  * network attributes in a type-generic way.
+ *
+ * @deprecated Make sure that your instrumentation implements the getters from the {@code
+ *     ...network} package instead. This class will be removed in the 2.0 release.
  */
+@Deprecated
 public interface NetClientAttributesGetter<REQUEST, RESPONSE>
     extends NetworkAttributesGetter<REQUEST, RESPONSE>, ServerAttributesGetter<REQUEST, RESPONSE> {
 

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InetSocketAddressUtil.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InetSocketAddressUtil.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter.net.internal;
 
+import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -42,7 +43,12 @@ public final class InetSocketAddressUtil {
       return null;
     }
     InetAddress remoteAddress = address.getAddress();
-    return remoteAddress instanceof Inet6Address ? "ipv6" : "ipv4";
+    if (remoteAddress instanceof Inet4Address) {
+      return "ipv6";
+    } else if (remoteAddress instanceof Inet6Address) {
+      return "ipv6";
+    }
+    return null;
   }
 
   @Nullable

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/internal/InternalNetClientAttributesExtractor.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.api.instrumenter.net.internal;
 import static io.opentelemetry.instrumentation.api.internal.AttributesExtractorUtil.internalSet;
 
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.AddressAndPort;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.FallbackAddressPortExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -18,14 +17,19 @@ import javax.annotation.Nullable;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
+@SuppressWarnings("deprecation") // this class will be removed in the 2.0 version
 public final class InternalNetClientAttributesExtractor<REQUEST, RESPONSE> {
 
-  private final NetClientAttributesGetter<REQUEST, RESPONSE> getter;
+  private final io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter<
+          REQUEST, RESPONSE>
+      getter;
   private final FallbackAddressPortExtractor<REQUEST> fallbackAddressPortExtractor;
   private final boolean emitOldHttpAttributes;
 
   public InternalNetClientAttributesExtractor(
-      NetClientAttributesGetter<REQUEST, RESPONSE> getter,
+      io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter<
+              REQUEST, RESPONSE>
+          getter,
       FallbackAddressPortExtractor<REQUEST> fallbackAddressPortExtractor,
       boolean emitOldHttpAttributes) {
     this.getter = getter;

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetterTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/InetSocketAddressNetClientAttributesGetterTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@SuppressWarnings("deprecation") // testing deprecated class
 @ExtendWith(MockitoExtension.class)
 class InetSocketAddressNetClientAttributesGetterTest {
 

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorTest.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation") // testing deprecated class
 class NetClientAttributesExtractorTest {
 
   static class TestNetClientAttributesGetter

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorBothSemconvTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation") // testing deprecated class
 class NetClientAttributesExtractorBothSemconvTest {
 
   static class TestNetClientAttributesGetter

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetClientAttributesExtractorStableSemconvTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation") // testing deprecated class
 class NetClientAttributesExtractorStableSemconvTest {
 
   static class TestNetClientAttributesGetter

--- a/instrumentation/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/OpenTelemetryFilter.java
+++ b/instrumentation/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/OpenTelemetryFilter.java
@@ -7,7 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.apachedubbo.v2_7;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboTelemetry;
-import io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboNetClientAttributesGetter;
+import io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboClientNetworkAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import org.apache.dubbo.common.extension.Activate;
@@ -26,7 +26,7 @@ public class OpenTelemetryFilter implements Filter {
         DubboTelemetry.builder(GlobalOpenTelemetry.get())
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
-                    new DubboNetClientAttributesGetter(),
+                    new DubboClientNetworkAttributesGetter(),
                     CommonConfig.get().getPeerServiceMapping()))
             .build()
             .newFilter();

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTelemetryBuilder.java
@@ -7,12 +7,11 @@ package io.opentelemetry.instrumentation.apachedubbo.v2_7;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboNetClientAttributesGetter;
+import io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboClientNetworkAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.ClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.rpc.RpcClientAttributesExtractor;
@@ -62,7 +61,8 @@ public final class DubboTelemetryBuilder {
     DubboRpcAttributesGetter rpcAttributesGetter = DubboRpcAttributesGetter.INSTANCE;
     SpanNameExtractor<DubboRequest> spanNameExtractor =
         RpcSpanNameExtractor.create(rpcAttributesGetter);
-    DubboNetClientAttributesGetter netClientAttributesGetter = new DubboNetClientAttributesGetter();
+    DubboClientNetworkAttributesGetter netClientAttributesGetter =
+        new DubboClientNetworkAttributesGetter();
     DubboNetworkServerAttributesGetter netServerAttributesGetter =
         new DubboNetworkServerAttributesGetter();
 
@@ -79,7 +79,7 @@ public final class DubboTelemetryBuilder {
         Instrumenter.<DubboRequest, Result>builder(
                 openTelemetry, INSTRUMENTATION_NAME, spanNameExtractor)
             .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter))
-            .addAttributesExtractor(NetClientAttributesExtractor.create(netClientAttributesGetter))
+            .addAttributesExtractor(ServerAttributesExtractor.create(netClientAttributesGetter))
             .addAttributesExtractors(attributesExtractors);
 
     if (peerService != null) {

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboClientNetworkAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboClientNetworkAttributesGetter.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.instrumentation.apachedubbo.v2_7.internal;
 
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboRequest;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 import org.apache.dubbo.rpc.Result;
@@ -15,8 +15,8 @@ import org.apache.dubbo.rpc.Result;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public final class DubboNetClientAttributesGetter
-    implements NetClientAttributesGetter<DubboRequest, Result> {
+public final class DubboClientNetworkAttributesGetter
+    implements ServerAttributesGetter<DubboRequest, Result> {
 
   @Nullable
   @Override

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetworkAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraNetworkAttributesGetter.java
@@ -6,24 +6,12 @@
 package io.opentelemetry.javaagent.instrumentation.cassandra.v3_0;
 
 import com.datastax.driver.core.ExecutionInfo;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
-final class CassandraNetAttributesGetter
-    implements NetClientAttributesGetter<CassandraRequest, ExecutionInfo> {
-
-  @Nullable
-  @Override
-  public String getServerAddress(CassandraRequest request) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(CassandraRequest request) {
-    return null;
-  }
+final class CassandraNetworkAttributesGetter
+    implements ServerAttributesGetter<CassandraRequest, ExecutionInfo> {
 
   @Override
   @Nullable

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
@@ -11,7 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.SqlClientAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
@@ -37,7 +37,7 @@ public final class CassandraSingletons {
                         CommonConfig.get().isStatementSanitizationEnabled())
                     .build())
             .addAttributesExtractor(
-                NetClientAttributesExtractor.create(new CassandraNetAttributesGetter()))
+                ServerAttributesExtractor.create(new CassandraNetworkAttributesGetter()))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetworkAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraNetworkAttributesGetter.java
@@ -7,25 +7,13 @@ package io.opentelemetry.javaagent.instrumentation.cassandra.v4_0;
 
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-final class CassandraNetAttributesGetter
-    implements NetClientAttributesGetter<CassandraRequest, ExecutionInfo> {
-
-  @Nullable
-  @Override
-  public String getServerAddress(CassandraRequest request) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(CassandraRequest request) {
-    return null;
-  }
+final class CassandraNetworkAttributesGetter
+    implements ServerAttributesGetter<CassandraRequest, ExecutionInfo> {
 
   @Override
   @Nullable

--- a/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v4_0/CassandraSingletons.java
@@ -11,7 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.SqlClientAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
@@ -36,7 +36,7 @@ public final class CassandraSingletons {
                         CommonConfig.get().isStatementSanitizationEnabled())
                     .build())
             .addAttributesExtractor(
-                NetClientAttributesExtractor.create(new CassandraNetAttributesGetter()))
+                ServerAttributesExtractor.create(new CassandraNetworkAttributesGetter()))
             .addAttributesExtractor(new CassandraAttributesExtractor())
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraNetworkAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraNetworkAttributesGetter.java
@@ -7,25 +7,13 @@ package io.opentelemetry.instrumentation.cassandra.v4_4;
 
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-final class CassandraNetAttributesGetter
-    implements NetClientAttributesGetter<CassandraRequest, ExecutionInfo> {
-
-  @Nullable
-  @Override
-  public String getServerAddress(CassandraRequest request) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(CassandraRequest request) {
-    return null;
-  }
+final class CassandraNetworkAttributesGetter
+    implements ServerAttributesGetter<CassandraRequest, ExecutionInfo> {
 
   @Override
   @Nullable

--- a/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraTelemetryBuilder.java
+++ b/instrumentation/cassandra/cassandra-4.4/library/src/main/java/io/opentelemetry/instrumentation/cassandra/v4_4/CassandraTelemetryBuilder.java
@@ -12,7 +12,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.SqlClientAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 /** A builder of {@link CassandraTelemetry}. */
@@ -59,7 +59,7 @@ public class CassandraTelemetryBuilder {
                 .setStatementSanitizationEnabled(statementSanitizationEnabled)
                 .build())
         .addAttributesExtractor(
-            NetClientAttributesExtractor.create(new CassandraNetAttributesGetter()))
+            ServerAttributesExtractor.create(new CassandraNetworkAttributesGetter()))
         .addAttributesExtractor(new CassandraAttributesExtractor())
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseNetworkAttributesGetter.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseNetworkAttributesGetter.java
@@ -5,25 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.couchbase.v2_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-public class CouchbaseNetAttributesGetter
-    implements NetClientAttributesGetter<CouchbaseRequestInfo, Void> {
-
-  @Nullable
-  @Override
-  public String getServerAddress(CouchbaseRequestInfo couchbaseRequest) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(CouchbaseRequestInfo couchbaseRequest) {
-    return null;
-  }
+public class CouchbaseNetworkAttributesGetter
+    implements ServerAttributesGetter<CouchbaseRequestInfo, Void> {
 
   @Nullable
   @Override

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSingletons.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSingletons.java
@@ -12,8 +12,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
 
@@ -27,13 +27,13 @@ public final class CouchbaseSingletons {
     CouchbaseAttributesGetter couchbaseAttributesGetter = new CouchbaseAttributesGetter();
     SpanNameExtractor<CouchbaseRequestInfo> spanNameExtractor =
         new CouchbaseSpanNameExtractor(DbClientSpanNameExtractor.create(couchbaseAttributesGetter));
-    CouchbaseNetAttributesGetter netAttributesGetter = new CouchbaseNetAttributesGetter();
+    CouchbaseNetworkAttributesGetter netAttributesGetter = new CouchbaseNetworkAttributesGetter();
 
     InstrumenterBuilder<CouchbaseRequestInfo, Void> builder =
         Instrumenter.<CouchbaseRequestInfo, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, spanNameExtractor)
             .addAttributesExtractor(DbClientAttributesExtractor.create(couchbaseAttributesGetter))
-            .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+            .addAttributesExtractor(ServerAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportSingletons.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportSingletons.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_0;
 
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
-import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticTransportNetResponseAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticTransportNetworkAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticTransportRequest;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticsearchTransportInstrumenterFactory;
 import org.elasticsearch.action.ActionResponse;
@@ -18,7 +18,7 @@ public final class Elasticsearch5TransportSingletons {
       ElasticsearchTransportInstrumenterFactory.create(
           "io.opentelemetry.elasticsearch-transport-5.0",
           new Elasticsearch5TransportExperimentalAttributesExtractor(),
-          NetClientAttributesExtractor.create(new ElasticTransportNetResponseAttributesGetter()));
+          ServerAttributesExtractor.create(new ElasticTransportNetworkAttributesGetter()));
 
   public static Instrumenter<ElasticTransportRequest, ActionResponse> instrumenter() {
     return INSTRUMENTER;

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportSingletons.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportSingletons.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_3;
 
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
-import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticTransportNetResponseAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticTransportNetworkAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticTransportRequest;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticsearchTransportInstrumenterFactory;
 import org.elasticsearch.action.ActionResponse;
@@ -18,7 +18,7 @@ public final class Elasticsearch53TransportSingletons {
       ElasticsearchTransportInstrumenterFactory.create(
           "io.opentelemetry.elasticsearch-transport-5.3",
           new Elasticsearch53TransportExperimentalAttributesExtractor(),
-          NetClientAttributesExtractor.create(new ElasticTransportNetResponseAttributesGetter()));
+          ServerAttributesExtractor.create(new ElasticTransportNetworkAttributesGetter()));
 
   public static Instrumenter<ElasticTransportRequest, ActionResponse> instrumenter() {
     return INSTRUMENTER;

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportNetworkAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportNetworkAttributesGetter.java
@@ -5,26 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v6_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticTransportRequest;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 import org.elasticsearch.action.ActionResponse;
 
-public class Elasticsearch6TransportNetAttributesGetter
-    implements NetClientAttributesGetter<ElasticTransportRequest, ActionResponse> {
-
-  @Nullable
-  @Override
-  public String getServerAddress(ElasticTransportRequest request) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(ElasticTransportRequest request) {
-    return null;
-  }
+public class Elasticsearch6TransportNetworkAttributesGetter
+    implements ServerAttributesGetter<ElasticTransportRequest, ActionResponse> {
 
   @Override
   @Nullable

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportSingletons.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportSingletons.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v6_0;
 
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticTransportRequest;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.ElasticsearchTransportInstrumenterFactory;
 import org.elasticsearch.action.ActionResponse;
@@ -17,7 +17,7 @@ public final class Elasticsearch6TransportSingletons {
       ElasticsearchTransportInstrumenterFactory.create(
           "io.opentelemetry.elasticsearch-transport-6.0",
           new Elasticsearch6TransportExperimentalAttributesExtractor(),
-          NetClientAttributesExtractor.create(new Elasticsearch6TransportNetAttributesGetter()));
+          ServerAttributesExtractor.create(new Elasticsearch6TransportNetworkAttributesGetter()));
 
   public static Instrumenter<ElasticTransportRequest, ActionResponse> instrumenter() {
     return INSTRUMENTER;

--- a/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticTransportNetworkAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/ElasticTransportNetworkAttributesGetter.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import javax.annotation.Nullable;
 import org.elasticsearch.action.ActionResponse;
 
-public class ElasticTransportNetResponseAttributesGetter
-    implements NetClientAttributesGetter<ElasticTransportRequest, ActionResponse> {
+public class ElasticTransportNetworkAttributesGetter
+    implements ServerAttributesGetter<ElasticTransportRequest, ActionResponse> {
 
   @Override
   @Nullable

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -13,14 +13,13 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.ClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.rpc.RpcClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.rpc.RpcServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.rpc.RpcServerMetrics;
-import io.opentelemetry.instrumentation.grpc.v1_6.internal.GrpcNetClientAttributesGetter;
+import io.opentelemetry.instrumentation.grpc.v1_6.internal.GrpcClientNetworkAttributesGetter;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -175,14 +174,15 @@ public final class GrpcTelemetryBuilder {
                     .setSpanStatusExtractor(new GrpcSpanStatusExtractor())
                     .addAttributesExtractors(additionalExtractors));
 
-    GrpcNetClientAttributesGetter netClientAttributesGetter = new GrpcNetClientAttributesGetter();
+    GrpcClientNetworkAttributesGetter netClientAttributesGetter =
+        new GrpcClientNetworkAttributesGetter();
     GrpcNetworkServerAttributesGetter netServerAttributesGetter =
         new GrpcNetworkServerAttributesGetter();
     GrpcRpcAttributesGetter rpcAttributesGetter = GrpcRpcAttributesGetter.INSTANCE;
 
     clientInstrumenterBuilder
         .addAttributesExtractor(RpcClientAttributesExtractor.create(rpcAttributesGetter))
-        .addAttributesExtractor(NetClientAttributesExtractor.create(netClientAttributesGetter))
+        .addAttributesExtractor(ServerAttributesExtractor.create(netClientAttributesGetter))
         .addAttributesExtractors(additionalClientExtractors)
         .addAttributesExtractor(
             new GrpcAttributesExtractor(

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcClientNetworkAttributesGetter.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcClientNetworkAttributesGetter.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.instrumentation.grpc.v1_6.internal;
 
 import io.grpc.Status;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcRequest;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -16,8 +16,8 @@ import javax.annotation.Nullable;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public final class GrpcNetClientAttributesGetter
-    implements NetClientAttributesGetter<GrpcRequest, Status> {
+public final class GrpcClientNetworkAttributesGetter
+    implements ServerAttributesGetter<GrpcRequest, Status> {
 
   @Nullable
   @Override

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcSingletons.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcSingletons.java
@@ -12,11 +12,11 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.SqlClientAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.jdbc.internal.DbRequest;
 import io.opentelemetry.instrumentation.jdbc.internal.JdbcAttributesGetter;
-import io.opentelemetry.instrumentation.jdbc.internal.JdbcNetAttributesGetter;
+import io.opentelemetry.instrumentation.jdbc.internal.JdbcNetworkAttributesGetter;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
 import io.opentelemetry.javaagent.bootstrap.jdbc.DbInfo;
@@ -31,7 +31,7 @@ public final class JdbcSingletons {
 
   static {
     JdbcAttributesGetter dbAttributesGetter = new JdbcAttributesGetter();
-    JdbcNetAttributesGetter netAttributesGetter = new JdbcNetAttributesGetter();
+    JdbcNetworkAttributesGetter netAttributesGetter = new JdbcNetworkAttributesGetter();
 
     STATEMENT_INSTRUMENTER =
         Instrumenter.<DbRequest, Void>builder(
@@ -46,7 +46,7 @@ public final class JdbcSingletons {
                                 "otel.instrumentation.jdbc.statement-sanitizer.enabled",
                                 CommonConfig.get().isStatementSanitizationEnabled()))
                     .build())
-            .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+            .addAttributesExtractor(ServerAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcInstrumenterFactory.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcInstrumenterFactory.java
@@ -11,7 +11,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.SqlClientAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 
 /**
@@ -21,7 +21,8 @@ import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 public final class JdbcInstrumenterFactory {
   public static final String INSTRUMENTATION_NAME = "io.opentelemetry.jdbc";
   private static final JdbcAttributesGetter dbAttributesGetter = new JdbcAttributesGetter();
-  private static final JdbcNetAttributesGetter netAttributesGetter = new JdbcNetAttributesGetter();
+  private static final JdbcNetworkAttributesGetter netAttributesGetter =
+      new JdbcNetworkAttributesGetter();
 
   public static Instrumenter<DbRequest, Void> createStatementInstrumenter() {
     return createStatementInstrumenter(GlobalOpenTelemetry.get());
@@ -39,7 +40,7 @@ public final class JdbcInstrumenterFactory {
                     ConfigPropertiesUtil.getBoolean(
                         "otel.instrumentation.common.db-statement-sanitizer.enabled", true))
                 .build())
-        .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+        .addAttributesExtractor(ServerAttributesExtractor.create(netAttributesGetter))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcNetworkAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcNetworkAttributesGetter.java
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import javax.annotation.Nullable;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public final class JdbcNetAttributesGetter implements NetClientAttributesGetter<DbRequest, Void> {
+public final class JdbcNetworkAttributesGetter implements ServerAttributesGetter<DbRequest, Void> {
 
   @Nullable
   @Override

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetworkAttributesGetter.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisNetworkAttributesGetter.java
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v1_4;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 
-final class JedisNetAttributesGetter implements NetClientAttributesGetter<JedisRequest, Void> {
+final class JedisNetworkAttributesGetter implements ServerAttributesGetter<JedisRequest, Void> {
 
   @Override
   public String getServerAddress(JedisRequest request) {

--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisSingletons.java
@@ -10,8 +10,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 
 public final class JedisSingletons {
@@ -21,7 +21,7 @@ public final class JedisSingletons {
 
   static {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
-    JedisNetAttributesGetter netAttributesGetter = new JedisNetAttributesGetter();
+    JedisNetworkAttributesGetter netAttributesGetter = new JedisNetworkAttributesGetter();
 
     INSTRUMENTER =
         Instrumenter.<JedisRequest, Void>builder(
@@ -29,7 +29,7 @@ public final class JedisSingletons {
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+            .addAttributesExtractor(ServerAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetworkAttributesGetter.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisNetworkAttributesGetter.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v3_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import javax.annotation.Nullable;
 
-final class JedisNetAttributesGetter implements NetClientAttributesGetter<JedisRequest, Void> {
+final class JedisNetworkAttributesGetter implements ServerAttributesGetter<JedisRequest, Void> {
 
   @Nullable
   @Override

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisSingletons.java
@@ -10,8 +10,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 
 public final class JedisSingletons {
@@ -21,7 +21,7 @@ public final class JedisSingletons {
 
   static {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
-    JedisNetAttributesGetter netAttributesGetter = new JedisNetAttributesGetter();
+    JedisNetworkAttributesGetter netAttributesGetter = new JedisNetworkAttributesGetter();
 
     INSTRUMENTER =
         Instrumenter.<JedisRequest, Void>builder(
@@ -29,7 +29,7 @@ public final class JedisSingletons {
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+            .addAttributesExtractor(ServerAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisNetworkAttributesGetter.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisNetworkAttributesGetter.java
@@ -5,24 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v4_0;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-final class JedisNetAttributesGetter implements NetClientAttributesGetter<JedisRequest, Void> {
-
-  @Nullable
-  @Override
-  public String getServerAddress(JedisRequest jedisRequest) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(JedisRequest jedisRequest) {
-    return null;
-  }
+final class JedisNetworkAttributesGetter implements ServerAttributesGetter<JedisRequest, Void> {
 
   @Override
   @Nullable

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisSingletons.java
@@ -10,8 +10,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 
 public final class JedisSingletons {
@@ -21,7 +21,7 @@ public final class JedisSingletons {
 
   static {
     JedisDbAttributesGetter dbAttributesGetter = new JedisDbAttributesGetter();
-    JedisNetAttributesGetter netAttributesGetter = new JedisNetAttributesGetter();
+    JedisNetworkAttributesGetter netAttributesGetter = new JedisNetworkAttributesGetter();
 
     INSTRUMENTER =
         Instrumenter.<JedisRequest, Void>builder(
@@ -29,7 +29,7 @@ public final class JedisSingletons {
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(dbAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-            .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+            .addAttributesExtractor(ServerAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetworkAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectNetworkAttributesGetter.java
@@ -6,9 +6,10 @@
 package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
 
 import com.lambdaworks.redis.RedisURI;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 
-final class LettuceConnectNetAttributesGetter implements NetClientAttributesGetter<RedisURI, Void> {
+final class LettuceConnectNetworkAttributesGetter
+    implements ServerAttributesGetter<RedisURI, Void> {
 
   @Override
   public String getServerAddress(RedisURI redisUri) {

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -14,8 +14,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 
 public final class LettuceSingletons {
@@ -38,12 +38,13 @@ public final class LettuceSingletons {
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
 
-    LettuceConnectNetAttributesGetter netAttributesGetter = new LettuceConnectNetAttributesGetter();
+    LettuceConnectNetworkAttributesGetter netAttributesGetter =
+        new LettuceConnectNetworkAttributesGetter();
 
     CONNECT_INSTRUMENTER =
         Instrumenter.<RedisURI, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, redisUri -> "CONNECT")
-            .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+            .addAttributesExtractor(ServerAttributesExtractor.create(netAttributesGetter))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetworkAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectNetworkAttributesGetter.java
@@ -6,9 +6,10 @@
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
 import io.lettuce.core.RedisURI;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 
-final class LettuceConnectNetAttributesGetter implements NetClientAttributesGetter<RedisURI, Void> {
+final class LettuceConnectNetworkAttributesGetter
+    implements ServerAttributesGetter<RedisURI, Void> {
 
   @Override
   public String getServerAddress(RedisURI redisUri) {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
@@ -14,8 +14,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 
 public final class LettuceSingletons {
@@ -38,16 +38,17 @@ public final class LettuceSingletons {
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
 
-    LettuceConnectNetAttributesGetter connectNetAttributesGetter =
-        new LettuceConnectNetAttributesGetter();
+    LettuceConnectNetworkAttributesGetter connectNetworkAttributesGetter =
+        new LettuceConnectNetworkAttributesGetter();
 
     CONNECT_INSTRUMENTER =
         Instrumenter.<RedisURI, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, redisUri -> "CONNECT")
-            .addAttributesExtractor(NetClientAttributesExtractor.create(connectNetAttributesGetter))
+            .addAttributesExtractor(
+                ServerAttributesExtractor.create(connectNetworkAttributesGetter))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
-                    connectNetAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
+                    connectNetworkAttributesGetter, CommonConfig.get().getPeerServiceMapping()))
             .addAttributesExtractor(new LettuceConnectAttributesExtractor())
             .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceNetworkAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceNetworkAttributesGetter.java
@@ -5,25 +5,13 @@
 
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import io.opentelemetry.instrumentation.lettuce.v5_1.OpenTelemetryTracing.OpenTelemetryEndpoint;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
-final class LettuceNetAttributesGetter
-    implements NetClientAttributesGetter<OpenTelemetryEndpoint, Void> {
-
-  @Nullable
-  @Override
-  public String getServerAddress(OpenTelemetryEndpoint openTelemetryEndpoint) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(OpenTelemetryEndpoint openTelemetryEndpoint) {
-    return null;
-  }
+final class LettuceNetworkAttributesGetter
+    implements ServerAttributesGetter<OpenTelemetryEndpoint, Void> {
 
   @Nullable
   @Override

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -26,7 +26,7 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.db.RedisCommandSanitizer;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DbSystemValues;
 import java.net.InetSocketAddress;
@@ -38,8 +38,8 @@ import javax.annotation.Nullable;
 
 final class OpenTelemetryTracing implements Tracing {
 
-  private static final AttributesExtractor<OpenTelemetryEndpoint, Void> netAttributesExtractor =
-      NetClientAttributesExtractor.create(new LettuceNetAttributesGetter());
+  private static final AttributesExtractor<OpenTelemetryEndpoint, Void> serverAttributesExtractor =
+      ServerAttributesExtractor.create(new LettuceNetworkAttributesGetter());
   private final TracerProvider tracerProvider;
 
   OpenTelemetryTracing(io.opentelemetry.api.trace.Tracer tracer, RedisCommandSanitizer sanitizer) {
@@ -204,7 +204,7 @@ final class OpenTelemetryTracing implements Tracing {
     private void fillEndpoint(OpenTelemetryEndpoint endpoint) {
       AttributesBuilder attributesBuilder = Attributes.builder();
       Context currentContext = span == null ? context : context.with(span);
-      netAttributesExtractor.onEnd(attributesBuilder, currentContext, endpoint, null, null);
+      serverAttributesExtractor.onEnd(attributesBuilder, currentContext, endpoint, null, null);
       if (span != null) {
         span.setAllAttributes(attributesBuilder.build());
       } else {

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoInstrumenterFactory.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoInstrumenterFactory.java
@@ -7,19 +7,16 @@ package io.opentelemetry.instrumentation.mongo.v3_1;
 
 import com.mongodb.event.CommandStartedEvent;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 
 class MongoInstrumenterFactory {
 
   private static final MongoAttributesExtractor attributesExtractor =
       new MongoAttributesExtractor();
-  private static final AttributesExtractor<CommandStartedEvent, Void> netAttributesExtractor =
-      NetClientAttributesExtractor.create(new MongoNetAttributesGetter());
 
   static Instrumenter<CommandStartedEvent, Void> createInstrumenter(
       OpenTelemetry openTelemetry,
@@ -34,7 +31,8 @@ class MongoInstrumenterFactory {
     return Instrumenter.<CommandStartedEvent, Void>builder(
             openTelemetry, "io.opentelemetry.mongo-3.1", spanNameExtractor)
         .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-        .addAttributesExtractor(netAttributesExtractor)
+        .addAttributesExtractor(
+            ServerAttributesExtractor.create(new MongoNetworkAttributesGetter()))
         .addAttributesExtractor(attributesExtractor)
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoNetworkAttributesGetter.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoNetworkAttributesGetter.java
@@ -6,10 +6,10 @@
 package io.opentelemetry.instrumentation.mongo.v3_1;
 
 import com.mongodb.event.CommandStartedEvent;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import javax.annotation.Nullable;
 
-class MongoNetAttributesGetter implements NetClientAttributesGetter<CommandStartedEvent, Void> {
+class MongoNetworkAttributesGetter implements ServerAttributesGetter<CommandStartedEvent, Void> {
 
   @Nullable
   @Override

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyClientInstrumenterFactory.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettyClientInstrumenterFactory.java
@@ -18,7 +18,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientExperime
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpSpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
 import io.opentelemetry.instrumentation.netty.common.internal.NettyConnectionRequest;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
@@ -108,6 +107,7 @@ public final class NettyClientInstrumenterFactory {
         : new NettyErrorOnlyConnectionInstrumenter(instrumenter);
   }
 
+  @SuppressWarnings("deprecation") // have to use the deprecated Net*AttributesExtractor for now
   public NettySslInstrumenter createSslInstrumenter() {
     if (sslTelemetryState == NettyConnectionInstrumentationFlag.DISABLED) {
       return NoopSslInstrumenter.INSTANCE;
@@ -119,7 +119,9 @@ public final class NettyClientInstrumenterFactory {
     Instrumenter<NettySslRequest, Void> instrumenter =
         Instrumenter.<NettySslRequest, Void>builder(
                 openTelemetry, instrumentationName, NettySslRequest::spanName)
-            .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+            .addAttributesExtractor(
+                io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor
+                    .create(netAttributesGetter))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(netAttributesGetter, peerServiceMapping))
             .buildInstrumenter(

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslNetAttributesGetter.java
@@ -9,13 +9,14 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTr
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NetTransportValues.IP_UDP;
 
 import io.netty.channel.socket.DatagramChannel;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
 import io.opentelemetry.instrumentation.netty.v4.common.internal.ChannelUtil;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
+@SuppressWarnings("deprecation") // have to use the deprecated Net*AttributesGetter for now
 final class NettySslNetAttributesGetter
-    implements NetClientAttributesGetter<NettySslRequest, Void> {
+    implements io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter<
+        NettySslRequest, Void> {
 
   @Override
   public String getTransport(NettySslRequest request, @Nullable Void unused) {

--- a/instrumentation/opensearch/opensearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/OpenSearchRestInstrumenterFactory.java
+++ b/instrumentation/opensearch/opensearch-rest-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/OpenSearchRestInstrumenterFactory.java
@@ -10,13 +10,13 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import org.opensearch.client.Response;
 
 public final class OpenSearchRestInstrumenterFactory {
 
+  @SuppressWarnings("deprecation") // have to use the deprecated Net*AttributesExtractor for now
   public static Instrumenter<OpenSearchRestRequest, Response> create(String instrumentationName) {
     OpenSearchRestAttributesGetter dbClientAttributesGetter = new OpenSearchRestAttributesGetter();
     OpenSearchRestNetResponseAttributesGetter netAttributesGetter =
@@ -27,7 +27,9 @@ public final class OpenSearchRestInstrumenterFactory {
             instrumentationName,
             DbClientSpanNameExtractor.create(dbClientAttributesGetter))
         .addAttributesExtractor(DbClientAttributesExtractor.create(dbClientAttributesGetter))
-        .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+        .addAttributesExtractor(
+            io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor
+                .create(netAttributesGetter))
         .addAttributesExtractor(
             PeerServiceAttributesExtractor.create(
                 netAttributesGetter, CommonConfig.get().getPeerServiceMapping()))

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarNetClientAttributesGetter.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarNetClientAttributesGetter.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import javax.annotation.Nullable;
 
 public final class PulsarNetClientAttributesGetter
-    implements NetClientAttributesGetter<BasePulsarRequest, Void> {
+    implements ServerAttributesGetter<BasePulsarRequest, Void> {
 
   @Nullable
   @Override

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
@@ -18,7 +18,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperat
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.Timer;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
@@ -71,7 +71,7 @@ public final class PulsarSingletons {
         .addAttributesExtractor(
             createMessagingAttributesExtractor(getter, MessageOperation.RECEIVE))
         .addAttributesExtractor(
-            NetClientAttributesExtractor.create(new PulsarNetClientAttributesGetter()))
+            ServerAttributesExtractor.create(new PulsarNetClientAttributesGetter()))
         .buildConsumerInstrumenter(MessageTextMapGetter.INSTANCE);
   }
 
@@ -86,7 +86,7 @@ public final class PulsarSingletons {
         .addAttributesExtractor(
             createMessagingAttributesExtractor(getter, MessageOperation.RECEIVE))
         .addAttributesExtractor(
-            NetClientAttributesExtractor.create(new PulsarNetClientAttributesGetter()))
+            ServerAttributesExtractor.create(new PulsarNetClientAttributesGetter()))
         .setEnabled(ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
         .addSpanLinksExtractor(
             new PulsarBatchRequestSpanLinksExtractor(
@@ -119,7 +119,7 @@ public final class PulsarSingletons {
             .addAttributesExtractor(
                 createMessagingAttributesExtractor(getter, MessageOperation.PUBLISH))
             .addAttributesExtractor(
-                NetClientAttributesExtractor.create(new PulsarNetClientAttributesGetter()));
+                ServerAttributesExtractor.create(new PulsarNetClientAttributesGetter()));
 
     if (InstrumentationConfig.get()
         .getBoolean("otel.instrumentation.pulsar.experimental-span-attributes", false)) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcInstrumenterBuilder.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcInstrumenterBuilder.java
@@ -12,7 +12,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.SqlClientAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,8 +50,7 @@ public final class R2dbcInstrumenterBuilder {
             SqlClientAttributesExtractor.builder(R2dbcSqlAttributesGetter.INSTANCE)
                 .setStatementSanitizationEnabled(statementSanitizationEnabled)
                 .build())
-        .addAttributesExtractor(
-            NetClientAttributesExtractor.create(R2dbcNetAttributesGetter.INSTANCE))
+        .addAttributesExtractor(ServerAttributesExtractor.create(R2dbcNetAttributesGetter.INSTANCE))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcNetAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcNetAttributesGetter.java
@@ -5,14 +5,14 @@
 
 package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import javax.annotation.Nullable;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public enum R2dbcNetAttributesGetter implements NetClientAttributesGetter<DbExecution, Void> {
+public enum R2dbcNetAttributesGetter implements ServerAttributesGetter<DbExecution, Void> {
   INSTANCE;
 
   @Nullable

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitChannelNetAttributesGetter.java
@@ -5,12 +5,36 @@
 
 package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.InetAddress;
 import javax.annotation.Nullable;
 
+@SuppressWarnings("deprecation") // have to use the deprecated Net*AttributesGetter for now
 public class RabbitChannelNetAttributesGetter
-    implements NetClientAttributesGetter<ChannelAndMethod, Void> {
+    implements io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter<
+        ChannelAndMethod, Void> {
+
+  @Nullable
+  @Override
+  public String getSockFamily(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+    if (channelAndMethod.getChannel().getConnection().getAddress() instanceof Inet6Address) {
+      return "inet6";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getNetworkType(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
+    InetAddress address = channelAndMethod.getChannel().getConnection().getAddress();
+    if (address instanceof Inet4Address) {
+      return "ipv6";
+    } else if (address instanceof Inet6Address) {
+      return "ipv6";
+    }
+    return null;
+  }
 
   @Nullable
   @Override
@@ -33,14 +57,5 @@ public class RabbitChannelNetAttributesGetter
   @Override
   public Integer getServerSocketPort(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
     return channelAndMethod.getChannel().getConnection().getPort();
-  }
-
-  @Nullable
-  @Override
-  public String getSockFamily(ChannelAndMethod channelAndMethod, @Nullable Void unused) {
-    if (channelAndMethod.getChannel().getConnection().getAddress() instanceof Inet6Address) {
-      return "inet6";
-    }
-    return null;
   }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitReceiveNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/RabbitReceiveNetAttributesGetter.java
@@ -6,12 +6,36 @@
 package io.opentelemetry.javaagent.instrumentation.rabbitmq;
 
 import com.rabbitmq.client.GetResponse;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.InetAddress;
 import javax.annotation.Nullable;
 
+@SuppressWarnings("deprecation") // have to use the deprecated Net*AttributesGetter for now
 public class RabbitReceiveNetAttributesGetter
-    implements NetClientAttributesGetter<ReceiveRequest, GetResponse> {
+    implements io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter<
+        ReceiveRequest, GetResponse> {
+
+  @Nullable
+  @Override
+  public String getSockFamily(ReceiveRequest request, @Nullable GetResponse response) {
+    if (request.getConnection().getAddress() instanceof Inet6Address) {
+      return "inet6";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getNetworkType(ReceiveRequest request, @Nullable GetResponse response) {
+    InetAddress address = request.getConnection().getAddress();
+    if (address instanceof Inet4Address) {
+      return "ipv6";
+    } else if (address instanceof Inet6Address) {
+      return "ipv6";
+    }
+    return null;
+  }
 
   @Nullable
   @Override
@@ -35,14 +59,5 @@ public class RabbitReceiveNetAttributesGetter
   @Override
   public Integer getServerSocketPort(ReceiveRequest request, @Nullable GetResponse response) {
     return request.getConnection().getPort();
-  }
-
-  @Nullable
-  @Override
-  public String getSockFamily(ReceiveRequest request, @Nullable GetResponse response) {
-    if (request.getConnection().getAddress() instanceof Inet6Address) {
-      return "inet6";
-    }
-    return null;
   }
 }

--- a/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonInstrumenterFactory.java
+++ b/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonInstrumenterFactory.java
@@ -10,7 +10,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 
 public final class RedissonInstrumenterFactory {
 
@@ -23,7 +23,7 @@ public final class RedissonInstrumenterFactory {
             instrumentationName,
             DbClientSpanNameExtractor.create(dbAttributesGetter))
         .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
-        .addAttributesExtractor(NetClientAttributesExtractor.create(netAttributesGetter))
+        .addAttributesExtractor(ServerAttributesExtractor.create(netAttributesGetter))
         .buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 

--- a/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonNetAttributesGetter.java
+++ b/instrumentation/redisson/redisson-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/RedissonNetAttributesGetter.java
@@ -5,24 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.redisson;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
-final class RedissonNetAttributesGetter
-    implements NetClientAttributesGetter<RedissonRequest, Void> {
-
-  @Nullable
-  @Override
-  public String getServerAddress(RedissonRequest redissonRequest) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(RedissonRequest redissonRequest) {
-    return null;
-  }
+final class RedissonNetAttributesGetter implements ServerAttributesGetter<RedissonRequest, Void> {
 
   @Override
   public InetSocketAddress getServerInetSocketAddress(

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientNetAttributesGetter.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientNetAttributesGetter.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql;
 
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
 import javax.annotation.Nullable;
 
 public enum VertxSqlClientNetAttributesGetter
-    implements NetClientAttributesGetter<VertxSqlClientRequest, Void> {
+    implements ServerAttributesGetter<VertxSqlClientRequest, Void> {
   INSTANCE;
 
   @Nullable

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientSingletons.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientSingletons.java
@@ -14,8 +14,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.db.SqlClientAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.net.NetClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import io.vertx.sqlclient.SqlConnectOptions;
 import java.util.Map;
@@ -41,7 +41,7 @@ public final class VertxSqlClientSingletons {
                         CommonConfig.get().isStatementSanitizationEnabled())
                     .build())
             .addAttributesExtractor(
-                NetClientAttributesExtractor.create(VertxSqlClientNetAttributesGetter.INSTANCE))
+                ServerAttributesExtractor.create(VertxSqlClientNetAttributesGetter.INSTANCE))
             .addAttributesExtractor(
                 PeerServiceAttributesExtractor.create(
                     VertxSqlClientNetAttributesGetter.INSTANCE,


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9013

#9156 needs to be merged first