### PR TITLE
Add logging timestamp for log4j1 appender instrument

### DIFF
--- a/instrumentation/log4j/log4j-appender-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v1_2/LogEventMapper.java
+++ b/instrumentation/log4j/log4j-appender-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v1_2/LogEventMapper.java
@@ -19,6 +19,7 @@ import io.opentelemetry.javaagent.bootstrap.internal.InstrumentationConfig;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.Instant;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
@@ -107,6 +108,7 @@ public final class LogEventMapper {
     // span context
     builder.setContext(Context.current());
 
+    builder.setTimestamp(Instant.now());
     builder.emit();
   }
 

--- a/instrumentation/log4j/log4j-appender-1.2/javaagent/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v1_2/Log4j1Test.java
+++ b/instrumentation/log4j/log4j-appender-1.2/javaagent/src/test/java/io/opentelemetry/instrumentation/log4j/appender/v1_2/Log4j1Test.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.log4j.appender.v1_2;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.logs.Severity;
@@ -17,6 +18,7 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.lang.reflect.Field;
+import java.time.Instant;
 import java.util.stream.Stream;
 import org.apache.log4j.Logger;
 import org.apache.log4j.MDC;
@@ -79,6 +81,8 @@ class Log4j1Test {
       String expectedSeverityText)
       throws InterruptedException {
 
+    Instant start = Instant.now();
+
     // when
     if (withParent) {
       testing.runWithSpan(
@@ -99,6 +103,11 @@ class Log4j1Test {
           .hasInstrumentationScope(InstrumentationScopeInfo.builder(expectedLoggerName).build())
           .hasSeverity(expectedSeverity)
           .hasSeverityText(expectedSeverityText);
+
+      assertThat(log.getTimestampEpochNanos())
+          .isGreaterThanOrEqualTo(MILLISECONDS.toNanos(start.toEpochMilli()))
+          .isLessThanOrEqualTo(MILLISECONDS.toNanos(Instant.now().toEpochMilli()));
+
       if (logException) {
         assertThat(log)
             .hasAttributesSatisfyingExactly(


### PR DESCRIPTION
## Fix
- Add missing timestamp for log4j1 appender instrument due to https://github.com/open-telemetry/opentelemetry-java/pull/5374

## Reference
Same changes as in following pull requests made:
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8761
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9159