### PR TITLE
Pin hibernate version in spring data latest dep tests

### DIFF
--- a/instrumentation/hibernate/hibernate-6.0/spring-testing/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-6.0/spring-testing/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
   testImplementation("org.springframework.data:spring-data-jpa:3.0.0")
 
   springAgent("org.springframework:spring-instrument:6.0.7")
+
+  latestDepTestLibrary("org.hibernate:hibernate-core:6.2.+")
 }
 
 otelJava {

--- a/instrumentation/spring/spring-data/spring-data-3.0/testing/build.gradle.kts
+++ b/instrumentation/spring/spring-data/spring-data-3.0/testing/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
   testLibrary("org.springframework:spring-test:6.0.0")
 
   testImplementation("org.hsqldb:hsqldb:2.0.0")
+
+  latestDepTestLibrary("org.hibernate.orm:hibernate-core:6.2.+")
 }
 
 otelJava {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9363
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9365
Either a bug in newly released hibernate 6.3 or compat issue with spring. Probably will get sorted in next hibernate or spring data release.