### PR TITLE
Refactor HTTP server `server.address` and `server.port` attributes

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedHostAddressAndPortExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedHostAddressAndPortExtractor.java
@@ -42,6 +42,13 @@ final class ForwardedHostAddressAndPortExtractor<REQUEST>
         return;
       }
     }
+
+    // try :authority (HTTP 2.0 pseudo-header)
+    for (String host : getter.getHttpRequestHeader(request, ":authority")) {
+      if (extractHost(sink, host, 0, host.length())) {
+        return;
+      }
+    }
   }
 
   private static boolean extractFromForwardedHeader(AddressPortSink sink, String forwarded) {

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBuilder.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBuilder.java
@@ -16,7 +16,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.network.internal.Client
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalNetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.InternalServerAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.network.internal.ServerAddressAndPortExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.url.internal.InternalUrlAttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
@@ -55,9 +54,7 @@ public final class HttpServerAttributesExtractorBuilder<REQUEST, RESPONSE> {
     clientAddressPortExtractor =
         new ClientAddressAndPortExtractor<>(
             netAttributesGetter, new ForwardedForAddressAndPortExtractor<>(httpAttributesGetter));
-    serverAddressPortExtractor =
-        new ServerAddressAndPortExtractor<>(
-            netAttributesGetter, new ForwardedHostAddressAndPortExtractor<>(httpAttributesGetter));
+    serverAddressPortExtractor = new ForwardedHostAddressAndPortExtractor<>(httpAttributesGetter);
   }
 
   /**

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
@@ -27,6 +27,7 @@ public interface HttpServerAttributesGetter<REQUEST, RESPONSE>
         io.opentelemetry.instrumentation.api.instrumenter.net.NetServerAttributesGetter<
             REQUEST, RESPONSE>,
         NetworkAttributesGetter<REQUEST, RESPONSE>,
+        // TODO remove ServerAttributesGetter from here
         ServerAttributesGetter<REQUEST, RESPONSE>,
         ClientAttributesGetter<REQUEST, RESPONSE> {
 

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesGetter.java
@@ -55,4 +55,32 @@ public interface HttpServerAttributesGetter<REQUEST, RESPONSE>
   default String getHttpRoute(REQUEST request) {
     return null;
   }
+
+  /**
+   * Returns the name of the local HTTP server that received the request.
+   *
+   * @deprecated This method is deprecated and will be removed without replacement. The {@link
+   *     HttpServerAttributesExtractor} now extracts the server address and port from the received
+   *     HTTP request's headers.
+   */
+  @Deprecated
+  @Nullable
+  @Override
+  default String getServerAddress(REQUEST request) {
+    return null;
+  }
+
+  /**
+   * Returns the port of the local HTTP server that received the request.
+   *
+   * @deprecated This method is deprecated and will be removed without replacement. The {@link
+   *     HttpServerAttributesExtractor} now extracts the server address and port from the received
+   *     HTTP request's headers.
+   */
+  @Deprecated
+  @Nullable
+  @Override
+  default Integer getServerPort(REQUEST request) {
+    return null;
+  }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesGetter.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ServerAttributesGetter.java
@@ -39,8 +39,6 @@ public interface ServerAttributesGetter<REQUEST, RESPONSE> {
     return null;
   }
 
-  // TODO deprecate
-
   /**
    * Returns an {@link InetSocketAddress} object representing the server socket address.
    *

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedHostAddressAndPortExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedHostAddressAndPortExtractorTest.java
@@ -109,6 +109,22 @@ class ForwardedHostAddressAndPortExtractorTest {
     assertThat(sink.getPort()).isEqualTo(expectedPort);
   }
 
+  @ParameterizedTest
+  @ArgumentsSource(HostArgs.class)
+  void shouldParsePseudoAuthority(
+      List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "forwarded");
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "x-forwarded-host");
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "host");
+    doReturn(headers).when(getter).getHttpRequestHeader(REQUEST, ":authority");
+
+    AddressAndPort sink = new AddressAndPort();
+    underTest.extract(sink, REQUEST);
+
+    assertThat(sink.getAddress()).isEqualTo(expectedAddress);
+    assertThat(sink.getPort()).isEqualTo(expectedPort);
+  }
+
   static final class HostArgs implements ArgumentsProvider {
 
     @Override

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorTest.java
@@ -111,18 +111,6 @@ class HttpServerAttributesExtractorTest {
         Map<String, Object> request, Map<String, Object> response) {
       return (String) request.get("protocolVersion");
     }
-
-    @Nullable
-    @Override
-    public String getServerAddress(Map<String, Object> request) {
-      return (String) request.get("serverAddress");
-    }
-
-    @Nullable
-    @Override
-    public Integer getServerPort(Map<String, Object> request) {
-      return (Integer) request.get("serverPort");
-    }
   }
 
   @Test
@@ -232,27 +220,6 @@ class HttpServerAttributesExtractorTest {
   void extractNetHostAndPortFromHostHeader() {
     Map<String, Object> request = new HashMap<>();
     request.put("header.host", "thehost:777");
-
-    AttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
-        HttpServerAttributesExtractor.builder(new TestHttpServerAttributesGetter())
-            .setCapturedRequestHeaders(emptyList())
-            .setCapturedResponseHeaders(emptyList())
-            .build();
-
-    AttributesBuilder attributes = Attributes.builder();
-    extractor.onStart(attributes, Context.root(), request);
-    assertThat(attributes.build())
-        .containsOnly(
-            entry(SemanticAttributes.NET_HOST_NAME, "thehost"),
-            entry(SemanticAttributes.NET_HOST_PORT, 777L));
-  }
-
-  @Test
-  void extractNetHostAndPortFromNetAttributesGetter() {
-    Map<String, Object> request = new HashMap<>();
-    request.put("header.host", "notthehost:77777"); // this should have lower precedence
-    request.put("serverAddress", "thehost");
-    request.put("serverPort", 777);
 
     AttributesExtractor<Map<String, Object>, Map<String, Object>> extractor =
         HttpServerAttributesExtractor.builder(new TestHttpServerAttributesGetter())

--- a/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
+++ b/instrumentation-api-semconv/src/testBothHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBothSemconvTest.java
@@ -103,18 +103,6 @@ class HttpServerAttributesExtractorBothSemconvTest {
         Map<String, Object> request, Map<String, Object> response) {
       return (String) request.get("protocolVersion");
     }
-
-    @Nullable
-    @Override
-    public String getServerAddress(Map<String, Object> request) {
-      return (String) request.get("serverAddress");
-    }
-
-    @Nullable
-    @Override
-    public Integer getServerPort(Map<String, Object> request) {
-      return (Integer) request.get("serverPort");
-    }
   }
 
   @Test

--- a/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/akkahttp/server/AkkaHttpServerAttributesGetter.java
@@ -7,7 +7,6 @@ package io.opentelemetry.javaagent.instrumentation.akkahttp.server;
 
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
-import akka.http.scaladsl.model.Uri;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerAttributesGetter;
 import io.opentelemetry.javaagent.instrumentation.akkahttp.AkkaHttpUtil;
 import java.util.List;
@@ -67,17 +66,5 @@ class AkkaHttpServerAttributesGetter
   public String getNetworkProtocolVersion(
       HttpRequest request, @Nullable HttpResponse httpResponse) {
     return AkkaHttpUtil.protocolVersion(request);
-  }
-
-  @Nullable
-  @Override
-  public String getServerAddress(HttpRequest request) {
-    Uri.Host host = request.uri().authority().host();
-    return host.isEmpty() ? null : host.address();
-  }
-
-  @Override
-  public Integer getServerPort(HttpRequest request) {
-    return request.uri().authority().port();
   }
 }

--- a/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
+++ b/instrumentation/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerAttributesGetter.java
@@ -89,18 +89,6 @@ enum ArmeriaHttpServerAttributesGetter
     return protocol.isMultiplex() ? "2" : "1.1";
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(RequestContext ctx) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(RequestContext ctx) {
-    return null;
-  }
-
   @Override
   @Nullable
   public InetSocketAddress getNetworkPeerInetSocketAddress(

--- a/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
+++ b/instrumentation/grizzly-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grizzly/GrizzlyHttpAttributesGetter.java
@@ -119,19 +119,6 @@ final class GrizzlyHttpAttributesGetter
 
   @Nullable
   @Override
-  public String getServerAddress(HttpRequestPacket request) {
-    // rely on the 'host' header parsing
-    return null;
-  }
-
-  @Override
-  public Integer getServerPort(HttpRequestPacket request) {
-    // rely on the 'host' header parsing
-    return null;
-  }
-
-  @Nullable
-  @Override
   public String getNetworkPeerAddress(
       HttpRequestPacket request, @Nullable HttpResponsePacket response) {
     return request.getRemoteAddress();

--- a/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerAttributesGetter.kt
@@ -56,12 +56,4 @@ internal enum class KtorHttpServerAttributesGetter :
     }
     return null
   }
-
-  override fun getServerAddress(request: ApplicationRequest): String {
-    return request.local.host
-  }
-
-  override fun getServerPort(request: ApplicationRequest): Int {
-    return request.local.port
-  }
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorHttpServerAttributesGetter.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/main/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/server/KtorHttpServerAttributesGetter.kt
@@ -49,14 +49,6 @@ internal enum class KtorHttpServerAttributesGetter :
   override fun getNetworkProtocolVersion(request: ApplicationRequest, response: ApplicationResponse?): String? =
     if (request.httpVersion.startsWith("HTTP/")) request.httpVersion.substring("HTTP/".length) else null
 
-  override fun getServerAddress(request: ApplicationRequest): String {
-    return request.local.host
-  }
-
-  override fun getServerPort(request: ApplicationRequest): Int {
-    return request.local.port
-  }
-
   override fun getNetworkPeerAddress(request: ApplicationRequest, response: ApplicationResponse?): String? {
     val remote = request.local.remoteHost
     if ("unknown" != remote && isIpAddress(remote)) {

--- a/instrumentation/liberty/compile-stub/src/main/java/com/ibm/wsspi/http/channel/HttpRequestMessage.java
+++ b/instrumentation/liberty/compile-stub/src/main/java/com/ibm/wsspi/http/channel/HttpRequestMessage.java
@@ -27,8 +27,4 @@ public interface HttpRequestMessage {
   String getVersion();
 
   List<String> getAllHeaderNames();
-
-  String getURLHost();
-
-  int getURLPort();
 }

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyDispatcherHttpAttributesGetter.java
@@ -76,17 +76,6 @@ public class LibertyDispatcherHttpAttributesGetter
     return null;
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(LibertyRequest request) {
-    return request.request().getURLHost();
-  }
-
-  @Override
-  public Integer getServerPort(LibertyRequest request) {
-    return request.request().getURLPort();
-  }
-
   @Override
   @Nullable
   public String getNetworkPeerAddress(LibertyRequest request, @Nullable LibertyResponse response) {

--- a/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/liberty/dispatcher/LibertyRequest.java
@@ -91,8 +91,4 @@ public class LibertyRequest {
   public int getClientSocketPort() {
     return clientSocketPort;
   }
-
-  public HttpRequestMessage request() {
-    return httpRequestMessage;
-  }
 }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/NettyHttpServerAttributesGetter.java
@@ -91,18 +91,6 @@ final class NettyHttpServerAttributesGetter
     return version.getMajorVersion() + "." + version.getMinorVersion();
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(HttpRequestAndChannel requestAndChannel) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(HttpRequestAndChannel requestAndChannel) {
-    return null;
-  }
-
   @Override
   @Nullable
   public InetSocketAddress getNetworkPeerInetSocketAddress(

--- a/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyHttpServerAttributesGetter.java
+++ b/instrumentation/netty/netty-4-common/library/src/main/java/io/opentelemetry/instrumentation/netty/v4/common/internal/server/NettyHttpServerAttributesGetter.java
@@ -91,18 +91,6 @@ final class NettyHttpServerAttributesGetter
     return version.majorVersion() + "." + version.minorVersion();
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(HttpRequestAndChannel requestAndChannel) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(HttpRequestAndChannel requestAndChannel) {
-    return null;
-  }
-
   @Override
   @Nullable
   public InetSocketAddress getNetworkPeerInetSocketAddress(

--- a/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
@@ -54,16 +54,4 @@ enum MockHttpServerAttributesGetter implements HttpServerAttributesGetter<String
   public String getUrlQuery(String s) {
     return null;
   }
-
-  @Nullable
-  @Override
-  public String getServerAddress(String s) {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(String s) {
-    return null;
-  }
 }

--- a/instrumentation/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/PekkoHttpServerAttributesGetter.java
+++ b/instrumentation/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/PekkoHttpServerAttributesGetter.java
@@ -11,7 +11,6 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pekko.http.scaladsl.model.HttpRequest;
 import org.apache.pekko.http.scaladsl.model.HttpResponse;
-import org.apache.pekko.http.scaladsl.model.Uri;
 import scala.Option;
 
 class PekkoHttpServerAttributesGetter
@@ -67,17 +66,5 @@ class PekkoHttpServerAttributesGetter
   public String getNetworkProtocolVersion(
       HttpRequest request, @Nullable HttpResponse httpResponse) {
     return PekkoHttpUtil.protocolVersion(request);
-  }
-
-  @Nullable
-  @Override
-  public String getServerAddress(HttpRequest request) {
-    Uri.Host host = request.uri().authority().host();
-    return host.isEmpty() ? null : host.address();
-  }
-
-  @Override
-  public Integer getServerPort(HttpRequest request) {
-    return request.uri().authority().port();
   }
 }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpAttributesGetter.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpAttributesGetter.java
@@ -83,28 +83,6 @@ enum RatpackHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
     return null;
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(Request request) {
-    PublicAddress publicAddress = getPublicAddress(request);
-    return publicAddress == null ? null : publicAddress.get().getHost();
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(Request request) {
-    PublicAddress publicAddress = getPublicAddress(request);
-    return publicAddress == null ? null : publicAddress.get().getPort();
-  }
-
-  private static PublicAddress getPublicAddress(Request request) {
-    Context ratpackContext = request.get(Context.class);
-    if (ratpackContext == null) {
-      return null;
-    }
-    return ratpackContext.get(PublicAddress.class);
-  }
-
   @Override
   public Integer getNetworkPeerPort(Request request, @Nullable Response response) {
     return request.getRemoteAddress().getPort();

--- a/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/main/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletHttpAttributesGetter.java
@@ -106,20 +106,6 @@ enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Request, 
     return (String) request.getAttributes().get("org.restlet.http.version");
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(Request request) {
-    HttpCall call = httpCall(request);
-    return call == null ? null : call.getHostDomain();
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(Request request) {
-    HttpCall call = httpCall(request);
-    return call == null ? null : call.getServerPort();
-  }
-
   @Override
   @Nullable
   public String getNetworkPeerAddress(Request request, @Nullable Response response) {

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/RestletHttpAttributesGetter.java
@@ -82,18 +82,6 @@ public enum RestletHttpAttributesGetter implements HttpServerAttributesGetter<Re
     return request.getProtocol().getVersion();
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(Request request) {
-    return ServerCallAccess.getHostDomain(request);
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(Request request) {
-    return ServerCallAccess.getServerPort(request);
-  }
-
   @Override
   @Nullable
   public String getNetworkPeerAddress(Request request, @Nullable Response response) {

--- a/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/ServerCallAccess.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/main/java/io/opentelemetry/instrumentation/restlet/v2_0/internal/ServerCallAccess.java
@@ -16,16 +16,12 @@ final class ServerCallAccess {
 
   private static final Class<?> HTTP_REQUEST_CLASS;
   private static final MethodHandle GET_HTTP_CALL;
-  private static final MethodHandle GET_HOST_DOMAIN;
-  private static final MethodHandle GET_SERVER_PORT;
   private static final MethodHandle GET_SERVER_ADDRESS;
 
   static {
     Class<?> httpRequestClass = null;
     Class<?> serverCallClass = null;
     MethodHandle getHttpCall = null;
-    MethodHandle getHostDomain = null;
-    MethodHandle getServerPort = null;
     MethodHandle getServerAddress = null;
 
     try {
@@ -55,9 +51,6 @@ final class ServerCallAccess {
         MethodHandles.Lookup lookup = MethodHandles.publicLookup();
         getHttpCall =
             lookup.findVirtual(httpRequestClass, "getHttpCall", methodType(serverCallClass));
-        getHostDomain =
-            lookup.findVirtual(serverCallClass, "getHostDomain", methodType(String.class));
-        getServerPort = lookup.findVirtual(serverCallClass, "getServerPort", methodType(int.class));
         getServerAddress =
             lookup.findVirtual(serverCallClass, "getServerAddress", methodType(String.class));
       } catch (NoSuchMethodException | IllegalAccessException e) {
@@ -67,41 +60,7 @@ final class ServerCallAccess {
 
     HTTP_REQUEST_CLASS = httpRequestClass;
     GET_HTTP_CALL = getHttpCall;
-    GET_HOST_DOMAIN = getHostDomain;
-    GET_SERVER_PORT = getServerPort;
     GET_SERVER_ADDRESS = getServerAddress;
-  }
-
-  @Nullable
-  static String getHostDomain(Request request) {
-    if (GET_HOST_DOMAIN == null) {
-      return null;
-    }
-    Object call = serverCall(request);
-    if (call == null) {
-      return null;
-    }
-    try {
-      return (String) GET_HOST_DOMAIN.invoke(call);
-    } catch (Throwable e) {
-      return null;
-    }
-  }
-
-  @Nullable
-  static Integer getServerPort(Request request) {
-    if (GET_SERVER_PORT == null) {
-      return null;
-    }
-    Object call = serverCall(request);
-    if (call == null) {
-      return null;
-    }
-    try {
-      return (int) GET_SERVER_PORT.invoke(call);
-    } catch (Throwable e) {
-      return null;
-    }
   }
 
   @Nullable

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
@@ -69,16 +69,6 @@ public class Servlet5Accessor
   }
 
   @Override
-  public String getRequestServerName(HttpServletRequest request) {
-    return request.getServerName();
-  }
-
-  @Override
-  public Integer getRequestServerPort(HttpServletRequest request) {
-    return request.getServerPort();
-  }
-
-  @Override
   public String getRequestRemoteAddr(HttpServletRequest request) {
     return request.getRemoteAddr();
   }

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletAccessor.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletAccessor.java
@@ -35,10 +35,6 @@ public interface ServletAccessor<REQUEST, RESPONSE> {
 
   String getRequestMethod(REQUEST request);
 
-  String getRequestServerName(REQUEST request);
-
-  Integer getRequestServerPort(REQUEST request);
-
   String getRequestRemoteAddr(REQUEST request);
 
   Integer getRequestRemotePort(REQUEST request);

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/ServletHttpAttributesGetter.java
@@ -106,18 +106,6 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
     return null;
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(ServletRequestContext<REQUEST> requestContext) {
-    return accessor.getRequestServerName(requestContext.request());
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(ServletRequestContext<REQUEST> requestContext) {
-    return accessor.getRequestServerPort(requestContext.request());
-  }
-
   @Override
   @Nullable
   public String getNetworkPeerAddress(

--- a/instrumentation/servlet/servlet-javax-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/javax/JavaxServletAccessor.java
+++ b/instrumentation/servlet/servlet-javax-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/javax/JavaxServletAccessor.java
@@ -56,16 +56,6 @@ public abstract class JavaxServletAccessor<R> implements ServletAccessor<HttpSer
   }
 
   @Override
-  public String getRequestServerName(HttpServletRequest request) {
-    return request.getServerName();
-  }
-
-  @Override
-  public Integer getRequestServerPort(HttpServletRequest request) {
-    return request.getServerPort();
-  }
-
-  @Override
   public String getRequestRemoteAddr(HttpServletRequest request) {
     return request.getRemoteAddr();
   }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/WebfluxServerHttpAttributesGetter.java
@@ -81,19 +81,6 @@ enum WebfluxServerHttpAttributesGetter
 
   @Nullable
   @Override
-  public String getServerAddress(ServerWebExchange request) {
-    return request.getRequest().getURI().getHost();
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(ServerWebExchange request) {
-    int port = request.getRequest().getURI().getPort();
-    return port == -1 ? null : port;
-  }
-
-  @Nullable
-  @Override
   public InetSocketAddress getNetworkPeerInetSocketAddress(
       ServerWebExchange request, @Nullable ServerWebExchange response) {
     return request.getRequest().getRemoteAddress();

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
@@ -103,17 +103,6 @@ enum SpringWebMvcHttpAttributesGetter
     return null;
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(HttpServletRequest request) {
-    return request.getServerName();
-  }
-
-  @Override
-  public Integer getServerPort(HttpServletRequest request) {
-    return request.getServerPort();
-  }
-
   @Override
   @Nullable
   public String getNetworkPeerAddress(

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcHttpAttributesGetter.java
@@ -103,17 +103,6 @@ enum SpringWebMvcHttpAttributesGetter
     return null;
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(HttpServletRequest request) {
-    return request.getServerName();
-  }
-
-  @Override
-  public Integer getServerPort(HttpServletRequest request) {
-    return request.getServerPort();
-  }
-
   @Override
   @Nullable
   public String getNetworkPeerAddress(

--- a/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
+++ b/instrumentation/tomcat/tomcat-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/common/TomcatHttpAttributesGetter.java
@@ -79,17 +79,6 @@ public class TomcatHttpAttributesGetter implements HttpServerAttributesGetter<Re
     return null;
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(Request request) {
-    return messageBytesToString(request.serverName());
-  }
-
-  @Override
-  public Integer getServerPort(Request request) {
-    return request.getServerPort();
-  }
-
   @Override
   @Nullable
   public String getNetworkPeerAddress(Request request, @Nullable Response response) {

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHttpAttributesGetter.java
@@ -83,18 +83,6 @@ public class UndertowHttpAttributesGetter
     return null;
   }
 
-  @Nullable
-  @Override
-  public String getServerAddress(HttpServerExchange exchange) {
-    return exchange.getHostName();
-  }
-
-  @Nullable
-  @Override
-  public Integer getServerPort(HttpServerExchange exchange) {
-    return exchange.getHostPort();
-  }
-
   @Override
   @Nullable
   public InetSocketAddress getNetworkPeerInetSocketAddress(

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
@@ -177,17 +177,5 @@ final class TestInstrumenters {
     public String getUrlQuery(String s) {
       return null;
     }
-
-    @Nullable
-    @Override
-    public String getServerAddress(String unused) {
-      return null;
-    }
-
-    @Nullable
-    @Override
-    public Integer getServerPort(String unused) {
-      return null;
-    }
   }
 }


### PR DESCRIPTION
Implements https://github.com/open-telemetry/semantic-conventions/pull/423