### PR TITLE
Fix npe with pulsar and ssl

### DIFF
--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslInstrumentationHandler.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/client/NettySslInstrumentationHandler.java
@@ -94,7 +94,8 @@ public final class NettySslInstrumentationHandler extends ChannelDuplexHandler {
     promise.addListener(
         future -> {
           // there won't be any SSL handshake if the channel fails to connect
-          if (!future.isSuccess()) {
+          // give up when channelRegistered wasn't called and parentContext is null
+          if (!future.isSuccess() || parentContext == null) {
             return;
           }
           request = NettySslRequest.create(ctx.channel());


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8939
As far as I understand this NPE happens because `NettySslInstrumentationHandler.channelRegistered()` is never called. In our test `SslHandler` is set up in the `ChannelInitializer.initChannel`. Pulsar does it from a background thread, by the time `SslHandler` is added the channel is already registered.