### PR TITLE
Allow starting and stopping of test server to throw an exception

### DIFF
--- a/instrumentation/tapestry-5.4/javaagent/src/test/java/TapestryTest.java
+++ b/instrumentation/tapestry-5.4/javaagent/src/test/java/TapestryTest.java
@@ -31,33 +31,26 @@ class TapestryTest extends AbstractHttpServerUsingTest<Server> {
       HttpServerInstrumentationExtension.forAgent();
 
   @Override
-  protected Server setupServer() {
+  protected Server setupServer() throws Exception {
     WebAppContext webAppContext = new WebAppContext();
     webAppContext.setContextPath(getContextPath());
     Server jettyServer = new Server(port);
 
     // set up test application
-    try {
-      webAppContext.setBaseResource(Resource.newResource("src/test/webapp"));
-      for (Connector connector : jettyServer.getConnectors()) {
-        connector.setHost("localhost");
-      }
-
-      jettyServer.setHandler(webAppContext);
-      jettyServer.start();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    webAppContext.setBaseResource(Resource.newResource("src/test/webapp"));
+    for (Connector connector : jettyServer.getConnectors()) {
+      connector.setHost("localhost");
     }
+
+    jettyServer.setHandler(webAppContext);
+    jettyServer.start();
+
     return jettyServer;
   }
 
   @Override
-  protected void stopServer(Server server) {
-    try {
-      server.stop();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+  protected void stopServer(Server server) throws Exception {
+    server.stop();
   }
 
   @Override

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerUsingTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerUsingTest.java
@@ -27,9 +27,9 @@ public abstract class AbstractHttpServerUsingTest<SERVER> {
   public int port;
   public URI address;
 
-  protected abstract SERVER setupServer();
+  protected abstract SERVER setupServer() throws Exception;
 
-  protected abstract void stopServer(SERVER server);
+  protected abstract void stopServer(SERVER server) throws Exception;
 
   protected final InstrumentationTestRunner testing() {
     return testing;
@@ -40,7 +40,11 @@ public abstract class AbstractHttpServerUsingTest<SERVER> {
       address = buildAddress();
     }
 
-    server = setupServer();
+    try {
+      server = setupServer();
+    } catch (Exception exception) {
+      throw new IllegalStateException("Failed to start server", exception);
+    }
     if (server != null) {
       logger.info(
           getClass().getName()
@@ -57,7 +61,11 @@ public abstract class AbstractHttpServerUsingTest<SERVER> {
       logger.info(getClass().getName() + " can't stop null server");
       return;
     }
-    stopServer(server);
+    try {
+      stopServer(server);
+    } catch (Exception exception) {
+      throw new IllegalStateException("Failed to stop server", exception);
+    }
     server = null;
     logger.info(getClass().getName() + " http server stopped at: http://localhost:" + port + "/");
   }


### PR DESCRIPTION
Jetty, that is used in many tests, throws checked exceptions on start and stop. This pr removes the need to handle them in the test code.