### PR TITLE
Run vertx-sql tests with netty instrumentation

### DIFF
--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 
   // for hibernateReactive2Test
   testInstrumentation(project(":instrumentation:hibernate:hibernate-6.0:javaagent"))
+  testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
 
   testLibrary("io.vertx:vertx-pg-client:4.0.0")
   testLibrary("io.vertx:vertx-codegen:4.0.0")

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/hibernateReactive1Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/HibernateReactiveTest.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/hibernateReactive1Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/HibernateReactiveTest.java
@@ -101,10 +101,7 @@ class HibernateReactiveTest {
                   session ->
                       session
                           .find(Value.class, 1L)
-                          .invoke(
-                              value -> {
-                                testing.runWithSpan("callback", () -> {});
-                              }))
+                          .invoke(value -> testing.runWithSpan("callback", () -> {})))
               .await()
               .atMost(Duration.ofSeconds(30));
         });
@@ -123,10 +120,7 @@ class HibernateReactiveTest {
                         session ->
                             session
                                 .find(Value.class, 1L)
-                                .thenAccept(
-                                    value -> {
-                                      testing.runWithSpan("callback", () -> {});
-                                    }))
+                                .thenAccept(value -> testing.runWithSpan("callback", () -> {})))
                     .toCompletableFuture())
         .get(30, TimeUnit.SECONDS);
 

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/hibernateReactive2Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v2_0/HibernateReactiveTest.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/hibernateReactive2Test/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v2_0/HibernateReactiveTest.java
@@ -101,10 +101,7 @@ class HibernateReactiveTest {
                   session ->
                       session
                           .find(Value.class, 1L)
-                          .invoke(
-                              value -> {
-                                testing.runWithSpan("callback", () -> {});
-                              }))
+                          .invoke(value -> testing.runWithSpan("callback", () -> {})))
               .await()
               .atMost(Duration.ofSeconds(30));
         });
@@ -123,10 +120,7 @@ class HibernateReactiveTest {
                         session ->
                             session
                                 .find(Value.class, 1L)
-                                .thenAccept(
-                                    value -> {
-                                      testing.runWithSpan("callback", () -> {});
-                                    }))
+                                .thenAccept(value -> testing.runWithSpan("callback", () -> {})))
                     .toCompletableFuture())
         .get(30, TimeUnit.SECONDS);
 


### PR DESCRIPTION
Under the hood vertx-sql uses netty so it makes sense to enable netty instrumentation for these tests.