### PR TITLE
Fix mockito failure

### DIFF
--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ClientAddressAndPortExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ClientAddressAndPortExtractorTest.java
@@ -10,6 +10,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.FallbackAddressPortExtractor;
@@ -94,8 +95,8 @@ class ClientAddressAndPortExtractorTest {
   @ArgumentsSource(ForwardedForArgs.class)
   void shouldParseForwardedFor(
       List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
-    when(getter.getHttpRequestHeader("request", "forwarded")).thenReturn(emptyList());
-    when(getter.getHttpRequestHeader("request", "x-forwarded-for")).thenReturn(headers);
+    doReturn(emptyList()).when(getter).getHttpRequestHeader("request", "forwarded");
+    doReturn(headers).when(getter).getHttpRequestHeader("request", "x-forwarded-for");
 
     AddressAndPort sink = new AddressAndPort();
     underTest.extract(sink, "request");
@@ -110,7 +111,6 @@ class ClientAddressAndPortExtractorTest {
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
       return Stream.of(
           // empty/invalid headers
-          arguments(singletonList(""), null, null),
           arguments(singletonList(""), null, null),
           arguments(singletonList(";"), null, null),
           arguments(singletonList("\""), null, null),


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9414
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9412
I don't know why this failed only on openj9 17, but googling the failure seems to indicate that `when(...).thenReturn(...)` isn't supposed to work for stubbing the same method twice (unless in lenient mode). 