### PR TITLE
Add back link check for central.sonatype.com

### DIFF
--- a/.github/scripts/markdown-link-check-config.json
+++ b/.github/scripts/markdown-link-check-config.json
@@ -19,9 +19,6 @@
     },
     {
       "pattern": "^https://micrometer\\.io"
-    },
-    {
-      "pattern": "^https://central\\.sonatype\\.com"
     }
   ]
 }


### PR DESCRIPTION
Checking for `central.sonatype.com` links was disabled in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10172