### PR TITLE
Optimize the Netty instrumentation for judging msg surperclass

### DIFF
--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/TypeUtils.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/TypeUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.netty.v4_1.internal;
+
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
+
+public class TypeUtils {
+
+  public static boolean isLastHttpContent(Object obj) {
+    Class<?> objClass = obj.getClass();
+    if (objClass == DefaultLastHttpContent.class) {
+      return true;
+    }
+
+    return obj instanceof LastHttpContent;
+  }
+
+  public static boolean isFullHttpResponse(Object obj) {
+    Class<?> objClass = obj.getClass();
+    if (objClass == DefaultFullHttpResponse.class) {
+      return true;
+    }
+
+    return obj instanceof FullHttpResponse;
+  }
+
+  public static boolean isHttpResponse(Object obj) {
+    Class<?> objClass = obj.getClass();
+    if (objClass == DefaultFullHttpResponse.class || objClass == DefaultHttpResponse.class) {
+      return true;
+    }
+
+    return obj instanceof HttpResponse;
+  }
+
+  public static boolean isHttpRequest(Object msg) {
+    Class<?> objClass = msg.getClass();
+    if (objClass == DefaultFullHttpRequest.class || objClass == DefaultHttpRequest.class) {
+      return true;
+    }
+
+    return msg instanceof HttpRequest;
+  }
+}

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/TypeUtils.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/TypeUtils.java
@@ -15,7 +15,13 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
 public class TypeUtils {
+
+  private TypeUtils() {}
 
   public static boolean isLastHttpContent(Object obj) {
     Class<?> objClass = obj.getClass();

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientRequestTracingHandler.java
@@ -17,6 +17,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.AttributeKeys;
+import io.opentelemetry.instrumentation.netty.v4_1.internal.TypeUtils;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -36,7 +37,7 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
 
   @Override
   public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise prm) throws Exception {
-    if (!(msg instanceof HttpRequest)) {
+    if (!TypeUtils.isHttpRequest(msg)) {
       super.write(ctx, msg, prm);
       return;
     }

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientResponseTracingHandler.java
@@ -9,9 +9,7 @@ import static io.opentelemetry.instrumentation.netty.v4_1.internal.client.HttpCl
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.opentelemetry.context.Context;

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/client/HttpClientResponseTracingHandler.java
@@ -19,6 +19,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.AttributeKeys;
+import io.opentelemetry.instrumentation.netty.v4_1.internal.TypeUtils;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -48,15 +49,15 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     Attribute<Context> parentContextAttr = ctx.channel().attr(AttributeKeys.CLIENT_PARENT_CONTEXT);
     Context parentContext = parentContextAttr.get();
 
-    if (msg instanceof FullHttpResponse) {
+    if (TypeUtils.isFullHttpResponse(msg)) {
       HttpRequestAndChannel request = ctx.channel().attr(HTTP_CLIENT_REQUEST).getAndSet(null);
       instrumenter.end(context, request, (HttpResponse) msg, null);
       contextAttr.set(null);
       parentContextAttr.set(null);
-    } else if (msg instanceof HttpResponse) {
+    } else if (TypeUtils.isHttpResponse(msg)) {
       // Headers before body have been received, store them to use when finishing the span.
       ctx.channel().attr(HTTP_CLIENT_RESPONSE).set((HttpResponse) msg);
-    } else if (msg instanceof LastHttpContent) {
+    } else if (TypeUtils.isLastHttpContent(msg)) {
       // Not a FullHttpResponse so this is content that has been received after headers.
       // Finish the span using what we stored in attrs.
       HttpRequestAndChannel request = ctx.channel().attr(HTTP_CLIENT_REQUEST).getAndSet(null);

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerRequestTracingHandler.java
@@ -18,6 +18,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.AttributeKeys;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.ServerContext;
+import io.opentelemetry.instrumentation.netty.v4_1.internal.TypeUtils;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -39,7 +40,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     Channel channel = ctx.channel();
     Deque<ServerContext> serverContexts = getOrCreate(channel, AttributeKeys.SERVER_CONTEXT);
 
-    if (!(msg instanceof HttpRequest)) {
+    if (! TypeUtils.isHttpRequest(msg)) {
       ServerContext serverContext = serverContexts.peekLast();
       if (serverContext == null) {
         super.channelRead(ctx, msg);

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerRequestTracingHandler.java
@@ -40,7 +40,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     Channel channel = ctx.channel();
     Deque<ServerContext> serverContexts = getOrCreate(channel, AttributeKeys.SERVER_CONTEXT);
 
-    if (! TypeUtils.isHttpRequest(msg)) {
+    if (!TypeUtils.isHttpRequest(msg)) {
       ServerContext serverContext = serverContexts.peekLast();
       if (serverContext == null) {
         super.channelRead(ctx, msg);

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerResponseTracingHandler.java
@@ -11,7 +11,6 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.opentelemetry.context.Context;

--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerResponseTracingHandler.java
@@ -21,6 +21,7 @@ import io.opentelemetry.instrumentation.netty.common.internal.NettyErrorHolder;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.AttributeKeys;
 import io.opentelemetry.instrumentation.netty.v4_1.internal.ServerContext;
+import io.opentelemetry.instrumentation.netty.v4_1.internal.TypeUtils;
 import java.util.Deque;
 import javax.annotation.Nullable;
 
@@ -57,7 +58,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
 
     ChannelPromise writePromise;
 
-    if (msg instanceof LastHttpContent) {
+    if (TypeUtils.isLastHttpContent(msg)) {
       if (prm.isVoid()) {
         // Some frameworks don't actually listen for response completion and optimize for
         // allocations by using a singleton, unnotifiable promise. Hopefully these frameworks don't
@@ -68,7 +69,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       }
 
       // Going to finish the span after the write of the last content finishes.
-      if (msg instanceof FullHttpResponse) {
+      if (TypeUtils.isFullHttpResponse(msg)) {
         // Headers and body all sent together, we have the response information in the msg.
         beforeCommitHandler.handle(serverContext.context(), (HttpResponse) msg);
         serverContexts.removeFirst();
@@ -91,7 +92,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
       }
     } else {
       writePromise = prm;
-      if (msg instanceof HttpResponse) {
+      if (TypeUtils.isHttpResponse(msg)) {
         // Headers before body has been sent, store them to use when finishing the span.
         beforeCommitHandler.handle(serverContext.context(), (HttpResponse) msg);
         ctx.channel().attr(HTTP_SERVER_RESPONSE).set((HttpResponse) msg);


### PR DESCRIPTION
Class type checks use ```instanceof```  cost CPU resources,it is likely that most of these just are default  Netty classes,therefore, i believe it will optimize some enhance performances.