### PR TITLE
Remove peer service fallback to server.socket.*

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractor.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -60,7 +61,7 @@ public final class PeerServiceAttributesExtractor<REQUEST, RESPONSE>
 
     String serverAddress = attributesGetter.getServerAddress(request);
     String peerService = mapToPeerService(serverAddress);
-    if (peerService == null) {
+    if (peerService == null && SemconvStability.emitOldHttpSemconv()) {
       String serverSocketDomain = attributesGetter.getServerSocketDomain(request, response);
       peerService = mapToPeerService(serverSocketDomain);
     }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/net/PeerServiceAttributesExtractorTest.java
@@ -18,9 +18,11 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttributesGetter;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -101,6 +103,9 @@ class PeerServiceAttributesExtractorTest {
 
   @Test
   void shouldSetSockPeerNameIfItMatchesAndNoPeerNameProvided() {
+
+    Assumptions.assumeTrue(SemconvStability.emitOldHttpSemconv());
+
     // given
     Map<String, String> peerServiceMapping = new HashMap<>();
     peerServiceMapping.put("example.com", "myService");


### PR DESCRIPTION
I don't think this fallback is needed with the new semconv definitions, see https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7888#issuecomment-1538962941