### PR TITLE
Suppress exception test should not count as advice failure

### DIFF
--- a/testing-common/integration-tests/src/test/java/indy/IndyInstrumentationTest.java
+++ b/testing-common/integration-tests/src/test/java/indy/IndyInstrumentationTest.java
@@ -8,11 +8,18 @@ package indy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 @SuppressWarnings({"unused", "MethodCanBeStatic"})
 public class IndyInstrumentationTest {
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
   private String privateField;
 
@@ -92,6 +99,7 @@ public class IndyInstrumentationTest {
   @Test
   void testSuppressException() {
     assertThat(noExceptionPlease("foo")).isEqualTo("foo_no_exception");
+    assertThat(TestAgentListenerAccess.getAndResetAdviceFailureCount()).isEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
Reset advice failure count in suppress exception test to avoid it counting as advice failure. Also add agent instrumentation extensions to avoid advice failures in this class leaking to the next test.