### PR TITLE
Add ability to capture all http query params.

### DIFF
--- a/instrumentation/servlet/README.md
+++ b/instrumentation/servlet/README.md
@@ -2,10 +2,10 @@
 
 ## Settings
 
-| System property                                                        | Type    | Default | Description                                                                      |
-| ---------------------------------------------------------------------- | ------- | ------- |----------------------------------------------------------------------------------|
-| `otel.instrumentation.servlet.experimental-span-attributes`            | Boolean | `false` | Enable the capture of experimental span attributes.                              |
-| `otel.instrumentation.servlet.experimental.capture-request-parameters` | List    | Empty   | Request parameters to be captured (experimental). Use `*` to capture all values. |
+| System property                                                        | Type    | Default | Description                                                                                                                                                     |
+| ---------------------------------------------------------------------- | ------- | ------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `otel.instrumentation.servlet.experimental-span-attributes`            | Boolean | `false` | Enable the capture of experimental span attributes.                                                                                                             |
+| `otel.instrumentation.servlet.experimental.capture-request-parameters` | List    | Empty   | Request parameters to be captured (experimental). Use `*` to capture all values. *WARNING*: This is potentially dangerous and could leak sensitive information. |
 
 ### A word about version
 

--- a/instrumentation/servlet/README.md
+++ b/instrumentation/servlet/README.md
@@ -2,10 +2,10 @@
 
 ## Settings
 
-| System property                                                        | Type    | Default | Description                                         |
-| ---------------------------------------------------------------------- | ------- | ------- | --------------------------------------------------- |
-| `otel.instrumentation.servlet.experimental-span-attributes`            | Boolean | `false` | Enable the capture of experimental span attributes. |
-| `otel.instrumentation.servlet.experimental.capture-request-parameters` | List    | Empty   | Request parameters to be captured (experimental).   |
+| System property                                                        | Type    | Default | Description                                                                      |
+| ---------------------------------------------------------------------- | ------- | ------- |----------------------------------------------------------------------------------|
+| `otel.instrumentation.servlet.experimental-span-attributes`            | Boolean | `false` | Enable the capture of experimental span attributes.                              |
+| `otel.instrumentation.servlet.experimental.capture-request-parameters` | List    | Empty   | Request parameters to be captured (experimental). Use `*` to capture all values. |
 
 ### A word about version
 

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 
 public class Servlet5Accessor
     implements ServletAccessor<HttpServletRequest, HttpServletResponse>,
