### PR TITLE
Generate only consumer span for sqs receive message

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -268,6 +268,17 @@ public class Instrumenter<REQUEST, RESPONSE> {
             return instrumenter.startAndEnd(
                 parentContext, request, response, error, startTime, endTime);
           }
+
+          @Override
+          public <REQUEST, RESPONSE> Context suppressSpan(
+              Instrumenter<REQUEST, RESPONSE> instrumenter,
+              Context parentContext,
+              REQUEST request) {
+            SpanKind spanKind = instrumenter.spanKindExtractor.extract(request);
+
+            return instrumenter.spanSuppressor.storeInContext(
+                parentContext, spanKind, Span.getInvalid());
+          }
         });
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/InstrumenterAccess.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/InstrumenterAccess.java
@@ -24,4 +24,7 @@ public interface InstrumenterAccess {
       @Nullable Throwable error,
       Instant startTime,
       Instant endTime);
+
+  <REQUEST, RESPONSE> Context suppressSpan(
+      Instrumenter<REQUEST, RESPONSE> instrumenter, Context parentContext, REQUEST request);
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/InstrumenterUtil.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/InstrumenterUtil.java
@@ -45,6 +45,11 @@ public final class InstrumenterUtil {
         instrumenter, parentContext, request, response, error, startTime, endTime);
   }
 
