### PR TITLE
log4j MDC attribute capture configuration

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/README.md
@@ -5,6 +5,6 @@
 | `otel.instrumentation.log4j-appender.experimental-log-attributes`                  | Boolean | `false` | Enable the capture of experimental span attributes `thread.name` and `thread.id`.                                     |
 | `otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes`  | Boolean | `false` | Enable the capture of `MapMessage` attributes.                                                                        |
 | `otel.instrumentation.log4j-appender.experimental.capture-marker-attribute`        | Boolean | `false` | Enable the capture of Log4j markers as attributes.                                                                    |
-| `otel.instrumentation.log4j-appender.experimental.capture-context-data-attributes` | String  |         | Comma separated list of context data attributes to capture. Use the wildcard character `*` to capture all attributes. |
+| `otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes` | String  |         | Comma separated list of context data attributes to capture. Use the wildcard character `*` to capture all attributes. |
 
 [source code attributes]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attributes.md#source-code-attributes

--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/build.gradle.kts
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/build.gradle.kts
@@ -57,7 +57,7 @@ tasks {
 tasks.withType<Test>().configureEach {
   // TODO run tests both with and without experimental log attributes
   jvmArgs("-Dotel.instrumentation.log4j-appender.experimental.capture-map-message-attributes=true")
-  jvmArgs("-Dotel.instrumentation.log4j-appender.experimental.capture-context-data-attributes=*")
+  jvmArgs("-Dotel.instrumentation.log4j-appender.experimental.capture-mdc-attributes=*")
   jvmArgs("-Dotel.instrumentation.log4j-appender.experimental-log-attributes=true")
   jvmArgs("-Dotel.instrumentation.log4j-appender.experimental.capture-marker-attribute=true")
 }

--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v2_17/Log4jHelper.java
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v2_17/Log4jHelper.java
@@ -43,7 +43,7 @@ public final class Log4jHelper {
             "otel.instrumentation.log4j-appender.experimental.capture-marker-attribute", false);
     List<String> captureContextDataAttributes =
         config.getList(
-            "otel.instrumentation.log4j-appender.experimental.capture-context-data-attributes",
+            "otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes",
             emptyList());
 
     mapper =

--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v2_17/Log4jHelper.java
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/appender/v2_17/Log4jHelper.java
@@ -43,8 +43,7 @@ public final class Log4jHelper {
             "otel.instrumentation.log4j-appender.experimental.capture-marker-attribute", false);
     List<String> captureContextDataAttributes =
         config.getList(
-            "otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes",
-            emptyList());
+            "otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes", emptyList());
 
     mapper =
         new LogEventMapper<>(


### PR DESCRIPTION
Breaking change: rename `otel.instrumentation.log4j-appender.experimental.capture-context-data-attributes` to `otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes`

Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9758