### PR TITLE
JMX metrics for Tomcat with 'Tomcat' JMX domain

### DIFF
--- a/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
+++ b/instrumentation/jmx-metrics/javaagent/src/main/resources/jmx/rules/tomcat.yaml
@@ -1,4 +1,8 @@
 ---
+# For Tomcat, the default JMX domain is "Catalina:", however with some deployments like embedded in spring-boot
+# we can have the "Tomcat:" domain used, thus we have to duplicate metrics definitions as using a wildcard
+# would match too broadly
+
 rules:
   - bean: Catalina:type=GlobalRequestProcessor,name=*
     unit: "1"
@@ -38,6 +42,45 @@ rules:
         desc: The number of bytes transmitted
         metricAttribute:
           direction: const(sent)
+  - bean: Tomcat:type=GlobalRequestProcessor,name=*
+    unit: "1"
+    prefix: http.server.tomcat.
+    metricAttribute:
+      name: param(name)
+    mapping:
+      errorCount:
+        metric: errorCount
+        type: gauge
+        desc: The number of errors per second on all request processors
+      requestCount:
+        metric: requestCount
+        type: gauge
+        desc: The number of requests per second across all request processors
+      maxTime:
+        metric: maxTime
+        type: gauge
+        unit: ms
+        desc: The longest request processing time
+      processingTime:
+        metric: processingTime
+        type: counter
+        unit: ms
+        desc: Total time for processing all requests
+      bytesReceived:
+        metric: traffic
+        type: counter
+        unit: By
+        desc: The number of bytes transmitted
+        metricAttribute:
+          direction: const(received)
+      bytesSent:
+        metric: traffic
+        type: counter
+        unit: By
+        desc: The number of bytes transmitted
+        metricAttribute:
+          direction: const(sent)
+
   - bean: Catalina:type=Manager,host=localhost,context=*
     unit: "1"
     prefix: http.server.tomcat.
@@ -48,7 +91,35 @@ rules:
       activeSessions:
         metric: sessions.activeSessions
         desc: The number of active sessions
+  - bean: Tomcat:type=Manager,host=localhost,context=*
+    unit: "1"
+    prefix: http.server.tomcat.
+    type: updowncounter
+    metricAttribute:
+      context: param(context)
+    mapping:
+      activeSessions:
+        metric: sessions.activeSessions
+        desc: The number of active sessions
+
   - bean: Catalina:type=ThreadPool,name=*
+    unit: "{threads}"
+    prefix: http.server.tomcat.
+    type: updowncounter
+    metricAttribute:
+      name: param(name)
+    mapping:
+      currentThreadCount:
+        metric: threads
+        desc: Thread Count of the Thread Pool
+        metricAttribute:
+          state: const(idle)
+      currentThreadsBusy:
+        metric: threads
+        desc: Thread Count of the Thread Pool
+        metricAttribute:
+          state: const(busy)
+  - bean: Tomcat:type=ThreadPool,name=*
     unit: "{threads}"
     prefix: http.server.tomcat.
     type: updowncounter


### PR DESCRIPTION
When using the JMX Insights feature with a spring-boot application, I noticed that the JMX metrics were not captured when setting `OTEL_JMX_TARGET_SYSTEM=tomcat`.

The problem is that the JMX MBeans are registered with `Tomcat` domain instead of `Catalina`, and thus the rules do not match.

With standalone tomcat servers (tested latest 8.5, 9.0.x and 10.x), the JMX domain is always `Catalina`. I am not an expert in Tomcat internals but this comes from the implementation of `org.apache.catalina.util.LifecycleMBeanBase#getDomain` that returns any sub-class implementation of `org.apache.catalina.util.LifecycleMBeanBase#getDomainInternal` and falls back to `Catalina`.

Searching for the `Tomcat:` string in the Tomcat codebase seems to indicate that this is quite a common value, for example [here in tests](https://github.com/apache/tomcat/blob/11fb662af9f8e26290be5c881b5a6837157894e7/test/org/apache/catalina/mbeans/TestRegistration.java#L65).

While we could use a wildcard in the rules for the JMX domain, for example `*:type=GlobalRequestProcessor,name=*` in place of `Catalina:type=GlobalRequestProcessor,name=*`, that might also introduce false-positives if other application servers also have similar named MBeans, thus duplication sounds the best compromize here.