### PR TITLE
Add NVD api key to speed up owasp dependency check

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -69,6 +69,7 @@ for [`dependabot/**/**`](https://github.com/open-telemetry/community/blob/main/d
     see [docs](https://docs.gradle.com/enterprise/gradle-plugin/#via_environment_variable)
 - `GRADLE_PUBLISH_KEY`
 - `GRADLE_PUBLISH_SECRET`
+- `NVD_API_KEY` - stored in OpenTelemetry-Java 1Password
 - `OPENTELEMETRYBOT_GITHUB_TOKEN` - owned by [@trask](https://github.com/trask)
 - `SONATYPE_KEY` - owned by [@trask](https://github.com/trask)
 - `SONATYPE_USER` - owned by [@trask](https://github.com/trask)

--- a/.github/workflows/owasp-dependency-check-daily.yml
+++ b/.github/workflows/owasp-dependency-check-daily.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         with:
           arguments: ":javaagent:dependencyCheckAnalyze"
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
 
       - name: Upload report
         if: always()

--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -415,6 +415,7 @@ dependencyCheck {
   skipConfigurations = listOf("errorprone", "checkstyle", "annotationProcessor")
   suppressionFile = "buildscripts/dependency-check-suppressions.xml"
   failBuildOnCVSS = 7.0f // fail on high or critical CVE
+  nvd.apiKey = System.getenv("NVD_API_KEY")
 }
 
 idea {


### PR DESCRIPTION
Running on my fork with the new secret to test: https://github.com/trask/opentelemetry-java-instrumentation/actions/runs/7103551919