### PR TITLE
Change the precedence between :authority and Host headers

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedHostAddressAndPortExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedHostAddressAndPortExtractor.java
@@ -36,15 +36,15 @@ final class ForwardedHostAddressAndPortExtractor<REQUEST>
       }
     }
 
-    // try Host
-    for (String host : getter.getHttpRequestHeader(request, "host")) {
+    // try :authority (HTTP 2.0 pseudo-header)
+    for (String host : getter.getHttpRequestHeader(request, ":authority")) {
       if (extractHost(sink, host, 0, host.length())) {
         return;
       }
     }
 
-    // try :authority (HTTP 2.0 pseudo-header)
-    for (String host : getter.getHttpRequestHeader(request, ":authority")) {
+    // try Host
+    for (String host : getter.getHttpRequestHeader(request, "host")) {
       if (extractHost(sink, host, 0, host.length())) {
         return;
       }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedHostAddressAndPortExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedHostAddressAndPortExtractorTest.java
@@ -96,11 +96,11 @@ class ForwardedHostAddressAndPortExtractorTest {
 
   @ParameterizedTest
   @ArgumentsSource(HostArgs.class)
-  void shouldParseHost(
+  void shouldParsePseudoAuthority(
       List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
     doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "forwarded");
     doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "x-forwarded-host");
-    doReturn(headers).when(getter).getHttpRequestHeader(REQUEST, "host");
+    doReturn(headers).when(getter).getHttpRequestHeader(REQUEST, ":authority");
 
     AddressAndPort sink = new AddressAndPort();
     underTest.extract(sink, REQUEST);
@@ -111,12 +111,12 @@ class ForwardedHostAddressAndPortExtractorTest {
 
   @ParameterizedTest
   @ArgumentsSource(HostArgs.class)
-  void shouldParsePseudoAuthority(
+  void shouldParseHost(
       List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
     doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "forwarded");
     doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "x-forwarded-host");
-    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, "host");
-    doReturn(headers).when(getter).getHttpRequestHeader(REQUEST, ":authority");
+    doReturn(emptyList()).when(getter).getHttpRequestHeader(REQUEST, ":authority");
+    doReturn(headers).when(getter).getHttpRequestHeader(REQUEST, "host");
 
     AddressAndPort sink = new AddressAndPort();
     underTest.extract(sink, REQUEST);


### PR DESCRIPTION
Implements https://github.com/open-telemetry/semantic-conventions/pull/455