### PR TITLE
Fix flaky lettuce 4 test

### DIFF
--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSyncClientTest.java
@@ -85,6 +85,7 @@ class LettuceSyncClientTest {
     syncCommands.hmset("TESTHM", testHashMap);
 
     // 2 sets + 1 connect trace
+    testing.waitForTraces(3);
     testing.clearData();
   }
 


### PR DESCRIPTION
https://ge.opentelemetry.io/s/smalf4easaz4c/tests/task/:instrumentation:lettuce:lettuce-4.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSyncClientTest/testCommandWithNoArguments()?top-execution=1
groovy -> java conversion lost waiting for traces from setup which now leak over to the first test run