### PR TITLE
Fix logback-appender-1.0 dependency example

### DIFF
--- a/instrumentation/logback/logback-appender-1.0/library/README.md
+++ b/instrumentation/logback/logback-appender-1.0/library/README.md
@@ -20,7 +20,6 @@ For Maven, add to your `pom.xml` dependencies:
     <groupId>io.opentelemetry.instrumentation</groupId>
     <artifactId>opentelemetry-logback-appender-1.0</artifactId>
     <version>OPENTELEMETRY_VERSION</version>
-    <scope>runtime</scope>
   </dependency>
 </dependencies>
 ```
@@ -28,7 +27,7 @@ For Maven, add to your `pom.xml` dependencies:
 For Gradle, add to your dependencies:
 
 ```groovy
-runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:OPENTELEMETRY_VERSION")
+implementation("io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:OPENTELEMETRY_VERSION")
 ```
 
 ### Usage


### PR DESCRIPTION
It can't be declared a runtime dependency since, as Usage example shows, you need to call the class in your own initialization code.