### PR TITLE
Fix missing db.operation for CREATE/DROP/ALTER SQL statement 

### DIFF
--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -122,10 +122,53 @@ WHITESPACE          = [ \t\r\n]+
     /** @return true if all statement info is gathered */
     boolean handleNext() {
       return false;
-     }
+    }
+
+    /** @return true if all statement info is gathered */
+    boolean handleOperationTarget(String target) {
+      return false;
+    }
+
+    boolean expectingOperationTarget() {
+      return false;
+    }
 
     SqlStatementInfo getResult(String fullStatement) {
       return SqlStatementInfo.create(fullStatement, getClass().getSimpleName().toUpperCase(java.util.Locale.ROOT), mainIdentifier);
+    }
+  }
+
+  private abstract class DdlOperation extends Operation {
+    private String operationTarget = "";
+    private boolean expectingOperationTarget = true;
+
+    boolean expectingOperationTarget() {
+      return expectingOperationTarget;
+    }
+
+    boolean handleOperationTarget(String target) {
+      operationTarget = target;
+      expectingOperationTarget = false;
+      return false;
+    }
+
+    boolean shouldHandleIdentifier() {
+      // Return true only if the provided value corresponds to a table, as it will be used to set the attribute `db.sql.table`.
+      return "TABLE".equals(operationTarget);
+    }
+
+    boolean handleIdentifier() {
+      if (shouldHandleIdentifier()) {
+        mainIdentifier = readIdentifierName();
+      }
+      return true;
+    }
+
+    SqlStatementInfo getResult(String fullStatement) {
+      if (!"".equals(operationTarget)) {
+        return SqlStatementInfo.create(fullStatement, getClass().getSimpleName().toUpperCase(java.util.Locale.ROOT) + " " + operationTarget, mainIdentifier);
+      }
+      return super.getResult(fullStatement);
     }
   }
 
@@ -273,6 +316,15 @@ WHITESPACE          = [ \t\r\n]+
     }
   }
 
