### PR TITLE
Fix flaky http client test

### DIFF
--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.testing.junit.http;
 
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.comparingRootSpanAttribute;
+import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static java.util.Arrays.asList;
@@ -182,7 +183,8 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
 
     assertThat(responseCode).isEqualTo(200);
 
-    testing.waitAndAssertTraces(
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanName("parent-client-span", "test-http-server"),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent-client-span").hasKind(SpanKind.CLIENT).hasNoParent()),


### PR DESCRIPTION
https://ge.opentelemetry.io/s/23cqhboyw6yck/tests/task/:instrumentation:apache-httpclient:apache-httpclient-5.0:javaagent:testStableSemconv/details/io.opentelemetry.javaagent.instrumentation.apachehttpclient.v5_0.ApacheHttpAsyncClientTest$ApacheClientUriRequestTest/shouldSuppressNestedClientSpanIfAlreadyUnderParentClientSpan(String)%5B2%5D?top-execution=1
https://ge.opentelemetry.io/s/55qx2eamrdn7s/tests/task/:instrumentation:play:play-ws:play-ws-1.0:javaagent:testStableSemconv/details/PlayJavaWsClientTest/should%20suppress%20nested%20CLIENT%20span%20if%20already%20under%20parent%20CLIENT%20span%20(PUT)?top-execution=1
on jdk8 the order of these spans can vary