### PR TITLE
Rework async smoke test

### DIFF
--- a/smoke-tests/images/servlet/servlet-3.0/src/main/java/io/opentelemetry/smoketest/matrix/AsyncGreetingServlet.java
+++ b/smoke-tests/images/servlet/servlet-3.0/src/main/java/io/opentelemetry/smoketest/matrix/AsyncGreetingServlet.java
@@ -10,15 +10,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.servlet.AsyncContext;
+import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @SuppressWarnings("SystemOut")
-public class AsyncGreetingServlet extends GreetingServlet {
+public class AsyncGreetingServlet extends HttpServlet {
   private static final long serialVersionUID = 1L;
 
   private static final BlockingQueue<AsyncContext> jobQueue = new LinkedBlockingQueue<>();
   private static final ExecutorService executor = Executors.newFixedThreadPool(2);
+  private static final GreetingServlet greetingServlet = new GreetingServlet();
 
   @Override
   public void init() {
@@ -56,14 +58,15 @@ public class AsyncGreetingServlet extends GreetingServlet {
   }
 
   private static void handleRequest(AsyncContext ac) {
-    System.err.println("dispatch async request");
+    System.err.println("handle async request");
     try {
-      ac.dispatch("/greeting");
-      System.err.println("async request dispatched");
+      greetingServlet.doGet(
+          (HttpServletRequest) ac.getRequest(), (HttpServletResponse) ac.getResponse());
+      ac.complete();
+      System.err.println("async request handled");
     } catch (Throwable throwable) {
-      System.err.println("dispatching async request failed");
+      System.err.println("handling async request failed");
       throwable.printStackTrace();
-      throw throwable;
     }
   }
 }

--- a/smoke-tests/images/servlet/servlet-5.0/src/main/java/io/opentelemetry/smoketest/matrix/AsyncGreetingServlet.java
+++ b/smoke-tests/images/servlet/servlet-5.0/src/main/java/io/opentelemetry/smoketest/matrix/AsyncGreetingServlet.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.smoketest.matrix;
 
 import jakarta.servlet.AsyncContext;
+import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.concurrent.BlockingQueue;
@@ -14,10 +15,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 
 @SuppressWarnings("SystemOut")
-public class AsyncGreetingServlet extends GreetingServlet {
+public class AsyncGreetingServlet extends HttpServlet {
   private static final long serialVersionUID = 1L;
   private static final BlockingQueue<AsyncContext> jobQueue = new LinkedBlockingQueue<>();
   private static final ExecutorService executor = Executors.newFixedThreadPool(2);
+  private static final GreetingServlet greetingServlet = new GreetingServlet();
 
   @Override
   public void init() {
@@ -55,14 +57,15 @@ public class AsyncGreetingServlet extends GreetingServlet {
   }
 
   private static void handleRequest(AsyncContext ac) {
-    System.err.println("dispatch async request");
+    System.err.println("handle async request");
     try {
-      ac.dispatch("/greeting");
-      System.err.println("async request dispatched");
+      greetingServlet.doGet(
+          (HttpServletRequest) ac.getRequest(), (HttpServletResponse) ac.getResponse());
+      ac.complete();
+      System.err.println("async request handled");
     } catch (Throwable throwable) {
-      System.err.println("dispatching async request failed");
+      System.err.println("handling async request failed");
       throwable.printStackTrace();
-      throw throwable;
     }
   }
 }


### PR DESCRIPTION
https://ge.opentelemetry.io/s/j75okyr54of4i/tests/task/:smoke-tests:test/details/io.opentelemetry.smoketest.Payara52020Jdk8/5.2020.6%20async%20smoke%20test%20on%20JDK%208?top-execution=1
It seems to me that Payara has a race condition between exiting from the servlet and `AsyncContext.dispatch`. Dispatch ends in https://github.com/payara/Payara/blob/5bd30a967c295f666e45bb32501624ff995efd8d/appserver/web/web-core/src/main/java/org/apache/catalina/connector/AsyncContextImpl.java#L228 where `handler` is set but not passed to the executor. This handler is not executed because servlet exit sequence already called https://github.com/payara/Payara/blob/5bd30a967c295f666e45bb32501624ff995efd8d/appserver/web/web-core/src/main/java/org/apache/catalina/connector/AsyncContextImpl.java#L251 and saw that `handler` was `null` because it got called before the `handler` was set from dispatch. I didn't try to verify this with debugger, this is just a guess based on debug output.
This pr attempts to work around this by changing the async test to not use `AsyncContext.dispatch` and instead calls the code in `GreetingServlet`, that we used to dispatch to, directly and after it is done calls `AsyncContext.complete` to finish the request.