### PR TITLE
Remove TODO

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/build.gradle.kts
@@ -24,9 +24,6 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:apache-httpclient:apache-httpclient-4.0:javaagent"))
   testInstrumentation(project(":instrumentation:apache-httpasyncclient-4.1:javaagent"))
-  // TODO: review the following claim, we are not using embedded ES anymore
-  // Netty is used, but it adds complexity to the tests since we're using embedded ES.
-  // testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
 
   testImplementation("org.apache.logging.log4j:log4j-core:2.11.0")
   testImplementation("org.apache.logging.log4j:log4j-api:2.11.0")

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/build.gradle.kts
@@ -24,9 +24,6 @@ dependencies {
 
   testInstrumentation(project(":instrumentation:apache-httpclient:apache-httpclient-4.0:javaagent"))
   testInstrumentation(project(":instrumentation:apache-httpasyncclient-4.1:javaagent"))
-  // TODO: review the following claim, we are not using embedded ES anymore
-  // Netty is used, but it adds complexity to the tests since we're using embedded ES.
-  // testInstrumentation(project(":instrumentation:netty:netty-4.1:javaagent"))
 
   testImplementation("com.fasterxml.jackson.core:jackson-databind")
   testImplementation("org.testcontainers:elasticsearch")


### PR DESCRIPTION
elasticsearch-rest-client tests don't include netty so there is no need to run them with netty instrumentation