### PR TITLE
Update Muzzle docs to describe VirtualField dependency

### DIFF
--- a/docs/contributing/muzzle.md
+++ b/docs/contributing/muzzle.md
@@ -9,6 +9,10 @@ symbols on the application classpath.
 
 Muzzle will prevent loading an instrumentation if it detects any mismatch or conflict.
 
+Muzzle's dependency graph and class injection are encountered especially during the writing of
+[`instrumentation modules`](writing-instrumentation-module.md). This functionality is required if
+the packaged instrumentation utilizes `VirtualField`.
+
 ## How it works
 
 Muzzle has two phases:

--- a/docs/contributing/writing-instrumentation-module.md
+++ b/docs/contributing/writing-instrumentation-module.md
@@ -341,6 +341,9 @@ limited: the `VirtualField#get()` method must receive class references as its pa
 work with variables, method params, etc. Both the owner class and the field class must be known at
 compile time for it to work.
 
+Use of `VirtualField` requires the `muzzle-generation` gradle plugin. Failing to use the plugin will result in
+ClassNotFoundException when trying to access the field.
+
 ### Why we don't use ByteBuddy @Advice.Origin Method
 
 Instead of


### PR DESCRIPTION
Following slack discussion, I'm making this proposed documentation change to make implementation of instrumentation modules a bit more straightforward, especially with extensions.