### PR TITLE
Remove unneeded dependency

### DIFF
--- a/instrumentation/hibernate/hibernate-common/javaagent/build.gradle.kts
+++ b/instrumentation/hibernate/hibernate-common/javaagent/build.gradle.kts
@@ -4,7 +4,3 @@
 plugins {
   id("otel.javaagent-instrumentation")
 }
-
-dependencies {
-  compileOnly(project(":javaagent-extension-api"))
-}


### PR DESCRIPTION
`:javaagent-extension-api` should be automatically added with `otel.javaagent-instrumentation`