### PR TITLE
Using a delegate is simpler and faster than a proxy

### DIFF
--- a/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/OpenTelemetryAppender.java
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/OpenTelemetryAppender.java
@@ -19,8 +19,8 @@ import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.logback.mdc.v1_0.internal.UnionMap;
 import io.opentelemetry.instrumentation.logback.mdc.v1_0.internal.BaseLoggingEventDelegate;
+import io.opentelemetry.instrumentation.logback.mdc.v1_0.internal.UnionMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -122,18 +122,13 @@ public class OpenTelemetryAppender extends UnsynchronizedAppenderBase<ILoggingEv
     return aai.detachAppender(name);
   }
 
-  /**
-   * Wraps another logging event, overriding MDC & LoggerContextVO.
-   */
+  /** Wraps another logging event, overriding MDC & LoggerContextVO. */
   private static class WrappedLoggingEvent extends BaseLoggingEventDelegate {
     private final Map<String, String> mdc;
     private final LoggerContextVO contextViewOnly;
 
     public WrappedLoggingEvent(
-        ILoggingEvent event,
-        Map<String, String> mdc,
-        LoggerContextVO contextViewOnly
-    ) {
+        ILoggingEvent event, Map<String, String> mdc, LoggerContextVO contextViewOnly) {
       super(event);
       this.mdc = mdc;
       this.contextViewOnly = contextViewOnly;

--- a/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/BaseLoggingEventDelegate.java
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/BaseLoggingEventDelegate.java
@@ -1,11 +1,16 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.logback.mdc.v1_0.internal;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.LoggerContextVO;
-import org.slf4j.Marker;
 import java.util.Map;
+import org.slf4j.Marker;
 
 /**
  * A convenience class that wraps a logging event and delegates all method calls to it. A subclass

--- a/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/BaseLoggingEventDelegate.java
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/BaseLoggingEventDelegate.java
@@ -15,9 +15,9 @@ import org.slf4j.Marker;
 /**
  * A convenience class that wraps a logging event and delegates all method calls to it. A subclass
  * can then override only what it needs.
- * <p>
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 public abstract class BaseLoggingEventDelegate implements ILoggingEvent {
   protected ILoggingEvent wrappedEvent;

--- a/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/BaseLoggingEventDelegate.java
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/main/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/BaseLoggingEventDelegate.java
@@ -1,0 +1,100 @@
+package io.opentelemetry.instrumentation.logback.mdc.v1_0.internal;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import org.slf4j.Marker;
+import java.util.Map;
+
+/**
+ * A convenience class that wraps a logging event and delegates all method calls to it. A subclass
+ * can then override only what it needs.
+ * <p>
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public abstract class BaseLoggingEventDelegate implements ILoggingEvent {
+  protected ILoggingEvent wrappedEvent;
+
+  public BaseLoggingEventDelegate(ILoggingEvent event) {
+    wrappedEvent = event;
+  }
+
+  @Override
+  public String getThreadName() {
+    return wrappedEvent.getThreadName();
+  }
+
+  @Override
+  public Level getLevel() {
+    return wrappedEvent.getLevel();
+  }
+
+  @Override
+  public String getMessage() {
+    return wrappedEvent.getMessage();
+  }
+
+  @Override
+  public Object[] getArgumentArray() {
+    return wrappedEvent.getArgumentArray();
+  }
+
+  @Override
+  public String getFormattedMessage() {
+    return wrappedEvent.getFormattedMessage();
+  }
+
+  @Override
+  public String getLoggerName() {
+    return wrappedEvent.getLoggerName();
+  }
+
+  @Override
+  public LoggerContextVO getLoggerContextVO() {
+    return wrappedEvent.getLoggerContextVO();
+  }
+
+  @Override
+  public IThrowableProxy getThrowableProxy() {
+    return wrappedEvent.getThrowableProxy();
+  }
+
+  @Override
+  public StackTraceElement[] getCallerData() {
+    return wrappedEvent.getCallerData();
+  }
+
+  @Override
+  public boolean hasCallerData() {
+    return wrappedEvent.hasCallerData();
+  }
+
+  @Override
+  public Marker getMarker() {
+    return wrappedEvent.getMarker();
+  }
+
+  @Override
+  public Map<String, String> getMDCPropertyMap() {
+    return wrappedEvent.getMDCPropertyMap();
+  }
+
+  @Override
+  // We are forced to implement this as it's part of the interface
+  @SuppressWarnings("deprecation")
+  public Map<String, String> getMdc() {
+    return this.getMDCPropertyMap();
+  }
+
+  @Override
+  public long getTimeStamp() {
+    return wrappedEvent.getTimeStamp();
+  }
+
+  @Override
+  public void prepareForDeferredProcessing() {
+    wrappedEvent.prepareForDeferredProcessing();
+  }
+}

--- a/instrumentation/logback/logback-mdc-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/BaseLoggingEventDelegateTest.java
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/BaseLoggingEventDelegateTest.java
@@ -1,0 +1,156 @@
+package io.opentelemetry.instrumentation.logback.mdc.v1_0.internal;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Marker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BaseLoggingEventDelegateTest {
+  ILoggingEvent event = mock(ILoggingEvent.class);
+  BaseLoggingEventDelegate delegate = new WrappedEvent(event);
+
+  @BeforeEach
+  void beforeEach() {
+    Mockito.reset(event);
+  }
+
+  @Test
+  void testGetThreadName() {
+    when(event.getThreadName()).thenReturn("testThread");
+
+    assertEquals("testThread", delegate.getThreadName());
+    verify(event).getThreadName();
+  }
+
+  @Test
+  void testGetLevel() {
+    when(event.getLevel()).thenReturn(Level.INFO);
+
+    assertEquals(Level.INFO, delegate.getLevel());
+    verify(event).getLevel();
+  }
+
+  @Test
+  void testGetMessage() {
+    when(event.getMessage()).thenReturn("testMessage");
+
+    assertEquals("testMessage", delegate.getMessage());
+    verify(event).getMessage();
+  }
+
+  @Test
+  void testGetFormattedMessage() {
+    when(event.getFormattedMessage()).thenReturn("formattedTestMessage");
+
+    assertEquals("formattedTestMessage", delegate.getFormattedMessage());
+    verify(event).getFormattedMessage();
+  }
+
+  @Test
+  void testGetLoggerName() {
+    when(event.getLoggerName()).thenReturn("testLogger");
+
+    assertEquals("testLogger", delegate.getLoggerName());
+    verify(event).getLoggerName();
+  }
+
+  @Test
+  void testGetTimeStamp() {
+    ILoggingEvent event = mock(ILoggingEvent.class);
+    when(event.getTimeStamp()).thenReturn(123456L);
+
+    BaseLoggingEventDelegate delegate = new WrappedEvent(event);
+
+    assertEquals(123456L, delegate.getTimeStamp());
+    verify(event).getTimeStamp();
+  }
+
+  @Test
+  void testGetLoggerContextVO() {
+    LoggerContextVO loggerContextVO = mock(LoggerContextVO.class);
+    when(event.getLoggerContextVO()).thenReturn(loggerContextVO);
+
+    assertEquals(loggerContextVO, delegate.getLoggerContextVO());
+    verify(event).getLoggerContextVO();
+  }
+
+  @Test
+  void testGetArgumentArray() {
+    Object[] argumentArray = new Object[] {"arg1", "arg2"};
+    when(event.getArgumentArray()).thenReturn(argumentArray);
+
+    assertSame(argumentArray, delegate.getArgumentArray());
+    verify(event).getArgumentArray();
+  }
+
+  @Test
+  void testGetThrowableProxy() {
+    IThrowableProxy throwableProxy = mock(IThrowableProxy.class);
+    when(event.getThrowableProxy()).thenReturn(throwableProxy);
+
+    assertSame(throwableProxy, delegate.getThrowableProxy());
+    verify(event).getThrowableProxy();
+  }
+
+  @Test
+  void testGetCallerData() {
+    StackTraceElement[] callerData = new StackTraceElement[] {};
+    when(event.getCallerData()).thenReturn(callerData);
+
+    assertSame(callerData, delegate.getCallerData());
+    verify(event).getCallerData();
+  }
+
+  @Test
+  void testGetMarker() {
+    Marker marker = mock(Marker.class);
+    when(event.getMarker()).thenReturn(marker);
+
+    assertSame(marker, delegate.getMarker());
+    verify(event).getMarker();
+  }
+
+  @Test
+  void testGetMDCPropertyMap() {
+    Map<String, String> mdcPropertyMap = new HashMap<>();
+    when(event.getMDCPropertyMap()).thenReturn(mdcPropertyMap);
+
+    assertSame(mdcPropertyMap, delegate.getMDCPropertyMap());
+    verify(event).getMDCPropertyMap();
+  }
+
+  @Test
+  void testHasCallerData() {
+    when(event.hasCallerData()).thenReturn(true);
+
+    assertTrue(delegate.hasCallerData());
+    verify(event).hasCallerData();
+  }
+
+  @Test
+  void testPrepareForDeferredProcessing() {
+    delegate.prepareForDeferredProcessing();
+
+    verify(event).prepareForDeferredProcessing();
+  }
+
+  private static class WrappedEvent extends BaseLoggingEventDelegate {
+    public WrappedEvent(ILoggingEvent event) {
+      super(event);
+    }
+  }
+}

--- a/instrumentation/logback/logback-mdc-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/BaseLoggingEventDelegateTest.java
+++ b/instrumentation/logback/logback-mdc-1.0/library/src/test/java/io/opentelemetry/instrumentation/logback/mdc/v1_0/internal/BaseLoggingEventDelegateTest.java
@@ -1,16 +1,9 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.logback.mdc.v1_0.internal;
-
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.IThrowableProxy;
-import ch.qos.logback.classic.spi.LoggerContextVO;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.slf4j.Marker;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -18,6 +11,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Marker;
 
 class BaseLoggingEventDelegateTest {
   ILoggingEvent event = mock(ILoggingEvent.class);


### PR DESCRIPTION
Instead of using a proxy to supply our version of the MDC & context, we could rely on the fact that `ILoggingEvent` is an interface that we can simply implement and return our custom instance.

This is what this PR does, we return an ILoggingEvent that delegates all calls to the underlying event, except for the two ones we wish to override.

Advantages of this approach:
* Faster. Proxies are a bit slower than a simple & direct implementation. I've made a quick benchmark and saw a 2x improvement (which seems to still match [decade old benchmarks on the matter](https://ordinaryjava.blogspot.com/2008/08/benchmarking-cost-of-dynamic-proxies.html))
* Safer, as in the proxy version, the compiler wouldn't warn us if the underlying interface changes (method name, return value, etc) because we are using string comparison to match the name: `if ("getMDCPropertyMap".equals(method.getName())) { ... }` 