### PR TITLE
Compile ktor library instrumentation for earlier kotlin version

### DIFF
--- a/instrumentation/ktor/ktor-1.0/library/build.gradle.kts
+++ b/instrumentation/ktor/ktor-1.0/library/build.gradle.kts
@@ -28,4 +28,10 @@ tasks {
       jvmTarget = "1.8"
     }
   }
+
+  compileKotlin {
+    kotlinOptions {
+      languageVersion = "1.4"
+    }
+  }
 }

--- a/instrumentation/ktor/ktor-2.0/library/build.gradle.kts
+++ b/instrumentation/ktor/ktor-2.0/library/build.gradle.kts
@@ -30,4 +30,10 @@ tasks {
       jvmTarget = "1.8"
     }
   }
+
+  compileKotlin {
+    kotlinOptions {
+      languageVersion = "1.6"
+    }
+  }
 }

--- a/instrumentation/ktor/ktor-common/library/build.gradle.kts
+++ b/instrumentation/ktor/ktor-common/library/build.gradle.kts
@@ -16,4 +16,10 @@ tasks {
       jvmTarget = "1.8"
     }
   }
+
+  compileKotlin {
+    kotlinOptions {
+      languageVersion = "1.4"
+    }
+  }
 }


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java/issues/5903
1.4 should be the earliest supported version for 1.9 compiler. Used 1.6 for ktor2 because I think this is the earliest that library itself supports.