### PR TITLE
Second attempt at fixing flaky spring rabbit test

### DIFF
--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/ContextPropagationTest.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/ContextPropagationTest.java
@@ -17,6 +17,7 @@ import io.opentelemetry.instrumentation.testing.GlobalTraceUtil;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.semconv.SemanticAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -177,7 +178,27 @@ public class ContextPropagationTest {
                               .hasParent(trace.getSpan(1))
                               .hasAttributesSatisfyingExactly(
                                   getAssertions("testQueue", "process", null, false, testHeaders)),
-                      span -> span.hasName("consumer").hasParent(trace.getSpan(3)));
+                      span -> {
+                        // occasionally "testQueue process" spans have their order swapped, usually
+                        // it would be
+                        // 0 - parent
+                        // 1 - <default> publish
+                        // 2 - testQueue process (<default>)
+                        // 3 - testQueue process (testQueue)
+                        // 4 - consumer
+                        // but it could also be
+                        // 0 - parent
+                        // 1 - <default> publish
+                        // 2 - testQueue process (testQueue)
+                        // 3 - consumer
+                        // 4 - testQueue process (<default>)
+                        // determine the correct parent span based on the span name
+                        SpanData parentSpan = trace.getSpan(3);
+                        if (!"testQueue process".equals(parentSpan.getName())) {
+                          parentSpan = trace.getSpan(2);
+                        }
+                        span.hasName("consumer").hasParent(parentSpan);
+                      });
             },
             trace -> {
               trace


### PR DESCRIPTION
https://ge.opentelemetry.io/s/fv3e3td2cf6i6/tests/task/:instrumentation:spring:spring-rabbit-1.0:javaagent:test/details/io.opentelemetry.javaagent.instrumentation.spring.rabbit.v1_0.ContextPropagationTest/test(boolean)%5B2%5D?top-execution=1
https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9795 wasn't enough because the position of the parent span also changes.