### PR TITLE
Fix flaky hibernate reactive test

### DIFF
--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/build.gradle.kts
@@ -38,6 +38,7 @@ testing {
           implementation("org.hibernate.reactive:hibernate-reactive-core:1.0.0.Final")
           implementation("io.vertx:vertx-pg-client:4.1.5")
         }
+        compileOnly("io.vertx:vertx-codegen:4.1.5")
       }
     }
 


### PR DESCRIPTION
https://ge.opentelemetry.io/s/hfmcangwvhojs/tests/task/:instrumentation:hibernate:hibernate-reactive-1.0:javaagent:hibernateReactive1Test/details/io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0.HibernateReactiveTest/testStage()?expanded-stacktrace=WyIwLTEiLCIwIl0&top-execution=1
Apparently `stageSessionFactory.withSession(...)` needs to be called on a vert.x thread, the same issue doesn't seem to affect other tests so left them as they were. This should be the last flaky bit in current hibernate reactive tests.