### PR TITLE
Only set `server.port` when `server.address` is set

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalClientAttributesExtractor.java
@@ -33,14 +33,16 @@ public final class InternalClientAttributesExtractor<REQUEST> {
   public void onStart(AttributesBuilder attributes, REQUEST request) {
     AddressAndPort clientAddressAndPort = addressAndPortExtractor.extract(request);
 
-    if (emitStableUrlAttributes) {
-      internalSet(attributes, SemanticAttributes.CLIENT_ADDRESS, clientAddressAndPort.address);
-      if (clientAddressAndPort.port != null && clientAddressAndPort.port > 0) {
-        internalSet(attributes, SemanticAttributes.CLIENT_PORT, (long) clientAddressAndPort.port);
+    if (clientAddressAndPort.address != null) {
+      if (emitStableUrlAttributes) {
+        internalSet(attributes, SemanticAttributes.CLIENT_ADDRESS, clientAddressAndPort.address);
+        if (clientAddressAndPort.port != null && clientAddressAndPort.port > 0) {
+          internalSet(attributes, SemanticAttributes.CLIENT_PORT, (long) clientAddressAndPort.port);
+        }
       }
-    }
-    if (emitOldHttpAttributes) {
-      internalSet(attributes, SemanticAttributes.HTTP_CLIENT_IP, clientAddressAndPort.address);
+      if (emitOldHttpAttributes) {
+        internalSet(attributes, SemanticAttributes.HTTP_CLIENT_IP, clientAddressAndPort.address);
+      }
     }
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalServerAttributesExtractor.java
@@ -40,21 +40,23 @@ public final class InternalServerAttributesExtractor<REQUEST> {
   public void onStart(AttributesBuilder attributes, REQUEST request) {
     AddressAndPort serverAddressAndPort = addressAndPortExtractor.extract(request);
 
-    if (emitStableUrlAttributes) {
-      internalSet(attributes, SemanticAttributes.SERVER_ADDRESS, serverAddressAndPort.address);
-    }
-    if (emitOldHttpAttributes) {
-      internalSet(attributes, oldSemconvMode.address, serverAddressAndPort.address);
-    }
-
-    if (serverAddressAndPort.port != null
-        && serverAddressAndPort.port > 0
-        && captureServerPortCondition.test(serverAddressAndPort.port, request)) {
+    if (serverAddressAndPort.address != null) {
       if (emitStableUrlAttributes) {
-        internalSet(attributes, SemanticAttributes.SERVER_PORT, (long) serverAddressAndPort.port);
+        internalSet(attributes, SemanticAttributes.SERVER_ADDRESS, serverAddressAndPort.address);
       }
       if (emitOldHttpAttributes) {
-        internalSet(attributes, oldSemconvMode.port, (long) serverAddressAndPort.port);
+        internalSet(attributes, oldSemconvMode.address, serverAddressAndPort.address);
+      }
+
+      if (serverAddressAndPort.port != null
+          && serverAddressAndPort.port > 0
+          && captureServerPortCondition.test(serverAddressAndPort.port, request)) {
+        if (emitStableUrlAttributes) {
+          internalSet(attributes, SemanticAttributes.SERVER_PORT, (long) serverAddressAndPort.port);
+        }
+        if (emitOldHttpAttributes) {
+          internalSet(attributes, oldSemconvMode.port, (long) serverAddressAndPort.port);
+        }
       }
     }
   }

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/network/ClientAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/network/ClientAttributesExtractorTest.java
@@ -89,4 +89,21 @@ class ClientAttributesExtractorTest {
     extractor.onEnd(endAttributes, Context.root(), request, null, null);
     assertThat(endAttributes.build()).isEmpty();
   }
+
+  @Test
+  void portWithoutAddress() {
+    Map<String, String> request = new HashMap<>();
+    request.put("port", "80");
+
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        ClientAttributesExtractor.create(new TestClientAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build()).isEmpty();
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, null, null);
+    assertThat(endAttributes.build()).isEmpty();
+  }
 }

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesExtractorTest.java
@@ -87,4 +87,21 @@ class ServerAttributesExtractorTest {
     assertThat(startAttributes.build())
         .containsOnly(entry(SemanticAttributes.SERVER_ADDRESS, "opentelemetry.io"));
   }
+
+  @Test
+  void portWithoutAddress() {
+    Map<String, String> request = new HashMap<>();
+    request.put("port", "80");
+
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        ServerAttributesExtractor.create(new TestServerAttributesGetter());
+
+    AttributesBuilder startAttributes = Attributes.builder();
+    extractor.onStart(startAttributes, Context.root(), request);
+    assertThat(startAttributes.build()).isEmpty();
+
+    AttributesBuilder endAttributes = Attributes.builder();
+    extractor.onEnd(endAttributes, Context.root(), request, null, null);
+    assertThat(endAttributes.build()).isEmpty();
+  }
 }


### PR DESCRIPTION
Implements https://github.com/open-telemetry/semantic-conventions/pull/429