### PR TITLE
Remove unneeded spock test dependency for camel tests

### DIFF
--- a/instrumentation/camel-2.20/javaagent/build.gradle.kts
+++ b/instrumentation/camel-2.20/javaagent/build.gradle.kts
@@ -44,7 +44,6 @@ dependencies {
   testImplementation("org.springframework.boot:spring-boot-starter-test:1.5.17.RELEASE")
   testImplementation("org.springframework.boot:spring-boot-starter:1.5.17.RELEASE")
 
-  testImplementation("org.spockframework:spock-spring")
   testImplementation("javax.xml.bind:jaxb-api:2.3.1")
   testImplementation("org.elasticmq:elasticmq-rest-sqs_2.12:1.0.0")
 


### PR DESCRIPTION
Related to #7195 

When I converted the camel tests from groovy to java (#8813) I missed removing this spock dependency that is no longer needed.
