### PR TITLE
Flaky tomcat access log tests

### DIFF
--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
@@ -9,7 +9,6 @@ import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import io.opentelemetry.javaagent.bootstrap.servlet.ExperimentalSnippetHolder
-import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest
 
 import javax.servlet.Servlet
 

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/AbstractServlet3Test.groovy
@@ -82,14 +82,6 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
     addServlet(context, HTML_SERVLET_OUTPUT_STREAM.path, servlet)
   }
 
-  protected ServerEndpoint lastRequest
-
-  @Override
-  AggregatedHttpRequest request(ServerEndpoint uri, String method) {
-    lastRequest = uri
-    super.request(uri, method)
-  }
-
   @Override
   String expectedHttpRoute(ServerEndpoint endpoint) {
     switch (endpoint) {

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3Test.groovy
@@ -40,6 +40,11 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue
 @Unroll
 abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> {
 
+  static final ServerEndpoint ACCESS_LOG_SUCCESS = new ServerEndpoint("ACCESS_LOG_SUCCESS",
+    "success?access-log=true", SUCCESS.status, SUCCESS.body, false)
+  static final ServerEndpoint ACCESS_LOG_ERROR = new ServerEndpoint("ACCESS_LOG_ERROR",
+      "error-status?access-log=true", ERROR.status, ERROR.body, false)
+
   @Override
   Throwable expectedException() {
     new ServletException(EXCEPTION.body)
@@ -101,7 +106,6 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
 
   def setup() {
     accessLogValue.loggedIds.clear()
-    accessLogValue.disable()
   }
 
   @Override
@@ -123,10 +127,8 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
   }
 
   def "access log has ids for #count requests"() {
-    accessLogValue.enable()
-
     given:
-    def request = request(SUCCESS, method)
+    def request = request(ACCESS_LOG_SUCCESS, method)
 
     when:
     List<AggregatedHttpResponse> responses = (1..count).collect {
@@ -135,8 +137,8 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
 
     then:
     responses.each { response ->
-      assert response.status().code() == SUCCESS.status
-      assert response.contentUtf8() == SUCCESS.body
+      assert response.status().code() == ACCESS_LOG_SUCCESS.status
+      assert response.contentUtf8() == ACCESS_LOG_SUCCESS.body
     }
 
     and:
@@ -148,7 +150,7 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
 
       (0..count - 1).each {
         trace(it, 2) {
-          serverSpan(it, 0, null, null, "GET", SUCCESS.body.length())
+          serverSpan(it, 0, null, null, "GET", ACCESS_LOG_SUCCESS.body.length(), ACCESS_LOG_SUCCESS)
           controllerSpan(it, 1, span(0))
         }
 
@@ -165,14 +167,13 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
   def "access log has ids for error request"() {
     setup:
     assumeTrue(testError())
-    accessLogValue.enable()
 
-    def request = request(ERROR, method)
+    def request = request(ACCESS_LOG_ERROR, method)
     def response = client.execute(request).aggregate().join()
 
     expect:
-    response.status().code() == ERROR.status
-    response.contentUtf8() == ERROR.body
+    response.status().code() == ACCESS_LOG_ERROR.status
+    response.contentUtf8() == ACCESS_LOG_ERROR.body
 
     and:
     def spanCount = 2
@@ -181,7 +182,7 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
     }
     assertTraces(1) {
       trace(0, spanCount) {
-        serverSpan(it, 0, null, null, method, response.content().length(), ERROR)
+        serverSpan(it, 0, null, null, method, response.content().length(), ACCESS_LOG_ERROR)
         def spanIndex = 1
         controllerSpan(it, spanIndex, span(spanIndex - 1))
         spanIndex++
@@ -251,22 +252,13 @@ class ErrorHandlerValve extends ErrorReportValve {
 
 class TestAccessLogValve extends ValveBase implements AccessLog {
   final List<Tuple2<String, String>> loggedIds = []
-  volatile boolean enabled = false
 
   TestAccessLogValve() {
     super(true)
   }
 
-  void disable() {
-    enabled = false
-  }
-
-  void enable() {
-    enabled = true
-  }
-
   void log(Request request, Response response, long time) {
-    if (!enabled) {
+    if (request.getParameter("access-log") == null) {
       return
     }
 

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
@@ -9,7 +9,6 @@ import io.opentelemetry.instrumentation.test.asserts.TraceAssert
 import io.opentelemetry.instrumentation.test.base.HttpServerTest
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import io.opentelemetry.javaagent.bootstrap.servlet.ExperimentalSnippetHolder
-import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest
 import jakarta.servlet.Servlet
 
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.AUTH_REQUIRED

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/AbstractServlet5Test.groovy
@@ -82,14 +82,6 @@ abstract class AbstractServlet5Test<SERVER, CONTEXT> extends HttpServerTest<SERV
     addServlet(context, HTML_SERVLET_OUTPUT_STREAM.path, servlet)
   }
 
-  protected ServerEndpoint lastRequest
-
-  @Override
-  AggregatedHttpRequest request(ServerEndpoint uri, String method) {
-    lastRequest = uri
-    super.request(uri, method)
-  }
-
   @Override
   boolean testCapturedRequestParameters() {
     true

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5Test.groovy
@@ -40,6 +40,11 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue
 @Unroll
 abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> {
 
+  static final ServerEndpoint ACCESS_LOG_SUCCESS = new ServerEndpoint("ACCESS_LOG_SUCCESS",
+    "success?access-log=true", SUCCESS.status, SUCCESS.body, false)
+  static final ServerEndpoint ACCESS_LOG_ERROR = new ServerEndpoint("ACCESS_LOG_ERROR",
+    "error-status?access-log=true", ERROR.status, ERROR.body, false)
+
   @Override
   Throwable expectedException() {
     new ServletException(EXCEPTION.body)
@@ -101,7 +106,6 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
 
   def setup() {
     accessLogValue.loggedIds.clear()
-    accessLogValue.disable()
   }
 
   @Override
@@ -123,10 +127,8 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
   }
 
   def "access log has ids for #count requests"() {
-    accessLogValue.enable()
-
     given:
-    def request = request(SUCCESS, method)
+    def request = request(ACCESS_LOG_SUCCESS, method)
 
     when:
     List<AggregatedHttpResponse> responses = (1..count).collect {
@@ -135,8 +137,8 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
 
     then:
     responses.each { response ->
-      assert response.status().code() == SUCCESS.status
-      assert response.contentUtf8() == SUCCESS.body
+      assert response.status().code() == ACCESS_LOG_SUCCESS.status
+      assert response.contentUtf8() == ACCESS_LOG_SUCCESS.body
     }
 
     and:
@@ -148,7 +150,7 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
 
       (0..count - 1).each {
         trace(it, 2) {
-          serverSpan(it, 0, null, null, "GET", SUCCESS.body.length())
+          serverSpan(it, 0, null, null, "GET", ACCESS_LOG_SUCCESS.body.length(), ACCESS_LOG_SUCCESS)
           controllerSpan(it, 1, span(0))
         }
 
@@ -165,14 +167,13 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
   def "access log has ids for error request"() {
     setup:
     assumeTrue(testError())
-    accessLogValue.enable()
 
-    def request = request(ERROR, method)
+    def request = request(ACCESS_LOG_ERROR, method)
     def response = client.execute(request).aggregate().join()
 
     expect:
-    response.status().code() == ERROR.status
-    response.contentUtf8() == ERROR.body
+    response.status().code() == ACCESS_LOG_ERROR.status
+    response.contentUtf8() == ACCESS_LOG_ERROR.body
 
     and:
     def spanCount = 2
@@ -181,7 +182,7 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
     }
     assertTraces(1) {
       trace(0, spanCount) {
-        serverSpan(it, 0, null, null, method, response.content().length(), ERROR)
+        serverSpan(it, 0, null, null, method, response.content().length(), ACCESS_LOG_ERROR)
         def spanIndex = 1
         controllerSpan(it, spanIndex, span(spanIndex - 1))
         spanIndex++
@@ -251,24 +252,16 @@ class ErrorHandlerValve extends ErrorReportValve {
 
 class TestAccessLogValve extends ValveBase implements AccessLog {
   final List<Tuple2<String, String>> loggedIds = []
-  volatile boolean enabled = false
 
   TestAccessLogValve() {
     super(true)
   }
 
-  void disable() {
-    enabled = false
-  }
-
-  void enable() {
-    enabled = true
-  }
-
   void log(Request request, Response response, long time) {
-    if (!enabled) {
+    if (request.getParameter("access-log") == null) {
       return
     }
+
     synchronized (loggedIds) {
       loggedIds.add(new Tuple2(request.getAttribute("trace_id"),
         request.getAttribute("span_id")))

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -12,7 +12,6 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.INDEXED_CHILD;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.NOT_FOUND;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.PATH_PARAM;
-import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.QUERY_PARAM;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.REDIRECT;
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
@@ -704,7 +703,7 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
                 .containsEntry(
                     SemanticAttributes.HTTP_TARGET,
                     endpoint.resolvePath(address).getPath()
-                        + (endpoint == QUERY_PARAM ? "?" + endpoint.body : ""));
+                        + (endpoint.getQuery() != null ? "?" + endpoint.getQuery() : ""));
           }
 
           if (attrs.get(SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH) != null) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/ServerEndpoint.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/ServerEndpoint.java
@@ -81,6 +81,10 @@ public class ServerEndpoint {
   }
 
   public ServerEndpoint(String name, String uri, int status, String body) {
+    this(name, uri, status, body, true);
+  }
+
+  public ServerEndpoint(String name, String uri, int status, String body, boolean registerPath) {
     this.name = name;
     this.uriObj = URI.create(uri);
     this.path = uriObj.getPath();
@@ -88,7 +92,9 @@ public class ServerEndpoint {
     this.fragment = uriObj.getFragment();
     this.status = status;
     this.body = body;
-    PATH_MAP.put(this.getPath(), this);
+    if (registerPath) {
+      PATH_MAP.put(this.getPath(), this);
+    }
   }
 
   public String getPath() {


### PR DESCRIPTION
https://ge.opentelemetry.io/s/jekgjg4vqxmze/tests/task/:instrumentation:servlet:servlet-3.0:javaagent:test/details/TomcatServlet3TestForward/access%20log%20has%20ids%20for%201%20requests?expanded-stacktrace=WyIwIl0&top-execution=1
Previous attempt to fix this by enabling data collection in `TestAccessLogValve` only when running the access log tests didn't work because `TestAccessLogValve` runs after span has ended, so when access log test enabled it it could still see the request from a previous test. This pr changes it so that `TestAccessLogValve` collects only the requests that originate from access log tests. Hopefully this way `TestAccessLogValve` won't collect requests from previous tests.