### PR TITLE
Don't log stack trace for expected exceptions

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/PluginImplUtil.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/PluginImplUtil.java
@@ -45,10 +45,12 @@ final class PluginImplUtil { // TODO: Copy & paste from v2
       // dependency is not on the class path).
       logger.log(
           Level.FINE,
-          e,
           () ->
-              implFullClassName
-                  + " not present. "
+              "Failed to load "
+                  + implFullClassName
+                  + " ("
+                  + e.getClass().getName()
+                  + "). "
                   + "Most likely, corresponding SDK component is either not on classpath or incompatible.");
       return false;
     }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/PluginImplUtil.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/PluginImplUtil.java
@@ -45,10 +45,12 @@ final class PluginImplUtil { // TODO: Copy & pasted to v1
       // dependency is not on the class path).
       logger.log(
           Level.FINE,
-          e,
           () ->
-              implFullClassName
-                  + " not present. "
+              "Failed to load "
+                  + implFullClassName
+                  + " ("
+                  + e.getClass().getName()
+                  + "). "
                   + "Most likely, corresponding SDK component is either not on classpath or incompatible.");
       return false;
     }


### PR DESCRIPTION
In aws sdk instrumentation there are optional components for sqs and sns. We should not log a stack trace when either sqs or sns is missing as this is expected.