### PR TITLE
Fix NoSuchBeanDefinitionException with the JDBC driver configuration

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/instrumentation/jdbc/OpenTelemetryJdbcDriverAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/instrumentation/jdbc/OpenTelemetryJdbcDriverAutoConfiguration.java
@@ -9,6 +9,8 @@ import io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver;
 import io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryInjector;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -19,6 +21,8 @@ import org.springframework.context.annotation.Configuration;
     name = "spring.datasource.driver-class-name",
     havingValue = "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver")
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(name = "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
+@ConditionalOnBean(name = "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
 public class OpenTelemetryJdbcDriverAutoConfiguration {
   @Bean
   OpenTelemetryInjector injectOtelIntoJdbcDriver() {

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/instrumentation/jdbc/OpenTelemetryJdbcDriverAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/instrumentation/jdbc/OpenTelemetryJdbcDriverAutoConfiguration.java
@@ -21,7 +21,8 @@ import org.springframework.context.annotation.Configuration;
     name = "spring.datasource.driver-class-name",
     havingValue = "io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver")
 @Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter(name = "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
+@AutoConfigureAfter(
+    name = "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
 @ConditionalOnBean(name = "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
 public class OpenTelemetryJdbcDriverAutoConfiguration {
   @Bean


### PR DESCRIPTION
When the [JDBC driver configuration](https://opentelemetry.io/docs/instrumentation/java/automatic/spring-boot/#jdbc-instrumentation) was used and the [DataSourceAutoConfiguration](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jdbc/DataSourceAutoConfiguration.html) not enabled then the code raised a `NoSuchBeanDefinitionException` [here](https://github.com/jeanbisutti/opentelemetry-java-instrumentation/blob/1aad15171be37986faa956ec37953b720ae067f9/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/instrumentation/jdbc/OpenTelemetryJdbcDriverAutoConfiguration.java#L35).

I have found the issue from the Spring Petclinic tests.