### PR TITLE
Exclude another version from muzzle

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/build.gradle.kts
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/javaagent/build.gradle.kts
@@ -21,7 +21,7 @@ muzzle {
     versions.set("(,3.0.0)")
     assertInverse.set(true)
     // Could not find com.google.code.findbugs:jsr305:.
-    skip("4.0.2")
+    skip("3.0.2", "4.0.2")
   }
 }
 


### PR DESCRIPTION
Both `dropwizard-client` `4.0.2` and `3.0.2` were released today.