+  public static <REQUEST, RESPONSE> Context suppressSpan(
+      Instrumenter<REQUEST, RESPONSE> instrumenter, Context parentContext, REQUEST request) {
+    return instrumenterAccess.suppressSpan(instrumenter, parentContext, request);
+  }
+
   public static <REQUEST, RESPONSE> Instrumenter<REQUEST, RESPONSE> buildUpstreamInstrumenter(
       InstrumenterBuilder<REQUEST, RESPONSE> builder,
       TextMapGetter<REQUEST> getter,

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/S3TracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/S3TracingTest.groovy
@@ -42,7 +42,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
     awsConnector.purgeQueue(queueUrl)
 
     then:
-    assertTraces(12) {
+    assertTraces(10) {
       trace(0, 1) {
 
         span(0) {
@@ -168,31 +168,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-      trace(5, 1) {
-        span(0) {
-          name "SQS.ReceiveMessage"
-          kind CLIENT
-          hasNoParent()
-          attributes {
-            "aws.agent" "java-aws-sdk"
-            "aws.endpoint" String
-            "rpc.method" "ReceiveMessage"
-            "aws.queue.url" queueUrl
-            "rpc.system" "aws-api"
-            "rpc.service" "AmazonSQS"
-            "http.method" "POST"
-            "http.status_code" 200
-            "http.url" String
-            "net.peer.name" String
-            "$SemanticAttributes.NET_PROTOCOL_NAME" "http"
-            "$SemanticAttributes.NET_PROTOCOL_VERSION" "1.1"
-            "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
-          }
-        }
-      }
-      trace(6, 2) {
+      trace(5, 2) {
         span(0) {
           name "S3.PutObject"
           kind CLIENT
@@ -239,36 +215,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-
-      /**
-       * This span represents HTTP "sending of receive message" operation. It's always single, while there can be multiple CONSUMER spans (one per consumed message).
-       * This one could be suppressed (by IF in TracingRequestHandler#beforeRequest but then HTTP instrumentation span would appear
-       */
-      trace(7, 1) {
-        span(0) {
-          name "SQS.ReceiveMessage"
-          kind CLIENT
-          hasNoParent()
-          attributes {
-            "aws.agent" "java-aws-sdk"
-            "aws.endpoint" String
-            "rpc.method" "ReceiveMessage"
-            "aws.queue.url" queueUrl
-            "rpc.system" "aws-api"
-            "rpc.service" "AmazonSQS"
-            "http.method" "POST"
-            "http.status_code" 200
-            "http.url" String
-            "net.peer.name" String
-            "$SemanticAttributes.NET_PROTOCOL_NAME" "http"
-            "$SemanticAttributes.NET_PROTOCOL_VERSION" "1.1"
-            "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
-          }
-        }
-      }
-      trace(8, 1) {
+      trace(6, 1) {
         span(0) {
           name "S3.ListObjects"
           kind CLIENT
@@ -292,7 +239,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-      trace(9, 1) {
+      trace(7, 1) {
         span(0) {
           name "S3.DeleteObject"
           kind CLIENT
@@ -316,7 +263,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-      trace(10, 1) {
+      trace(8, 1) {
         span(0) {
           name "S3.DeleteBucket"
           kind CLIENT
@@ -340,7 +287,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-      trace(11, 1) {
+      trace(9, 1) {
         span(0) {
           name "SQS.PurgeQueue"
           kind CLIENT
@@ -393,7 +340,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
     awsConnector.purgeQueue(queueUrl)
 
     then:
-    assertTraces(16) {
+    assertTraces(14) {
       trace(0, 1) {
         span(0) {
           name "SQS.CreateQueue"
@@ -583,32 +530,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-      // test even receive
       trace(8, 1) {
-        span(0) {
-          name "SQS.ReceiveMessage"
-          kind CLIENT
-          hasNoParent()
-          attributes {
-            "aws.agent" "java-aws-sdk"
-            "aws.endpoint" String
-            "rpc.method" "ReceiveMessage"
-            "aws.queue.url" queueUrl
-            "rpc.system" "aws-api"
-            "rpc.service" "AmazonSQS"
-            "http.method" "POST"
-            "http.status_code" 200
-            "http.url" String
-            "net.peer.name" String
-            "$SemanticAttributes.NET_PROTOCOL_NAME" "http"
-            "$SemanticAttributes.NET_PROTOCOL_VERSION" "1.1"
-            "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
-          }
-        }
-      }
-      trace(9, 1) {
         span(0) {
           name "S3.PutObject"
           kind CLIENT
@@ -632,35 +554,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-      /**
-       * This span represents HTTP "sending of receive message" operation. It's always single, while there can be multiple CONSUMER spans (one per consumed message).
-       * This one could be suppressed (by IF in TracingRequestHandler#beforeRequest but then HTTP instrumentation span would appear
-       */
-      trace(10, 1) {
-        span(0) {
-          name "SQS.ReceiveMessage"
-          kind CLIENT
-          hasNoParent()
-          attributes {
-            "aws.agent" "java-aws-sdk"
-            "aws.endpoint" String
-            "rpc.method" "ReceiveMessage"
-            "aws.queue.url" queueUrl
-            "rpc.system" "aws-api"
-            "rpc.service" "AmazonSQS"
-            "http.method" "POST"
-            "http.status_code" 200
-            "http.url" String
-            "net.peer.name" String
-            "$SemanticAttributes.NET_PROTOCOL_NAME" "http"
-            "$SemanticAttributes.NET_PROTOCOL_VERSION" "1.1"
-            "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH" { it == null || it instanceof Long }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" { it == null || it instanceof Long }
-          }
-        }
-      }
-      trace(11, 1) {
+      trace(9, 1) {
         span(0) {
           name "SQS.ReceiveMessage"
           kind CONSUMER
@@ -685,7 +579,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-      trace(12, 1) {
+      trace(10, 1) {
         span(0) {
           name "S3.ListObjects"
           kind CLIENT
@@ -709,7 +603,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-      trace(13, 1) {
+      trace(11, 1) {
         span(0) {
           name "S3.DeleteObject"
           kind CLIENT
@@ -733,7 +627,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-      trace(14, 1) {
+      trace(12, 1) {
         span(0) {
           name "S3.DeleteBucket"
           kind CLIENT
@@ -757,7 +651,7 @@ class S3TracingTest extends AgentInstrumentationSpecification {
           }
         }
       }
-      trace(15, 1) {
+      trace(13, 1) {
         span(0) {
           name "SQS.PurgeQueue"
           kind CLIENT

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SnsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/test/groovy/SnsTracingTest.groovy
@@ -35,7 +35,7 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
     awsConnector.receiveMessage(queueUrl)
 
     then:
-    assertTraces(7) {
+    assertTraces(6) {
       trace(0, 1) {
 
         span(0) {
@@ -190,33 +190,6 @@ class SnsTracingTest extends AgentInstrumentationSpecification {
             "http.status_code" 200
             "http.url" String
             "$SemanticAttributes.USER_AGENT_ORIGINAL" String
-            "net.peer.name" String
-            "$SemanticAttributes.NET_PROTOCOL_NAME" "http"
-            "$SemanticAttributes.NET_PROTOCOL_VERSION" "1.1"
-            "net.peer.port" { it == null || Number }
-            "$SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH" Long
-          }
-        }
-      }
-      /**
-       * This span represents HTTP "sending of receive message" operation. It's always single, while there can be multiple CONSUMER spans (one per consumed message).
-       * This one could be suppressed (by IF in TracingRequestHandler#beforeRequest but then HTTP instrumentation span would appear
-       */
-      trace(6, 1) {
-        span(0) {
-          name "SQS.ReceiveMessage"
-          kind CLIENT
-          hasNoParent()
-          attributes {
-            "aws.agent" "java-aws-sdk"
-            "aws.endpoint" String
-            "aws.queue.url" queueUrl
-            "rpc.system" "aws-api"
-            "rpc.service" "AmazonSQS"
-            "rpc.method" "ReceiveMessage"
-            "http.method" "POST"
-            "http.status_code" 200
-            "http.url" String
             "net.peer.name" String
             "$SemanticAttributes.NET_PROTOCOL_NAME" "http"
             "$SemanticAttributes.NET_PROTOCOL_VERSION" "1.1"

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/SqsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/SqsCamelTest.java
@@ -66,9 +66,6 @@ class SqsCamelTest {
                     CamelSpanAssertions.sqsConsume(span, queueName).hasParent(trace.getSpan(2))),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sqs(span, "SQS.ReceiveMessage", queueUrl).hasNoParent()),
-        trace ->
-            trace.hasSpansSatisfyingExactly(
                 span -> AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl).hasNoParent()));
     camelApp.stop();
   }
@@ -104,13 +101,7 @@ class SqsCamelTest {
                     CamelSpanAssertions.sqsConsume(span, queueName).hasParent(trace.getSpan(0))),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sqs(span, "SQS.ReceiveMessage", queueUrl).hasNoParent()),
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl).hasNoParent()),
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sqs(span, "SQS.ReceiveMessage", queueUrl).hasNoParent()));
+                span -> AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl).hasNoParent()));
     camelApp.stop();
   }
 
@@ -142,14 +133,7 @@ class SqsCamelTest {
                 span ->
                     AwsSpanAssertions.sqs(
                             span, "SQS.ReceiveMessage", queueUrl, null, SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(2))),
-        /*
-         * This span represents HTTP "sending of receive message" operation. It's always single, while there can be multiple CONSUMER spans (one per consumed message).
-         * This one could be suppressed (by IF in TracingRequestHandler#beforeRequest but then HTTP instrumentation span would appear
-         */
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sqs(span, "SQS.ReceiveMessage", queueUrl).hasNoParent()));
+                        .hasParent(trace.getSpan(2))));
     camelApp.stop();
   }
 }


### PR DESCRIPTION
Currently sqs instrumentation generates two spans named `SQS.ReceiveMessage`. One is the consumer span that is in the same trace as the producer. The other is the rpc/http client span that is in a separate trace, this span is responsible of suppressing the underlying http client instrumentation. This pr skips creating the rpc/http span if there is no parent trace and no error. When there is no parent trace this span would be in its own trace which is not connected to the trace with the messaging spans.