+  private class Create extends DdlOperation {
+  }
+
+  private class Drop extends DdlOperation {
+  }
+
+  private class Alter extends DdlOperation {
+  }
+
   private SqlStatementInfo getResult() {
     if (builder.length() > LIMIT) {
       builder.delete(LIMIT, builder.length());
@@ -329,6 +381,27 @@ WHITESPACE          = [ \t\r\n]+
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
+  "CREATE" {
+          if (!insideComment) {
+            setOperation(new Create());
+          }
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
+  "DROP" {
+          if (!insideComment) {
+            setOperation(new Drop());
+          }
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
+  "ALTER" {
+          if (!insideComment) {
+            setOperation(new Alter());
+          }
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
   "FROM" {
           if (!insideComment && !extractionDone) {
             if (operation == NoOp.INSTANCE) {
@@ -357,11 +430,27 @@ WHITESPACE          = [ \t\r\n]+
       }
   "NEXT" {
           if (!insideComment && !extractionDone) {
-              extractionDone = operation.handleNext();
-            }
+            extractionDone = operation.handleNext();
+          }
           appendCurrentFragment();
           if (isOverLimit()) return YYEOF;
       }
+  "IF" | "NOT" | "EXISTS" {
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
+  "TABLE" | "INDEX" | "DATABASE" | "PROCEDURE" | "VIEW" {
+          if (!insideComment && !extractionDone) {
+            if (operation.expectingOperationTarget()) {
+              extractionDone = operation.handleOperationTarget(yytext());
+            } else {
+              extractionDone = operation.handleIdentifier();
+            }
+          }
+          appendCurrentFragment();
+          if (isOverLimit()) return YYEOF;
+      }
+
   {COMMA} {
           if (!insideComment && !extractionDone) {
             extractionDone = operation.handleComma();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementSanitizerTest.java
@@ -60,6 +60,17 @@ public class SqlStatementSanitizerTest {
     assertThat(result).isEqualTo(expected);
   }
 
+  @ParameterizedTest
+  @ArgumentsSource(DdlArgs.class)
+  void checkDdlOperationStatementsAreOk(
+      String actual, Function<String, SqlStatementInfo> expectFunc) {
+    SqlStatementInfo result = SqlStatementSanitizer.create(true).sanitize(actual);
+    SqlStatementInfo expected = expectFunc.apply(actual);
+    assertThat(result.getFullStatement()).isEqualTo(expected.getFullStatement());
+    assertThat(result.getOperation()).isEqualTo(expected.getOperation());
+    assertThat(result.getMainIdentifier()).isEqualTo(expected.getMainIdentifier());
+  }
+
   @Test
   void lotsOfTicksDontCauseStackOverflowOrLongRuntimes() {
     String s = "'";
@@ -329,6 +340,36 @@ public class SqlStatementSanitizerTest {
           Arguments.of("and now for something completely different", expect(null, null)),
           Arguments.of("", expect(null, null)),
           Arguments.of(null, expect(null, null)));
+    }
+  }
+
+  static class DdlArgs implements ArgumentsProvider {
+
+    static Function<String, SqlStatementInfo> expect(String operation, String identifier) {
+      return sql -> SqlStatementInfo.create(sql, operation, identifier);
+    }
+
+    static Function<String, SqlStatementInfo> expect(
+        String sql, String operation, String identifier) {
+      return ignored -> SqlStatementInfo.create(sql, operation, identifier);
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+      return Stream.of(
+          Arguments.of("CREATE TABLE `table`", expect("CREATE TABLE", "table")),
+          Arguments.of("CREATE TABLE IF NOT EXISTS table", expect("CREATE TABLE", "table")),
+          Arguments.of("DROP TABLE `if`", expect("DROP TABLE", "if")),
+          Arguments.of(
+              "ALTER TABLE table ADD CONSTRAINT c FOREIGN KEY (foreign_id) REFERENCES ref (id)",
+              expect("ALTER TABLE", "table")),
+          Arguments.of("CREATE INDEX types_name ON types (name)", expect("CREATE INDEX", null)),
+          Arguments.of("DROP INDEX types_name ON types (name)", expect("DROP INDEX", null)),
+          Arguments.of(
+              "CREATE VIEW tmp AS SELECT type FROM table WHERE id = ?",
+              expect("CREATE VIEW", null)),
+          Arguments.of(
+              "CREATE PROCEDURE p AS SELECT * FROM table GO", expect("CREATE PROCEDURE", null)));
     }
   }
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/CassandraClientTest.java
@@ -225,8 +225,8 @@ public class CassandraClientTest {
                     null,
                     "DROP KEYSPACE IF EXISTS sync_test",
                     "DROP KEYSPACE IF EXISTS sync_test",
-                    "DB Query",
-                    null,
+                    "DROP",
+                    "DROP",
                     null))),
         Arguments.of(
             named(
@@ -235,8 +235,8 @@ public class CassandraClientTest {
                     null,
                     "CREATE KEYSPACE sync_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':3}",
                     "CREATE KEYSPACE sync_test WITH REPLICATION = {?:?, ?:?}",
-                    "DB Query",
-                    null,
+                    "CREATE",
+                    "CREATE",
                     null))),
         Arguments.of(
             named(
@@ -245,9 +245,9 @@ public class CassandraClientTest {
                     "sync_test",
                     "CREATE TABLE sync_test.users ( id UUID PRIMARY KEY, name text )",
                     "CREATE TABLE sync_test.users ( id UUID PRIMARY KEY, name text )",
-                    "sync_test",
-                    null,
-                    null))),
+                    "CREATE TABLE sync_test.users",
+                    "CREATE TABLE",
+                    "sync_test.users"))),
         Arguments.of(
             named(
                 "Insert data",
@@ -279,8 +279,8 @@ public class CassandraClientTest {
                     null,
                     "DROP KEYSPACE IF EXISTS async_test",
                     "DROP KEYSPACE IF EXISTS async_test",
-                    "DB Query",
-                    null,
+                    "DROP",
+                    "DROP",
                     null))),
         Arguments.of(
             named(
@@ -289,8 +289,8 @@ public class CassandraClientTest {
                     null,
                     "CREATE KEYSPACE async_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':3}",
                     "CREATE KEYSPACE async_test WITH REPLICATION = {?:?, ?:?}",
-                    "DB Query",
-                    null,
+                    "CREATE",
+                    "CREATE",
                     null))),
         Arguments.of(
             named(
@@ -299,9 +299,9 @@ public class CassandraClientTest {
                     "async_test",
                     "CREATE TABLE async_test.users ( id UUID PRIMARY KEY, name text )",
                     "CREATE TABLE async_test.users ( id UUID PRIMARY KEY, name text )",
-                    "async_test",
-                    null,
-                    null))),
+                    "CREATE TABLE async_test.users",
+                    "CREATE TABLE",
+                    "async_test.users"))),
         Arguments.of(
             named(
                 "Insert data",

--- a/instrumentation/cassandra/cassandra-4-common/testing/src/main/java/io/opentelemetry/cassandra/v4/common/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-4-common/testing/src/main/java/io/opentelemetry/cassandra/v4/common/AbstractCassandraTest.java
@@ -200,8 +200,8 @@ public abstract class AbstractCassandraTest {
                     null,
                     "DROP KEYSPACE IF EXISTS sync_test",
                     "DROP KEYSPACE IF EXISTS sync_test",
-                    "DB Query",
-                    null,
+                    "DROP",
+                    "DROP",
                     null))),
         Arguments.of(
             named(
@@ -210,8 +210,8 @@ public abstract class AbstractCassandraTest {
                     null,
                     "CREATE KEYSPACE sync_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':3}",
                     "CREATE KEYSPACE sync_test WITH REPLICATION = {?:?, ?:?}",
-                    "DB Query",
-                    null,
+                    "CREATE",
+                    "CREATE",
                     null))),
         Arguments.of(
             named(
@@ -220,9 +220,9 @@ public abstract class AbstractCassandraTest {
                     "sync_test",
                     "CREATE TABLE sync_test.users ( id UUID PRIMARY KEY, name text )",
                     "CREATE TABLE sync_test.users ( id UUID PRIMARY KEY, name text )",
-                    "sync_test",
-                    null,
-                    null))),
+                    "CREATE TABLE sync_test.users",
+                    "CREATE TABLE",
+                    "sync_test.users"))),
         Arguments.of(
             named(
                 "Insert data",
@@ -254,8 +254,8 @@ public abstract class AbstractCassandraTest {
                     null,
                     "DROP KEYSPACE IF EXISTS async_test",
                     "DROP KEYSPACE IF EXISTS async_test",
-                    "DB Query",
-                    null,
+                    "DROP",
+                    "DROP",
                     null))),
         Arguments.of(
             named(
@@ -264,8 +264,8 @@ public abstract class AbstractCassandraTest {
                     null,
                     "CREATE KEYSPACE async_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':3}",
                     "CREATE KEYSPACE async_test WITH REPLICATION = {?:?, ?:?}",
-                    "DB Query",
-                    null,
+                    "CREATE",
+                    "CREATE",
                     null))),
         Arguments.of(
             named(
@@ -274,9 +274,9 @@ public abstract class AbstractCassandraTest {
                     "async_test",
                     "CREATE TABLE async_test.users ( id UUID PRIMARY KEY, name text )",
                     "CREATE TABLE async_test.users ( id UUID PRIMARY KEY, name text )",
-                    "async_test",
-                    null,
-                    null))),
+                    "CREATE TABLE async_test.users",
+                    "CREATE TABLE",
+                    "async_test.users"))),
         Arguments.of(
             named(
                 "Insert data",

--- a/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
+++ b/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
@@ -106,8 +106,8 @@ public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
                     null,
                     "DROP KEYSPACE IF EXISTS reactive_test",
                     "DROP KEYSPACE IF EXISTS reactive_test",
-                    "DB Query",
-                    null,
+                    "DROP",
+                    "DROP",
                     null))),
         Arguments.of(
             named(
@@ -116,8 +116,8 @@ public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
                     null,
                     "CREATE KEYSPACE reactive_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':3}",
                     "CREATE KEYSPACE reactive_test WITH REPLICATION = {?:?, ?:?}",
-                    "DB Query",
-                    null,
+                    "CREATE",
+                    "CREATE",
                     null))),
         Arguments.of(
             named(
@@ -126,9 +126,9 @@ public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
                     "reactive_test",
                     "CREATE TABLE reactive_test.users ( id UUID PRIMARY KEY, name text )",
                     "CREATE TABLE reactive_test.users ( id UUID PRIMARY KEY, name text )",
-                    "reactive_test",
-                    null,
-                    null))),
+                    "CREATE TABLE reactive_test.users",
+                    "CREATE TABLE",
+                    "reactive_test.users"))),
         Arguments.of(
             named(
                 "Insert data",

--- a/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
+++ b/instrumentation/jdbc/javaagent/src/test/groovy/JdbcInstrumentationTest.groovy
@@ -399,7 +399,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           hasNoParent()
         }
         span(1) {
-          name dbNameLower
+          name spanName
           kind CLIENT
           childOf span(0)
           attributes {
@@ -410,6 +410,8 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
             }
             "$SemanticAttributes.DB_STATEMENT" query
             "$SemanticAttributes.DB_CONNECTION_STRING" url
+            "$SemanticAttributes.DB_OPERATION" "CREATE TABLE"
+            "$SemanticAttributes.DB_SQL_TABLE" table
           }
         }
       }
