### PR TITLE
Fix typo in logging framework instrumentation readme

### DIFF
--- a/instrumentation/java-util-logging/javaagent/README.md
+++ b/instrumentation/java-util-logging/javaagent/README.md
@@ -1,5 +1,5 @@
 # Settings for the Java Util Logging instrumentation
 
-| System property                                                      | Type    | Default | Description                                                                       |
-| -------------------------------------------------------------------- | ------- | ------- | --------------------------------------------------------------------------------- |
-| `otel.instrumentation.java-util-logging.experimental-log-attributes` | Boolean | `false` | Enable the capture of experimental span attributes `thread.name` and `thread.id`. |
+| System property                                                      | Type    | Default | Description                                                                      |
+| -------------------------------------------------------------------- | ------- | ------- |----------------------------------------------------------------------------------|
+| `otel.instrumentation.java-util-logging.experimental-log-attributes` | Boolean | `false` | Enable the capture of experimental log attributes `thread.name` and `thread.id`. |

--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/README.md
@@ -1,8 +1,8 @@
 # Settings for the Log4j Appender instrumentation
 
 | System property                                                                    | Type    | Default | Description                                                                                                           |
-| ---------------------------------------------------------------------------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
-| `otel.instrumentation.log4j-appender.experimental-log-attributes`                  | Boolean | `false` | Enable the capture of experimental span attributes `thread.name` and `thread.id`.                                     |
+| ---------------------------------------------------------------------------------- | ------- | ------- |-----------------------------------------------------------------------------------------------------------------------|
+| `otel.instrumentation.log4j-appender.experimental-log-attributes`                  | Boolean | `false` | Enable the capture of experimental log attributes `thread.name` and `thread.id`.                                      |
 | `otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes`  | Boolean | `false` | Enable the capture of `MapMessage` attributes.                                                                        |
 | `otel.instrumentation.log4j-appender.experimental.capture-marker-attribute`        | Boolean | `false` | Enable the capture of Log4j markers as attributes.                                                                    |
 | `otel.instrumentation.log4j-appender.experimental.capture-context-data-attributes` | String  |         | Comma separated list of context data attributes to capture. Use the wildcard character `*` to capture all attributes. |

--- a/instrumentation/log4j/log4j-appender-2.17/library/README.md
+++ b/instrumentation/log4j/log4j-appender-2.17/library/README.md
@@ -93,12 +93,12 @@ Setting can be configured as XML attributes, for example:
 
 The available settings are:
 
-| XML Attribute                   | Type    | Default | Description                                                                                                                                                                                                |
-|---------------------------------|---------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `captureExperimentalAttributes` | Boolean | `false` | Enable the capture of experimental span attributes `thread.name` and `thread.id`.                                                                                                                          |
-| `captureMapMessageAttributes`   | Boolean | `false` | Enable the capture of `MapMessage` attributes.                                                                                                                                                             |
-| `captureMarkerAttribute;`       | Boolean | `false` | Enable the capture of Log4j markers as attributes.                                                                                                                                                         |
-| `captureContextDataAttributes`  | String  |         | Comma separated list of context data attributes to capture. Use the wildcard character `*` to capture all attributes.                                                                                      |
-| `numLogsCapturedBeforeOtelInstall`            | Integer | 1000    | Log telemetry is emitted after the initialization of the OpenTelemetry Log4j appender with an OpenTelemetry object. This setting allows you to modify the size of the cache used to replay the first logs. |
+| XML Attribute                      | Type    | Default | Description                                                                                                                                                                                                |
+|------------------------------------|---------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `captureExperimentalAttributes`    | Boolean | `false` | Enable the capture of experimental log attributes `thread.name` and `thread.id`.                                                                                                                           |
+| `captureMapMessageAttributes`      | Boolean | `false` | Enable the capture of `MapMessage` attributes.                                                                                                                                                             |
+| `captureMarkerAttribute;`          | Boolean | `false` | Enable the capture of Log4j markers as attributes.                                                                                                                                                         |
+| `captureContextDataAttributes`     | String  |         | Comma separated list of context data attributes to capture. Use the wildcard character `*` to capture all attributes.                                                                                      |
+| `numLogsCapturedBeforeOtelInstall` | Integer | 1000    | Log telemetry is emitted after the initialization of the OpenTelemetry Log4j appender with an OpenTelemetry object. This setting allows you to modify the size of the cache used to replay the first logs. |
 
 [source code attributes]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attributes.md#source-code-attributes


### PR DESCRIPTION
replace `span attributes` with `log attributes`