### PR TITLE
Split hibernate reactive instrumentation

### DIFF
--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/mutiny/ContextOperator.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/mutiny/ContextOperator.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0;
+package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0.mutiny;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/mutiny/HibernateReactiveMutinyInstrumentationModule.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/mutiny/HibernateReactiveMutinyInstrumentationModule.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0.mutiny;
+
+import static java.util.Collections.singletonList;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import java.util.List;
+
+@AutoService(InstrumentationModule.class)
+public class HibernateReactiveMutinyInstrumentationModule extends InstrumentationModule {
+
+  public HibernateReactiveMutinyInstrumentationModule() {
+    super("hibernate-reactive", "hibernate-reactive-1.0", "hibernate-reactive-mutiny");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new MutinySessionFactoryInstrumentation());
+  }
+}

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/mutiny/MutinySessionFactoryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/mutiny/MutinySessionFactoryInstrumentation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0;
+package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0.mutiny;
 
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/stage/CompletionStageWrapper.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/stage/CompletionStageWrapper.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0;
+package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0.stage;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/stage/FunctionWrapper.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/stage/FunctionWrapper.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0;
+package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0.stage;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/stage/HibernateReactiveStageInstrumentationModule.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/stage/HibernateReactiveStageInstrumentationModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0;
+package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0.stage;
 
 import static java.util.Arrays.asList;
 
@@ -13,17 +13,14 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class HibernateReactiveInstrumentationModule extends InstrumentationModule {
+public class HibernateReactiveStageInstrumentationModule extends InstrumentationModule {
 
-  public HibernateReactiveInstrumentationModule() {
-    super("hibernate-reactive", "hibernate-reactive-1.0");
+  public HibernateReactiveStageInstrumentationModule() {
+    super("hibernate-reactive", "hibernate-reactive-1.0", "hibernate-reactive-stage");
   }
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(
-        new StageSessionFactoryInstrumentation(),
-        new StageSessionImplInstrumentation(),
-        new MutinySessionFactoryInstrumentation());
+    return asList(new StageSessionFactoryInstrumentation(), new StageSessionImplInstrumentation());
   }
 }

--- a/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/stage/StageSessionFactoryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-reactive-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/reactive/v1_0/stage/StageSessionFactoryInstrumentation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0;
+package io.opentelemetry.javaagent.instrumentation.hibernate.reactive.v1_0.stage;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
@@ -18,30 +18,45 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-public class StageSessionImplInstrumentation implements TypeInstrumentation {
+public class StageSessionFactoryInstrumentation implements TypeInstrumentation {
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return namedOneOf(
-        "org.hibernate.reactive.stage.impl.StageSessionImpl",
-        "org.hibernate.reactive.stage.impl.StageStatelessSessionImpl");
+    return named("org.hibernate.reactive.stage.impl.StageSessionFactoryImpl");
   }
 
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        named("withTransaction")
-            .and(takesArgument(0, Function.class).and(returns(CompletionStage.class))),
-        this.getClass().getName() + "$WithTransactionAdvice");
+        namedOneOf("withSession", "withStatelessSession").and(takesArgument(0, Function.class)),
+        this.getClass().getName() + "$Function0Advice");
+    transformer.applyAdviceToMethod(
+        namedOneOf("withSession", "withStatelessSession").and(takesArgument(1, Function.class)),
+        this.getClass().getName() + "$Function1Advice");
+    transformer.applyAdviceToMethod(
+        namedOneOf("openSession", "openStatelessSession").and(returns(CompletionStage.class)),
+        this.getClass().getName() + "$OpenSessionAdvice");
   }
 
   @SuppressWarnings("unused")
-  public static class WithTransactionAdvice {
+  public static class Function0Advice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
         @Advice.Argument(value = 0, readOnly = false) Function<?, ?> function) {
       function = FunctionWrapper.wrap(function);
     }
+  }
 
+  @SuppressWarnings("unused")
+  public static class Function1Advice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+        @Advice.Argument(value = 1, readOnly = false) Function<?, ?> function) {
+      function = FunctionWrapper.wrap(function);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class OpenSessionAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.Return(readOnly = false) CompletionStage<?> completionStage) {
       completionStage = CompletionStageWrapper.wrap(completionStage);


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/discussions/9474#discussioncomment-7058447
Hibernate reactive provides 2 apis - one is based on completion stages and the other uses smallrye mutiny. If the mutiny dependency is missing the completion stage api still works.