### PR TITLE
Remove server.socket.address from HTTP/RPC metrics

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpMetricsAdvice.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpMetricsAdvice.java
@@ -29,8 +29,7 @@ final class HttpMetricsAdvice {
                 SemanticAttributes.NETWORK_PROTOCOL_NAME,
                 SemanticAttributes.NETWORK_PROTOCOL_VERSION,
                 SemanticAttributes.SERVER_ADDRESS,
-                SemanticAttributes.SERVER_PORT,
-                SemanticAttributes.SERVER_SOCKET_ADDRESS));
+                SemanticAttributes.SERVER_PORT));
   }
 
   @SuppressWarnings("deprecation") // until old http semconv are dropped in 2.0
@@ -65,7 +64,6 @@ final class HttpMetricsAdvice {
                 SemanticAttributes.NETWORK_PROTOCOL_VERSION,
                 SemanticAttributes.SERVER_ADDRESS,
                 SemanticAttributes.SERVER_PORT,
-                SemanticAttributes.SERVER_SOCKET_ADDRESS,
                 // old attributes
                 SemanticAttributes.HTTP_METHOD,
                 SemanticAttributes.HTTP_STATUS_CODE,

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcMetricsAdvice.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/rpc/RpcMetricsAdvice.java
@@ -34,8 +34,6 @@ final class RpcMetricsAdvice {
       attributes.add(SemanticAttributes.NETWORK_TRANSPORT);
       attributes.add(SemanticAttributes.SERVER_ADDRESS);
       attributes.add(SemanticAttributes.SERVER_PORT);
-      attributes.add(SemanticAttributes.SERVER_SOCKET_ADDRESS);
-      attributes.add(SemanticAttributes.SERVER_SOCKET_PORT);
     }
     if (SemconvStability.emitOldHttpSemconv()) {
       attributes.add(SemanticAttributes.NET_PEER_NAME);
@@ -65,8 +63,6 @@ final class RpcMetricsAdvice {
       attributes.add(SemanticAttributes.NETWORK_TRANSPORT);
       attributes.add(SemanticAttributes.SERVER_ADDRESS);
       attributes.add(SemanticAttributes.SERVER_PORT);
-      attributes.add(SemanticAttributes.SERVER_SOCKET_ADDRESS);
-      attributes.add(SemanticAttributes.SERVER_SOCKET_PORT);
     }
     if (SemconvStability.emitOldHttpSemconv()) {
       attributes.add(SemanticAttributes.NET_HOST_NAME);

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientExperimentalMetricsStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientExperimentalMetricsStableSemconvTest.java
@@ -96,10 +96,7 @@ class HttpClientExperimentalMetricsStableSemconvTest {
                                             equalTo(
                                                 SemanticAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
                                             equalTo(SemanticAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(SemanticAttributes.SERVER_PORT, 1234),
-                                            equalTo(
-                                                SemanticAttributes.SERVER_SOCKET_ADDRESS,
-                                                "1.2.3.4"))
+                                            equalTo(SemanticAttributes.SERVER_PORT, 1234))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar
@@ -124,10 +121,7 @@ class HttpClientExperimentalMetricsStableSemconvTest {
                                             equalTo(
                                                 SemanticAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
                                             equalTo(SemanticAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(SemanticAttributes.SERVER_PORT, 1234),
-                                            equalTo(
-                                                SemanticAttributes.SERVER_SOCKET_ADDRESS,
-                                                "1.2.3.4"))
+                                            equalTo(SemanticAttributes.SERVER_PORT, 1234))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpClientMetricsStableSemconvTest.java
@@ -98,10 +98,7 @@ class HttpClientMetricsStableSemconvTest {
                                             equalTo(
                                                 SemanticAttributes.NETWORK_PROTOCOL_VERSION, "2.0"),
                                             equalTo(SemanticAttributes.SERVER_ADDRESS, "localhost"),
-                                            equalTo(SemanticAttributes.SERVER_PORT, 1234),
-                                            equalTo(
-                                                SemanticAttributes.SERVER_SOCKET_ADDRESS,
-                                                "1.2.3.4"))
+                                            equalTo(SemanticAttributes.SERVER_PORT, 1234))
                                         .hasExemplarsSatisfying(
                                             exemplar ->
                                                 exemplar


### PR DESCRIPTION
Implements https://github.com/open-telemetry/semantic-conventions/issues/341