### PR TITLE
Add http client test with non-standard request method

### DIFF
--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpClientInstrumentationTest.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/AkkaHttpClientInstrumentationTest.scala
@@ -117,6 +117,7 @@ class AkkaHttpClientInstrumentationTest
       options: HttpClientTestOptions.Builder
   ): Unit = {
     options.disableTestRedirects()
+    options.disableTestNonStandardHttpMethod()
     // singleConnection test would require instrumentation to support requests made through pools
     // (newHostConnectionPool, superPool, etc), which is currently not supported.
     options.setSingleConnectionFactory(

--- a/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpClientTest.java
+++ b/instrumentation/armeria-1.3/testing/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/AbstractArmeriaHttpClientTest.java
@@ -109,6 +109,8 @@ public abstract class AbstractArmeriaHttpClientTest extends AbstractHttpClientTe
     optionsBuilder.disableTestRedirects();
     // armeria requests can't be reused
     optionsBuilder.disableTestReusedRequest();
+    // can only use methods from HttpMethod enum
+    optionsBuilder.disableTestNonStandardHttpMethod();
   }
 
   @Test

--- a/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/AbstractGoogleHttpClientTest.java
+++ b/instrumentation/google-http-client-1.19/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/googlehttpclient/AbstractGoogleHttpClientTest.java
@@ -119,6 +119,9 @@ public abstract class AbstractGoogleHttpClientTest extends AbstractHttpClientTes
     // Circular redirects don't throw an exception with Google Http Client
     optionsBuilder.disableTestCircularRedirects();
 
+    // can only use supported method
+    optionsBuilder.disableTestNonStandardHttpMethod();
+
     optionsBuilder.setHttpAttributes(
         uri -> {
           Set<AttributeKey<?>> attributes =

--- a/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionResponseCodeOnlyTest.java
+++ b/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionResponseCodeOnlyTest.java
@@ -50,5 +50,6 @@ class HttpUrlConnectionResponseCodeOnlyTest extends AbstractHttpClientTest<HttpU
     // HttpURLConnection can't be reused
     optionsBuilder.disableTestReusedRequest();
     optionsBuilder.disableTestCallback();
+    optionsBuilder.disableTestNonStandardHttpMethod();
   }
 }

--- a/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionTest.java
+++ b/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionTest.java
@@ -82,6 +82,7 @@ class HttpUrlConnectionTest extends AbstractHttpClientTest<HttpURLConnection> {
     // HttpURLConnection can't be reused
     optionsBuilder.disableTestReusedRequest();
     optionsBuilder.disableTestCallback();
+    optionsBuilder.disableTestNonStandardHttpMethod();
   }
 
   @ParameterizedTest

--- a/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionUseCachesFalseTest.java
+++ b/instrumentation/http-url-connection/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/httpurlconnection/HttpUrlConnectionUseCachesFalseTest.java
@@ -60,5 +60,6 @@ class HttpUrlConnectionUseCachesFalseTest extends AbstractHttpClientTest<HttpURL
     // HttpURLConnection can't be reused
     optionsBuilder.disableTestReusedRequest();
     optionsBuilder.disableTestCallback();
+    optionsBuilder.disableTestNonStandardHttpMethod();
   }
 }

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebInstrumentationTest.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebInstrumentationTest.java
@@ -98,6 +98,7 @@ public class SpringWebInstrumentationTest extends AbstractHttpClientTest<HttpEnt
   protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
     optionsBuilder.disableTestCircularRedirects();
     optionsBuilder.disableTestReadTimeout();
+    optionsBuilder.disableTestNonStandardHttpMethod();
     optionsBuilder.setHttpAttributes(
         uri -> {
           Set<AttributeKey<?>> attributes =

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestOptions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpClientTestOptions.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.testing.junit.http;
 import com.google.auto.value.AutoValue;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import java.net.URI;
@@ -34,7 +35,7 @@ public abstract class HttpClientTestOptions {
                   SemanticAttributes.USER_AGENT_ORIGINAL)));
 
   public static final BiFunction<URI, String, String> DEFAULT_EXPECTED_CLIENT_SPAN_NAME_MAPPER =
-      (uri, method) -> method;
+      (uri, method) -> HttpConstants._OTHER.equals(method) ? "TEST" : method;
 
   public static final int FOUND_STATUS_CODE = HttpStatus.FOUND.code();
 
@@ -92,6 +93,8 @@ public abstract class HttpClientTestOptions {
 
   public abstract boolean getTestErrorWithCallback();
 
+  public abstract boolean getTestNonStandardHttpMethod();
+
   static Builder builder() {
     return new AutoValue_HttpClientTestOptions.Builder().withDefaults();
   }
@@ -120,7 +123,8 @@ public abstract class HttpClientTestOptions {
           .setTestCallback(true)
           .setTestCallbackWithParent(true)
           .setTestCallbackWithImplicitParent(false)
-          .setTestErrorWithCallback(true);
+          .setTestErrorWithCallback(true)
+          .setTestNonStandardHttpMethod(true);
     }
 
     Builder setHttpAttributes(Function<URI, Set<AttributeKey<?>>> value);
@@ -162,6 +166,8 @@ public abstract class HttpClientTestOptions {
     Builder setTestCallbackWithImplicitParent(boolean value);
 
     Builder setTestErrorWithCallback(boolean value);
+
+    Builder setTestNonStandardHttpMethod(boolean value);
 
     @CanIgnoreReturnValue
     default Builder disableTestWithClientParent() {
@@ -216,6 +222,11 @@ public abstract class HttpClientTestOptions {
     @CanIgnoreReturnValue
     default Builder disableTestErrorWithCallback() {
       return setTestErrorWithCallback(false);
+    }
+
+    @CanIgnoreReturnValue
+    default Builder disableTestNonStandardHttpMethod() {
+      return setTestNonStandardHttpMethod(false);
     }
 
     @CanIgnoreReturnValue


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8951
What I find odd is that the span name contains the original request method not `_OTHER`.