### PR TITLE
Remove deprecated experimental config

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -62,10 +62,6 @@ public class ExtensionClassLoader extends URLClassLoader {
 
     extensions.addAll(parseLocation(earlyConfig.getString(EXTENSIONS_CONFIG), javaagentFile));
 
-    extensions.addAll(
-        parseLocation(
-            earlyConfig.getString("otel.javaagent.experimental.extensions"), javaagentFile));
-
     // TODO when logging is configured add warning about deprecated property
 
     if (extensions.isEmpty()) {


### PR DESCRIPTION
Remove `otel.javaagent.experimental.extensions` which has been replaced by `otel.javaagent.extensions`.

Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8913#issuecomment-1634218444