### PR TITLE
Implement forEach support for aws sqs tracing list

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/TracingList.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/TracingList.java
@@ -13,6 +13,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 
 class TracingList extends SdkInternalList<Message> {
   private static final long serialVersionUID = 1L;
@@ -55,6 +56,13 @@ class TracingList extends SdkInternalList<Message> {
     }
 
     return it;
+  }
+
+  @Override
+  public void forEach(Consumer<? super Message> action) {
+    for (Message message : this) {
+      action.accept(message);
+    }
   }
 
   private static boolean inAwsClient() {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.groovy
@@ -68,8 +68,15 @@ abstract class AbstractSqsTracingTest extends InstrumentationSpecification {
       receiveMessageRequest.withMessageAttributeNames("test-message-header")
     }
     def receiveMessageResult = client.receiveMessage(receiveMessageRequest)
-    receiveMessageResult.messages.each {message ->
-      runWithSpan("process child") {}
+    // test different ways of iterating the messages list
+    if (testCaptureHeaders) {
+      receiveMessageResult.messages.each { message ->
+        runWithSpan("process child") {}
+      }
+    } else {
+      receiveMessageResult.messages.forEach { message ->
+        runWithSpan("process child") {}
+      }
     }
 
     then:

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/TracingList.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/TracingList.java
@@ -10,6 +10,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.services.sqs.model.Message;
 
@@ -58,5 +59,12 @@ class TracingList extends ArrayList<Message> {
     }
 
     return it;
+  }
+
+  @Override
+  public void forEach(Consumer<? super Message> action) {
+    for (Message message : this) {
+      action.accept(message);
+    }
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/groovy/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.groovy
@@ -300,7 +300,8 @@ abstract class AbstractAws2SqsTracingTest extends InstrumentationSpecification {
 
     then:
     resp.messages.size() == 1
-    resp.messages.each {message -> runWithSpan("process child") {}}
+    // using forEach instead of each here to test different ways of iterating messages list
+    resp.messages.forEach {message -> runWithSpan("process child") {}}
     assertSqsTraces(false, true)
   }
 


### PR DESCRIPTION
Currently we only handle the `iterator` method, this pr also adds handling for the `forEach` method. Similar change isn't needed for the kafka tracing list because it does not extend `ArrayList` and the default implementation of `forEach` already uses the iterator.