### PR TITLE
[grpc] fix `rpc.server.duration` metric description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix `rpc.server.duration` metric description to match semantic conventions
+   ([#9479](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9479))
+
 ## Version 1.30.0 (2023-09-14)
 
 ### Migration notes

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetrics.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcServerMetrics.java
@@ -39,7 +39,7 @@ public final class RpcServerMetrics implements OperationListener {
     DoubleHistogramBuilder durationBuilder =
         meter
             .histogramBuilder("rpc.server.duration")
-            .setDescription("The duration of an inbound RPC invocation")
+            .setDescription("Measures the duration of inbound RPC.")
             .setUnit("ms");
     RpcMetricsAdvice.applyServerDurationAdvice(durationBuilder);
     serverDurationHistogram = durationBuilder.build();


### PR DESCRIPTION
Fixes #9478 

This sets the description for the `rpc.server.duration` metric. This description is set as defined by the [semantic convention](https://github.com/open-telemetry/semantic-conventions/blob/main/model/metrics/rpc-metrics.yaml#L23) for this metric.

When used with other services written in other languages that emit the same metric, all services must emit the same metric metadata (name, description) when used in conjunction with a Prometheus backend. The OpenTelemetry Collector, Prometheus exporter, will drop metrics that match the name but not the description against already received metrics. We have faced this problem as part of the OpenTelemetry demo project.