### PR TITLE
Fix flaky spring webflux test

### DIFF
--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/SpringWebfluxTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/SpringWebfluxTest.java
@@ -860,7 +860,6 @@ public class SpringWebfluxTest {
     } catch (ExecutionException ignore) {
       // ignore
     }
-    SpringWebFluxTestApplication.resumeSlowRequest();
 
     testing.waitAndAssertTraces(
         trace ->
@@ -907,6 +906,8 @@ public class SpringWebfluxTest {
                                 value ->
                                     value.startsWith(
                                         "server.SpringWebFluxTestApplication$$Lambda")))));
+
+    SpringWebFluxTestApplication.resumeSlowRequest();
   }
 
   private static class Parameter {


### PR DESCRIPTION
https://ge.opentelemetry.io/s/mzhozjcyor522/tests/task/:instrumentation:spring:spring-webflux:spring-webflux-5.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.spring.webflux.v5_0.server.SpringWebfluxTest/cancelRequestTest()?top-execution=1
I think allowing the request to resume too early allows the request to successfully complete (`http.status_code` is 200) instead of completing because the client canceled (`http.status_code` is not set) which the test expects.