@@ -119,6 +120,11 @@ public class Servlet5Accessor
       HttpServletRequest httpServletRequest, String name) {
     String[] values = httpServletRequest.getParameterValues(name);
     return values == null ? Collections.emptyList() : Arrays.asList(values);
+  }
+
+  @Override
+  public Map<String, String[]> getQueryParamsMap(HttpServletRequest request) {
+    return request.getParameterMap();
   }
 
   @Override

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/QueryParameterKeyCache.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/QueryParameterKeyCache.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 
 class QueryParameterKeyCache {
 
-  public static final String KEY_PREFIX = "servlet.request.parameter.";
+  private static final String KEY_PREFIX = "servlet.request.parameter.";
   private static final Cache<String, AttributeKey<List<String>>> cache = Cache.bounded(500);
 
   private QueryParameterKeyCache() {}

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/QueryParameterKeyCache.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/QueryParameterKeyCache.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.servlet;
+
+import io.opentelemetry.api.common.AttributeKey;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+class QueryParameterKeyCache {
+
+  public static final String KEY_PREFIX = "servlet.request.parameter.";
+  private static final ConcurrentMap<String, AttributeKey<List<String>>> cache =
+      new ConcurrentHashMap<>();
+
+  static AttributeKey<List<String>> get(String headerName) {
+    // TODO: Limit cache size to prevent cache bloating attacks
+    return cache.computeIfAbsent(headerName, QueryParameterKeyCache::createKey);
+  }
+
+  private static AttributeKey<List<String>> createKey(String parameterName) {
+    // normalize parameter name similarly as is done with header names when header values are
+    // captured as span attributes
+    parameterName = parameterName.toLowerCase(Locale.ROOT);
+    String key = KEY_PREFIX + parameterName.replace('-', '_');
+    return AttributeKey.stringArrayKey(key);
+  }
+}

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/QueryParameterKeyCache.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/QueryParameterKeyCache.java
@@ -17,6 +17,8 @@ class QueryParameterKeyCache {
   private static final ConcurrentMap<String, AttributeKey<List<String>>> cache =
       new ConcurrentHashMap<>();
 
+  private QueryParameterKeyCache() {}
+
   static AttributeKey<List<String>> get(String headerName) {
     // TODO: Limit cache size to prevent cache bloating attacks
     return cache.computeIfAbsent(headerName, QueryParameterKeyCache::createKey);

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/QueryParameterKeyCache.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/QueryParameterKeyCache.java
@@ -6,21 +6,18 @@
 package io.opentelemetry.javaagent.instrumentation.servlet;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 class QueryParameterKeyCache {
 
   public static final String KEY_PREFIX = "servlet.request.parameter.";
-  private static final ConcurrentMap<String, AttributeKey<List<String>>> cache =
-      new ConcurrentHashMap<>();
+  private static final Cache<String, AttributeKey<List<String>>> cache = Cache.bounded(500);
 
   private QueryParameterKeyCache() {}
 
   static AttributeKey<List<String>> get(String parameterName) {
-    // TODO: Limit cache size to prevent cache bloating attacks
     return cache.computeIfAbsent(parameterName, QueryParameterKeyCache::createKey);
   }
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/QueryParameterKeyCache.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/QueryParameterKeyCache.java
@@ -19,9 +19,9 @@ class QueryParameterKeyCache {
 
   private QueryParameterKeyCache() {}
 
-  static AttributeKey<List<String>> get(String headerName) {
+  static AttributeKey<List<String>> get(String parameterName) {
     // TODO: Limit cache size to prevent cache bloating attacks
-    return cache.computeIfAbsent(headerName, QueryParameterKeyCache::createKey);
+    return cache.computeIfAbsent(parameterName, QueryParameterKeyCache::createKey);
   }
 
   private static AttributeKey<List<String>> createKey(String parameterName) {

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletAccessor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletAccessor.java
@@ -5,8 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet;
 
+import io.opentelemetry.api.common.AttributeKey;
 import java.security.Principal;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  * This interface is used to access methods of ServletContext, HttpServletRequest and
@@ -54,6 +58,17 @@ public interface ServletAccessor<REQUEST, RESPONSE> {
   Iterable<String> getRequestHeaderNames(REQUEST request);
 
   List<String> getRequestParameterValues(REQUEST request, String name);
+
+  default void forAllQueryParams(
+      REQUEST request, BiConsumer<AttributeKey<List<String>>, List<String>> consumer) {
+    Map<String, String[]> parameterMap = getQueryParamsMap(request);
+    for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+      AttributeKey<List<String>> key = AttributeKey.stringArrayKey(entry.getKey());
+      consumer.accept(key, Arrays.asList(entry.getValue()));
+    }
+  }
+
+  Map<String, String[]> getQueryParamsMap(REQUEST request);
 
   String getRequestServletPath(REQUEST request);
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletAccessor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletAccessor.java
@@ -63,7 +63,7 @@ public interface ServletAccessor<REQUEST, RESPONSE> {
       REQUEST request, BiConsumer<AttributeKey<List<String>>, List<String>> consumer) {
     Map<String, String[]> parameterMap = getQueryParamsMap(request);
     for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
-      AttributeKey<List<String>> key = AttributeKey.stringArrayKey(entry.getKey());
+      AttributeKey<List<String>> key = QueryParameterKeyCache.get(entry.getKey());
       consumer.accept(key, Arrays.asList(entry.getValue()));
     }
   }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletRequestParametersExtractor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletRequestParametersExtractor.java
@@ -40,8 +40,16 @@ public class ServletRequestParametersExtractor<REQUEST, RESPONSE>
     return !CAPTURE_REQUEST_PARAMETERS.isEmpty();
   }
 
+  private static boolean captureAll() {
+    return CAPTURE_REQUEST_PARAMETERS.size() == 1 && CAPTURE_REQUEST_PARAMETERS.get(0).equals("*");
+  }
+
   public void setAttributes(
       REQUEST request, BiConsumer<AttributeKey<List<String>>, List<String>> consumer) {
+    if (captureAll()) {
+      accessor.forAllQueryParams(request, consumer);
+      return;
+    }
     for (String name : CAPTURE_REQUEST_PARAMETERS) {
       List<String> values = accessor.getRequestParameterValues(request, name);
       if (!values.isEmpty()) {

--- a/instrumentation/servlet/servlet-javax-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/javax/JavaxServletAccessor.java
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/javax/JavaxServletAccessor.java
@@ -10,6 +10,7 @@ import java.security.Principal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.ServletException;
@@ -100,7 +101,14 @@ public abstract class JavaxServletAccessor<R> implements ServletAccessor<HttpSer
   @Override
   @SuppressWarnings("unchecked")
   public Map<String, String[]> getQueryParamsMap(HttpServletRequest request) {
-    return (Map<String, String[]>) request.getParameterMap();
+    Map<String, String[]> result = new HashMap<>();
+    Enumeration<String> names = request.getParameterNames();
+    while (names.hasMoreElements()) {
+      String name = names.nextElement();
+      String[] values = request.getParameterValues(name);
+      result.put(name, values);
+    }
+    return result;
   }
 
   @Override

--- a/instrumentation/servlet/servlet-javax-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/javax/JavaxServletAccessor.java
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/javax/JavaxServletAccessor.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
@@ -94,6 +95,12 @@ public abstract class JavaxServletAccessor<R> implements ServletAccessor<HttpSer
       HttpServletRequest httpServletRequest, String name) {
     String[] values = httpServletRequest.getParameterValues(name);
     return values == null ? Collections.emptyList() : Arrays.asList(values);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Map<String, String[]> getQueryParamsMap(HttpServletRequest request) {
+    return (Map<String, String[]>) request.getParameterMap();
   }
 
   @Override


### PR DESCRIPTION
Relates to #9183. User can specify a single wildcard to capture all http query params.

I wish there was a practical way to test this. Hrmph.