### PR TITLE
Fix flaky executor test

### DIFF
--- a/instrumentation/executors/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/executors/ThreadPoolExecutorTest.java
+++ b/instrumentation/executors/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/executors/ThreadPoolExecutorTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.context.Scope;
@@ -32,7 +33,7 @@ class ThreadPoolExecutorTest {
     latch.await(10, TimeUnit.SECONDS);
 
     assertThat(executor.sameTaskBefore).isTrue();
-    assertThat(executor.sameTaskAfter).isTrue();
+    await().untilAsserted(() -> assertThat(executor.sameTaskAfter).isTrue());
   }
 
   // class is configured to be instrumented via otel.instrumentation.executors.include


### PR DESCRIPTION
https://ge.opentelemetry.io/s/74xqiuu4ywcnw/tests/task/:instrumentation:executors:javaagent:testNoParallelism/details/io.opentelemetry.javaagent.instrumentation.executors.ThreadPoolExecutorTest/shouldPassOriginalRunnableToBeforeAfterMethods()?top-execution=1

`sameTaskAfter` might not have been set yet by the time assertion is run, we need to wait for a bit.