### PR TITLE
Revert "fix(deps): update dependency io.netty:netty-bom to v4.1.98.fi…

### DIFF
--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -122,7 +122,8 @@ abstract class NettyAlignmentRule : ComponentMetadataRule {
     with(ctx.details) {
       if (id.group == "io.netty" && id.name != "netty") {
         if (id.version.startsWith("4.1.")) {
-          belongsTo("io.netty:netty-bom:4.1.98.Final", false)
+          // netty 4.1.98 does not run correctly on MacOS
+          belongsTo("io.netty:netty-bom:4.1.97.Final", false)
         } else if (id.version.startsWith("4.0.")) {
           belongsTo("io.netty:netty-bom:4.0.56.Final", false)
         }


### PR DESCRIPTION
…nal (#9529)"

This reverts commit 97a9d696b5c2c6eb4e964baca07cbf1ea7c6f5a5.

See https://github.com/netty/netty/issues/13632