### PR TITLE
Reduce logging from okhttp3.internal.concurrent.TaskRunner

### DIFF
--- a/javaagent-internal-logging-simple/src/main/java/io/opentelemetry/javaagent/logging/simple/Slf4jSimpleLoggingCustomizer.java
+++ b/javaagent-internal-logging-simple/src/main/java/io/opentelemetry/javaagent/logging/simple/Slf4jSimpleLoggingCustomizer.java
@@ -39,6 +39,8 @@ public final class Slf4jSimpleLoggingCustomizer implements LoggingCustomizer {
     if (earlyConfig.getBoolean("otel.javaagent.debug", false)) {
       setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, "DEBUG");
       setSystemPropertyDefault(SIMPLE_LOGGER_PREFIX + "okhttp3.internal.http2", "INFO");
+      setSystemPropertyDefault(
+          SIMPLE_LOGGER_PREFIX + "okhttp3.internal.concurrent.TaskRunner", "INFO");
     }
 
     // trigger loading the provider from the agent CL

--- a/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
+++ b/smoke-tests/src/test/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
@@ -27,7 +27,6 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
         jvmArgsEnvVarName,
         "-Xmx512m -javaagent:/"
             + TARGET_AGENT_FILENAME
-            + " -Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.okhttp3.internal.concurrent.TaskRunner=INFO"
             // Liberty20Jdk11, Payara6Jdk11 and Payara6Jdk17 fail with
             // java.util.zip.ZipException: Invalid CEN header (invalid zip64 extra data field size)
             + " -Djdk.util.zip.disableZip64ExtraFieldValidation=true");


### PR DESCRIPTION
Let's suppress it everywhere instead of just in smoke tests