### PR TITLE
Rename flag to capture enduser id

### DIFF
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/CommonConfig.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/CommonConfig.java
@@ -74,8 +74,7 @@ public final class CommonConfig {
         config.getBoolean("otel.instrumentation.http.client.emit-experimental-metrics", false);
     emitExperimentalHttpServerMetrics =
         config.getBoolean("otel.instrumentation.http.server.emit-experimental-metrics", false);
-    captureEnduser =
-        config.getBoolean("otel.instrumentation.common.enduser.id.enabled", false);
+    captureEnduser = config.getBoolean("otel.instrumentation.common.enduser.id.enabled", false);
   }
 
   public PeerServiceResolver getPeerServiceResolver() {

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/CommonConfig.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/CommonConfig.java
@@ -75,7 +75,7 @@ public final class CommonConfig {
     emitExperimentalHttpServerMetrics =
         config.getBoolean("otel.instrumentation.http.server.emit-experimental-metrics", false);
     captureEnduser =
-        config.getBoolean("otel.instrumentation.common.capture-enduser.enabled", false);
+        config.getBoolean("otel.instrumentation.common.enduser.id.enabled", false);
   }
 
   public PeerServiceResolver getPeerServiceResolver() {


### PR DESCRIPTION
This is a small change to bring the flag name into alignment with #9777, as suggested by https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9751#issuecomment-1787307106, to reduce the chance of a backwards incompatibility if a release is created before that PR is merged.
