### PR TITLE
Improve vertx-sql client context propagation

### DIFF
--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/PoolInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/PoolInstrumentation.java
@@ -97,6 +97,7 @@ public class PoolInstrumentation implements TypeInstrumentation {
       SqlConnectOptions sqlConnectOptions = virtualField.get(pool);
 
       future = VertxSqlClientSingletons.attachConnectOptions(future, sqlConnectOptions);
+      future = VertxSqlClientSingletons.wrapContext(future);
     }
   }
 }

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/QueryExecutorInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/QueryExecutorInstrumentation.java
@@ -6,9 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql;
 
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
-import static io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql.VertxSqlClientSingletons.OTEL_CONTEXT_KEY;
-import static io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql.VertxSqlClientSingletons.OTEL_PARENT_CONTEXT_KEY;
-import static io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql.VertxSqlClientSingletons.OTEL_REQUEST_KEY;
 import static io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql.VertxSqlClientSingletons.getSqlConnectOptions;
 import static io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql.VertxSqlClientSingletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
@@ -98,9 +95,7 @@ public class QueryExecutorInstrumentation implements TypeInstrumentation {
 
       context = instrumenter().start(parentContext, otelRequest);
       scope = context.makeCurrent();
-      promiseInternal.context().localContextData().put(OTEL_REQUEST_KEY, otelRequest);
-      promiseInternal.context().localContextData().put(OTEL_CONTEXT_KEY, context);
-      promiseInternal.context().localContextData().put(OTEL_PARENT_CONTEXT_KEY, parentContext);
+      VertxSqlClientSingletons.attachRequest(promiseInternal, otelRequest, context, parentContext);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/QueryResultBuilderInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/QueryResultBuilderInstrumentation.java
@@ -13,8 +13,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.vertx.core.Promise;
-import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.impl.future.PromiseInternal;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -40,12 +38,7 @@ public class QueryResultBuilderInstrumentation implements TypeInstrumentation {
   public static class CompleteAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Scope onEnter(@Advice.FieldValue("handler") Promise<?> promise) {
-      if (!(promise instanceof PromiseInternal)) {
-        return null;
-      }
-      PromiseInternal<?> promiseInternal = (PromiseInternal<?>) promise;
-      ContextInternal contextInternal = promiseInternal.context();
-      return endQuerySpan(contextInternal.localContextData(), null);
+      return endQuerySpan(promise, null);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -61,12 +54,7 @@ public class QueryResultBuilderInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static Scope onEnter(
         @Advice.Argument(0) Throwable throwable, @Advice.FieldValue("handler") Promise<?> promise) {
-      if (!(promise instanceof PromiseInternal)) {
-        return null;
-      }
-      PromiseInternal<?> promiseInternal = (PromiseInternal<?>) promise;
-      ContextInternal contextInternal = promiseInternal.context();
-      return endQuerySpan(contextInternal.localContextData(), throwable);
+      return endQuerySpan(promise, throwable);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientSingletons.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientSingletons.java
@@ -19,15 +19,13 @@ import io.opentelemetry.instrumentation.api.instrumenter.network.ServerAttribute
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.bootstrap.internal.CommonConfig;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.impl.SqlClientBase;
-import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public final class VertxSqlClientSingletons {
-  public static final String OTEL_REQUEST_KEY = "otel.request";
-  public static final String OTEL_CONTEXT_KEY = "otel.context";
-  public static final String OTEL_PARENT_CONTEXT_KEY = "otel.parent-context";
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.vertx-sql-client-4.0";
   private static final Instrumenter<VertxSqlClientRequest, Void> INSTRUMENTER;
   private static final ThreadLocal<SqlConnectOptions> connectOptions = new ThreadLocal<>();
@@ -66,16 +64,33 @@ public final class VertxSqlClientSingletons {
     return connectOptions.get();
   }
 
-  public static Scope endQuerySpan(Map<Object, Object> contextData, Throwable throwable) {
-    VertxSqlClientRequest otelRequest =
-        (VertxSqlClientRequest) contextData.remove(OTEL_REQUEST_KEY);
-    Context otelContext = (Context) contextData.remove(OTEL_CONTEXT_KEY);
-    Context otelParentContext = (Context) contextData.remove(OTEL_PARENT_CONTEXT_KEY);
-    if (otelRequest == null || otelContext == null || otelParentContext == null) {
+  private static final VirtualField<Promise<?>, RequestData> requestDataField =
+      VirtualField.find(Promise.class, RequestData.class);
+
+  public static void attachRequest(
+      Promise<?> promise, VertxSqlClientRequest request, Context context, Context parentContext) {
+    requestDataField.set(promise, new RequestData(request, context, parentContext));
+  }
+
+  public static Scope endQuerySpan(Promise<?> promise, Throwable throwable) {
+    RequestData requestData = requestDataField.get(promise);
+    if (requestData == null) {
       return null;
     }
-    instrumenter().end(otelContext, otelRequest, null, throwable);
-    return otelParentContext.makeCurrent();
+    instrumenter().end(requestData.context, requestData.request, null, throwable);
+    return requestData.parentContext.makeCurrent();
+  }
+
+  static class RequestData {
+    final VertxSqlClientRequest request;
+    final Context context;
+    final Context parentContext;
+
+    RequestData(VertxSqlClientRequest request, Context context, Context parentContext) {
+      this.request = request;
+      this.context = context;
+      this.parentContext = parentContext;
+    }
   }
 
   // this virtual field is also used in SqlClientBase instrumentation
@@ -91,6 +106,24 @@ public final class VertxSqlClientSingletons {
           }
           return sqlConnection;
         });
+  }
+
+  public static <T> Future<T> wrapContext(Future<T> future) {
+    Context context = Context.current();
+    CompletableFuture<T> result = new CompletableFuture<>();
+    future
+        .toCompletionStage()
+        .whenComplete(
+            (value, throwable) -> {
+              try (Scope ignore = context.makeCurrent()) {
+                if (throwable != null) {
+                  result.completeExceptionally(throwable);
+                } else {
+                  result.complete(value);
+                }
+              }
+            });
+    return Future.fromCompletionStage(result);
   }
 
   private VertxSqlClientSingletons() {}


### PR DESCRIPTION
Adds tests for running many queries and concurrent queries and fixes the issues failures in these tests. Apparently using vert.x context for propagating our context was a mistake, that context is not used by a single request.