### PR TITLE
Add elasticsearch-api-client as instrumentation name to elasticsearch-api-client-7.16

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/apiclient/ElasticsearchApiClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/apiclient/ElasticsearchApiClientInstrumentationModule.java
@@ -18,7 +18,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(InstrumentationModule.class)
 public class ElasticsearchApiClientInstrumentationModule extends InstrumentationModule {
   public ElasticsearchApiClientInstrumentationModule() {
-    super("elasticsearch-api-client-7.16", "elasticsearch");
+    super("elasticsearch-api-client", "elasticsearch-api-client-7.16", "elasticsearch");
   }
 
   @Override


### PR DESCRIPTION
Usually the main instrumentation name is without the version number