### PR TITLE
Don't set metrics exporter to otlp for tests

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-testing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-testing.gradle.kts
@@ -85,7 +85,6 @@ class JavaagentTestArgumentsProvider(
     // Reduce noise in assertion messages since we don't need to verify this in most tests. We check
     // in smoke tests instead.
     "-Dotel.javaagent.add-thread-details=false",
-    "-Dotel.metrics.exporter=otlp",
     "-Dotel.javaagent.experimental.indy=${findProperty("testIndy") == "true"}",
     // suppress repeated logging of "No metric data to export - skipping export."
     // since PeriodicMetricReader is configured with a short interval

--- a/examples/distro/gradle/instrumentation.gradle
+++ b/examples/distro/gradle/instrumentation.gradle
@@ -52,7 +52,6 @@ tasks.withType(Test).configureEach {
   jvmArgs "-Dotel.javaagent.testing.fail-on-context-leak=true"
   // prevent sporadic gradle deadlocks, see SafeLogger for more details
   jvmArgs "-Dotel.javaagent.testing.transform-safe-logging.enabled=true"
-  jvmArgs "-Dotel.metrics.exporter=otlp"
 
   dependsOn shadowJar
   dependsOn configurations.testAgent.buildDependencies

--- a/testing/agent-for-testing/build.gradle.kts
+++ b/testing/agent-for-testing/build.gradle.kts
@@ -44,7 +44,6 @@ tasks {
   afterEvaluate {
     withType<Test>().configureEach {
       jvmArgs("-Dotel.javaagent.debug=true")
-      jvmArgs("-Dotel.metrics.exporter=otlp")
 
       jvmArgumentProviders.add(JavaagentProvider(jar.flatMap { it.archiveFile }))
     }


### PR DESCRIPTION
Setting it to otlp overrides the none set in the agent testing extension. This causes the failed to export metrics warnings in the test output.