### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/examples/distro/build.gradle
+++ b/examples/distro/build.gradle
@@ -33,13 +33,11 @@ subprojects {
       opentelemetryJavaagent     : "1.29.0-SNAPSHOT",
       opentelemetryJavaagentAlpha: "1.29.0-alpha-SNAPSHOT",
 
-      bytebuddy                  : "1.14.5",
       autoservice                : "1.1.1",
       junit                      : "5.10.0"
     ]
 
     deps = [
-      bytebuddy  : "net.bytebuddy:byte-buddy-dep:${versions.bytebuddy}",
       autoservice: [
         "com.google.auto.service:auto-service:${versions.autoservice}",
         "com.google.auto.service:auto-service-annotations:${versions.autoservice}",

--- a/examples/distro/gradle/instrumentation.gradle
+++ b/examples/distro/gradle/instrumentation.gradle
@@ -17,7 +17,6 @@ dependencies {
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
 
-  compileOnly deps.bytebuddy
   annotationProcessor deps.autoservice
   compileOnly deps.autoservice
 


### PR DESCRIPTION
No need for separate dependency update due to this: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9200/files

bytebuddy is already an `api` dependency of `opentelemetry-javaagent-extension-api`