### PR TITLE
Mention loading/unloading modules in IntelliJ

### DIFF
--- a/docs/contributing/intellij-setup-and-troubleshooting.md
+++ b/docs/contributing/intellij-setup-and-troubleshooting.md
@@ -19,6 +19,18 @@ Configuration:
 Note: If google-java-format generates errors in Intellij,
 see <https://github.com/google/google-java-format/issues/787#issuecomment-1200762464>.
 
+## Load/Unload Modules
+
+This project has many modules, which have many dependencies.
+Therefore, IntelliJ indexes a lot and consumes a lot of CPU/memory resources.
+
+To minimize IntelliJ's indexing and resource utilization,
+[unload any modules](https://www.jetbrains.com/help/idea/unloading-modules.html)
+on which you are not actively working.
+
+Specifically, unload all modules, and then selectively load the modules on which you need to work.
+IntelliJ will prompt you to load additional modules on which the selected modules depend.
+
 ## Troubleshooting
 
 Occasionally, Intellij gets confused, maybe due to the number of modules in this project,


### PR DESCRIPTION
Added a section to the Intellij Setup and Troubleshooting document to recommend only loading  modules on which you are actively working.

Only loading the modules on which you are actively working will drastically reduce IntelliJ's indexing and resource utilization.

Using the [Load/Unload Modules](https://www.jetbrains.com/help/idea/unloading-modules.html) feature was recommended in https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9757#issuecomment-1789269225