### PR TITLE
Minor HTTP extractor test refactor: parameter names

### DIFF
--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorTest.java
@@ -38,7 +38,7 @@ class HttpClientAttributesExtractorTest {
 
     @Override
     public String getUrlFull(Map<String, String> request) {
-      return request.get("url");
+      return request.get("urlFull");
     }
 
     @Override
@@ -69,14 +69,14 @@ class HttpClientAttributesExtractorTest {
     @Override
     public String getNetworkTransport(
         Map<String, String> request, @Nullable Map<String, String> response) {
-      return request.get("transport");
+      return request.get("networkTransport");
     }
 
     @Nullable
     @Override
     public String getNetworkType(
         Map<String, String> request, @Nullable Map<String, String> response) {
-      return request.get("type");
+      return request.get("networkType");
     }
 
     @Nullable
@@ -96,13 +96,13 @@ class HttpClientAttributesExtractorTest {
     @Nullable
     @Override
     public String getServerAddress(Map<String, String> request) {
-      return request.get("peerName");
+      return request.get("serverAddress");
     }
 
     @Nullable
     @Override
     public Integer getServerPort(Map<String, String> request) {
-      String statusCode = request.get("peerPort");
+      String statusCode = request.get("serverPort");
       return statusCode == null ? null : Integer.parseInt(statusCode);
     }
   }
@@ -111,16 +111,16 @@ class HttpClientAttributesExtractorTest {
   void normal() {
     Map<String, String> request = new HashMap<>();
     request.put("method", "POST");
-    request.put("url", "http://github.com");
+    request.put("urlFull", "http://github.com");
     request.put("header.content-length", "10");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.custom-request-header", "123,456");
-    request.put("transport", "tcp");
-    request.put("type", "ipv4");
+    request.put("networkTransport", "tcp");
+    request.put("networkType", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "1.1");
-    request.put("peerName", "github.com");
-    request.put("peerPort", "123");
+    request.put("serverAddress", "github.com");
+    request.put("serverPort", "123");
 
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");
@@ -168,7 +168,7 @@ class HttpClientAttributesExtractorTest {
   @ArgumentsSource(StripUrlArgumentSource.class)
   void stripBasicAuthTest(String url, String expectedResult) {
     Map<String, String> request = new HashMap<>();
-    request.put("url", url);
+    request.put("urlFull", url);
 
     AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.create(new TestHttpClientAttributesGetter());
@@ -243,8 +243,8 @@ class HttpClientAttributesExtractorTest {
   void extractNetHostAndPortFromNetAttributesGetter() {
     Map<String, String> request = new HashMap<>();
     request.put("header.host", "notthehost:77777"); // this should have lower precedence
-    request.put("peerName", "thehost");
-    request.put("peerPort", "777");
+    request.put("serverAddress", "thehost");
+    request.put("serverPort", "777");
 
     AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.create(new TestHttpClientAttributesGetter());
@@ -262,8 +262,8 @@ class HttpClientAttributesExtractorTest {
   @ArgumentsSource(DefaultPeerPortArgumentSource.class)
   void defaultPeerPort(int peerPort, String url) {
     Map<String, String> request = new HashMap<>();
-    request.put("url", url);
-    request.put("peerPort", String.valueOf(peerPort));
+    request.put("urlFull", url);
+    request.put("serverPort", String.valueOf(peerPort));
 
     AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.create(new TestHttpClientAttributesGetter());

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -43,19 +43,19 @@ class HttpServerAttributesExtractorTest {
 
     @Override
     public String getUrlScheme(Map<String, Object> request) {
-      return (String) request.get("scheme");
+      return (String) request.get("urlScheme");
     }
 
     @Nullable
     @Override
     public String getUrlPath(Map<String, Object> request) {
-      return (String) request.get("path");
+      return (String) request.get("urlPath");
     }
 
     @Nullable
     @Override
     public String getUrlQuery(Map<String, Object> request) {
-      return (String) request.get("query");
+      return (String) request.get("urlQuery");
     }
 
     @Override
@@ -87,14 +87,14 @@ class HttpServerAttributesExtractorTest {
     @Override
     public String getNetworkTransport(
         Map<String, Object> request, @Nullable Map<String, Object> response) {
-      return (String) request.get("transport");
+      return (String) request.get("networkTransport");
     }
 
     @Nullable
     @Override
     public String getNetworkType(
         Map<String, Object> request, @Nullable Map<String, Object> response) {
-      return (String) request.get("type");
+      return (String) request.get("networkType");
     }
 
     @Nullable
@@ -114,13 +114,13 @@ class HttpServerAttributesExtractorTest {
     @Nullable
     @Override
     public String getServerAddress(Map<String, Object> request) {
-      return (String) request.get("hostName");
+      return (String) request.get("serverAddress");
     }
 
     @Nullable
     @Override
     public Integer getServerPort(Map<String, Object> request) {
-      return (Integer) request.get("hostPort");
+      return (Integer) request.get("serverPort");
     }
   }
 
@@ -128,18 +128,18 @@ class HttpServerAttributesExtractorTest {
   void normal() {
     Map<String, Object> request = new HashMap<>();
     request.put("method", "POST");
-    request.put("url", "http://github.com");
-    request.put("path", "/repositories/1");
-    request.put("query", "details=true");
-    request.put("scheme", "http");
+    request.put("urlFull", "http://github.com");
+    request.put("urlPath", "/repositories/1");
+    request.put("urlQuery", "details=true");
+    request.put("urlScheme", "http");
     request.put("header.content-length", "10");
     request.put("route", "/repositories/{id}");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.host", "github.com");
     request.put("header.forwarded", "for=1.1.1.1;proto=https");
     request.put("header.custom-request-header", "123,456");
-    request.put("transport", "tcp");
-    request.put("type", "ipv4");
+    request.put("networkTransport", "tcp");
+    request.put("networkType", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "2.0");
 
@@ -250,8 +250,8 @@ class HttpServerAttributesExtractorTest {
   void extractNetHostAndPortFromNetAttributesGetter() {
     Map<String, Object> request = new HashMap<>();
     request.put("header.host", "notthehost:77777"); // this should have lower precedence
-    request.put("hostName", "thehost");
-    request.put("hostPort", 777);
+    request.put("serverAddress", "thehost");
+    request.put("serverPort", 777);
 
     AttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
         HttpServerAttributesExtractor.builder(new TestHttpServerAttributesGetter())
@@ -271,8 +271,8 @@ class HttpServerAttributesExtractorTest {
   @ArgumentsSource(DefaultHostPortArgumentSource.class)
   void defaultHostPort(int hostPort, String scheme) {
     Map<String, Object> request = new HashMap<>();
-    request.put("scheme", scheme);
-    request.put("hostPort", hostPort);
+    request.put("urlScheme", scheme);
+    request.put("serverPort", hostPort);
 
     AttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
         HttpServerAttributesExtractor.builder(new TestHttpServerAttributesGetter())
@@ -298,8 +298,8 @@ class HttpServerAttributesExtractorTest {
   @ArgumentsSource(PathAndQueryArgumentSource.class)
   void computeTargetFromPathAndQuery(String path, String query, String expectedTarget) {
     Map<String, Object> request = new HashMap<>();
-    request.put("path", path);
-    request.put("query", query);
+    request.put("urlPath", path);
+    request.put("urlQuery", query);
 
     AttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
         HttpServerAttributesExtractor.create(new TestHttpServerAttributesGetter());

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorBothSemconvTest.java
@@ -33,7 +33,7 @@ class HttpClientAttributesExtractorBothSemconvTest {
 
     @Override
     public String getUrlFull(Map<String, String> request) {
-      return request.get("url");
+      return request.get("urlFull");
     }
 
     @Override
@@ -64,14 +64,14 @@ class HttpClientAttributesExtractorBothSemconvTest {
     @Override
     public String getNetworkTransport(
         Map<String, String> request, @Nullable Map<String, String> response) {
-      return request.get("transport");
+      return request.get("networkTransport");
     }
 
     @Nullable
     @Override
     public String getNetworkType(
         Map<String, String> request, @Nullable Map<String, String> response) {
-      return request.get("type");
+      return request.get("networkType");
     }
 
     @Nullable
@@ -91,13 +91,13 @@ class HttpClientAttributesExtractorBothSemconvTest {
     @Nullable
     @Override
     public String getServerAddress(Map<String, String> request) {
-      return request.get("peerName");
+      return request.get("serverAddress");
     }
 
     @Nullable
     @Override
     public Integer getServerPort(Map<String, String> request) {
-      String statusCode = request.get("peerPort");
+      String statusCode = request.get("serverPort");
       return statusCode == null ? null : Integer.parseInt(statusCode);
     }
   }
@@ -106,16 +106,16 @@ class HttpClientAttributesExtractorBothSemconvTest {
   void normal() {
     Map<String, String> request = new HashMap<>();
     request.put("method", "POST");
-    request.put("url", "http://github.com");
+    request.put("urlFull", "http://github.com");
     request.put("header.content-length", "10");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.custom-request-header", "123,456");
-    request.put("transport", "udp");
-    request.put("type", "ipv4");
+    request.put("networkTransport", "udp");
+    request.put("networkType", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "1.1");
-    request.put("peerName", "github.com");
-    request.put("peerPort", "123");
+    request.put("serverAddress", "github.com");
+    request.put("serverPort", "123");
 
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
@@ -38,19 +38,19 @@ class HttpServerAttributesExtractorBothSemconvTest {
 
     @Override
     public String getUrlScheme(Map<String, Object> request) {
-      return (String) request.get("scheme");
+      return (String) request.get("urlScheme");
     }
 
     @Nullable
     @Override
     public String getUrlPath(Map<String, Object> request) {
-      return (String) request.get("path");
+      return (String) request.get("urlPath");
     }
 
     @Nullable
     @Override
     public String getUrlQuery(Map<String, Object> request) {
-      return (String) request.get("query");
+      return (String) request.get("urlQuery");
     }
 
     @Override
@@ -82,14 +82,14 @@ class HttpServerAttributesExtractorBothSemconvTest {
     @Override
     public String getNetworkTransport(
         Map<String, Object> request, @Nullable Map<String, Object> response) {
-      return (String) request.get("transport");
+      return (String) request.get("networkTransport");
     }
 
     @Nullable
     @Override
     public String getNetworkType(
         Map<String, Object> request, @Nullable Map<String, Object> response) {
-      return (String) request.get("type");
+      return (String) request.get("networkType");
     }
 
     @Nullable
@@ -109,13 +109,13 @@ class HttpServerAttributesExtractorBothSemconvTest {
     @Nullable
     @Override
     public String getServerAddress(Map<String, Object> request) {
-      return (String) request.get("hostName");
+      return (String) request.get("serverAddress");
     }
 
     @Nullable
     @Override
     public Integer getServerPort(Map<String, Object> request) {
-      return (Integer) request.get("hostPort");
+      return (Integer) request.get("serverPort");
     }
   }
 
@@ -123,18 +123,18 @@ class HttpServerAttributesExtractorBothSemconvTest {
   void normal() {
     Map<String, Object> request = new HashMap<>();
     request.put("method", "POST");
-    request.put("url", "http://github.com");
-    request.put("path", "/repositories/1");
-    request.put("query", "details=true");
-    request.put("scheme", "http");
+    request.put("urlFull", "http://github.com");
+    request.put("urlPath", "/repositories/1");
+    request.put("urlQuery", "details=true");
+    request.put("urlScheme", "http");
     request.put("header.content-length", "10");
     request.put("route", "/repositories/{id}");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.host", "github.com");
     request.put("header.forwarded", "for=1.1.1.1;proto=https");
     request.put("header.custom-request-header", "123,456");
-    request.put("transport", "udp");
-    request.put("type", "ipv4");
+    request.put("networkTransport", "udp");
+    request.put("networkType", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "2.0");
 

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesExtractorStableSemconvTest.java
@@ -44,7 +44,7 @@ class HttpClientAttributesExtractorStableSemconvTest {
 
     @Override
     public String getUrlFull(Map<String, String> request) {
-      return request.get("url");
+      return request.get("urlFull");
     }
 
     @Override
@@ -76,14 +76,14 @@ class HttpClientAttributesExtractorStableSemconvTest {
     @Override
     public String getNetworkTransport(
         Map<String, String> request, @Nullable Map<String, String> response) {
-      return request.get("transport");
+      return request.get("networkTransport");
     }
 
     @Nullable
     @Override
     public String getNetworkType(
         Map<String, String> request, @Nullable Map<String, String> response) {
-      return request.get("type");
+      return request.get("networkType");
     }
 
     @Nullable
@@ -103,13 +103,13 @@ class HttpClientAttributesExtractorStableSemconvTest {
     @Nullable
     @Override
     public String getServerAddress(Map<String, String> request) {
-      return request.get("peerName");
+      return request.get("serverAddress");
     }
 
     @Nullable
     @Override
     public Integer getServerPort(Map<String, String> request) {
-      String value = request.get("peerPort");
+      String value = request.get("serverPort");
       return value == null ? null : Integer.parseInt(value);
     }
   }
@@ -118,16 +118,16 @@ class HttpClientAttributesExtractorStableSemconvTest {
   void normal() {
     Map<String, String> request = new HashMap<>();
     request.put("method", "POST");
-    request.put("url", "http://github.com");
+    request.put("urlFull", "http://github.com");
     request.put("header.content-length", "10");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.custom-request-header", "123,456");
-    request.put("transport", "udp");
-    request.put("type", "ipv4");
+    request.put("networkTransport", "udp");
+    request.put("networkType", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "1.1");
-    request.put("peerName", "github.com");
-    request.put("peerPort", "123");
+    request.put("serverAddress", "github.com");
+    request.put("serverPort", "123");
 
     Map<String, String> response = new HashMap<>();
     response.put("statusCode", "202");
@@ -183,7 +183,7 @@ class HttpClientAttributesExtractorStableSemconvTest {
     Map<String, String> request = new HashMap<>();
     request.put("protocolName", observedProtocolName);
     request.put("protocolVersion", observedProtocolVersion);
-    request.put("transport", observedTransport);
+    request.put("networkTransport", observedTransport);
 
     AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.create(new TestHttpClientAttributesGetter());

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorStableSemconvTest.java
@@ -49,19 +49,19 @@ class HttpServerAttributesExtractorStableSemconvTest {
 
     @Override
     public String getUrlScheme(Map<String, String> request) {
-      return request.get("scheme");
+      return request.get("urlScheme");
     }
 
     @Nullable
     @Override
     public String getUrlPath(Map<String, String> request) {
-      return request.get("path");
+      return request.get("urlPath");
     }
 
     @Nullable
     @Override
     public String getUrlQuery(Map<String, String> request) {
-      return request.get("query");
+      return request.get("urlQuery");
     }
 
     @Override
@@ -93,14 +93,14 @@ class HttpServerAttributesExtractorStableSemconvTest {
     @Override
     public String getNetworkTransport(
         Map<String, String> request, @Nullable Map<String, String> response) {
-      return request.get("transport");
+      return request.get("networkTransport");
     }
 
     @Nullable
     @Override
     public String getNetworkType(
         Map<String, String> request, @Nullable Map<String, String> response) {
-      return request.get("type");
+      return request.get("networkType");
     }
 
     @Nullable
@@ -120,13 +120,13 @@ class HttpServerAttributesExtractorStableSemconvTest {
     @Nullable
     @Override
     public String getServerAddress(Map<String, String> request) {
-      return request.get("hostName");
+      return request.get("serverAddress");
     }
 
     @Nullable
     @Override
     public Integer getServerPort(Map<String, String> request) {
-      String value = request.get("hostPort");
+      String value = request.get("serverPort");
       return value == null ? null : Integer.parseInt(value);
     }
 
@@ -150,18 +150,18 @@ class HttpServerAttributesExtractorStableSemconvTest {
   void normal() {
     Map<String, String> request = new HashMap<>();
     request.put("method", "POST");
-    request.put("url", "http://github.com");
-    request.put("path", "/repositories/1");
-    request.put("query", "details=true");
-    request.put("scheme", "http");
+    request.put("urlFull", "http://github.com");
+    request.put("urlPath", "/repositories/1");
+    request.put("urlQuery", "details=true");
+    request.put("urlScheme", "http");
     request.put("header.content-length", "10");
     request.put("route", "/repositories/{id}");
     request.put("header.user-agent", "okhttp 3.x");
     request.put("header.host", "github.com");
     request.put("header.forwarded", "for=1.1.1.1;proto=https");
     request.put("header.custom-request-header", "123,456");
-    request.put("transport", "udp");
-    request.put("type", "ipv4");
+    request.put("networkTransport", "udp");
+    request.put("networkType", "ipv4");
     request.put("protocolName", "http");
     request.put("protocolVersion", "2.0");
     request.put("serverSocketAddress", "1.2.3.4");
@@ -224,7 +224,7 @@ class HttpServerAttributesExtractorStableSemconvTest {
     Map<String, String> request = new HashMap<>();
     request.put("protocolName", observedProtocolName);
     request.put("protocolVersion", observedProtocolVersion);
-    request.put("transport", observedTransport);
+    request.put("networkTransport", observedTransport);
 
     AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpServerAttributesExtractor.create(new TestHttpServerAttributesGetter());


### PR DESCRIPTION
I wanted to remove some of the old nomenclature (`peerName`) and make them a bit closer to the attribute names. 