### PR TITLE
Limit latest dep version for tomcat-jdbc

### DIFF
--- a/instrumentation/jdbc/javaagent/build.gradle.kts
+++ b/instrumentation/jdbc/javaagent/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   testImplementation("org.scala-lang:scala-library:2.11.12")
   testImplementation("com.typesafe.slick:slick_2.11:3.2.0")
   testImplementation("com.h2database:h2:1.4.197")
+  latestDepTestLibrary("org.apache.tomcat:tomcat-jdbc:10.1.13")
 }
 
 sourceSets {

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -92,7 +92,7 @@ public class PreparedStatementInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelRequest") DbRequest request,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
-      if (callDepth.decrementAndGet() > 0) {
+      if (callDepth == null || callDepth.decrementAndGet() > 0) {
         return;
       }
 


### PR DESCRIPTION
Freshly release `10.1.14` has a bug where `org.apache.tomcat.jdbc.pool.PooledConnection` is used instead of `javax.sql.PooledConnection`