### PR TITLE
Clean up in spring scheduling tests

### DIFF
--- a/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
+++ b/instrumentation/spring/spring-scheduling-3.1/javaagent/src/test/groovy/SpringSchedulingTest.groovy
@@ -23,6 +23,9 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
     expect:
     assert task != null
     assertTraces(0) {}
+
+    cleanup:
+    context.close()
   }
 
   def "schedule trigger test according to cron expression"() {
@@ -47,6 +50,9 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
         }
       }
     }
+
+    cleanup:
+    context.close()
   }
 
   def "schedule interval test"() {
@@ -71,6 +77,9 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
         }
       }
     }
+
+    cleanup:
+    context.close()
   }
 
   def "schedule lambda test"() {
@@ -122,6 +131,9 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
         }
       }
     }
+
+    cleanup:
+    context.close()
   }
 
   def "task with error test"() {
@@ -159,5 +171,8 @@ class SpringSchedulingTest extends AgentInstrumentationSpecification {
         }
       }
     }
+
+    cleanup:
+    context.close()
   }
 }


### PR DESCRIPTION
https://ge.opentelemetry.io/s/37ip6vmf6cjgg/tests/task/:instrumentation:spring:spring-scheduling-3.1:javaagent:test/details/SpringSchedulingTest/task%20with%20error%20test?top-execution=1
`TriggerTask.run` span should be created by some other test, hopefully closing application context is enough to stop tests interfering with each other.