### PR TITLE
Change quarkus bom

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
       "groupName": "guava packages"
     },
     {
-      "matchPackageNames": ["io.quarkus", "io.quarkus.platform:quarkus-bom"],
+      "matchPackageNames": ["io.quarkus", "io.quarkus:quarkus-bom"],
       "groupName": "quarkus packages"
     },
     {

--- a/smoke-tests/images/quarkus/build.gradle.kts
+++ b/smoke-tests/images/quarkus/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 dependencies {
-  implementation(enforcedPlatform("io.quarkus.platform:quarkus-bom:3.2.4.Final"))
+  implementation(enforcedPlatform("io.quarkus:quarkus-bom:3.2.4.Final"))
   implementation("io.quarkus:quarkus-resteasy")
 }
 

--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -167,7 +167,6 @@ fun configureImage(
   } else if (vm == "openj9") {
     if (isWindows) {
       // ibm-semeru-runtimes doesn't publish windows images
-      // adoptopenjdk doesn't publish Windows 2022 images (and is deprecated)
       throw GradleException("Unexpected vm: $vm")
     } else {
       "ibm-semeru-runtimes:open-$jdk-jdk"
@@ -232,7 +231,6 @@ fun createDockerTasks(parentTask: TaskProvider<out Task>, isWindows: Boolean) {
         for (vm in entry.vm) {
           if (vm == "openj9" && isWindows) {
             // ibm-semeru-runtimes doesn't publish windows images
-            // adoptopenjdk is deprecated and doesn't publish Windows 2022 images
             continue
           }
           for (jdk in entry.jdk) {


### PR DESCRIPTION
I think this (smaller scoped) bom is all that's needed.

The real reason for this change though is it looks like the "platform" bom gets published later than the core quarkus artifacts and bom, which I think is why renovate is not combining the updates I had hoped it would (e.g. #9220)