### PR TITLE
Deprecate HttpServerRouteBiGetter

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerRoute.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerRoute.java
@@ -87,19 +87,26 @@ public final class HttpServerRoute {
    *
    * <p>If there is a server span in the context, and the context has been customized with a {@link
    * HttpServerRoute}, then this method will update the route using the provided {@link
-   * HttpServerRouteBiGetter} if and only if the last {@link HttpServerRouteSource} to update the
-   * route using this method has strictly lower priority than the provided {@link
-   * HttpServerRouteSource}, and the value returned from the {@link HttpServerRouteBiGetter} is
+   * io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerRouteBiGetter} if and only if
+   * the last {@link HttpServerRouteSource} to update the route using this method has strictly lower
+   * priority than the provided {@link HttpServerRouteSource}, and the value returned from the
+   * {@link io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerRouteBiGetter} is
    * non-null.
    *
    * <p>If there is a server span in the context, and the context has NOT been customized with a
    * {@code ServerSpanName}, then this method will update the route using the provided {@link
-   * HttpServerRouteBiGetter} if the value returned from it is non-null.
+   * io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerRouteBiGetter} if the value
+   * returned from it is non-null.
+   *
+   * @deprecated Use {@link #update(Context, HttpServerRouteSource, HttpServerRouteGetter, Object)}
+   *     with capturing lambda instead.
    */
+  @Deprecated
   public static <T, U> void update(
       Context context,
       HttpServerRouteSource source,
-      HttpServerRouteBiGetter<T, U> httpRouteGetter,
+      io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerRouteBiGetter<T, U>
+          httpRouteGetter,
       T arg1,
       U arg2) {
     Span serverSpan = LocalRootSpan.fromContextOrNull(context);
@@ -164,8 +171,10 @@ public final class HttpServerRoute {
     return httpRouteState == null ? null : httpRouteState.getRoute();
   }
 
+  @SuppressWarnings("deprecation") // supporting deprecated functionality
   private static final class OneArgAdapter<T>
-      implements HttpServerRouteBiGetter<T, HttpServerRouteGetter<T>> {
+      implements io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerRouteBiGetter<
+          T, HttpServerRouteGetter<T>> {
 
     private static final OneArgAdapter<Object> INSTANCE = new OneArgAdapter<>();
 

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerRouteBiGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerRouteBiGetter.java
@@ -8,7 +8,12 @@ package io.opentelemetry.instrumentation.api.instrumenter.http;
 import io.opentelemetry.context.Context;
 import javax.annotation.Nullable;
 
-/** An interface for getting the {@code http.route} attribute. */
+/**
+ * An interface for getting the {@code http.route} attribute.
+ *
+ * @deprecated Use {@link HttpServerRouteGetter} with capturing lambda instead.
+ */
+@Deprecated
 @FunctionalInterface
 public interface HttpServerRouteBiGetter<T, U> {
 

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/HttpSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachecamel/decorators/HttpSpanDecorator.java
@@ -125,9 +125,8 @@ class HttpSpanDecorator extends BaseSpanDecorator {
     HttpServerRoute.update(
         context,
         HttpServerRouteSource.CONTROLLER,
-        (c, exchange, endpoint) -> getPath(exchange, endpoint),
-        camelExchange,
-        camelEndpoint);
+        (ctx, exchange) -> getPath(exchange, camelEndpoint),
+        camelExchange);
   }
 
   protected String getHttpUrl(Exchange exchange, Endpoint endpoint) {

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/BaseServletHelper.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/BaseServletHelper.java
@@ -87,7 +87,10 @@ public abstract class BaseServletHelper<REQUEST, RESPONSE> {
     Context result = addServletContextPath(context, request);
     if (mappingResolver != null) {
       HttpServerRoute.update(
-          result, servlet ? SERVER : SERVER_FILTER, spanNameProvider, mappingResolver, request);
+          result,
+          servlet ? SERVER : SERVER_FILTER,
+          (ctx, req) -> spanNameProvider.get(ctx, req, mappingResolver),
+          request);
     }
 
     return result;

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletSpanNameProvider.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletSpanNameProvider.java
@@ -6,23 +6,20 @@
 package io.opentelemetry.javaagent.instrumentation.servlet;
 
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerRouteBiGetter;
 import io.opentelemetry.javaagent.bootstrap.servlet.MappingResolver;
 import io.opentelemetry.javaagent.bootstrap.servlet.ServletContextPath;
 import javax.annotation.Nullable;
 
 /** Helper class for constructing span name for given servlet/filter mapping and request. */
-public class ServletSpanNameProvider<REQUEST>
-    implements HttpServerRouteBiGetter<MappingResolver, REQUEST> {
+public class ServletSpanNameProvider<REQUEST> {
   private final ServletAccessor<REQUEST, ?> servletAccessor;
 
   public ServletSpanNameProvider(ServletAccessor<REQUEST, ?> servletAccessor) {
     this.servletAccessor = servletAccessor;
   }
 
-  @Override
   @Nullable
-  public String get(Context context, MappingResolver mappingResolver, REQUEST request) {
+  public String get(Context context, REQUEST request, MappingResolver mappingResolver) {
     String servletPath = servletAccessor.getRequestServletPath(request);
     String pathInfo = servletAccessor.getRequestPathInfo(request);
     String mapping = mappingResolver.resolve(servletPath, pathInfo);


### PR DESCRIPTION
Related to #5215

I'm 50/50 on this, sending this PR to get others' thoughts.

Should we also deprecate HttpServerRouteGetter and just use simple Supplier with capturing lambdas?