### PR TITLE
Resolve `ParameterNameDiscoverer` Bean Conflict in `spring-boot-autoconfigure`

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/instrumentation/annotations/InstrumentationAnnotationsAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/instrumentation/annotations/InstrumentationAnnotationsAutoConfiguration.java
@@ -10,7 +10,6 @@ import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,25 +22,19 @@ import org.springframework.core.ParameterNameDiscoverer;
 @ConditionalOnProperty(name = "otel.instrumentation.annotations.enabled", matchIfMissing = true)
 @Configuration
 public class InstrumentationAnnotationsAutoConfiguration {
-
-  @Bean
-  @ConditionalOnMissingBean
-  ParameterNameDiscoverer parameterNameDiscoverer() {
-    return new DefaultParameterNameDiscoverer();
-  }
+  private final ParameterNameDiscoverer parameterNameDiscoverer =
+      new DefaultParameterNameDiscoverer();
 
   @Bean
   @ConditionalOnClass(WithSpan.class)
-  InstrumentationWithSpanAspect otelInstrumentationWithSpanAspect(
-      OpenTelemetry openTelemetry, ParameterNameDiscoverer parameterNameDiscoverer) {
+  InstrumentationWithSpanAspect otelInstrumentationWithSpanAspect(OpenTelemetry openTelemetry) {
     return new InstrumentationWithSpanAspect(openTelemetry, parameterNameDiscoverer);
   }
 
   @Bean
   @SuppressWarnings("deprecation") // instrumenting deprecated class for backwards compatibility
   @ConditionalOnClass(io.opentelemetry.extension.annotations.WithSpan.class)
-  SdkExtensionWithSpanAspect otelSdkExtensionWithSpanAspect(
-      OpenTelemetry openTelemetry, ParameterNameDiscoverer parameterNameDiscoverer) {
+  SdkExtensionWithSpanAspect otelSdkExtensionWithSpanAspect(OpenTelemetry openTelemetry) {
     return new SdkExtensionWithSpanAspect(openTelemetry, parameterNameDiscoverer);
   }
 }


### PR DESCRIPTION
This update addresses a conflict arising in the `spring-boot-autoconfigure` project when using `opentelemetry-spring-boot-starter` and other projects which use the `ParameterNameDiscoverer` bean simultaneously, e.g. `springdoc-openapi-starter-webmvc-ui`.
The issue occurs due to the presence of multiple candidates for the `ParameterNameDiscoverer` object, leading to an injection conflict.

When both starters are used together, the application fails to start, displaying an error related to the ParameterNameDiscoverer object. This is due to the ambiguity in selecting the correct bean to inject, as multiple candidates are present.

Example of the error output:

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Parameter 1 of method otelInstrumentationWithSpanAspect in io.opentelemetry.instrumentation.spring.autoconfigure.instrumentation.annotations.InstrumentationAnnotationsAutoConfiguration required a single bean, but 2 were found:
        - parameterNameDiscoverer: defined by method 'parameterNameDiscoverer' in class path resource [io/opentelemetry/instrumentation/spring/autoconfigure/instrumentation/annotations/InstrumentationAnnotationsAutoConfiguration.class]
        - localSpringDocParameterNameDiscoverer: defined by method 'localSpringDocParameterNameDiscoverer' in class path resource [org/springdoc/core/configuration/SpringDocConfiguration.class]

Action:

Consider marking one of the beans as @Primary, updating the consumer to accept multiple beans, or using @Qualifier to identify the bean that should be consumed
```

~To resolve this issue, the `@Qualifier` annotation has been added to the ParameterNameDiscoverer bean within the spring-boot-autoconfigure project. This annotation assigns a unique label to the ParameterNameDiscoverer bean, ensuring that the project-specific bean is consistently chosen for injection, thereby eliminating the conflict.~

Update:
To resolve this issue, this commit defines the private static `ParameterNameDiscoverer` instance and use that directly instead of injection in `InstrumentationAnnotationsAutoConfiguration`.
