### PR TITLE
Fix context propagation in Executor#execute() for non-capturing lambdas

### DIFF
--- a/instrumentation/executors/bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/executors/ContextPropagatingRunnable.java
+++ b/instrumentation/executors/bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/executors/ContextPropagatingRunnable.java
@@ -13,7 +13,8 @@ public final class ContextPropagatingRunnable implements Runnable {
   public static boolean shouldDecorateRunnable(Runnable task) {
     // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
     // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
-    // note: it is always safe to decorate lambdas since downstream code cannot be expecting a specific runnable implementation anyways
+    // note: it is always safe to decorate lambdas since downstream code cannot be expecting a
+    // specific runnable implementation anyways
     return task.getClass().getName().contains("/") && !(task instanceof ContextPropagatingRunnable);
   }
 

--- a/instrumentation/executors/bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/executors/ContextPropagatingRunnable.java
+++ b/instrumentation/executors/bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/executors/ContextPropagatingRunnable.java
@@ -13,6 +13,7 @@ public final class ContextPropagatingRunnable implements Runnable {
   public static boolean shouldDecorateRunnable(Runnable task) {
     // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
     // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
+    // note: it is always safe to decorate lambdas since downstream code cannot be expecting a specific runnable implementation anyways
     return task.getClass().getName().contains("/") && !(task instanceof ContextPropagatingRunnable);
   }
 

--- a/instrumentation/executors/bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/executors/ContextPropagatingRunnable.java
+++ b/instrumentation/executors/bootstrap/src/main/java/io/opentelemetry/javaagent/bootstrap/executors/ContextPropagatingRunnable.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.bootstrap.executors;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+public final class ContextPropagatingRunnable implements Runnable {
+
+  public static boolean shouldDecorateRunnable(Runnable task) {
+    // We wrap only lambdas' anonymous classes and if given object has not already been wrapped.
+    // Anonymous classes have '/' in class name which is not allowed in 'normal' classes.
+    return task.getClass().getName().contains("/") && !(task instanceof ContextPropagatingRunnable);
+  }
+
+  public static Runnable propagateContext(Runnable task, Context context) {
+    return new ContextPropagatingRunnable(task, context);
+  }
+
+  private final Runnable delegate;
+  private final Context context;
+
+  private ContextPropagatingRunnable(Runnable delegate, Context context) {
+    this.delegate = delegate;
+    this.context = context;
+  }
+
+  @Override
+  public void run() {
+    try (Scope ignored = context.makeCurrent()) {
+      delegate.run();
+    }
+  }
+}

--- a/instrumentation/executors/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/executors/LambdaContextPropagationTest.java
+++ b/instrumentation/executors/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/executors/LambdaContextPropagationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.context.Scope;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+// regression test for #9175
+class LambdaContextPropagationTest {
+
+  // must be static! the lambda that uses that must be non-capturing
+  private static final AtomicInteger failureCounter = new AtomicInteger();
+
+  @Test
+  void shouldCorrectlyPropagateContextToRunnables() {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    Baggage baggage = Baggage.builder().put("test", "test").build();
+    try (Scope ignored = baggage.makeCurrent()) {
+      for (int i = 0; i < 20; i++) {
+        // must text execute() -- other methods like submit() decorate the Runnable with a
+        // FutureTask
+        executor.execute(LambdaContextPropagationTest::assertBaggage);
+      }
+    }
+
+    assertThat(failureCounter).hasValue(0);
+  }
+
+  private static void assertBaggage() {
+    if (Baggage.current().getEntryValue("test") == null) {
+      failureCounter.incrementAndGet();
+    }
+  }
+}


### PR DESCRIPTION
Fixes #9175

This is an interesting issue that only occurs when using a non-capturing lambda (or any other singleton/cached `Runnable` instance), and only when `Executor#execute()` is used (since all other `ExecutorService` methods typically wrap the passed task in a new `FutureTask` and delegate to `execute()` anyway).

Because a singleton `Runnable` instance was passed, the whole machinery in `ExecutorAdviceHelper` and `TaskAdviceHelper` that handles a stateful virtual field completely broke when trying to correctly update the `PropagatedContext`, and sometimes overwrote the propagated context with a `null`. 

While this is a surgical fix that handles precisely the issue posted by the user, I believe we should rethink our executors instrumentation as a whole: I think instead of the complex and buggy state management we have right now we should switch to decoration whenever it's possible. While this will add a little bit of extra memory overhead, I think it's much safer that way.