### PR TITLE
Fixed getDefinedPackage lookup for OpenJ9 (8)

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -246,7 +246,7 @@ class InstrumentationModuleClassLoader extends ClassLoader {
       } catch (NoSuchMethodException ex) {
         throw new IllegalStateException("expected method to always exist!", ex);
       } catch (IllegalAccessException ex2) {
-        throw new IllegalStateException("Method should be accessible from here", e);
+        throw new IllegalStateException("Method should be accessible from here", ex2);
       }
     }
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoader.java
@@ -238,18 +238,16 @@ class InstrumentationModuleClassLoader extends ClassLoader {
     MethodType methodType = MethodType.methodType(Package.class, String.class);
     MethodHandles.Lookup lookup = MethodHandles.lookup();
     try {
+      return lookup.findVirtual(ClassLoader.class, "getDefinedPackage", methodType);
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      // In Java 8 getDefinedPackage does not exist (HotSpot) or is not accessible (OpenJ9)
       try {
-        return lookup.findVirtual(ClassLoader.class, "getDefinedPackage", methodType);
-      } catch (NoSuchMethodException e) {
-        // Java 8 case
-        try {
-          return lookup.findVirtual(ClassLoader.class, "getPackage", methodType);
-        } catch (NoSuchMethodException ex) {
-          throw new IllegalStateException("expected method to always exist!", ex);
-        }
+        return lookup.findVirtual(ClassLoader.class, "getPackage", methodType);
+      } catch (NoSuchMethodException ex) {
+        throw new IllegalStateException("expected method to always exist!", ex);
+      } catch (IllegalAccessException ex2) {
+        throw new IllegalStateException("Method should be accessible from here", e);
       }
-    } catch (IllegalAccessException e) {
-      throw new IllegalStateException("Method should be accessible from here", e);
     }
   }
 }


### PR DESCRIPTION
The `InstrumentationModuleClassLoaderTest` exposed a bug with the current implementation on OpenJ9 (Java 8):

```
2023-08-22T06:01:32.4244988Z     java.lang.ExceptionInInitializerError
2023-08-22T06:01:32.4245586Z         at java.lang.J9VMInternals.ensureError(J9VMInternals.java:158)
2023-08-22T06:01:32.4246371Z         at java.lang.J9VMInternals.recordInitializationFailure(J9VMInternals.java:147)
2023-08-22T06:01:32.4247576Z         at io.opentelemetry.javaagent.tooling.instrumentation.indy.InstrumentationModuleClassLoaderTest.checkClassLookupPrecedence(InstrumentationModuleClassLoaderTest.java:122)
2023-08-22T06:01:32.4248388Z 
2023-08-22T06:01:32.4249077Z         Caused by:
2023-08-22T06:01:32.4249942Z         java.lang.IllegalStateException: Method should be accessible from here
2023-08-22T06:01:32.4250867Z             at io.opentelemetry.javaagent.tooling.instrumentation.indy.InstrumentationModuleClassLoader.getFindPackageMethod(InstrumentationModuleClassLoader.java:252)
2023-08-22T06:01:32.4262113Z             at io.opentelemetry.javaagent.tooling.instrumentation.indy.InstrumentationModuleClassLoader.<clinit>(InstrumentationModuleClassLoader.java:50)
2023-08-22T06:01:32.4262964Z             ... 1 more
2023-08-22T06:01:32.4263150Z 
2023-08-22T06:01:32.4263276Z             Caused by:
2023-08-22T06:01:32.4264426Z             java.lang.IllegalAccessException: 'io.opentelemetry.javaagent.tooling.instrumentation.indy.InstrumentationModuleClassLoader' no access to: 'java.lang.ClassLoadergetDefinedPackage:(ClassLoader,String)Package/invokeSpecial'
2023-08-22T06:01:32.4265349Z                 at java.lang.invoke.MethodHandles$Lookup.checkAccess(MethodHandles.java:440)
2023-08-22T06:01:32.4265928Z                 at java.lang.invoke.MethodHandles$Lookup.checkAccess(MethodHandles.java:346)
2023-08-22T06:01:32.4266488Z                 at java.lang.invoke.MethodHandles$Lookup.findVirtual(MethodHandles.java:632)
2023-08-22T06:01:32.4267501Z                 at io.opentelemetry.javaagent.tooling.instrumentation.indy.InstrumentationModuleClassLoader.getFindPackageMethod(InstrumentationModuleClassLoader.java:242)
2023-08-22T06:01:32.4268196Z                 ... 2 more
```

It looks like in OpenJ9 Java 8 there is a `getDefinedPackage` method, which is however not accessible (it is either private or package private). I've adapted the logic to fallback to `getPackage` for this case aswell.