### PR TITLE
Change `client.port` from recommended to opt-in on HTTP server spans

### DIFF
--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedForAddressAndPortExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedForAddressAndPortExtractor.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.api.instrumenter.http;
 
 import static io.opentelemetry.instrumentation.api.instrumenter.http.HeaderParsingHelper.notFound;
-import static io.opentelemetry.instrumentation.api.instrumenter.http.HeaderParsingHelper.setPort;
 
 import io.opentelemetry.instrumentation.api.instrumenter.network.internal.AddressAndPortExtractor;
 import java.util.Locale;
@@ -92,12 +91,6 @@ final class ForwardedForAddressAndPortExtractor<REQUEST>
       }
       sink.setAddress(forwarded.substring(start + 1, ipv6End));
 
-      int portStart = ipv6End + 1;
-      if (portStart < end && forwarded.charAt(portStart) == ':') {
-        int portEnd = findPortEnd(forwarded, portStart + 1, end);
-        setPort(sink, forwarded, portStart + 1, portEnd);
-      }
-
       return true;
     }
 
@@ -120,13 +113,6 @@ final class ForwardedForAddressAndPortExtractor<REQUEST>
         }
 
         sink.setAddress(forwarded.substring(start, i));
-
-        if (isIpv4PortSeparator) {
-          int portStart = i;
-          int portEnd = findPortEnd(forwarded, portStart + 1, end);
-          setPort(sink, forwarded, portStart + 1, portEnd);
-        }
-
         return true;
       }
     }
@@ -134,13 +120,5 @@ final class ForwardedForAddressAndPortExtractor<REQUEST>
     // just an address without a port
     sink.setAddress(forwarded.substring(start, end));
     return true;
-  }
-
-  private static int findPortEnd(String header, int start, int end) {
-    int numberEnd = start;
-    while (numberEnd < end && Character.isDigit(header.charAt(numberEnd))) {
-      ++numberEnd;
-    }
-    return numberEnd;
   }
 }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBuilder.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorBuilder.java