@@ -420,19 +422,19 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
     connection.close()
 
     where:
-    system   | connection                                                | username | query                                                                           | url
-    "h2"     | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "CREATE TABLE S_H2 (id INTEGER not NULL, PRIMARY KEY ( id ))"                   | "h2:mem:"
-    "derby"  | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "CREATE TABLE S_DERBY (id INTEGER not NULL, PRIMARY KEY ( id ))"                | "derby:memory:"
-    "hsqldb" | new JDBCDriver().connect(jdbcUrls.get("hsqldb"), null)    | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB (id INTEGER not NULL, PRIMARY KEY ( id ))"        | "hsqldb:mem:"
-    "h2"     | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "CREATE TABLE S_H2_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"            | "h2:mem:"
-    "derby"  | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "CREATE TABLE S_DERBY_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"         | "derby:memory:"
-    "hsqldb" | cpDatasources.get("tomcat").get("hsqldb").getConnection() | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))" | "hsqldb:mem:"
-    "h2"     | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "CREATE TABLE S_H2_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"            | "h2:mem:"
-    "derby"  | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "CREATE TABLE S_DERBY_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"         | "derby:memory:"
-    "hsqldb" | cpDatasources.get("hikari").get("hsqldb").getConnection() | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))" | "hsqldb:mem:"
-    "h2"     | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "CREATE TABLE S_H2_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"              | "h2:mem:"
-    "derby"  | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "CREATE TABLE S_DERBY_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"           | "derby:memory:"
-    "hsqldb" | cpDatasources.get("c3p0").get("hsqldb").getConnection()   | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"   | "hsqldb:mem:"
+    system   | connection                                                           | username | query                                                                           | spanName                                   | url             | table
+    "h2"     | new Driver().connect(jdbcUrls.get("h2"), null)                       | null     | "CREATE TABLE S_H2 (id INTEGER not NULL, PRIMARY KEY ( id ))"                   | "CREATE TABLE jdbcunittest.S_H2"           | "h2:mem:"       | "S_H2"
+    "derby"  | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null)            | "APP"    | "CREATE TABLE S_DERBY (id INTEGER not NULL, PRIMARY KEY ( id ))"                | "CREATE TABLE jdbcunittest.S_DERBY"        | "derby:memory:" | "S_DERBY"
+    "hsqldb" | new JDBCDriver().connect(jdbcUrls.get("hsqldb"), null)               | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB (id INTEGER not NULL, PRIMARY KEY ( id ))"        | "CREATE TABLE PUBLIC.S_HSQLDB"             | "hsqldb:mem:"   | "PUBLIC.S_HSQLDB"
+    "h2"     | cpDatasources.get("tomcat").get("h2").getConnection()                | null     | "CREATE TABLE S_H2_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"            | "CREATE TABLE jdbcunittest.S_H2_TOMCAT"    | "h2:mem:"       | "S_H2_TOMCAT"
+    "derby"  | cpDatasources.get("tomcat").get("derby").getConnection()             | "APP"    | "CREATE TABLE S_DERBY_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"         | "CREATE TABLE jdbcunittest.S_DERBY_TOMCAT" | "derby:memory:" | "S_DERBY_TOMCAT"
+    "hsqldb" | cpDatasources.get("tomcat").get("hsqldb").getConnection()            | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE TABLE PUBLIC.S_HSQLDB_TOMCAT"      | "hsqldb:mem:"   | "PUBLIC.S_HSQLDB_TOMCAT"
+    "h2"     | cpDatasources.get("hikari").get("h2").getConnection()                | null     | "CREATE TABLE S_H2_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"            | "CREATE TABLE jdbcunittest.S_H2_HIKARI"    | "h2:mem:"       | "S_H2_HIKARI"
+    "derby"  | cpDatasources.get("hikari").get("derby").getConnection()             | "APP"    | "CREATE TABLE S_DERBY_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"         | "CREATE TABLE jdbcunittest.S_DERBY_HIKARI" | "derby:memory:" | "S_DERBY_HIKARI"
+    "hsqldb" | cpDatasources.get("hikari").get("hsqldb").getConnection()            | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE TABLE PUBLIC.S_HSQLDB_HIKARI"      | "hsqldb:mem:"   | "PUBLIC.S_HSQLDB_HIKARI"
+    "h2"     | cpDatasources.get("c3p0").get("h2").getConnection()                  | null     | "CREATE TABLE S_H2_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"              | "CREATE TABLE jdbcunittest.S_H2_C3P0"      | "h2:mem:"       | "S_H2_C3P0"
+    "derby"  | cpDatasources.get("c3p0").get("derby").getConnection()               | "APP"    | "CREATE TABLE S_DERBY_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"           | "CREATE TABLE jdbcunittest.S_DERBY_C3P0"   | "derby:memory:" | "S_DERBY_C3P0"
+    "hsqldb" | cpDatasources.get("c3p0").get("hsqldb").getConnection()              | "SA"     | "CREATE TABLE PUBLIC.S_HSQLDB_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"   | "CREATE TABLE PUBLIC.S_HSQLDB_C3P0"        | "hsqldb:mem:"   | "PUBLIC.S_HSQLDB_C3P0"
   }
 
   def "prepared statement update on #system with #connection.getClass().getCanonicalName() generates a span"() {
@@ -452,7 +454,7 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
           hasNoParent()
         }
         span(1) {
-          name dbNameLower
+          name spanName
           kind CLIENT
           childOf span(0)
           attributes {
@@ -463,6 +465,8 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
             }
             "$SemanticAttributes.DB_STATEMENT" query
             "$SemanticAttributes.DB_CONNECTION_STRING" url
+            "$SemanticAttributes.DB_OPERATION" "CREATE TABLE"
+            "$SemanticAttributes.DB_SQL_TABLE" table
           }
         }
       }
