### PR TITLE
Ignore aws sdk v2 presign requests

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -84,6 +84,22 @@ dependencies {
   testLibrary("software.amazon.awssdk:ses:2.2.0")
 }
 
+val latestDepTest = findProperty("testLatestDeps") as Boolean
+
+testing {
+  suites {
+    val s3PresignerTest by registering(JvmTestSuite::class) {
+      dependencies {
+        if (latestDepTest) {
+          implementation("software.amazon.awssdk:s3:+")
+        } else {
+          implementation("software.amazon.awssdk:s3:2.10.12")
+        }
+      }
+    }
+  }
+}
+
 tasks {
   val testExperimentalSqs by registering(Test::class) {
     group = "verification"
@@ -93,6 +109,7 @@ tasks {
 
   check {
     dependsOn(testExperimentalSqs)
+    dependsOn(testing.suites)
   }
 
   withType<Test>().configureEach {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/SnsInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/SnsInstrumentationModule.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
 import com.google.auto.service.AutoService;
@@ -12,12 +13,18 @@ import io.opentelemetry.instrumentation.awssdk.v2_2.SnsAdviceBridge;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class SnsInstrumentationModule extends AbstractAwsSdkInstrumentationModule {
 
   public SnsInstrumentationModule() {
     super("aws-sdk-2.2-sns");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("software.amazon.awssdk.services.sns.SnsClient");
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/SqsInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/SqsInstrumentationModule.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
 import com.google.auto.service.AutoService;
@@ -12,12 +13,18 @@ import io.opentelemetry.instrumentation.awssdk.v2_2.SqsAdviceBridge;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class SqsInstrumentationModule extends AbstractAwsSdkInstrumentationModule {
 
   public SqsInstrumentationModule() {
     super("aws-sdk-2.2-sqs");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return hasClassesNamed("software.amazon.awssdk.services.sqs.SqsClient");
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/s3PresignerTest/java/S3PresignerTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/s3PresignerTest/java/S3PresignerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+class S3PresignerTest {
+  @RegisterExtension
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  private static final StaticCredentialsProvider CREDENTIALS_PROVIDER =
+      StaticCredentialsProvider.create(
+          AwsBasicCredentials.create("my-access-key", "my-secret-key"));
+
+  private static S3Presigner s3Presigner;
+
+  @BeforeAll
+  static void setUp() {
+    // trigger adding tracing interceptor
+    S3Client.builder()
+        .region(Region.AP_NORTHEAST_1)
+        .credentialsProvider(CREDENTIALS_PROVIDER)
+        .build();
+
+    s3Presigner =
+        S3Presigner.builder()
+            .region(Region.AP_NORTHEAST_1)
+            .credentialsProvider(CREDENTIALS_PROVIDER)
+            .build();
+  }
+
+  @Test
+  void testPresignGetObject() {
+    s3Presigner.presignGetObject(
+        GetObjectPresignRequest.builder()
+            .getObjectRequest(builder -> builder.bucket("test").key("test"))
+            .signatureDuration(Duration.ofDays(1))
+            .build());
+
+    assertThat(Span.current().getSpanContext().isValid()).isFalse();
+  }
+
+  @Test
+  void testPresignPutObject() {
+    s3Presigner.presignPutObject(
+        PutObjectPresignRequest.builder()
+            .putObjectRequest(builder -> builder.bucket("test").key("test"))
+            .signatureDuration(Duration.ofDays(1))
+            .build());
+
+    assertThat(Span.current().getSpanContext().isValid()).isFalse();
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9238
Presign requests don't make an actual request to aws. They run only a subset of interceptor methods which cause a scope leak.