### PR TITLE
Fix flaky application logging test

### DIFF
--- a/javaagent-internal-logging-application/src/main/java/io/opentelemetry/javaagent/logging/application/ApplicationLoggerFactory.java
+++ b/javaagent-internal-logging-application/src/main/java/io/opentelemetry/javaagent/logging/application/ApplicationLoggerFactory.java
@@ -45,6 +45,7 @@ final class ApplicationLoggerFactory extends ApplicationLoggerBridge
     while (inMemoryLogStore.currentSize() > 0) {
       inMemoryLogStore.flush(applicationLoggerFactory);
     }
+    inMemoryLogStore.setApplicationLoggerFactory(applicationLoggerFactory);
 
     // actually install the application logger - from this point, everything will be logged
     // directly through the application logging system
@@ -53,7 +54,6 @@ final class ApplicationLoggerFactory extends ApplicationLoggerBridge
         .forEach(
             logger -> logger.replaceByActualLogger(applicationLoggerFactory.create(logger.name())));
     this.actual = applicationLoggerFactory;
-    inMemoryLogStore.setApplicationLoggerFactory(applicationLoggerFactory);
 
     // if there are any leftover logs left in the memory store, flush them - this will cause some
     // logs to go out of order, but at least we'll not lose any of them

--- a/javaagent-internal-logging-application/src/main/java/io/opentelemetry/javaagent/logging/application/ApplicationLoggerFactory.java
+++ b/javaagent-internal-logging-application/src/main/java/io/opentelemetry/javaagent/logging/application/ApplicationLoggerFactory.java
@@ -53,6 +53,7 @@ final class ApplicationLoggerFactory extends ApplicationLoggerBridge
         .forEach(
             logger -> logger.replaceByActualLogger(applicationLoggerFactory.create(logger.name())));
     this.actual = applicationLoggerFactory;
+    inMemoryLogStore.setApplicationLoggerFactory(applicationLoggerFactory);
 
     // if there are any leftover logs left in the memory store, flush them - this will cause some
     // logs to go out of order, but at least we'll not lose any of them

--- a/javaagent-internal-logging-application/src/test/java/io/opentelemetry/javaagent/logging/application/ApplicationLoggerFactoryTest.java
+++ b/javaagent-internal-logging-application/src/test/java/io/opentelemetry/javaagent/logging/application/ApplicationLoggerFactoryTest.java
@@ -60,6 +60,7 @@ class ApplicationLoggerFactoryTest {
 
     verify(logStore, times(3)).currentSize();
     verify(logStore).flush(applicationLoggerBridge);
+    verify(logStore).setApplicationLoggerFactory(applicationLoggerBridge);
     verify(logStore).freeMemory();
 
     underTest.install(applicationLoggerBridge);


### PR DESCRIPTION
https://ge.opentelemetry.io/s/sylaklv6ycvyq/tests/task/:javaagent-internal-logging-application:test/details/io.opentelemetry.javaagent.logging.application.ConcurrentIntegrationTest/shouldLogEverything()?expanded-stacktrace=WyIwIl0&page=eyIwIjo1fQ&top-execution=1
We can lose log messages when switching from in memory to application logging.