### PR TITLE
Minor cleanup after bytebuddy 1.14.8 release

### DIFF
--- a/javaagent-tooling/src/testPatchBytecodeVersion/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/PatchBytecodeVersionTest.java
+++ b/javaagent-tooling/src/testPatchBytecodeVersion/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/PatchBytecodeVersionTest.java
@@ -155,8 +155,7 @@ class PatchBytecodeVersionTest {
 
   private static ClassFileVersion getBytecodeVersion(Path file) {
     try {
-      byte[] bytecode = Files.readAllBytes(file);
-      return ClassFileVersion.ofMinorMajor((bytecode[5] << 16) | (bytecode[7] & 0xFF));
+      return ClassFileVersion.ofClassFile(Files.readAllBytes(file));
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }


### PR DESCRIPTION
There was a minor issue when trying to use bytebuddy to read the class file version with `ClassFileVersion.ofClassFile` when I implemented https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9239.

This is now fixed in bytebuddy and we can use a simpler method call and avoid relying on binary class file format since it is part of release 1.14.8.

Related PR on bytebuddy: https://github.com/raphw/byte-buddy/pull/1510