### PR TITLE
Refactor the HTTP server assertions a little bit

### DIFF
--- a/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3Test.groovy
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/test/groovy/TomcatServlet3Test.groovy
@@ -150,7 +150,7 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
 
       (0..count - 1).each {
         trace(it, 2) {
-          serverSpan(it, 0, null, null, "GET", ACCESS_LOG_SUCCESS.body.length(), ACCESS_LOG_SUCCESS)
+          serverSpan(it, 0, null, null, "GET", ACCESS_LOG_SUCCESS)
           controllerSpan(it, 1, span(0))
         }
 
@@ -182,7 +182,7 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
     }
     assertTraces(1) {
       trace(0, spanCount) {
-        serverSpan(it, 0, null, null, method, response.content().length(), ACCESS_LOG_ERROR)
+        serverSpan(it, 0, null, null, method, ACCESS_LOG_ERROR)
         def spanIndex = 1
         controllerSpan(it, spanIndex, span(spanIndex - 1))
         spanIndex++

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5Test.groovy
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/test/groovy/TomcatServlet5Test.groovy
@@ -150,7 +150,7 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
 
       (0..count - 1).each {
         trace(it, 2) {
-          serverSpan(it, 0, null, null, "GET", ACCESS_LOG_SUCCESS.body.length(), ACCESS_LOG_SUCCESS)
+          serverSpan(it, 0, null, null, "GET", ACCESS_LOG_SUCCESS)
           controllerSpan(it, 1, span(0))
         }
 
@@ -182,7 +182,7 @@ abstract class TomcatServlet5Test extends AbstractServlet5Test<Tomcat, Context> 
     }
     assertTraces(1) {
       trace(0, spanCount) {
-        serverSpan(it, 0, null, null, method, response.content().length(), ACCESS_LOG_ERROR)
+        serverSpan(it, 0, null, null, method, ACCESS_LOG_ERROR)
         def spanIndex = 1
         controllerSpan(it, spanIndex, span(spanIndex - 1))
         spanIndex++

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/server/base/ImmediateHandlerSpringWebFluxServerTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/server/base/ImmediateHandlerSpringWebFluxServerTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,6 @@ public class ImmediateHandlerSpringWebFluxServerTest extends HandlerSpringWebFlu
     assertThat(response.contentUtf8()).isEqualTo(NESTED_PATH.getBody());
     assertResponseHasCustomizedHeaders(response, NESTED_PATH, null);
 
-    assertTheTraces(1, null, null, null, method, NESTED_PATH, response);
+    assertTheTraces(1, method, NESTED_PATH, SpanDataAssert::hasNoParent);
   }
 }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-common/testing/src/main/groovy/boot/AbstractSpringBootBasedTest.groovy
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-common/testing/src/main/groovy/boot/AbstractSpringBootBasedTest.groovy
@@ -113,7 +113,7 @@ abstract class AbstractSpringBootBasedTest extends HttpServerTest<ConfigurableAp
     and:
     assertTraces(1) {
       trace(0, 3) {
-        serverSpan(it, 0, null, null, "GET", null, AUTH_ERROR)
+        serverSpan(it, 0, null, null, "GET", AUTH_ERROR)
         sendErrorSpan(it, 1, span(0))
         errorPageSpans(it, 2, null)
       }
@@ -140,7 +140,7 @@ abstract class AbstractSpringBootBasedTest extends HttpServerTest<ConfigurableAp
     and:
     assertTraces(1) {
       trace(0, 2) {
-        serverSpan(it, 0, null, null, "POST", response.contentUtf8().length(), LOGIN)
+        serverSpan(it, 0, null, null, "POST", LOGIN)
         redirectSpan(it, 1, span(0))
       }
     }


### PR DESCRIPTION
I started looking into adding the non-standard HTTP methods test, and I needed to refactor/clean up the current assertions first.