### PR TITLE
Skip PreparedStatement wrappers

### DIFF
--- a/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
+++ b/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
@@ -21,6 +21,8 @@ import spock.lang.Shared
 import spock.lang.Unroll
 
 import javax.sql.DataSource
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
 import java.sql.CallableStatement
 import java.sql.Connection
 import java.sql.DatabaseMetaData
@@ -837,6 +839,38 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
     Statement proxyStatement = ProxyStatementFactory.proxyStatement(statement)
     ResultSet resultSet = runWithSpan("parent") {
       return proxyStatement.executeQuery("SELECT 3")
+    }
+
+    expect:
+    resultSet.next()
+    resultSet.getInt(1) == 3
+    assertTraces(1) {
+      trace(0, 2) {
+        span(0) {
+          name "parent"
+          kind SpanKind.INTERNAL
+          hasNoParent()
+        }
+        span(1) {
+          name "SELECT $dbNameLower"
+          kind CLIENT
+          childOf span(0)
+        }
+      }
+    }
+
+    cleanup:
+    statement.close()
+    connection.close()
+  }
+
+  // regression test for https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9359
+  def "test proxy prepared statement"() {
+    def connection = new Driver().connect(jdbcUrls.get("h2"), null)
+    PreparedStatement statement = connection.prepareStatement("SELECT 3")
+    PreparedStatement proxyStatement = ProxyStatementFactory.proxyPreparedStatement(statement)
+    ResultSet resultSet = runWithSpan("parent") {
+      return proxyStatement.executeQuery()
     }
 
     expect:

--- a/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
+++ b/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
@@ -21,8 +21,6 @@ import spock.lang.Shared
 import spock.lang.Unroll
 
 import javax.sql.DataSource
-import java.lang.reflect.InvocationHandler
-import java.lang.reflect.Method
 import java.sql.CallableStatement
 import java.sql.Connection
 import java.sql.DatabaseMetaData


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9359
If prepared statement doesn't have attached sql it is probably a wrapper, ignore it. Span will be created when the invocation chain reaches the actual prepared statement that has the attached sql. An alternative fix would be to ignore known wrapper class like `org.datanucleus.store.rdbms.ParamLoggingPreparedStatement` from the attached issue.