### PR TITLE
Allow spans in any order in http client connectionErrorUnopenedPortWi…

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -31,7 +31,6 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -592,25 +591,14 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
 
     testing.waitAndAssertTraces(
         trace -> {
-          List<Consumer<SpanDataAssert>> spanAsserts =
-              Arrays.asList(
-                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                  span ->
-                      assertClientSpan(span, uri, method, null, null)
-                          .hasParent(trace.getSpan(0))
-                          .hasException(clientError),
-                  span ->
-                      span.hasName("callback")
-                          .hasKind(SpanKind.INTERNAL)
-                          .hasParent(trace.getSpan(0)));
-          boolean jdk8 = Objects.equals(System.getProperty("java.specification.version"), "1.8");
-          if (jdk8) {
-            // on some netty based http clients order of `CONNECT` and `callback` spans isn't
-            // guaranteed when running on jdk8
-            trace.hasSpansSatisfyingExactlyInAnyOrder(spanAsserts);
-          } else {
-            trace.hasSpansSatisfyingExactly(spanAsserts);
-          }
+          trace.hasSpansSatisfyingExactlyInAnyOrder(
+              span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+              span ->
+                  assertClientSpan(span, uri, method, null, null)
+                      .hasParent(trace.getSpan(0))
+                      .hasException(clientError),
+              span ->
+                  span.hasName("callback").hasKind(SpanKind.INTERNAL).hasParent(trace.getSpan(0)));
         });
   }
 


### PR DESCRIPTION
…thCallback test
https://ge.opentelemetry.io/s/je6p3yavsw2hm/tests/task/:instrumentation:netty:netty-4.1:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.netty.v4_1.Netty41ClientTest/connectionErrorUnopenedPortWithCallback()?top-execution=1
https://ge.opentelemetry.io/s/skdrapy2eeudi/tests/task/:instrumentation:okhttp:okhttp-3.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.okhttp.v3_0.OkHttp3Test/connectionErrorUnopenedPortWithCallback()?expanded-stacktrace=WyIwIl0&top-execution=2
According to span start/end times in test output `callback` runs before the request `CLIENT` span. I wasn't able to figure out how that could happen. Perhaps the issue is related to the `CLIENT` span that represent connection error using `Instant.now()` for timing but rest of the spans using the monotonic clock from sdk?