### PR TITLE
Revert "Fix application logger latestDepTest (#9169)"

### DIFF
--- a/instrumentation/internal/internal-application-logger/javaagent/build.gradle.kts
+++ b/instrumentation/internal/internal-application-logger/javaagent/build.gradle.kts
@@ -31,8 +31,7 @@ dependencies {
   }
 
   if (findProperty("testLatestDeps") as Boolean) {
-    // 1.4.9 breaks the Configurer interface, and Spring Boot hasn't caught up with that yet
-    testImplementation("ch.qos.logback:logback-classic:1.4.8")
+    testImplementation("ch.qos.logback:logback-classic:+")
   } else {
     testImplementation("ch.qos.logback:logback-classic") {
       version {


### PR DESCRIPTION
This reverts commit a1c60f6ea0ed7117b53e8134ad8d4aab3f54b72c.

This should be no longer needed, logback 1.4.11 fixed the `Configurer` problem.