@@ -150,7 +150,9 @@ public final class HttpServerAttributesExtractorBuilder<REQUEST, RESPONSE> {
         netAttributesGetter,
         serverAddressPortExtractor,
         clientAddressPortExtractor,
+        // network.type and network.transport are opt-in
         /* captureNetworkTransportAndType= */ false,
+        // network.local.* are opt-in
         /* captureLocalSocketAttributes= */ false,
         /* captureOldPeerDomainAttribute= */ false,
         SemconvStability.emitStableHttpSemconv(),
@@ -169,6 +171,8 @@ public final class HttpServerAttributesExtractorBuilder<REQUEST, RESPONSE> {
   InternalClientAttributesExtractor<REQUEST> buildClientExtractor() {
     return new InternalClientAttributesExtractor<>(
         clientAddressPortExtractor,
+        // client.port is opt-in
+        /* capturePort= */ false,
         SemconvStability.emitStableHttpSemconv(),
         SemconvStability.emitOldHttpSemconv());
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/net/NetServerAttributesExtractor.java
@@ -69,6 +69,7 @@ public final class NetServerAttributesExtractor<REQUEST, RESPONSE>
     internalClientExtractor =
         new InternalClientAttributesExtractor<>(
             clientAddressAndPortExtractor,
+            /* capturePort= */ true,
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv());
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/ClientAttributesExtractor.java
@@ -37,6 +37,7 @@ public final class ClientAttributesExtractor<REQUEST, RESPONSE>
     internalExtractor =
         new InternalClientAttributesExtractor<>(
             new ClientAddressAndPortExtractor<>(getter, AddressAndPortExtractor.noop()),
+            /* capturePort= */ true,
             SemconvStability.emitStableHttpSemconv(),
             SemconvStability.emitOldHttpSemconv());
   }

--- a/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalClientAttributesExtractor.java
+++ b/instrumentation-api-semconv/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/network/internal/InternalClientAttributesExtractor.java
@@ -17,14 +17,17 @@ import io.opentelemetry.semconv.SemanticAttributes;
 public final class InternalClientAttributesExtractor<REQUEST> {
 
   private final AddressAndPortExtractor<REQUEST> addressAndPortExtractor;
+  private final boolean capturePort;
   private final boolean emitStableUrlAttributes;
   private final boolean emitOldHttpAttributes;
 
   public InternalClientAttributesExtractor(
       AddressAndPortExtractor<REQUEST> addressAndPortExtractor,
+      boolean capturePort,
       boolean emitStableUrlAttributes,
       boolean emitOldHttpAttributes) {
     this.addressAndPortExtractor = addressAndPortExtractor;
+    this.capturePort = capturePort;
     this.emitStableUrlAttributes = emitStableUrlAttributes;
     this.emitOldHttpAttributes = emitOldHttpAttributes;
   }
@@ -36,7 +39,7 @@ public final class InternalClientAttributesExtractor<REQUEST> {
     if (clientAddressAndPort.address != null) {
       if (emitStableUrlAttributes) {
         internalSet(attributes, SemanticAttributes.CLIENT_ADDRESS, clientAddressAndPort.address);
-        if (clientAddressAndPort.port != null && clientAddressAndPort.port > 0) {
+        if (capturePort && clientAddressAndPort.port != null && clientAddressAndPort.port > 0) {
           internalSet(attributes, SemanticAttributes.CLIENT_PORT, (long) clientAddressAndPort.port);
         }
       }

--- a/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedForAddressAndPortExtractorTest.java
+++ b/instrumentation-api-semconv/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/http/ForwardedForAddressAndPortExtractorTest.java
@@ -35,15 +35,14 @@ class ForwardedForAddressAndPortExtractorTest {
 
   @ParameterizedTest
   @ArgumentsSource(ForwardedArgs.class)
-  void shouldParseForwarded(
-      List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
+  void shouldParseForwarded(List<String> headers, @Nullable String expectedAddress) {
     doReturn(headers).when(getter).getHttpRequestHeader("request", "forwarded");
 
     AddressAndPort sink = new AddressAndPort();
     underTest.extract(sink, "request");
 
     assertThat(sink.getAddress()).isEqualTo(expectedAddress);
-    assertThat(sink.getPort()).isEqualTo(expectedPort);
+    assertThat(sink.getPort()).isNull();
   }
 
   static final class ForwardedArgs implements ArgumentsProvider {
@@ -52,48 +51,47 @@ class ForwardedForAddressAndPortExtractorTest {
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
       return Stream.of(
           // empty/invalid headers
-          arguments(singletonList(""), null, null),
-          arguments(singletonList("for="), null, null),
-          arguments(singletonList("for=;"), null, null),
-          arguments(singletonList("for=\""), null, null),
-          arguments(singletonList("for=\"\""), null, null),
-          arguments(singletonList("for=\"1.2.3.4"), null, null),
-          arguments(singletonList("for=\"[::1]"), null, null),
-          arguments(singletonList("for=[::1"), null, null),
-          arguments(singletonList("for=\"[::1\""), null, null),
-          arguments(singletonList("for=\"[::1\"]"), null, null),
-          arguments(singletonList("by=1.2.3.4, test=abc"), null, null),
+          arguments(singletonList(""), null),
+          arguments(singletonList("for="), null),
+          arguments(singletonList("for=;"), null),
+          arguments(singletonList("for=\""), null),
+          arguments(singletonList("for=\"\""), null),
+          arguments(singletonList("for=\"1.2.3.4"), null),
+          arguments(singletonList("for=\"[::1]"), null),
+          arguments(singletonList("for=[::1"), null),
+          arguments(singletonList("for=\"[::1\""), null),
+          arguments(singletonList("for=\"[::1\"]"), null),
+          arguments(singletonList("by=1.2.3.4, test=abc"), null),
 
           // ipv6
-          arguments(singletonList("for=[::1]"), "::1", null),
-          arguments(singletonList("For=[::1]"), "::1", null),
-          arguments(singletonList("for=\"[::1]\":42"), "::1", null),
-          arguments(singletonList("for=[::1]:42"), "::1", 42),
-          arguments(singletonList("for=\"[::1]:42\""), "::1", 42),
-          arguments(singletonList("for=[::1], for=1.2.3.4"), "::1", null),
-          arguments(singletonList("for=[::1]; for=1.2.3.4:42"), "::1", null),
-          arguments(singletonList("for=[::1]:42abc"), "::1", 42),
-          arguments(singletonList("for=[::1]:abc"), "::1", null),
+          arguments(singletonList("for=[::1]"), "::1"),
+          arguments(singletonList("For=[::1]"), "::1"),
+          arguments(singletonList("for=\"[::1]\":42"), "::1"),
+          arguments(singletonList("for=[::1]:42"), "::1"),
+          arguments(singletonList("for=\"[::1]:42\""), "::1"),
+          arguments(singletonList("for=[::1], for=1.2.3.4"), "::1"),
+          arguments(singletonList("for=[::1]; for=1.2.3.4:42"), "::1"),
+          arguments(singletonList("for=[::1]:42abc"), "::1"),
+          arguments(singletonList("for=[::1]:abc"), "::1"),
 
           // ipv4
-          arguments(singletonList("for=1.2.3.4"), "1.2.3.4", null),
-          arguments(singletonList("FOR=1.2.3.4"), "1.2.3.4", null),
-          arguments(singletonList("for=1.2.3.4, :42"), "1.2.3.4", null),
-          arguments(singletonList("for=1.2.3.4;proto=https;by=4.3.2.1"), "1.2.3.4", null),
-          arguments(singletonList("for=1.2.3.4:42"), "1.2.3.4", 42),
-          arguments(singletonList("for=1.2.3.4:42abc"), "1.2.3.4", 42),
-          arguments(singletonList("for=1.2.3.4:abc"), "1.2.3.4", null),
-          arguments(singletonList("for=1.2.3.4; for=4.3.2.1:42"), "1.2.3.4", null),
+          arguments(singletonList("for=1.2.3.4"), "1.2.3.4"),
+          arguments(singletonList("FOR=1.2.3.4"), "1.2.3.4"),
+          arguments(singletonList("for=1.2.3.4, :42"), "1.2.3.4"),
+          arguments(singletonList("for=1.2.3.4;proto=https;by=4.3.2.1"), "1.2.3.4"),
+          arguments(singletonList("for=1.2.3.4:42"), "1.2.3.4"),
+          arguments(singletonList("for=1.2.3.4:42abc"), "1.2.3.4"),
+          arguments(singletonList("for=1.2.3.4:abc"), "1.2.3.4"),
+          arguments(singletonList("for=1.2.3.4; for=4.3.2.1:42"), "1.2.3.4"),
 
           // multiple headers
-          arguments(asList("proto=https", "for=1.2.3.4", "for=[::1]:42"), "1.2.3.4", null));
+          arguments(asList("proto=https", "for=1.2.3.4", "for=[::1]:42"), "1.2.3.4"));
     }
   }
 
   @ParameterizedTest
   @ArgumentsSource(ForwardedForArgs.class)
-  void shouldParseForwardedFor(
-      List<String> headers, @Nullable String expectedAddress, @Nullable Integer expectedPort) {
+  void shouldParseForwardedFor(List<String> headers, @Nullable String expectedAddress) {
     doReturn(emptyList()).when(getter).getHttpRequestHeader("request", "forwarded");
     doReturn(headers).when(getter).getHttpRequestHeader("request", "x-forwarded-for");
 
@@ -101,7 +99,7 @@ class ForwardedForAddressAndPortExtractorTest {
     underTest.extract(sink, "request");
 
     assertThat(sink.getAddress()).isEqualTo(expectedAddress);
-    assertThat(sink.getPort()).isEqualTo(expectedPort);
+    assertThat(sink.getPort()).isNull();
   }
 
   static final class ForwardedForArgs implements ArgumentsProvider {
@@ -110,41 +108,41 @@ class ForwardedForAddressAndPortExtractorTest {
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
       return Stream.of(
           // empty/invalid headers
-          arguments(singletonList(""), null, null),
-          arguments(singletonList(";"), null, null),
-          arguments(singletonList("\""), null, null),
-          arguments(singletonList("\"\""), null, null),
-          arguments(singletonList("\"1.2.3.4"), null, null),
-          arguments(singletonList("\"[::1]"), null, null),
-          arguments(singletonList("[::1"), null, null),
-          arguments(singletonList("\"[::1\""), null, null),
-          arguments(singletonList("\"[::1\"]"), null, null),
+          arguments(singletonList(""), null),
+          arguments(singletonList(";"), null),
+          arguments(singletonList("\""), null),
+          arguments(singletonList("\"\""), null),
+          arguments(singletonList("\"1.2.3.4"), null),
+          arguments(singletonList("\"[::1]"), null),
+          arguments(singletonList("[::1"), null),
+          arguments(singletonList("\"[::1\""), null),
+          arguments(singletonList("\"[::1\"]"), null),
 
           // ipv6
-          arguments(singletonList("[::1]"), "::1", null),
-          arguments(singletonList("\"[::1]\":42"), "::1", null),
-          arguments(singletonList("[::1]:42"), "::1", 42),
-          arguments(singletonList("\"[::1]:42\""), "::1", 42),
-          arguments(singletonList("[::1],1.2.3.4"), "::1", null),
-          arguments(singletonList("[::1];1.2.3.4:42"), "::1", null),
-          arguments(singletonList("[::1]:42abc"), "::1", 42),
-          arguments(singletonList("[::1]:abc"), "::1", null),
+          arguments(singletonList("[::1]"), "::1"),
+          arguments(singletonList("\"[::1]\":42"), "::1"),
+          arguments(singletonList("[::1]:42"), "::1"),
+          arguments(singletonList("\"[::1]:42\""), "::1"),
+          arguments(singletonList("[::1],1.2.3.4"), "::1"),
+          arguments(singletonList("[::1];1.2.3.4:42"), "::1"),
+          arguments(singletonList("[::1]:42abc"), "::1"),
+          arguments(singletonList("[::1]:abc"), "::1"),
 
           // ipv4
-          arguments(singletonList("1.2.3.4"), "1.2.3.4", null),
-          arguments(singletonList("1.2.3.4, :42"), "1.2.3.4", null),
-          arguments(singletonList("1.2.3.4,4.3.2.1"), "1.2.3.4", null),
-          arguments(singletonList("1.2.3.4:42"), "1.2.3.4", 42),
-          arguments(singletonList("1.2.3.4:42abc"), "1.2.3.4", 42),
-          arguments(singletonList("1.2.3.4:abc"), "1.2.3.4", null),
+          arguments(singletonList("1.2.3.4"), "1.2.3.4"),
+          arguments(singletonList("1.2.3.4, :42"), "1.2.3.4"),
+          arguments(singletonList("1.2.3.4,4.3.2.1"), "1.2.3.4"),
+          arguments(singletonList("1.2.3.4:42"), "1.2.3.4"),
+          arguments(singletonList("1.2.3.4:42abc"), "1.2.3.4"),
+          arguments(singletonList("1.2.3.4:abc"), "1.2.3.4"),
 
           // ipv6 without brackets
-          arguments(singletonList("::1"), "::1", null),
-          arguments(singletonList("::1,::2,1.2.3.4"), "::1", null),
-          arguments(singletonList("::1;::2;1.2.3.4"), "::1", null),
+          arguments(singletonList("::1"), "::1"),
+          arguments(singletonList("::1,::2,1.2.3.4"), "::1"),
+          arguments(singletonList("::1;::2;1.2.3.4"), "::1"),
 
           // multiple headers
-          arguments(asList("1.2.3.4", "::1"), "1.2.3.4", null));
+          arguments(asList("1.2.3.4", "::1"), "1.2.3.4"));
     }
   }
 }

--- a/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorStableSemconvTest.java
+++ b/instrumentation-api-semconv/src/testStableHttpSemconv/java/io/opentelemetry/instrumentation/api/instrumenter/http/HttpServerAttributesExtractorStableSemconvTest.java
@@ -520,9 +520,7 @@ class HttpServerAttributesExtractorStableSemconvTest {
     AttributesBuilder startAttributes = Attributes.builder();
     extractor.onStart(startAttributes, Context.root(), request);
     assertThat(startAttributes.build())
-        .containsOnly(
-            entry(SemanticAttributes.CLIENT_ADDRESS, "1.2.3.4"),
-            entry(SemanticAttributes.CLIENT_PORT, 123L));
+        .containsOnly(entry(SemanticAttributes.CLIENT_ADDRESS, "1.2.3.4"));
 
     AttributesBuilder endAttributes = Attributes.builder();
     extractor.onEnd(endAttributes, Context.root(), request, response, null);

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -788,11 +788,9 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
                           .satisfiesAnyOf(
                               value -> assertThat(value).isNull(),
                               value -> assertThat(value).isEqualTo(TEST_CLIENT_IP)));
-          if (SemconvStability.emitStableHttpSemconv()
-              && attrs.get(SemanticAttributes.CLIENT_PORT) != null) {
-            assertThat(attrs)
-                .hasEntrySatisfying(
-                    SemanticAttributes.CLIENT_PORT, port -> assertThat(port).isGreaterThan(0));
+          if (SemconvStability.emitStableHttpSemconv()) {
+            // client.port is opt-in
+            assertThat(attrs).doesNotContainKey(SemanticAttributes.CLIENT_PORT);
           }
           assertThat(attrs).containsEntry(getAttributeKey(SemanticAttributes.HTTP_METHOD), method);
 


### PR DESCRIPTION
Implements https://github.com/open-telemetry/semantic-conventions/pull/472