### PR TITLE
Fix flaky aws1 test

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.groovy
@@ -260,6 +260,21 @@ abstract class AbstractSqsTracingTest extends InstrumentationSpecification {
         publishSpan = span(0)
       }
       trace(2, 5) {
+        // sort spans with a ranking function
+        spans.sort({
+          // job span is first
+          if (it.name == "parent") {
+            return 0
+          }
+          if (it.name == "SQS.ReceiveMessage") {
+            return 1
+          }
+          if (it.name == "testSdkSqs receive") {
+            return 2
+          }
+          return 3
+        })
+
         span(0) {
           name "parent"
           hasNoParent()


### PR DESCRIPTION
https://ge.opentelemetry.io/s/l3ymupsbuynym/tests/task/:instrumentation:aws-sdk:aws-sdk-1.11:javaagent:testSqs/details/io.opentelemetry.javaagent.instrumentation.awssdk.v1_11.SqsTracingTest/simple%20sqs%20producer-consumer%20services%20with%20parent%20span?top-execution=1
Order of `SQS.ReceiveMessage` and `testSdkSqs receive` can be swapped on jdk8