### PR TITLE
Pin aws sqs version to fix latest dep tests

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
@@ -61,6 +61,9 @@ dependencies {
 
   // needed by S3
   testImplementation("javax.xml.bind:jaxb-api:2.3.1")
+
+  // last version that does not use json protocol
+  latestDepTestLibrary("com.amazonaws:aws-java-sdk-sqs:1.12.583")
 }
 
 testing {
@@ -94,7 +97,12 @@ testing {
       dependencies {
         implementation(project(":instrumentation:aws-sdk:aws-sdk-1.11:testing"))
 
-        implementation("com.amazonaws:aws-java-sdk-sqs:1.11.106")
+        if (findProperty("testLatestDeps") as Boolean) {
+          // last version that does not use json protocol
+          implementation("com.amazonaws:aws-java-sdk-sqs:1.12.583")
+        } else {
+          implementation("com.amazonaws:aws-java-sdk-sqs:1.11.106")
+        }
       }
 
       targets {
@@ -110,7 +118,12 @@ testing {
       dependencies {
         implementation(project(":instrumentation:aws-sdk:aws-sdk-1.11:testing"))
 
-        implementation("com.amazonaws:aws-java-sdk-sqs:1.11.106")
+        if (findProperty("testLatestDeps") as Boolean) {
+          // last version that does not use json protocol
+          implementation("com.amazonaws:aws-java-sdk-sqs:1.12.583")
+        } else {
+          implementation("com.amazonaws:aws-java-sdk-sqs:1.11.106")
+        }
       }
     }
   }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
   testLibrary("com.amazonaws:aws-java-sdk-dynamodb:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-sns:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-sqs:1.11.106")
+
+  // last version that does not use json protocol
+  latestDepTestLibrary("com.amazonaws:aws-java-sdk-sqs:1.12.583")
 }
 
 tasks {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
@@ -17,4 +17,7 @@ dependencies {
   testLibrary("com.amazonaws:aws-java-sdk-kinesis:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-dynamodb:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-sns:1.11.106")
+
+  // last version that does not use json protocol
+  latestDepTestLibrary("com.amazonaws:aws-java-sdk-sqs:1.12.583")
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -84,6 +84,9 @@ dependencies {
   testLibrary("software.amazon.awssdk:sqs:2.2.0")
   testLibrary("software.amazon.awssdk:sns:2.2.0")
   testLibrary("software.amazon.awssdk:ses:2.2.0")
+
+  // last version that does not use json protocol
+  latestDepTestLibrary("software.amazon.awssdk:sqs:2.21.17")
 }
 
 val latestDepTest = findProperty("testLatestDeps") as Boolean

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
   testLibrary("software.amazon.awssdk:s3:2.2.0")
   testLibrary("software.amazon.awssdk:sqs:2.2.0")
   testLibrary("software.amazon.awssdk:sns:2.2.0")
+
+  // last version that does not use json protocol
+  latestDepTestLibrary("software.amazon.awssdk:sqs:2.21.17")
 }
 
 tasks {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
   testLibrary("software.amazon.awssdk:rds:2.2.0")
   testLibrary("software.amazon.awssdk:s3:2.2.0")
   testLibrary("software.amazon.awssdk:ses:2.2.0")
+
+  // last version that does not use json protocol
+  latestDepTestLibrary("software.amazon.awssdk:sqs:2.21.17")
 }
 
 testing {
@@ -33,9 +36,15 @@ testing {
       dependencies {
         implementation(project())
         implementation(project(":instrumentation:aws-sdk:aws-sdk-2.2:testing"))
-        implementation("software.amazon.awssdk:aws-core:2.2.0")
-        implementation("software.amazon.awssdk:aws-json-protocol:2.2.0")
-        implementation("software.amazon.awssdk:dynamodb:2.2.0")
+        if (findProperty("testLatestDeps") as Boolean) {
+          implementation("software.amazon.awssdk:aws-core:+")
+          implementation("software.amazon.awssdk:aws-json-protocol:+")
+          implementation("software.amazon.awssdk:dynamodb:+")
+        } else {
+          implementation("software.amazon.awssdk:aws-core:2.2.0")
+          implementation("software.amazon.awssdk:aws-json-protocol:2.2.0")
+          implementation("software.amazon.awssdk:dynamodb:2.2.0")
+        }
       }
     }
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9829
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9831
The protocol for sqs was changed from xml to json, last time there was a similar changed it got reverted in a day. For aws2   last time the tests passed with https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/8423 hopefully the same approach will work (if the protocol change doesn't get reverted again). For aws1 I suspect we may need to wait for localstack to start handling the json.