### PR TITLE
Wait for redis to start in lettuce 4 tests

### DIFF
--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
@@ -45,11 +45,16 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 @SuppressWarnings("deprecation") // until old http semconv are dropped in 2.0
 class LettuceAsyncClientTest {
+  private static final Logger logger = LoggerFactory.getLogger(LettuceAsyncClientTest.class);
 
   @RegisterExtension
   protected static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
@@ -65,7 +70,10 @@ class LettuceAsyncClientTest {
       new ClientOptions.Builder().autoReconnect(false).build();
 
   private static final GenericContainer<?> redisServer =
-      new GenericContainer<>(containerImage).withExposedPorts(6379);
+      new GenericContainer<>(containerImage)
+          .withExposedPorts(6379)
+          .withLogConsumer(new Slf4jLogConsumer(logger))
+          .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
 
   private static String host;
   private static int port;


### PR DESCRIPTION
https://ge.opentelemetry.io/s/cuizf5vlb3ong/tests/task/:instrumentation:lettuce:lettuce-4.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSyncClientTest?top-execution=1
reveals that there are 2 `CONNECT` spans and the first one gets connection refused. This should hopefully resolve the flakiness in lettuce 4 tests.