### PR TITLE
update sqs and sns attributes for camel tests

### DIFF
--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsConnector.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsConnector.java
@@ -18,6 +18,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.SetBucketNotificationConfigurationRequest;
 import com.amazonaws.services.sns.AmazonSNSAsyncClient;
 import com.amazonaws.services.sns.model.CreateTopicResult;
+import com.amazonaws.services.sns.model.PublishRequest;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
 import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
 import com.amazonaws.services.sqs.model.Message;
@@ -160,7 +161,7 @@ class AwsConnector {
   }
 
   void publishSampleNotification(String topicArn) {
-    snsClient.publish(topicArn, "Hello There");
+    snsClient.publish(new PublishRequest().withMessage("Hello There").withTopicArn(topicArn));
   }
 
   String createTopicAndSubscribeQueue(String topicName, String queueArn) {

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/AwsSpanAssertions.java
@@ -128,7 +128,7 @@ class AwsSpanAssertions {
                         v -> val.isInstanceOf(Number.class), v -> assertThat(v).isNull())));
   }
 
-  static SpanDataAssert sns(SpanDataAssert span, String spanName) {
+  static SpanDataAssert sns(SpanDataAssert span, String spanName, String topicArn) {
     return span.hasName(spanName)
         .hasKind(CLIENT)
         .hasAttributesSatisfyingExactly(
@@ -137,6 +137,7 @@ class AwsSpanAssertions {
             equalTo(stringKey("rpc.system"), "aws-api"),
             equalTo(stringKey("rpc.method"), spanName.substring(4)),
             equalTo(stringKey("rpc.service"), "AmazonSNS"),
+            equalTo(SemanticAttributes.MESSAGING_DESTINATION_NAME, topicArn),
             equalTo(SemanticAttributes.HTTP_REQUEST_METHOD, "POST"),
             equalTo(SemanticAttributes.HTTP_RESPONSE_STATUS_CODE, 200),
             satisfies(SemanticAttributes.URL_FULL, val -> val.isInstanceOf(String.class)),

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/S3CamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachecamel/aws/S3CamelTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachecamel.aws;
 
-import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 
 import com.amazonaws.services.sqs.model.PurgeQueueInProgressException;
@@ -70,17 +69,12 @@ class S3CamelTest {
                     AwsSpanAssertions.s3(span, "S3.PutObject", bucketName, "PUT")
                         .hasParent(trace.getSpan(1)),
                 span ->
-                    AwsSpanAssertions.sqs(span, "SQS.ReceiveMessage", queueUrl, null, CONSUMER)
+                    AwsSpanAssertions.sqs(
+                            span, "s3SqsCamelTest process", queueUrl, queueName, CONSUMER)
                         .hasParent(trace.getSpan(2)),
                 span ->
                     CamelSpanAssertions.sqsConsume(span, queueName, sqsDelay)
                         .hasParent(trace.getSpan(2))),
-        // HTTP "client" receiver span, one per each SQS request
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    AwsSpanAssertions.sqs(span, "SQS.ReceiveMessage", queueUrl, null, CLIENT)
-                        .hasNoParent()),
         // camel cleaning received msg
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -137,11 +131,9 @@ class S3CamelTest {
                         .hasNoParent()),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sqs(span, "SQS.ReceiveMessage", queueUrl).hasNoParent()),
-        trace ->
-            trace.hasSpansSatisfyingExactly(
                 span ->
-                    AwsSpanAssertions.sqs(span, "SQS.ReceiveMessage", queueUrl, null, CONSUMER)
+                    AwsSpanAssertions.sqs(
+                            span, "s3SqsCamelTest process", queueUrl, queueName, CONSUMER)
                         .hasNoParent()));
     testing.clearData();
   }


### PR DESCRIPTION
Some recent PR's have changed some of the SQS/SNS functionality. This PR updates the camel aws integration tests that are disabled by default as they require AWS resources to run.

The related PRs are:
- #10096  (SNS)
- #9796 (SQS)

Since the build won't test these, here are screenshots from running them locally:

<img width="441" alt="Screenshot 2024-01-04 at 7 25 51 AM" src="https://github.com/open-telemetry/opentelemetry-java-instrumentation/assets/7630696/01accd20-f544-4ace-8b0f-f5ab1028cc8e">
<img width="444" alt="Screenshot 2024-01-04 at 7 18 08 AM" src="https://github.com/open-telemetry/opentelemetry-java-instrumentation/assets/7630696/624ad82e-50ad-404b-81dd-bd1e961fffe0">


