### PR TITLE
Exclude jedis instrumentation from Indy-automigration

### DIFF
--- a/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v1_4/JedisInstrumentationModule.java
@@ -32,4 +32,14 @@ public class JedisInstrumentationModule extends InstrumentationModule {
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(new JedisConnectionInstrumentation(), new JedisInstrumentation());
   }
+
+  @Override
+  public boolean isIndyModule() {
+    // java.lang.NoClassDefFoundError:
+    //      io/opentelemetry/javaagent/instrumentation/jedis/JedisRequestContext
+    //  at redis.clients.jedis.Jedis.flushAll(Jedis.java:367)
+    //  at io.opentelemetry.javaagent.instrumentation.jedis.v1_4
+    //          .JedisClientTest.setup(JedisClientTest.java:49)
+    return false;
+  }
 }

--- a/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v3_0/JedisInstrumentationModule.java
@@ -34,4 +34,14 @@ public class JedisInstrumentationModule extends InstrumentationModule {
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(new JedisConnectionInstrumentation(), new JedisInstrumentation());
   }
+
+  @Override
+  public boolean isIndyModule() {
+    // java.lang.NoClassDefFoundError:
+    //      io/opentelemetry/javaagent/instrumentation/jedis/JedisRequestContext
+    //  at redis.clients.jedis.BinaryJedis.flushAll(BinaryJedis.java:595)
+    //  at io.opentelemetry.javaagent.instrumentation.jedis.v3_0
+    //       .Jedis30ClientTest.setup(Jedis30ClientTest.java:50)
+    return false;
+  }
 }

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisInstrumentationModule.java
@@ -33,7 +33,7 @@ public class JedisInstrumentationModule extends InstrumentationModule {
 
   @Override
   public boolean isIndyModule() {
-    //java.lang.NoClassDefFoundError: 
+    // java.lang.NoClassDefFoundError:
     //      io/opentelemetry/javaagent/instrumentation/jedis/JedisRequestContext
     // at redis.clients.jedis.Jedis.set(Jedis.java:4613)
     // at io.opentelemetry.javaagent.instrumentation.jedis

--- a/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v4_0/JedisInstrumentationModule.java
@@ -30,4 +30,14 @@ public class JedisInstrumentationModule extends InstrumentationModule {
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(new JedisConnectionInstrumentation(), new JedisInstrumentation());
   }
+
+  @Override
+  public boolean isIndyModule() {
+    //java.lang.NoClassDefFoundError: 
+    //      io/opentelemetry/javaagent/instrumentation/jedis/JedisRequestContext
+    // at redis.clients.jedis.Jedis.set(Jedis.java:4613)
+    // at io.opentelemetry.javaagent.instrumentation.jedis
+    //     .v4_0.Jedis40ClientTest.getCommand(Jedis40ClientTest.java:78)
+    return false;
+  }
 }


### PR DESCRIPTION
Looks like #9654 uncovered some new indy test failures. Those suddenly appeared in #9565 after a rebase.

~I think those exceptions come from the fact that some jedis instrumentations are applied even though they shouldn't, likely because the muzzle check is not active yet.~

After some more looking I think the reason is actually that the Advice passes a `JedisRequestContext` from enter to exit. This type is then present on the stack of the instrumented method, causing it to fail because `JedisRequestContext` is not injected anymore.

Please add the `test Indy` label to this PR to verify it actually fixes the build.