@@ -473,15 +477,15 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
     connection.close()
 
     where:
-    system  | connection                                                | username | query                                                                    | url
-    "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "CREATE TABLE PS_H2 (id INTEGER not NULL, PRIMARY KEY ( id ))"           | "h2:mem:"
-    "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "CREATE TABLE PS_DERBY (id INTEGER not NULL, PRIMARY KEY ( id ))"        | "derby:memory:"
-    "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "CREATE TABLE PS_H2_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"    | "h2:mem:"
-    "derby" | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "CREATE TABLE PS_DERBY_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))" | "derby:memory:"
-    "h2"    | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "CREATE TABLE PS_H2_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"    | "h2:mem:"
-    "derby" | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "CREATE TABLE PS_DERBY_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))" | "derby:memory:"
-    "h2"    | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "CREATE TABLE PS_H2_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"      | "h2:mem:"
-    "derby" | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "CREATE TABLE PS_DERBY_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"   | "derby:memory:"
+    system  | connection                                                | username | query                                                                    | spanName                                    | url             | table
+    "h2"    | new Driver().connect(jdbcUrls.get("h2"), null)            | null     | "CREATE TABLE PS_H2 (id INTEGER not NULL, PRIMARY KEY ( id ))"           | "CREATE TABLE jdbcunittest.PS_H2"           | "h2:mem:"       | "PS_H2"
+    "derby" | new EmbeddedDriver().connect(jdbcUrls.get("derby"), null) | "APP"    | "CREATE TABLE PS_DERBY (id INTEGER not NULL, PRIMARY KEY ( id ))"        | "CREATE TABLE jdbcunittest.PS_DERBY"        | "derby:memory:" | "PS_DERBY"
+    "h2"    | cpDatasources.get("tomcat").get("h2").getConnection()     | null     | "CREATE TABLE PS_H2_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))"    | "CREATE TABLE jdbcunittest.PS_H2_TOMCAT"    | "h2:mem:"       | "PS_H2_TOMCAT"
+    "derby" | cpDatasources.get("tomcat").get("derby").getConnection()  | "APP"    | "CREATE TABLE PS_DERBY_TOMCAT (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE TABLE jdbcunittest.PS_DERBY_TOMCAT" | "derby:memory:" | "PS_DERBY_TOMCAT"
+    "h2"    | cpDatasources.get("hikari").get("h2").getConnection()     | null     | "CREATE TABLE PS_H2_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))"    | "CREATE TABLE jdbcunittest.PS_H2_HIKARI"    | "h2:mem:"       | "PS_H2_HIKARI"
+    "derby" | cpDatasources.get("hikari").get("derby").getConnection()  | "APP"    | "CREATE TABLE PS_DERBY_HIKARI (id INTEGER not NULL, PRIMARY KEY ( id ))" | "CREATE TABLE jdbcunittest.PS_DERBY_HIKARI" | "derby:memory:" | "PS_DERBY_HIKARI"
+    "h2"    | cpDatasources.get("c3p0").get("h2").getConnection()       | null     | "CREATE TABLE PS_H2_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"      | "CREATE TABLE jdbcunittest.PS_H2_C3P0"      | "h2:mem:"       | "PS_H2_C3P0"
+    "derby" | cpDatasources.get("c3p0").get("derby").getConnection()    | "APP"    | "CREATE TABLE PS_DERBY_C3P0 (id INTEGER not NULL, PRIMARY KEY ( id ))"   | "CREATE TABLE jdbcunittest.PS_DERBY_C3P0"   | "derby:memory:" | "PS_DERBY_C3P0"
   }
 
   def "connection constructor throwing then generating correct spans after recovery using #driver connection (prepare statement = #prepareStatement)"() {
@@ -698,12 +702,12 @@ class JdbcInstrumentationTest extends AgentInstrumentationSpecification {
     }
 
     where:
-    url                                         | query                 | sanitizedQuery        | spanName            | databaseName | operation | table
-    "jdbc:testdb://localhost?databaseName=test" | "SELECT * FROM table" | "SELECT * FROM table" | "SELECT test.table" | "test"       | "SELECT"  | "table"
-    "jdbc:testdb://localhost?databaseName=test" | "SELECT 42"           | "SELECT ?"            | "SELECT test"       | "test"       | "SELECT"  | null
-    "jdbc:testdb://localhost"                   | "SELECT * FROM table" | "SELECT * FROM table" | "SELECT table"      | null         | "SELECT"  | "table"
-    "jdbc:testdb://localhost?databaseName=test" | "CREATE TABLE table"  | "CREATE TABLE table"  | "test"              | "test"       | null      | null
-    "jdbc:testdb://localhost"                   | "CREATE TABLE table"  | "CREATE TABLE table"  | "DB Query"          | null         | null      | null
+    url                                         | query                 | sanitizedQuery        | spanName                  | databaseName | operation      | table
+    "jdbc:testdb://localhost?databaseName=test" | "SELECT * FROM table" | "SELECT * FROM table" | "SELECT test.table"       | "test"       | "SELECT"       | "table"
+    "jdbc:testdb://localhost?databaseName=test" | "SELECT 42"           | "SELECT ?"            | "SELECT test"             | "test"       | "SELECT"       | null
+    "jdbc:testdb://localhost"                   | "SELECT * FROM table" | "SELECT * FROM table" | "SELECT table"            | null         | "SELECT"       | "table"
+    "jdbc:testdb://localhost?databaseName=test" | "CREATE TABLE table"  | "CREATE TABLE table"  | "CREATE TABLE test.table" | "test"       | "CREATE TABLE" | "table"
+    "jdbc:testdb://localhost"                   | "CREATE TABLE table"  | "CREATE TABLE table"  | "CREATE TABLE table"      | null         | "CREATE TABLE" | "table"
   }
 
   def "#connectionPoolName connections should be cached in case of wrapped connections"() {

--- a/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
+++ b/instrumentation/r2dbc-1.0/testing/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/AbstractR2dbcStatementTest.java
@@ -204,9 +204,9 @@ public abstract class AbstractR2dbcStatementTest {
                                 system.system,
                                 "CREATE TABLE person (id SERIAL PRIMARY KEY, first_name VARCHAR(255), last_name VARCHAR(255))",
                                 "CREATE TABLE person (id SERIAL PRIMARY KEY, first_name VARCHAR(?), last_name VARCHAR(?))",
-                                DB,
-                                null,
-                                null))),
+                                "CREATE TABLE " + DB + ".person",
+                                "person",
+                                "CREATE TABLE"))),
                     Arguments.of(
                         named(
                             system.system + " Insert",


### PR DESCRIPTION
This PR fixed https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10031.

## After the fix
Sample trace
```
Span #6
    Trace ID       : 657116b404695ceda8a8588db87581c9
    Parent ID      : 
    ID             : 7845374ea3a9d910
    Name           : CREATE dd62840f-1bdb-44f2-9d95-dc796dabe06d.INDEX
    Kind           : Client
    Start time     : 2023-12-07 00:49:56.179481 +0000 UTC
    End time       : 2023-12-07 00:49:56.179686303 +0000 UTC
    Status code    : Unset
    Status message : 
Attributes:
     -> db.name: Str(xxx)
     -> db.operation: Str(CREATE INDEX)
     -> db.statement: Str(CREATE INDEX types_name ON types (name))
     -> db.system: Str(xxx)
     -> db.user: Str(xxx)
     -> thread.id: Int(1)
     -> thread.name: Str(main)
```