### PR TITLE
Disable elasticsearch-rest-7.0 instrumentation when elasticsearch-jav…

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   testImplementation("org.testcontainers:elasticsearch")
 
   // 8.10+ has native, on-by-default opentelemetry instrumentation
-  latestDepTestLibrary("co.elastic.clients:elasticsearch-java:8.0.+")
+  latestDepTestLibrary("co.elastic.clients:elasticsearch-java:8.9.+")
 }
 
 tasks {

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
@@ -12,6 +12,15 @@ muzzle {
 
   fail {
     group.set("org.elasticsearch.client")
+    module.set("elasticsearch-rest-client")
+    versions.set("[8.10,)")
+    // elasticsearch-java 8.10+ has native, on-by-default opentelemetry instrumentation
+    // we disable our elasticsearch-rest-client instrumentation when elasticsearch-java is present
+    extraDependency("co.elastic.clients:elasticsearch-java:8.10.0")
+  }
+
+  fail {
+    group.set("org.elasticsearch.client")
     module.set("rest")
     versions.set("(,)")
   }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7InstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7InstrumentationModule.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v7_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -23,7 +24,12 @@ public class ElasticsearchRest7InstrumentationModule extends InstrumentationModu
   @Override
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Class `org.elasticsearch.client.RestClient$InternalRequest` introduced in 7.0.0.
-    return hasClassesNamed("org.elasticsearch.client.RestClient$InternalRequest");
+    // Since Elasticsearch client version 8.10, the ES client comes with a native OTel
+    // instrumentation that introduced the class
+    // `co.elastic.clients.transport.instrumentation.Instrumentation`.
+    // Disabling agent instrumentation for those cases.
+    return hasClassesNamed("org.elasticsearch.client.RestClient$InternalRequest")
+        .and(not(hasClassesNamed("co.elastic.clients.transport.instrumentation.Instrumentation")));
   }
 
   @Override


### PR DESCRIPTION
…a 8.10+ is present
Continuation of https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9337