### PR TITLE
Small cleanup

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -141,6 +141,14 @@ dependencies {
 
   codenarc("org.codenarc:CodeNarc:3.3.0")
   codenarc(platform("org.codehaus.groovy:groovy-bom:3.0.18"))
+
+  modules {
+    // checkstyle uses the very old google-collections which causes Java 9 module conflict with
+    // guava which is also on the classpath
+    module("com.google.collections:google-collections") {
+      replacedBy("com.google.guava:guava", "google-collections is now part of Guava")
+    }
+  }
 }
 
 testing {
@@ -410,15 +418,5 @@ configurations.configureEach {
     // Excluding the bom as well helps ensure if we miss a substitution, we get a resolution failure instead of using the
     // wrong version.
     exclude("io.opentelemetry.instrumentation", "opentelemetry-instrumentation-bom-alpha")
-  }
-}
-
-dependencies {
-  modules {
-    // checkstyle uses the very old google-collections which causes Java 9 module conflict with
-    // guava which is also on the classpath
-    module("com.google.collections:google-collections") {
-      replacedBy("com.google.guava:guava", "google-collections is now part of Guava")
-    }
   }
 }


### PR DESCRIPTION
noticed there was already a `dependencies` block when sending https://github.com/open-telemetry/opentelemetry-java/pull/5736