### PR TITLE
Make more tests run with indy

### DIFF
--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseInstrumentationModule.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseInstrumentationModule.java
@@ -6,14 +6,18 @@
 package io.opentelemetry.javaagent.instrumentation.couchbase.v2_0;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class CouchbaseInstrumentationModule extends InstrumentationModule {
+public class CouchbaseInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
+
   public CouchbaseInstrumentationModule() {
     super("couchbase", "couchbase-2.0");
   }
@@ -24,13 +28,12 @@ public class CouchbaseInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
-  public boolean isIndyModule() {
-    // rx.__OpenTelemetryTracingUtil is used for accessing a package private field
-    return false;
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return asList(new CouchbaseBucketInstrumentation(), new CouchbaseClusterInstrumentation());
   }
 
   @Override
-  public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(new CouchbaseBucketInstrumentation(), new CouchbaseClusterInstrumentation());
+  public List<String> injectedClassNames() {
+    return singletonList("rx.__OpenTelemetryTracingUtil");
   }
 }

--- a/instrumentation/hystrix-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixInstrumentationModule.java
+++ b/instrumentation/hystrix-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hystrix/HystrixInstrumentationModule.java
@@ -10,10 +10,12 @@ import static java.util.Collections.singletonList;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class HystrixInstrumentationModule extends InstrumentationModule {
+public class HystrixInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
 
   public HystrixInstrumentationModule() {
     super("hystrix", "hystrix-1.4");
@@ -25,13 +27,12 @@ public class HystrixInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
-  public boolean isIndyModule() {
-    // rx.__OpenTelemetryTracingUtil is used for accessing a package private field
-    return false;
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new HystrixCommandInstrumentation());
   }
 
   @Override
-  public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new HystrixCommandInstrumentation());
+  public List<String> injectedClassNames() {
+    return singletonList("rx.__OpenTelemetryTracingUtil");
   }
 }

--- a/instrumentation/ktor/ktor-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v2_0/KtorInstrumentationModule.java
+++ b/instrumentation/ktor/ktor-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ktor/v2_0/KtorInstrumentationModule.java
@@ -25,14 +25,6 @@ public class KtorInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
-  public boolean isIndyModule() {
-    // java.lang.LinkageError: loader constraint violation in interface itable initialization for
-    // class
-    // io.opentelemetry.javaagent.shaded.instrumentation.ktor.v2_0.client.KtorClientTracing$Companion: when selecting method 'java.lang.Object io.ktor.client.plugins.HttpClientPlugin.prepare(kotlin.jvm.functions.Function1)' the class loader 'app' for super interface io.ktor.client.plugins.HttpClientPlugin, and the class loader io.opentelemetry.javaagent.tooling.instrumentation.indy.InstrumentationModuleClassLoader @2565a7d0 of the selected method's class, io.opentelemetry.javaagent.shaded.instrumentation.ktor.v2_0.client.KtorClientTracing$Companion have different Class objects for the type kotlin.jvm.functions.Function1 used in the signature (io.ktor.client.plugins.HttpClientPlugin is in unnamed module of loader 'app'; io.opentelemetry.javaagent.shaded.instrumentation.ktor.v2_0.client.KtorClientTracing$Companion is in unnamed module of loader io.opentelemetry.javaagent.tooling.instrumentation.indy.InstrumentationModuleClassLoader @2565a7d0, parent loader io.opentelemetry.javaagent.bootstrap.AgentClassLoader @ea30797)
-    return false;
-  }
-
-  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(new ServerInstrumentation(), new HttpClientInstrumentation());
   }

--- a/instrumentation/okhttp/okhttp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttp3InstrumentationModule.java
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/okhttp/v3_0/OkHttp3InstrumentationModule.java
@@ -20,13 +20,6 @@ public class OkHttp3InstrumentationModule extends InstrumentationModule {
   }
 
   @Override
-  public boolean isIndyModule() {
-    // java.lang.LinkageError: bad method type alias: (Builder,Map)void not visible from class
-    // io.opentelemetry.javaagent.instrumentation.okhttp.v3_0.OkHttp3Instrumentation$ConstructorAdvice
-    return false;
-  }
-
-  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(new OkHttp3Instrumentation(), new OkHttp3DispatcherInstrumentation());
   }

--- a/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientInstrumentationModule.java
+++ b/instrumentation/vertx/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/v4_0/sql/VertxSqlClientInstrumentationModule.java
@@ -6,14 +6,17 @@
 package io.opentelemetry.javaagent.instrumentation.vertx.v4_0.sql;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
