### PR TITLE
Modify finatra test so it would not call system exit

### DIFF
--- a/instrumentation/finatra-2.9/javaagent/src/latestDepTest/scala/io/opentelemetry/javaagent/instrumentation/finatra/FinatraServerLatestTest.scala
+++ b/instrumentation/finatra-2.9/javaagent/src/latestDepTest/scala/io/opentelemetry/javaagent/instrumentation/finatra/FinatraServerLatestTest.scala
@@ -39,7 +39,7 @@ class FinatraServerLatestTest extends AbstractHttpServerTest[HttpServer] {
     implicit val ec: ExecutionContext =
       ExecutionContext.fromExecutor(startupThread)
     Future {
-      testServer.main(Array("-admin.port=:0", "-http.port=:" + port))
+      testServer.nonExitingMain(Array("-admin.port=:0", "-http.port=:" + port))
     }
     testServer.awaitReady()
   }

--- a/instrumentation/finatra-2.9/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/finatra/FinatraServerTest.scala
+++ b/instrumentation/finatra-2.9/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/finatra/FinatraServerTest.scala
@@ -39,7 +39,7 @@ class FinatraServerTest extends AbstractHttpServerTest[HttpServer] {
     implicit val ec: ExecutionContext =
       ExecutionContext.fromExecutor(startupThread)
     Future {
-      testServer.main(Array("-admin.port=:0", "-http.port=:" + port))
+      testServer.nonExitingMain(Array("-admin.port=:0", "-http.port=:" + port))
     }
     testServer.awaitReady()
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9285
Lately we have had test failures caused by gradle worker terminating after finatra tests. As far as I understand it is a race condition between finatra calling `System.exit(1)` and gradle worker calling `System.exit(0)` to exit gracefully.