### PR TITLE
Require `server.address` and `server.port` in the HTTP client getter

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientAttributesGetter.java
@@ -31,4 +31,14 @@ public interface HttpClientAttributesGetter<REQUEST, RESPONSE>
    */
   @Nullable
   String getUrlFull(REQUEST request);
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  String getServerAddress(REQUEST request);
+
+  /** {@inheritDoc} */
+  @Nullable
+  @Override
+  Integer getServerPort(REQUEST request);
 }

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3HttpAttributesGetter.java
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v3_0/client/Vertx3HttpAttributesGetter.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.vertx.v3_0.client;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.vertx.client.AbstractVertxHttpAttributesGetter;
 import io.vertx.core.http.HttpClientRequest;
+import javax.annotation.Nullable;
 
 final class Vertx3HttpAttributesGetter extends AbstractVertxHttpAttributesGetter {
 
@@ -21,9 +22,31 @@ final class Vertx3HttpAttributesGetter extends AbstractVertxHttpAttributesGetter
     // where relative is expected.
     if (!isAbsolute(uri)) {
       VertxRequestInfo requestInfo = requestInfoField.get(request);
-      uri = absoluteUri(requestInfo, uri);
+      if (requestInfo != null) {
+        uri = absoluteUri(requestInfo, uri);
+      }
     }
     return uri;
+  }
+
+  @Nullable
+  @Override
+  public String getServerAddress(HttpClientRequest request) {
+    VertxRequestInfo requestInfo = requestInfoField.get(request);
+    if (requestInfo == null) {
+      return null;
+    }
+    return requestInfo.getHost();
+  }
+
+  @Nullable
+  @Override
+  public Integer getServerPort(HttpClientRequest request) {
+    VertxRequestInfo requestInfo = requestInfoField.get(request);
+    if (requestInfo == null) {
+      return null;
+    }
+    return requestInfo.getPort();
   }
 
   private static boolean isAbsolute(String uri) {


### PR DESCRIPTION
These two are required by the spec, let's make them mandatory to implement