-public class VertxSqlClientInstrumentationModule extends InstrumentationModule {
+public class VertxSqlClientInstrumentationModule extends InstrumentationModule
+    implements ExperimentalInstrumentationModule {
 
   public VertxSqlClientInstrumentationModule() {
     super("vertx-sql-client", "vertx-sql-client-4.0", "vertx");
@@ -25,9 +28,8 @@ public class VertxSqlClientInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
-  public boolean isIndyModule() {
-    // QueryExecutorUtil accesses package private class io.vertx.sqlclient.impl.QueryExecutor
-    return false;
+  public List<String> injectedClassNames() {
+    return singletonList("io.vertx.sqlclient.impl.QueryExecutorUtil");
   }
 
   @Override

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/ExperimentalInstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/ExperimentalInstrumentationModule.java
@@ -5,8 +5,11 @@
 
 package io.opentelemetry.javaagent.extension.instrumentation.internal;
 
+import static java.util.Collections.emptyList;
+
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.injection.ClassInjector;
+import java.util.List;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -25,4 +28,12 @@ public interface ExperimentalInstrumentationModule {
    * @param injector the builder for injecting classes
    */
   default void injectClasses(ClassInjector injector) {}
+
+  /**
+   * Returns a list of helper classes that will be defined in the class loader of the instrumented
+   * library.
+   */
+  default List<String> injectedClassNames() {
+    return emptyList();
+  }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/MuzzleMatcher.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/MuzzleMatcher.java
@@ -14,6 +14,7 @@ import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModul
 import io.opentelemetry.javaagent.tooling.TransformSafeLogger;
 import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.javaagent.tooling.config.AgentConfig;
+import io.opentelemetry.javaagent.tooling.instrumentation.indy.IndyModuleRegistry;
 import io.opentelemetry.javaagent.tooling.muzzle.Mismatch;
 import io.opentelemetry.javaagent.tooling.muzzle.ReferenceMatcher;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -60,6 +61,10 @@ class MuzzleMatcher implements AgentBuilder.RawMatcher {
       ProtectionDomain protectionDomain) {
     if (classLoader == BOOTSTRAP_LOADER) {
       classLoader = Utils.getBootstrapProxy();
+    } else if (instrumentationModule.isIndyModule()) {
+      classLoader =
+          IndyModuleRegistry.getInstrumentationClassloader(
+              instrumentationModule.getClass().getName(), classLoader);
     }
     return matchCache.computeIfAbsent(classLoader, this::doesMatch);
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyModuleRegistry.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/IndyModuleRegistry.java
@@ -9,6 +9,7 @@ import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import io.opentelemetry.javaagent.tooling.muzzle.InstrumentationModuleMuzzle;
 import java.lang.ref.WeakReference;
 import java.util.HashSet;
@@ -84,6 +85,9 @@ public class IndyModuleRegistry {
     // TODO (Jonas): Make muzzle include advice classes as helper classes
     // so that we don't have to include them here
     toInject.addAll(getModuleAdviceNames(module));
+    if (module instanceof ExperimentalInstrumentationModule) {
+      toInject.removeAll(((ExperimentalInstrumentationModule) module).injectedClassNames());
+    }
 
     ClassLoader agentOrExtensionCl = module.getClass().getClassLoader();
     Map<String, ClassCopySource> injectedClasses =

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/InstrumentationModuleClassLoaderTest.java
@@ -43,9 +43,9 @@ class InstrumentationModuleClassLoaderTest {
     ClassLoader dummyParent = new URLClassLoader(new URL[] {}, null);
 
     InstrumentationModuleClassLoader m1 =
-        new InstrumentationModuleClassLoader(dummyParent, dummyParent, toInject);
+        new InstrumentationModuleClassLoader(dummyParent, dummyParent, toInject, true);
     InstrumentationModuleClassLoader m2 =
-        new InstrumentationModuleClassLoader(dummyParent, dummyParent, toInject);
+        new InstrumentationModuleClassLoader(dummyParent, dummyParent, toInject, true);
 
     // MethodHandles.publicLookup() always succeeds on the first invocation
     lookupAndInvokeFoo(m1);
@@ -79,7 +79,7 @@ class InstrumentationModuleClassLoaderTest {
 
     ClassLoader dummyParent = new URLClassLoader(new URL[] {}, null);
     InstrumentationModuleClassLoader m1 =
-        new InstrumentationModuleClassLoader(dummyParent, dummyParent, toInject);
+        new InstrumentationModuleClassLoader(dummyParent, dummyParent, toInject, true);
 
     Class<?> injected = Class.forName(A.class.getName(), true, m1);
     // inject two classes from the same package to trigger errors if we try to redefine the package
@@ -120,7 +120,7 @@ class InstrumentationModuleClassLoaderTest {
       toInject.put(C.class.getName(), ClassCopySource.create(C.class.getName(), moduleSourceCl));
 
       InstrumentationModuleClassLoader moduleCl =
-          new InstrumentationModuleClassLoader(appCl, agentCl, toInject);
+          new InstrumentationModuleClassLoader(appCl, agentCl, toInject, true);
 
       // Verify precedence for classloading
       Class<?> clA = moduleCl.loadClass(A.class.getName());

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -127,13 +127,15 @@ public class HelperInjector implements Transformer {
 
   public HelperInjector(
       String requestingName,
+      List<String> helperClassNames,
       Map<String, Function<ClassLoader, byte[]>> helperMap,
       List<HelperResource> helperResources,
       ClassLoader helpersSource,
       Instrumentation instrumentation) {
     this.requestingName = requestingName;
 
-    this.helperClassNames = helperMap.keySet();
+    this.helperClassNames = new LinkedHashSet<>(helperClassNames);
+    this.helperClassNames.addAll(helperMap.keySet());
     this.dynamicTypeMap.putAll(helperMap);
 
     this.helperResources = helperResources;
@@ -150,7 +152,12 @@ public class HelperInjector implements Transformer {
       bytes.put(helper.getTypeDescription().getName(), cl -> helper.getBytes());
     }
     return new HelperInjector(
-        requestingName, bytes, Collections.emptyList(), null, instrumentation);
+        requestingName,
+        Collections.emptyList(),
+        bytes,
+        Collections.emptyList(),
+        null,
+        instrumentation);
   }
 
   public static void setHelperInjectorListener(HelperInjectorListener listener) {

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/HelperInjector.java
@@ -127,15 +127,13 @@ public class HelperInjector implements Transformer {
 
   public HelperInjector(
       String requestingName,
-      List<String> helperClassNames,
       Map<String, Function<ClassLoader, byte[]>> helperMap,
       List<HelperResource> helperResources,
       ClassLoader helpersSource,
       Instrumentation instrumentation) {
     this.requestingName = requestingName;
 
-    this.helperClassNames = new LinkedHashSet<>(helperClassNames);
-    this.helperClassNames.addAll(helperMap.keySet());
+    this.helperClassNames = helperMap.keySet();
     this.dynamicTypeMap.putAll(helperMap);
 
     this.helperResources = helperResources;
@@ -152,12 +150,7 @@ public class HelperInjector implements Transformer {
       bytes.put(helper.getTypeDescription().getName(), cl -> helper.getBytes());
     }
     return new HelperInjector(
-        requestingName,
-        Collections.emptyList(),
-        bytes,
-        Collections.emptyList(),
-        null,
-        instrumentation);
+        requestingName, bytes, Collections.emptyList(), null, instrumentation);
   }
 
   public static void setHelperInjectorListener(HelperInjectorListener listener) {
@@ -167,7 +160,6 @@ public class HelperInjector implements Transformer {
   private Map<String, Supplier<byte[]>> getHelperMap(ClassLoader targetClassloader) {
     Map<String, Supplier<byte[]>> result = new LinkedHashMap<>();
     if (dynamicTypeMap.isEmpty()) {
-
       for (String helperClassName : helperClassNames) {
         result.put(
             helperClassName,

--- a/testing-common/integration-tests/src/main/java/io/opentelemetry/javaagent/IndyInstrumentationTestModule.java
+++ b/testing-common/integration-tests/src/main/java/io/opentelemetry/javaagent/IndyInstrumentationTestModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package indy;
+package io.opentelemetry.javaagent;
 
 import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
 import static net.bytebuddy.matcher.ElementMatchers.named;


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9552
Add an option to inject helper class into application class loader. This is useful for injecting helper classes that rely on being in the same runtime package as application classes. This will work only if these classes don't depend on any other helper classes (these are loaded into instrumentation class loader).
Make instrumentation class loader delegate to agent class loader only for classes in `io.opentelemetry.javaagent`. This will avoid linkage errors when instrumentation touches classes present in both application and the agent loader. I'd imagine that eventually we might need to make this use a configurable package list.
This pr also adds back muzzle matcher. 
@JonasKunz could you review