### PR TITLE
Ensure reactor netty spans are ended in the order they were started

### DIFF
--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/InstrumentationContexts.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/InstrumentationContexts.java
@@ -52,7 +52,9 @@ final class InstrumentationContexts {
     return context;
   }
 
-  void endClientSpan(@Nullable HttpClientResponse response, @Nullable Throwable error) {
+  // we are synchronizing here to ensure that spans are ended in the oder they are read from the
+  // queue
+  synchronized void endClientSpan(@Nullable HttpClientResponse response, @Nullable Throwable error) {
     RequestAndContext requestAndContext = clientContexts.poll();
     if (requestAndContext != null) {
       instrumenter().end(requestAndContext.context, requestAndContext.request, response, error);


### PR DESCRIPTION
https://ge.opentelemetry.io/s/5q4iabsomwrhg/tests/task/:instrumentation:reactor:reactor-netty:reactor-netty-1.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.reactornetty.v1_0.ReactorNettyHttpClientTest/redirectToSecuredCopiesAuthHeader()?expanded-stacktrace=WyIwIl0&top-execution=1
Apparently it is possible for the final request span (`200` status) to complete before the redirect span (`302` status). As a side effect of ending the spans in wrong order `http.resend_count` attribute is placed on the redirect span.
It reproduces when a `sleep` is placed between `clientContexts.poll()` and `instrumenter().end()`, for some reason it appears to reproduce more easily when running all tests in `ReactorNettyHttpClientTest`, when you disable/comment out all other tests then this test passes even with the sleep.