### PR TITLE
Add instrumentation to debug flaky payara smoke test

### DIFF
--- a/instrumentation/payara/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/payara/debug/AsyncContextImplInstrumentation.java
+++ b/instrumentation/payara/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/payara/debug/AsyncContextImplInstrumentation.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.payara.debug;
+
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.lang.reflect.Method;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@SuppressWarnings("SystemOut")
+public class AsyncContextImplInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.apache.catalina.connector.AsyncContextImpl");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(isMethod(), this.getClass().getName() + "$TraceAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class TraceAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Origin Method method) {
+      System.err.println("Calling " + method);
+    }
+  }
+}

--- a/instrumentation/payara/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/payara/debug/HandlerInstrumentation.java
+++ b/instrumentation/payara/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/payara/debug/HandlerInstrumentation.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.payara.debug;
+
+import static net.bytebuddy.matcher.ElementMatchers.any;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.lang.reflect.Executable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@SuppressWarnings("SystemOut")
+public class HandlerInstrumentation implements TypeInstrumentation {
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.apache.catalina.connector.AsyncContextImpl$Handler");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(any(), this.getClass().getName() + "$TraceAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class TraceAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(@Advice.Origin Executable executable) {
+      System.err.println("Calling " + executable);
+      new Exception().printStackTrace();
+    }
+  }
+}

--- a/instrumentation/payara/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/payara/debug/PayaraDebugInstrumentationModule.java
+++ b/instrumentation/payara/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/payara/debug/PayaraDebugInstrumentationModule.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.payara.debug;
+
+import static java.util.Arrays.asList;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.util.List;
+
+/** This module is only intended for debugging flaky payara async request smoke test. */
+@AutoService(InstrumentationModule.class)
+public class PayaraDebugInstrumentationModule extends InstrumentationModule {
+
+  public PayaraDebugInstrumentationModule() {
+    super("payara-debug", "payara");
+  }
+
+  @Override
+  public boolean defaultEnabled(ConfigProperties config) {
+    return false;
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return asList(new AsyncContextImplInstrumentation(), new HandlerInstrumentation());
+  }
+}

--- a/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PayaraSmokeTest.groovy
+++ b/smoke-tests/src/test/groovy/io/opentelemetry/smoketest/PayaraSmokeTest.groovy
@@ -15,7 +15,7 @@ abstract class PayaraSmokeTest extends AppServerTest {
 
   @Override
   protected Map<String, String> getExtraEnv() {
-    return ["HZ_PHONE_HOME_ENABLED": "false"]
+    return ["HZ_PHONE_HOME_ENABLED": "false", "OTEL_INSTRUMENTATION_PAYARA_DEBUG_ENABLED": "true"]
   }
 
   @Override


### PR DESCRIPTION
https://ge.opentelemetry.io/s/lakuzqrlzgpqq/tests/task/:smoke-tests:test/details/io.opentelemetry.smoketest.Payara52020Jdk11/5.2020.6%20async%20smoke%20test%20on%20JDK%2011?top-execution=1
This pr adds a disabled by default instrumentation that hopefully helps in understanding why this test is flaky. As this test is run on multiple payara versions it fails fairly regularly so it shouldn't take too long until we have the results and can either remove this or add more debug instrumentation.