### PR TITLE
Clear exported data after test

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/InstrumentationExtension.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/InstrumentationExtension.java
@@ -59,6 +59,7 @@ public abstract class InstrumentationExtension
 
   @Override
   public void afterAll(ExtensionContext extensionContext) throws Exception {
+    testRunner.clearAllExportedData();
     testRunner.afterTestClass();
   }
 


### PR DESCRIPTION
After reviewing the debug info from failing letuce test https://ge.opentelemetry.io/s/cuizf5vlb3ong/tests/task/:instrumentation:lettuce:lettuce-4.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSyncClientTest?top-execution=1 I realized that it is actually failing because a span from previously executed LettuceAsyncClientTest.testExceptionInsideTheConnectionFuture leaks over. I hope that this really fixes it.