### PR TITLE
Revert "Remove redundant gradle (#9422)"

### DIFF
--- a/conventions/src/main/kotlin/otel.bom-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.bom-conventions.gradle.kts
@@ -32,3 +32,21 @@ afterEvaluate {
     }
   }
 }
+
+evaluationDependsOn(":dependencyManagement")
+val dependencyManagementConf = configurations.create("dependencyManagement") {
+  isCanBeConsumed = false
+  isCanBeResolved = false
+  isVisible = false
+}
+afterEvaluate {
+  configurations.configureEach {
+    if (isCanBeResolved && !isCanBeConsumed) {
+      extendsFrom(dependencyManagementConf)
+    }
+  }
+}
+
+dependencies {
+  add(dependencyManagementConf.name, platform(project(":dependencyManagement")))
+}


### PR DESCRIPTION
This reverts commit d7f7d913cf0f5956425c536677b80cd330f0a579.

Turns out this was needed after all; without this code snippet the snapshot build produces invalid BOMs that contain SDK BOMs dependencies without versions. E.g. see build for #9427

Resolves #9428
Resolves #9429