### PR TITLE
Null check for nullable response object

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsImpl.java
@@ -137,7 +137,7 @@ final class SqsImpl {
   }
 
   static String getMessageId(Response<?> response) {
-    if (response.getAwsResponse() instanceof SendMessageResult) {
+    if (response != null && response.getAwsResponse() instanceof SendMessageResult) {
       return ((SendMessageResult) response.getAwsResponse()).getMessageId();
     }
     return null;


### PR DESCRIPTION
bug fix as `response` object is nullable and it will throw an NPE on` response.getAwsResponse()` in case of error response.


`[docker-java-stream--300619952] INFO application aws-sdk-v1 - STDERR: java.lang.NullPointerException: Cannot invoke "com.amazonaws.Response.getAwsResponse()" because "response" is null`



