### PR TITLE
Implemented InstrumentationModuleClassLoader for invokedynamic Advice dispatching

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/ClassCopySource.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/ClassCopySource.java
@@ -15,7 +15,9 @@ import net.bytebuddy.utility.StreamDrainer;
  * implementation is based on {@link net.bytebuddy.dynamic.ClassFileLocator.ForClassLoader}, with
  * the difference that it preserves the original classfile resource URL.
  */
-public abstract class ClassCopySource {
+abstract class ClassCopySource {
+
+  private ClassCopySource() {}
 
   /**
    * Provides a URL pointing to the specific classfile.

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/ClassCopySource.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/ClassCopySource.java
@@ -1,0 +1,127 @@
+package io.opentelemetry.javaagent.tooling.instrumentation.indy;
+
+import net.bytebuddy.utility.StreamDrainer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * Provides the bytecode and the original resource URL for loaded and not-yet loaded classes.
+ * The implementation is based on {@link net.bytebuddy.dynamic.ClassFileLocator.ForClassLoader},
+ * with the difference that it preserves the original classfile resource URL.
+ */
+public abstract class ClassCopySource {
+
+  /**
+   * Provides a URL pointing to the specific classfile.
+   *
+   * @return the URL
+   */
+  public abstract URL getUrl();
+
+  /**
+   * Provides the bytecode of the class. The result is the same as calling {@link URL#openStream()} on {@link #getUrl()}
+   * and draining that stream.
+   *
+   * @return the bytecode of the class.
+   */
+  public abstract byte[] getBytecode();
+
+  /**
+   * Creates a cached copy of this {@link ClassCopySource}.
+   * The cached copy eagerly loads the bytecode, so that {@link #getBytecode()} is guaranteed to not cause any IO.
+   * This comes at the cost of a higher heap consumption, as the bytecode is kept in memory.
+   *
+   * @return an ClassFileSource implementing the described caching behaviour.
+   */
+  public abstract ClassCopySource cached();
+
+  /**
+   * Creates a {@link ClassCopySource} for the class with the provided fully qualified name.
+   * The .class file for the provided classname must be available as a resource in the provided classloader.
+   * The class is guaranteed to not be loaded during this process.
+   *
+   * @param className the fully qualified name of the class to copy
+   * @param classLoader the classloader
+   * @return the ClassCopySource which can be used to copy the provided class to other classloaders.
+   */
+  public static ClassCopySource create(String className, ClassLoader classLoader) {
+    if(classLoader == null) {
+      throw new IllegalArgumentException("Copying classes from the bootstrap classloader is not supported!");
+    }
+    String classFileName = className.replace('.', '/') + ".class";
+    return new Lazy(classLoader, classFileName);
+  }
+
+  /**
+   * Same as {@link #create(String, ClassLoader)}, but easier to use for already loaded classes.
+   *
+   * @param loadedClass the class to copy
+   * @return the ClassCopySource which can be used to copy the provided class to other classloaders.
+   */
+  public static ClassCopySource create(Class<?> loadedClass) {
+    return create(loadedClass.getName(), loadedClass.getClassLoader());
+  }
+
+  private static class Lazy extends ClassCopySource {
+
+    private final ClassLoader classLoader;
+    private final String resourceName;
+
+    private Lazy(ClassLoader classLoader, String resourceName) {
+      this.classLoader = classLoader;
+      this.resourceName = resourceName;
+    }
+
+    @Override
+    public URL getUrl() {
+      URL url = classLoader.getResource(resourceName);
+      if(url == null) {
+        throw new IllegalStateException("Classfile "+resourceName+" does not exist in the provided classloader!");
+      }
+      return url;
+    }
+
+    @Override
+    public byte[] getBytecode() {
+      try(InputStream bytecodeStream = getUrl().openStream()) {
+        return StreamDrainer.DEFAULT.drain(bytecodeStream);
+      } catch (IOException e) {
+        throw new IllegalStateException("Failed to read classfile URL", e);
+      }
+    }
+
+    @Override
+    public ClassCopySource cached() {
+      return new Cached(this);
+    }
+  }
+
+  private static class Cached extends ClassCopySource {
+
+    private final URL classFileUrl;
+
+    private final byte[] cachedByteCode;
+
+    private Cached(ClassCopySource.Lazy from) {
+      classFileUrl = from.getUrl();
+      cachedByteCode = from.getBytecode();
+    }
+
+    @Override
+    public URL getUrl() {
+      return classFileUrl;
+    }
+
+    @Override
+    public byte[] getBytecode() {
+      return cachedByteCode;
+    }
+
+    @Override
+    public ClassCopySource cached() {
+      return this;
+    }
+  }
+
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/ClassCopySource.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/ClassCopySource.java
@@ -1,14 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.tooling.instrumentation.indy;
 
-import net.bytebuddy.utility.StreamDrainer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import net.bytebuddy.utility.StreamDrainer;
 
 /**
- * Provides the bytecode and the original resource URL for loaded and not-yet loaded classes.
- * The implementation is based on {@link net.bytebuddy.dynamic.ClassFileLocator.ForClassLoader},
- * with the difference that it preserves the original classfile resource URL.
+ * Provides the bytecode and the original resource URL for loaded and not-yet loaded classes. The
+ * implementation is based on {@link net.bytebuddy.dynamic.ClassFileLocator.ForClassLoader}, with
+ * the difference that it preserves the original classfile resource URL.
  */
 public abstract class ClassCopySource {
 
@@ -20,34 +25,35 @@ public abstract class ClassCopySource {
   public abstract URL getUrl();
 
   /**
-   * Provides the bytecode of the class. The result is the same as calling {@link URL#openStream()} on {@link #getUrl()}
-   * and draining that stream.
+   * Provides the bytecode of the class. The result is the same as calling {@link URL#openStream()}
+   * on {@link #getUrl()} and draining that stream.
    *
    * @return the bytecode of the class.
    */
   public abstract byte[] getBytecode();
 
   /**
-   * Creates a cached copy of this {@link ClassCopySource}.
-   * The cached copy eagerly loads the bytecode, so that {@link #getBytecode()} is guaranteed to not cause any IO.
-   * This comes at the cost of a higher heap consumption, as the bytecode is kept in memory.
+   * Creates a cached copy of this {@link ClassCopySource}. The cached copy eagerly loads the
+   * bytecode, so that {@link #getBytecode()} is guaranteed to not cause any IO. This comes at the
+   * cost of a higher heap consumption, as the bytecode is kept in memory.
    *
    * @return an ClassFileSource implementing the described caching behaviour.
    */
   public abstract ClassCopySource cached();
 
   /**
-   * Creates a {@link ClassCopySource} for the class with the provided fully qualified name.
-   * The .class file for the provided classname must be available as a resource in the provided classloader.
-   * The class is guaranteed to not be loaded during this process.
+   * Creates a {@link ClassCopySource} for the class with the provided fully qualified name. The
+   * .class file for the provided classname must be available as a resource in the provided
+   * classloader. The class is guaranteed to not be loaded during this process.
    *
    * @param className the fully qualified name of the class to copy
    * @param classLoader the classloader
    * @return the ClassCopySource which can be used to copy the provided class to other classloaders.
    */
   public static ClassCopySource create(String className, ClassLoader classLoader) {
-    if(classLoader == null) {
-      throw new IllegalArgumentException("Copying classes from the bootstrap classloader is not supported!");
+    if (classLoader == null) {
+      throw new IllegalArgumentException(
+          "Copying classes from the bootstrap classloader is not supported!");
     }
     String classFileName = className.replace('.', '/') + ".class";
     return new Lazy(classLoader, classFileName);
@@ -76,15 +82,16 @@ public abstract class ClassCopySource {
     @Override
     public URL getUrl() {
       URL url = classLoader.getResource(resourceName);
-      if(url == null) {
-        throw new IllegalStateException("Classfile "+resourceName+" does not exist in the provided classloader!");
+      if (url == null) {
+        throw new IllegalStateException(
+            "Classfile " + resourceName + " does not exist in the provided classloader!");
       }
       return url;
     }
 
     @Override
     public byte[] getBytecode() {
-      try(InputStream bytecodeStream = getUrl().openStream()) {
+      try (InputStream bytecodeStream = getUrl().openStream()) {
         return StreamDrainer.DEFAULT.drain(bytecodeStream);
       } catch (IOException e) {
         throw new IllegalStateException("Failed to read classfile URL", e);
@@ -123,5 +130,4 @@ public abstract class ClassCopySource {
       return this;
     }
   }
-
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -220,7 +220,7 @@ class InstrumentationModuleClassLoader extends ClassLoader {
   @SuppressWarnings({"deprecation", "InvalidLink"})
   Package findPackage(String name) {
     try {
-      return (Package) FIND_PACKAGE_METHOD.invokeExact((ClassLoader) this, name);
+      return (Package) FIND_PACKAGE_METHOD.invoke(this, name);
     } catch (Throwable t) {
       throw new IllegalStateException(t);
     }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -1,6 +1,10 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.tooling.instrumentation.indy;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -14,27 +18,34 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
- * Classloader used to load the helper classes from {@link io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule}s,
- * so that those classes have access to both the agent/extension classes and the instrumented application classes.
+ * Classloader used to load the helper classes from {@link
+ * io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule}s, so that those
+ * classes have access to both the agent/extension classes and the instrumented application classes.
  *
- * This classloader implements the following classloading delegation strategy:
+ * <p>This classloader implements the following classloading delegation strategy:
+ *
  * <ul>
- *   <li>First, injected classes are considered (usually the helper classes from the InstrumentationModule)</li>
- *   <li>Next, the classloader looks in the agent or extension classloader, depending on the where the InstrumentationModule comes from</li>
- *   <li>Finally, the instrumented application classloader is checked for the class</li>
+ *   <li>First, injected classes are considered (usually the helper classes from the
+ *       InstrumentationModule)
+ *   <li>Next, the classloader looks in the agent or extension classloader, depending on the where
+ *       the InstrumentationModule comes from
+ *   <li>Finally, the instrumented application classloader is checked for the class
  * </ul>
  *
- * In addition, this classloader ensures that the lookup of corresponding .class resources follow the same delegation strategy,
- * so that bytecode inspection tools work correctly.
+ * In addition, this classloader ensures that the lookup of corresponding .class resources follow
+ * the same delegation strategy, so that bytecode inspection tools work correctly.
  */
 public class InstrumentationModuleClassLoader extends ClassLoader {
 
   private static final Map<String, ClassCopySource> ALWAYS_INJECTED_CLASSES;
+
   static {
     Map<String, ClassCopySource> alwaysInjected = new HashMap<>();
-    alwaysInjected.put(LookupExposer.class.getName(), ClassCopySource.create(LookupExposer.class).cached());
+    alwaysInjected.put(
+        LookupExposer.class.getName(), ClassCopySource.create(LookupExposer.class).cached());
     ALWAYS_INJECTED_CLASSES = Collections.unmodifiableMap(alwaysInjected);
   }
 
@@ -45,22 +56,24 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
   private final ClassLoader agentCl;
   private final ClassLoader instrumentedCl;
 
-
-  public InstrumentationModuleClassLoader(ClassLoader instrumentedCl, ClassLoader agentCl, Map<String, ClassCopySource> injectedClasses) {
-    super(agentCl); //agent-classloader is "main"-parent, but class (and .class-resources) lookup is overridden
+  public InstrumentationModuleClassLoader(
+      ClassLoader instrumentedCl,
+      ClassLoader agentCl,
+      Map<String, ClassCopySource> injectedClasses) {
+    // agent-classloader is "main"-parent, but class (and .class-resources) lookup is overridden
+    super(agentCl);
     additionalInjectedClasses = injectedClasses;
     this.agentCl = agentCl;
     this.instrumentedCl = instrumentedCl;
   }
 
   /**
-   * Provides a Lookup within this classloader.
-   * See {@link LookupExposer} for the details.
+   * Provides a Lookup within this classloader. See {@link LookupExposer} for the details.
    *
    * @return a lookup capable of accessing public types in this classloader
    */
   public MethodHandles.Lookup getLookup() {
-    //Load the injected copy of LookupExposer and invoke it
+    // Load the injected copy of LookupExposer and invoke it
     try {
       Class<?> lookupExposer = loadClass(LookupExposer.class.getName());
       return (MethodHandles.Lookup) lookupExposer.getMethod("getLookup").invoke(null);
@@ -71,30 +84,32 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
 
   @Override
   protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-    synchronized (getClassLoadingLock( name)) {
+    synchronized (getClassLoadingLock(name)) {
       Class<?> result = findLoadedClass(name);
 
       // This CL is self-first: Injected class are loaded BEFORE a parent lookup
-      if(result == null) {
+      if (result == null) {
         ClassCopySource injected = getInjectedClass(name);
         if (injected != null) {
           byte[] bytecode = injected.getBytecode();
           if (System.getSecurityManager() == null) {
             result = defineClassWithPackage(name, bytecode);
           } else {
-            result = AccessController.doPrivileged((PrivilegedAction<Class<?>>)() -> defineClassWithPackage(name, bytecode));
+            result =
+                AccessController.doPrivileged(
+                    (PrivilegedAction<Class<?>>) () -> defineClassWithPackage(name, bytecode));
           }
         }
       }
-      if(result == null) {
+      if (result == null) {
         result = tryLoad(agentCl, name);
       }
-      if(result == null) {
+      if (result == null) {
         result = tryLoad(instrumentedCl, name);
       }
 
       if (result != null) {
-        if(resolve) {
+        if (resolve) {
           resolveClass(result);
         }
         return result;
@@ -115,19 +130,19 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
   @Override
   public URL getResource(String resourceName) {
     String className = resourceToClassName(resourceName);
-    if(className != null) {
-      //for classes use the same precedence as in loadClass
+    if (className != null) {
+      // for classes use the same precedence as in loadClass
       ClassCopySource injected = getInjectedClass(className);
       if (injected != null) {
         return injected.getUrl();
       }
       URL fromAgentCl = agentCl.getResource(resourceName);
-      if(fromAgentCl != null) {
+      if (fromAgentCl != null) {
         return fromAgentCl;
       }
       return instrumentedCl.getResource(resourceName);
     } else {
-      //delegate to just the default parent (the agent classloader)
+      // delegate to just the default parent (the agent classloader)
       return super.getResource(resourceName);
     }
   }
@@ -137,20 +152,20 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
     String className = resourceToClassName(resourceName);
     if (className != null) {
       URL resource = getResource(resourceName);
-      List<URL> result = resource != null ? Collections.singletonList(resource) : Collections.emptyList();
+      List<URL> result =
+          resource != null ? Collections.singletonList(resource) : Collections.emptyList();
       return new EnumeratorFromIterator<>(result.iterator());
     }
     return super.getResources(resourceName);
   }
 
-
   @Nullable
   private static String resourceToClassName(String resourceName) {
-    if(!resourceName.endsWith(".class")) {
+    if (!resourceName.endsWith(".class")) {
       return null;
     }
     String className = resourceName;
-    if(className.startsWith("/")) {
+    if (className.startsWith("/")) {
       className = className.substring(1);
     }
     className = className.replace('/', '.');
@@ -160,26 +175,27 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
 
   @Nullable
   private ClassCopySource getInjectedClass(String name) {
-    if(ALWAYS_INJECTED_CLASSES.containsKey(name)) {
+    if (ALWAYS_INJECTED_CLASSES.containsKey(name)) {
       return ALWAYS_INJECTED_CLASSES.get(name);
     }
     return additionalInjectedClasses.get(name);
   }
 
-
   private Class<?> defineClassWithPackage(String name, byte[] bytecode) {
-    if(name.contains(".")) {
+    if (name.contains(".")) {
       String packageName = name.substring(0, name.lastIndexOf('.'));
-      if(findPackage(packageName) == null) {
+      if (findPackage(packageName) == null) {
         definePackage(packageName, null, null, null, null, null, null, null);
       }
     }
     return defineClass(name, bytecode, 0, bytecode.length, PROTECTION_DOMAIN);
   }
+
   /**
-   * Invokes {@link #getPackage(String)} for Java 8 and {@link #getDefinedPackage(String)} for Java 9+.
+   * Invokes {@link #getPackage(String)} for Java 8 and {@link #getDefinedPackage(String)} for Java
+   * 9+.
    *
-   * Package-private for testing.
+   * <p>Package-private for testing.
    *
    * @param name the name of the package find
    * @return the found package or null if it was not found.
@@ -197,9 +213,10 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
     if (System.getSecurityManager() == null) {
       return InstrumentationModuleClassLoader.class.getProtectionDomain();
     }
-    return AccessController.doPrivileged((PrivilegedAction<ProtectionDomain>) ((Class<?>) InstrumentationModuleClassLoader.class)::getProtectionDomain);
+    return AccessController.doPrivileged(
+        (PrivilegedAction<ProtectionDomain>)
+            ((Class<?>) InstrumentationModuleClassLoader.class)::getProtectionDomain);
   }
-
 
   private static Method getFindPackageMethod() {
     try {
@@ -214,11 +231,13 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
     }
   }
 
-  private static class EnumeratorFromIterator<T> implements Enumeration<T>{
+  private static class EnumeratorFromIterator<T> implements Enumeration<T> {
 
     private final Iterator<T> iterator;
 
-    private EnumeratorFromIterator(Iterator<T> iterator) {this.iterator = iterator;}
+    private EnumeratorFromIterator(Iterator<T> iterator) {
+      this.iterator = iterator;
+    }
 
     @Override
     public boolean hasMoreElements() {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
  * <p>In addition, this classloader ensures that the lookup of corresponding .class resources follow
  * the same delegation strategy, so that bytecode inspection tools work correctly.
  */
-public class InstrumentationModuleClassLoader extends ClassLoader {
+class InstrumentationModuleClassLoader extends ClassLoader {
 
   private static final Map<String, ClassCopySource> ALWAYS_INJECTED_CLASSES =
       Collections.singletonMap(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
  *   <li>Finally, the instrumented application classloader is checked for the class
  * </ul>
  *
- * In addition, this classloader ensures that the lookup of corresponding .class resources follow
+ * <p>In addition, this classloader ensures that the lookup of corresponding .class resources follow
  * the same delegation strategy, so that bytecode inspection tools work correctly.
  */
 public class InstrumentationModuleClassLoader extends ClassLoader {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -14,7 +14,6 @@ import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -152,7 +151,7 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
       URL resource = getResource(resourceName);
       List<URL> result =
           resource != null ? Collections.singletonList(resource) : Collections.emptyList();
-      return new EnumeratorFromIterator<>(result.iterator());
+      return Collections.enumeration(result);
     }
     return super.getResources(resourceName);
   }
@@ -228,25 +227,6 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
       } catch (NoSuchMethodException ex) {
         throw new IllegalStateException("expected method to always exist!", ex);
       }
-    }
-  }
-
-  private static class EnumeratorFromIterator<T> implements Enumeration<T> {
-
-    private final Iterator<T> iterator;
-
-    private EnumeratorFromIterator(Iterator<T> iterator) {
-      this.iterator = iterator;
-    }
-
-    @Override
-    public boolean hasMoreElements() {
-      return iterator.hasNext();
-    }
-
-    @Override
-    public T nextElement() {
-      return iterator.next();
     }
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -28,8 +28,8 @@ import javax.annotation.Nullable;
  * <ul>
  *   <li>First, injected classes are considered (usually the helper classes from the
  *       InstrumentationModule)
- *   <li>Next, the classloader looks in the agent or extension classloader, depending on where
- *       the InstrumentationModule comes from
+ *   <li>Next, the classloader looks in the agent or extension classloader, depending on where the
+ *       InstrumentationModule comes from
  *   <li>Finally, the instrumented application classloader is checked for the class
  * </ul>
  *

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -197,8 +197,7 @@ class InstrumentationModuleClassLoader extends ClassLoader {
       try {
         definePackage(packageName, null, null, null, null, null, null, null);
       } catch (IllegalArgumentException e) {
-        // Can happen if a parent classloader attempts to define the same package at the same time
-        // in Java 8
+        // Can happen if two classes from the same package are loaded concurrently
         if (findPackage(packageName) == null) {
           // package still doesn't exist, the IllegalArgumentException must be for a different
           // reason than a race condition

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -1,0 +1,233 @@
+package io.opentelemetry.javaagent.tooling.instrumentation.indy;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Classloader used to load the helper classes from {@link io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule}s,
+ * so that those classes have access to both the agent/extension classes and the instrumented application classes.
+ *
+ * This classloader implements the following classloading delegation strategy:
+ * <ul>
+ *   <li>First, injected classes are considered (usually the helper classes from the InstrumentationModule)</li>
+ *   <li>Next, the classloader looks in the agent or extension classloader, depending on the where the InstrumentationModule comes from</li>
+ *   <li>Finally, the instrumented application classloader is checked for the class</li>
+ * </ul>
+ *
+ * In addition, this classloader ensures that the lookup of corresponding .class resources follow the same delegation strategy,
+ * so that bytecode inspection tools work correctly.
+ */
+public class InstrumentationModuleClassLoader extends ClassLoader {
+
+  private static final Map<String, ClassCopySource> ALWAYS_INJECTED_CLASSES;
+  static {
+    Map<String, ClassCopySource> alwaysInjected = new HashMap<>();
+    alwaysInjected.put(LookupExposer.class.getName(), ClassCopySource.create(LookupExposer.class).cached());
+    ALWAYS_INJECTED_CLASSES = Collections.unmodifiableMap(alwaysInjected);
+  }
+
+  private static final ProtectionDomain PROTECTION_DOMAIN = getProtectionDomain();
+  private static final Method FIND_PACKAGE_METHOD = getFindPackageMethod();
+
+  private final Map<String, ClassCopySource> additionalInjectedClasses;
+  private final ClassLoader agentCl;
+  private final ClassLoader instrumentedCl;
+
+
+  public InstrumentationModuleClassLoader(ClassLoader instrumentedCl, ClassLoader agentCl, Map<String, ClassCopySource> injectedClasses) {
+    super(agentCl); //agent-classloader is "main"-parent, but class (and .class-resources) lookup is overridden
+    additionalInjectedClasses = injectedClasses;
+    this.agentCl = agentCl;
+    this.instrumentedCl = instrumentedCl;
+  }
+
+  /**
+   * Provides a Lookup within this classloader.
+   * See {@link LookupExposer} for the details.
+   *
+   * @return a lookup capable of accessing public types in this classloader
+   */
+  public MethodHandles.Lookup getLookup() {
+    //Load the injected copy of LookupExposer and invoke it
+    try {
+      Class<?> lookupExposer = loadClass(LookupExposer.class.getName());
+      return (MethodHandles.Lookup) lookupExposer.getMethod("getLookup").invoke(null);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    synchronized (getClassLoadingLock( name)) {
+      Class<?> result = findLoadedClass(name);
+
+      // This CL is self-first: Injected class are loaded BEFORE a parent lookup
+      if(result == null) {
+        ClassCopySource injected = getInjectedClass(name);
+        if (injected != null) {
+          byte[] bytecode = injected.getBytecode();
+          if (System.getSecurityManager() == null) {
+            result = defineClassWithPackage(name, bytecode);
+          } else {
+            result = AccessController.doPrivileged((PrivilegedAction<Class<?>>)() -> defineClassWithPackage(name, bytecode));
+          }
+        }
+      }
+      if(result == null) {
+        result = tryLoad(agentCl, name);
+      }
+      if(result == null) {
+        result = tryLoad(instrumentedCl, name);
+      }
+
+      if (result != null) {
+        if(resolve) {
+          resolveClass(result);
+        }
+        return result;
+      } else {
+        throw new ClassNotFoundException(name);
+      }
+    }
+  }
+
+  private static Class<?> tryLoad(ClassLoader cl, String name) {
+    try {
+      return cl.loadClass(name);
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
+  }
+
+  @Override
+  public URL getResource(String resourceName) {
+    String className = resourceToClassName(resourceName);
+    if(className != null) {
+      //for classes use the same precedence as in loadClass
+      ClassCopySource injected = getInjectedClass(className);
+      if (injected != null) {
+        return injected.getUrl();
+      }
+      URL fromAgentCl = agentCl.getResource(resourceName);
+      if(fromAgentCl != null) {
+        return fromAgentCl;
+      }
+      return instrumentedCl.getResource(resourceName);
+    } else {
+      //delegate to just the default parent (the agent classloader)
+      return super.getResource(resourceName);
+    }
+  }
+
+  @Override
+  public Enumeration<URL> getResources(String resourceName) throws IOException {
+    String className = resourceToClassName(resourceName);
+    if (className != null) {
+      URL resource = getResource(resourceName);
+      List<URL> result = resource != null ? Collections.singletonList(resource) : Collections.emptyList();
+      return new EnumeratorFromIterator<>(result.iterator());
+    }
+    return super.getResources(resourceName);
+  }
+
+
+  @Nullable
+  private static String resourceToClassName(String resourceName) {
+    if(!resourceName.endsWith(".class")) {
+      return null;
+    }
+    String className = resourceName;
+    if(className.startsWith("/")) {
+      className = className.substring(1);
+    }
+    className = className.replace('/', '.');
+    className = className.substring(0, className.length() - ".class".length());
+    return className;
+  }
+
+  @Nullable
+  private ClassCopySource getInjectedClass(String name) {
+    if(ALWAYS_INJECTED_CLASSES.containsKey(name)) {
+      return ALWAYS_INJECTED_CLASSES.get(name);
+    }
+    return additionalInjectedClasses.get(name);
+  }
+
+
+  private Class<?> defineClassWithPackage(String name, byte[] bytecode) {
+    if(name.contains(".")) {
+      String packageName = name.substring(0, name.lastIndexOf('.'));
+      if(findPackage(packageName) == null) {
+        definePackage(packageName, null, null, null, null, null, null, null);
+      }
+    }
+    return defineClass(name, bytecode, 0, bytecode.length, PROTECTION_DOMAIN);
+  }
+  /**
+   * Invokes {@link #getPackage(String)} for Java 8 and {@link #getDefinedPackage(String)} for Java 9+.
+   *
+   * Package-private for testing.
+   *
+   * @param name the name of the package find
+   * @return the found package or null if it was not found.
+   */
+  @SuppressWarnings({"deprecation", "InvalidLink"})
+  Package findPackage(String name) {
+    try {
+      return (Package) FIND_PACKAGE_METHOD.invoke(this, name);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static ProtectionDomain getProtectionDomain() {
+    if (System.getSecurityManager() == null) {
+      return InstrumentationModuleClassLoader.class.getProtectionDomain();
+    }
+    return AccessController.doPrivileged((PrivilegedAction<ProtectionDomain>) ((Class<?>) InstrumentationModuleClassLoader.class)::getProtectionDomain);
+  }
+
+
+  private static Method getFindPackageMethod() {
+    try {
+      return ClassLoader.class.getMethod("getDefinedPackage", String.class);
+    } catch (NoSuchMethodException e) {
+      // Java 8 case
+      try {
+        return ClassLoader.class.getDeclaredMethod("getPackage", String.class);
+      } catch (NoSuchMethodException ex) {
+        throw new IllegalStateException("expected method to always exist!", ex);
+      }
+    }
+  }
+
+  private static class EnumeratorFromIterator<T> implements Enumeration<T>{
+
+    private final Iterator<T> iterator;
+
+    private EnumeratorFromIterator(Iterator<T> iterator) {this.iterator = iterator;}
+
+    @Override
+    public boolean hasMoreElements() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public T nextElement() {
+      return iterator.next();
+    }
+  }
+}

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -53,17 +53,17 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
   private static final Method FIND_PACKAGE_METHOD = getFindPackageMethod();
 
   private final Map<String, ClassCopySource> additionalInjectedClasses;
-  private final ClassLoader agentCl;
+  private final ClassLoader agentOrExtensionCl;
   private final ClassLoader instrumentedCl;
 
   public InstrumentationModuleClassLoader(
       ClassLoader instrumentedCl,
-      ClassLoader agentCl,
+      ClassLoader agentOrExtensionCl,
       Map<String, ClassCopySource> injectedClasses) {
-    // agent-classloader is "main"-parent, but class (and .class-resources) lookup is overridden
-    super(agentCl);
+    // agent/extension-classloader is "main"-parent, but class lookup is overridden
+    super(agentOrExtensionCl);
     additionalInjectedClasses = injectedClasses;
-    this.agentCl = agentCl;
+    this.agentOrExtensionCl = agentOrExtensionCl;
     this.instrumentedCl = instrumentedCl;
   }
 
@@ -102,7 +102,7 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
         }
       }
       if (result == null) {
-        result = tryLoad(agentCl, name);
+        result = tryLoad(agentOrExtensionCl, name);
       }
       if (result == null) {
         result = tryLoad(instrumentedCl, name);
@@ -136,7 +136,7 @@ public class InstrumentationModuleClassLoader extends ClassLoader {
       if (injected != null) {
         return injected.getUrl();
       }
-      URL fromAgentCl = agentCl.getResource(resourceName);
+      URL fromAgentCl = agentOrExtensionCl.getResource(resourceName);
       if (fromAgentCl != null) {
         return fromAgentCl;
       }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  * <ul>
  *   <li>First, injected classes are considered (usually the helper classes from the
  *       InstrumentationModule)
- *   <li>Next, the classloader looks in the agent or extension classloader, depending on the where
+ *   <li>Next, the classloader looks in the agent or extension classloader, depending on where
  *       the InstrumentationModule comes from
  *   <li>Finally, the instrumented application classloader is checked for the class
  * </ul>

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -151,13 +151,13 @@ class InstrumentationModuleClassLoader extends ClassLoader {
   @Override
   public Enumeration<URL> getResources(String resourceName) throws IOException {
     String className = resourceToClassName(resourceName);
-    if (className != null) {
-      URL resource = getResource(resourceName);
-      List<URL> result =
-          resource != null ? Collections.singletonList(resource) : Collections.emptyList();
-      return Collections.enumeration(result);
+    if (className == null) {
+      return super.getResources(resourceName);
     }
-    return super.getResources(resourceName);
+    URL resource = getResource(resourceName);
+    List<URL> result =
+        resource != null ? Collections.singletonList(resource) : Collections.emptyList();
+    return Collections.enumeration(result);
   }
 
   @Nullable

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/LookupExposer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/LookupExposer.java
@@ -1,19 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.tooling.instrumentation.indy;
 
 import java.lang.invoke.MethodHandles;
 
 /**
- * This class is injected into every {@link InstrumentationModuleClassLoader}
- * so that the bootstrap can use a {@link MethodHandles.Lookup} with a lookup class from within the {@link InstrumentationModuleClassLoader},
- * instead of calling {@link MethodHandles#lookup()} which uses the caller class as the lookup class.
- * <p>
- * This circumvents a nasty JVM bug that's described <a href="https://github.com/elastic/apm-agent-java/issues/1450">here</a>.
- * The error is reproduced in {@code InstrumentationModuleClassLoaderTest}
- * </p>
+ * This class is injected into every {@link InstrumentationModuleClassLoader} so that the bootstrap
+ * can use a {@link MethodHandles.Lookup} with a lookup class from within the {@link
+ * InstrumentationModuleClassLoader}, instead of calling {@link MethodHandles#lookup()} which uses
+ * the caller class as the lookup class.
+ *
+ * <p>This circumvents a nasty JVM bug that's described <a
+ * href="https://github.com/elastic/apm-agent-java/issues/1450">here</a>. The error is reproduced in
+ * {@code InstrumentationModuleClassLoaderTest}
  */
 public class LookupExposer {
 
-  private LookupExposer(){}
+  private LookupExposer() {}
 
   public static MethodHandles.Lookup getLookup() {
     return MethodHandles.lookup();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/LookupExposer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/LookupExposer.java
@@ -1,0 +1,21 @@
+package io.opentelemetry.javaagent.tooling.instrumentation.indy;
+
+import java.lang.invoke.MethodHandles;
+
+/**
+ * This class is injected into every {@link InstrumentationModuleClassLoader}
+ * so that the bootstrap can use a {@link MethodHandles.Lookup} with a lookup class from within the {@link InstrumentationModuleClassLoader},
+ * instead of calling {@link MethodHandles#lookup()} which uses the caller class as the lookup class.
+ * <p>
+ * This circumvents a nasty JVM bug that's described <a href="https://github.com/elastic/apm-agent-java/issues/1450">here</a>.
+ * The error is reproduced in {@code InstrumentationModuleClassLoaderTest}
+ * </p>
+ */
+public class LookupExposer {
+
+  private LookupExposer(){}
+
+  public static MethodHandles.Lookup getLookup() {
+    return MethodHandles.lookup();
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
@@ -91,7 +91,7 @@ public class InstrumentationModuleClassLoaderTest {
 
     assertThat(classPackage).isNotNull();
     assertThat(clPackage).isNotNull();
-    assertThat(classPackage).isSameAs(classPackage);
+    assertThat(classPackage).isSameAs(clPackage);
   }
 
   @Test

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
@@ -1,0 +1,223 @@
+package io.opentelemetry.javaagent.tooling.instrumentation.indy;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import io.opentelemetry.javaagent.tooling.instrumentation.indy.dummies.Bar;
+import io.opentelemetry.javaagent.tooling.instrumentation.indy.dummies.Foo;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.implementation.FixedValue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SuppressWarnings("ClassNamedLikeTypeParameter")
+public class InstrumentationModuleClassLoaderTest {
+
+  @Test
+  public void checkLookup() throws Throwable {
+    Map<String, ClassCopySource> toInject = new HashMap<>();
+    toInject.put(Foo.class.getName(), ClassCopySource.create(Foo.class));
+    toInject.put(Bar.class.getName(), ClassCopySource.create(Bar.class));
+
+    ClassLoader dummyParent = new URLClassLoader(new URL[]{}, null);
+
+    InstrumentationModuleClassLoader m1 = new InstrumentationModuleClassLoader(dummyParent, dummyParent, toInject);
+    InstrumentationModuleClassLoader m2 = new InstrumentationModuleClassLoader(dummyParent, dummyParent, toInject);
+
+    // MethodHandles.publicLookup() always succeeds on the first invocation
+    lookupAndInvokeFoo(m1);
+    // MethodHandles.publicLookup() fails on the second invocation,
+    // even though the classes are loaded from an isolated class loader hierarchy
+    lookupAndInvokeFoo(m2);
+  }
+
+  private static void lookupAndInvokeFoo(InstrumentationModuleClassLoader classLoader) throws Throwable {
+    Class<?> fooClass = classLoader.loadClass(Foo.class.getName());
+    MethodHandles.Lookup lookup;
+    // using public lookup fails with LinkageError on second invocation - is this a (known) JVM bug?
+    // The failure only occurs on certain JVM versions, e.g. Java 8 and 11
+    //lookup = MethodHandles.publicLookup();
+    lookup = classLoader.getLookup();
+    MethodHandle methodHandle = lookup
+        .findStatic(fooClass, "foo", MethodType.methodType(String.class, classLoader.loadClass(Bar.class.getName())));
+    assertThat(methodHandle.invoke((Bar) null)).isEqualTo("foo");
+  }
+
+  @Test
+  public void checkInjectedClassesHavePackage() throws Throwable {
+    Map<String, ClassCopySource> toInject = new HashMap<>();
+    toInject.put(A.class.getName(), ClassCopySource.create(A.class));
+    toInject.put(B.class.getName(), ClassCopySource.create(B.class));
+    String packageName = A.class.getName().substring(0, A.class.getName().lastIndexOf('.'));
+
+    ClassLoader dummyParent = new URLClassLoader(new URL[]{}, null);
+    InstrumentationModuleClassLoader m1 = new InstrumentationModuleClassLoader(dummyParent, dummyParent, toInject);
+
+    Class<?> injected = Class.forName(A.class.getName(), true, m1);
+    // inject two classes from the same package to trigger errors if we try to redefine the package
+    Class.forName(B.class.getName(), true, m1);
+
+    assertThat(injected.getClassLoader()).isSameAs(m1);
+    Package clPackage = m1.findPackage(packageName);
+    Package classPackage = injected.getPackage();
+
+    assertThat(classPackage).isNotNull();
+    assertThat(clPackage).isNotNull();
+    assertThat(classPackage).isSameAs(classPackage);
+  }
+
+
+  @Test
+  public void checkClassLookupPrecedence(@TempDir Path tempDir) throws Exception {
+
+    Map<String, byte[]> appClasses = copyClassesWithMarker("app-cl", A.class, B.class, C.class);
+    Map<String, byte[]> agentClasses = copyClassesWithMarker("agent-cl", B.class, C.class);
+    Map<String, byte[]> moduleClasses = copyClassesWithMarker("module-cl", A.class, B.class, C.class, D.class);
+
+    Path appJar = tempDir.resolve("dummy-app.jar");
+    createJar(appClasses, appJar);
+
+    Path agentJar = tempDir.resolve("dummy-agent.jar");
+    createJar(agentClasses, agentJar);
+
+    Path moduleJar = tempDir.resolve("instrumentation-module.jar");
+    createJar(moduleClasses, moduleJar);
+
+    URLClassLoader appCl = new URLClassLoader(new URL[]{appJar.toUri().toURL()}, null);
+    URLClassLoader agentCl = new URLClassLoader(new URL[]{agentJar.toUri().toURL()}, null);
+    URLClassLoader moduleSourceCl = new URLClassLoader(new URL[]{moduleJar.toUri().toURL()}, null);
+
+    try {
+      Map<String, ClassCopySource> toInject = new HashMap<>();
+      toInject.put(C.class.getName(), ClassCopySource.create(C.class.getName(), moduleSourceCl));
+
+      InstrumentationModuleClassLoader moduleCL = new InstrumentationModuleClassLoader(appCl, agentCl, toInject);
+
+      //Verify precedence for classloading
+      Class<?> clA = moduleCL.loadClass(A.class.getName());
+      assertThat(getMarkerValue(clA)).isEqualTo("app-cl");
+      assertThat(clA.getClassLoader()).isSameAs(appCl);
+
+      Class<?> clB = moduleCL.loadClass(B.class.getName());
+      assertThat(getMarkerValue(clB)).isEqualTo("agent-cl");
+      assertThat(clB.getClassLoader()).isSameAs(agentCl);
+
+      Class<?> clC = moduleCL.loadClass(C.class.getName());
+      assertThat(getMarkerValue(clC)).isEqualTo("module-cl");
+      assertThat(clC.getClassLoader()).isSameAs(moduleCL); //class must be copied, therefore moduleCL
+
+      assertThatThrownBy(() -> moduleCL.loadClass(D.class.getName())).isInstanceOf(ClassNotFoundException.class);
+
+      //Verify precedence for looking up .class resources
+      URL resourceA = moduleCL.getResource(getClassFile(A.class));
+      assertThat(resourceA.toString()).startsWith("jar:file:"+appJar);
+      assertThat(Collections.list(moduleCL.getResources(getClassFile(A.class))))
+          .containsExactly(resourceA);
+      assertThat(moduleCL.getResourceAsStream(getClassFile(A.class)))
+          .hasBinaryContent(appClasses.get(A.class.getName()));
+
+      URL resourceB = moduleCL.getResource(getClassFile(B.class));
+      assertThat(resourceB.toString()).startsWith("jar:file:"+agentJar);
+      assertThat(Collections.list(moduleCL.getResources(getClassFile(B.class))))
+          .containsExactly(resourceB);
+      assertThat(moduleCL.getResourceAsStream(getClassFile(B.class)))
+          .hasBinaryContent(agentClasses.get(B.class.getName()));
+
+      URL resourceC = moduleCL.getResource(getClassFile(C.class));
+      assertThat(resourceC.toString()).startsWith("jar:file:"+moduleJar);
+      assertThat(Collections.list(moduleCL.getResources(getClassFile(C.class))))
+          .containsExactly(resourceC);
+      assertThat(moduleCL.getResourceAsStream(getClassFile(C.class)))
+          .hasBinaryContent(moduleClasses.get(C.class.getName()));
+      assertThat(moduleCL.getResource("/" + getClassFile(C.class))).isEqualTo(resourceC);
+
+      assertThat(moduleCL.getResource(D.class.getName())).isNull();
+      assertThat(moduleCL.getResourceAsStream(D.class.getName())).isNull();
+      assertThat(Collections.list(moduleCL.getResources(D.class.getName()))).isEmpty();
+
+      // And finally verify that our resource handling does what it is supposed to do:
+      // Provide the correct bytecode sources when looking up bytecode with bytebuddy (or similar tools)
+
+      assertThat(ClassFileLocator.ForClassLoader.read(clA))
+          .isEqualTo(appClasses.get(A.class.getName()));
+      assertThat(ClassFileLocator.ForClassLoader.read(clB))
+          .isEqualTo(agentClasses.get(B.class.getName()));
+      assertThat(ClassFileLocator.ForClassLoader.read(clC))
+          .isEqualTo(moduleClasses.get(C.class.getName()));
+
+    } finally {
+      appCl.close();
+      agentCl.close();
+      moduleSourceCl.close();
+    }
+  }
+
+  private static String getClassFile(Class<?> cl) {
+    return cl.getName().replace('.', '/') +".class";
+  }
+
+  private static Map<String, byte[]> copyClassesWithMarker(String marker, Class<?>... toCopy) {
+
+    Map<String, byte[]> classes = new HashMap<>();
+    for(Class<?> clazz : toCopy) {
+      classes.put(clazz.getName(), copyClassWithMarker(clazz, marker));
+    }
+    return classes;
+  }
+
+
+  private static byte[] copyClassWithMarker(Class<?> original, String markerValue) {
+    return new ByteBuddy()
+        .redefine(original)
+        .defineMethod("marker", String.class, Modifier.PUBLIC | Modifier.STATIC)
+        .intercept(FixedValue.value(markerValue))
+        .make()
+        .getBytes();
+  }
+
+  private static String getMarkerValue(Class<?> clazz) {
+    try {
+      return (String) clazz.getMethod("marker").invoke(null);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void createJar(Map<String, byte[]> classNameToBytecode, Path jarFilePath) {
+    try(OutputStream fileOut = Files.newOutputStream(jarFilePath)) {
+      try(JarOutputStream jarOut = new JarOutputStream(fileOut)) {
+        for(String clName : classNameToBytecode.keySet()) {
+          String classFile = clName.replace('.', '/') +".class";
+          jarOut.putNextEntry(new JarEntry(classFile));
+          jarOut.write(classNameToBytecode.get(clName));
+          jarOut.closeEntry();
+        }
+      }
+    }catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
+  public static class A {}
+  public static class B {}
+  public static class C {}
+  public static class D {}
+
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
@@ -119,52 +119,52 @@ public class InstrumentationModuleClassLoaderTest {
       Map<String, ClassCopySource> toInject = new HashMap<>();
       toInject.put(C.class.getName(), ClassCopySource.create(C.class.getName(), moduleSourceCl));
 
-      InstrumentationModuleClassLoader moduleCL =
+      InstrumentationModuleClassLoader moduleCl =
           new InstrumentationModuleClassLoader(appCl, agentCl, toInject);
 
       // Verify precedence for classloading
-      Class<?> clA = moduleCL.loadClass(A.class.getName());
+      Class<?> clA = moduleCl.loadClass(A.class.getName());
       assertThat(getMarkerValue(clA)).isEqualTo("app-cl");
       assertThat(clA.getClassLoader()).isSameAs(appCl);
 
-      Class<?> clB = moduleCL.loadClass(B.class.getName());
+      Class<?> clB = moduleCl.loadClass(B.class.getName());
       assertThat(getMarkerValue(clB)).isEqualTo("agent-cl");
       assertThat(clB.getClassLoader()).isSameAs(agentCl);
 
-      Class<?> clC = moduleCL.loadClass(C.class.getName());
+      Class<?> clC = moduleCl.loadClass(C.class.getName());
       assertThat(getMarkerValue(clC)).isEqualTo("module-cl");
       assertThat(clC.getClassLoader())
-          .isSameAs(moduleCL); // class must be copied, therefore moduleCL
+          .isSameAs(moduleCl); // class must be copied, therefore moduleCL
 
-      assertThatThrownBy(() -> moduleCL.loadClass(D.class.getName()))
+      assertThatThrownBy(() -> moduleCl.loadClass(D.class.getName()))
           .isInstanceOf(ClassNotFoundException.class);
 
       // Verify precedence for looking up .class resources
-      URL resourceA = moduleCL.getResource(getClassFile(A.class));
+      URL resourceA = moduleCl.getResource(getClassFile(A.class));
       assertThat(resourceA.toString()).startsWith("jar:file:" + appJar);
-      assertThat(Collections.list(moduleCL.getResources(getClassFile(A.class))))
+      assertThat(Collections.list(moduleCl.getResources(getClassFile(A.class))))
           .containsExactly(resourceA);
-      assertThat(moduleCL.getResourceAsStream(getClassFile(A.class)))
+      assertThat(moduleCl.getResourceAsStream(getClassFile(A.class)))
           .hasBinaryContent(appClasses.get(A.class.getName()));
 
-      URL resourceB = moduleCL.getResource(getClassFile(B.class));
+      URL resourceB = moduleCl.getResource(getClassFile(B.class));
       assertThat(resourceB.toString()).startsWith("jar:file:" + agentJar);
-      assertThat(Collections.list(moduleCL.getResources(getClassFile(B.class))))
+      assertThat(Collections.list(moduleCl.getResources(getClassFile(B.class))))
           .containsExactly(resourceB);
-      assertThat(moduleCL.getResourceAsStream(getClassFile(B.class)))
+      assertThat(moduleCl.getResourceAsStream(getClassFile(B.class)))
           .hasBinaryContent(agentClasses.get(B.class.getName()));
 
-      URL resourceC = moduleCL.getResource(getClassFile(C.class));
+      URL resourceC = moduleCl.getResource(getClassFile(C.class));
       assertThat(resourceC.toString()).startsWith("jar:file:" + moduleJar);
-      assertThat(Collections.list(moduleCL.getResources(getClassFile(C.class))))
+      assertThat(Collections.list(moduleCl.getResources(getClassFile(C.class))))
           .containsExactly(resourceC);
-      assertThat(moduleCL.getResourceAsStream(getClassFile(C.class)))
+      assertThat(moduleCl.getResourceAsStream(getClassFile(C.class)))
           .hasBinaryContent(moduleClasses.get(C.class.getName()));
-      assertThat(moduleCL.getResource("/" + getClassFile(C.class))).isEqualTo(resourceC);
+      assertThat(moduleCl.getResource("/" + getClassFile(C.class))).isEqualTo(resourceC);
 
-      assertThat(moduleCL.getResource(D.class.getName())).isNull();
-      assertThat(moduleCL.getResourceAsStream(D.class.getName())).isNull();
-      assertThat(Collections.list(moduleCL.getResources(D.class.getName()))).isEmpty();
+      assertThat(moduleCl.getResource(D.class.getName())).isNull();
+      assertThat(moduleCl.getResourceAsStream(D.class.getName())).isNull();
+      assertThat(Collections.list(moduleCl.getResources(D.class.getName()))).isEmpty();
 
       // And finally verify that our resource handling does what it is supposed to do:
       // Provide the correct bytecode sources when looking up bytecode with bytebuddy (or similar

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 @SuppressWarnings("ClassNamedLikeTypeParameter")
-public class InstrumentationModuleClassLoaderTest {
+class InstrumentationModuleClassLoaderTest {
 
   @Test
   void checkLookup() throws Throwable {

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class InstrumentationModuleClassLoaderTest {
 
   @Test
-  public void checkLookup() throws Throwable {
+  void checkLookup() throws Throwable {
     Map<String, ClassCopySource> toInject = new HashMap<>();
     toInject.put(Foo.class.getName(), ClassCopySource.create(Foo.class));
     toInject.put(Bar.class.getName(), ClassCopySource.create(Bar.class));
@@ -71,7 +71,7 @@ public class InstrumentationModuleClassLoaderTest {
   }
 
   @Test
-  public void checkInjectedClassesHavePackage() throws Throwable {
+  void checkInjectedClassesHavePackage() throws Throwable {
     Map<String, ClassCopySource> toInject = new HashMap<>();
     toInject.put(A.class.getName(), ClassCopySource.create(A.class));
     toInject.put(B.class.getName(), ClassCopySource.create(B.class));
@@ -95,7 +95,7 @@ public class InstrumentationModuleClassLoaderTest {
   }
 
   @Test
-  public void checkClassLookupPrecedence(@TempDir Path tempDir) throws Exception {
+  void checkClassLookupPrecedence(@TempDir Path tempDir) throws Exception {
 
     Map<String, byte[]> appClasses = copyClassesWithMarker("app-cl", A.class, B.class, C.class);
     Map<String, byte[]> agentClasses = copyClassesWithMarker("agent-cl", B.class, C.class);

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/dummies/Bar.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/dummies/Bar.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.tooling.instrumentation.indy.dummies;
 
 public class Bar {}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/dummies/Bar.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/dummies/Bar.java
@@ -1,0 +1,3 @@
+package io.opentelemetry.javaagent.tooling.instrumentation.indy.dummies;
+
+public class Bar {}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/dummies/Foo.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/dummies/Foo.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.javaagent.tooling.instrumentation.indy.dummies;
 
 public class Foo {

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/dummies/Foo.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/dummies/Foo.java
@@ -1,0 +1,9 @@
+package io.opentelemetry.javaagent.tooling.instrumentation.indy.dummies;
+
+public class Foo {
+  private Foo() {}
+
+  public static String foo(Bar bar) {
+    return "foo";
+  }
+}


### PR DESCRIPTION
Implements the `InstrumentationModuleClassloader` with the delegation model described in #8999.
It might also be useful to have a look at the full [PoC implementation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/compare/14b063d55c193dbf49bcd5a310c9f9dbbc63748d...JonasKunz:opentelemetry-java-instrumentation:bcf187c525d055aec5bc11e7957a44f289fc4202) to see how things fit in the bigger picture.

The classloader also ensures that the lookup of `.class` resources is consistent with the classloading delegation.
This should avoid the need for manual resource injection in cases such as the [SpringWebInstrumentationModule](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/aab881736f0fcb717d93cb2461250e2bda6f45b7/instrumentation/spring/spring-web/spring-web-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/springweb/v3_1/SpringWebInstrumentationModule.java#L39).