### PR TITLE
Honor default enabled for instrumentation modules

### DIFF
--- a/instrumentation/internal/internal-application-logger/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/logging/ApplicationLoggingInstrumentationModule.java
+++ b/instrumentation/internal/internal-application-logger/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/logging/ApplicationLoggingInstrumentationModule.java
@@ -23,7 +23,8 @@ public class ApplicationLoggingInstrumentationModule extends InstrumentationModu
   @Override
   public boolean defaultEnabled(ConfigProperties config) {
     // only enable this instrumentation if the application logger is enabled
-    return "application".equals(config.getString("otel.javaagent.logging"));
+    return super.defaultEnabled(config)
+        && "application".equals(config.getString("otel.javaagent.logging"));
   }
 
   @Override

--- a/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxrsInstrumentationModule.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v1_0/JaxrsInstrumentationModule.java
@@ -39,6 +39,6 @@ public class JaxrsInstrumentationModule extends InstrumentationModule {
     // This instrumentation produces controller telemetry and sets http route. Http route is set by
     // this instrumentation only when it was not already set by a jax-rs framework instrumentation.
     // This instrumentation uses complex type matcher, disabling it can improve startup performance.
-    return ExperimentalConfig.get().controllerTelemetryEnabled();
+    return super.defaultEnabled(config) && ExperimentalConfig.get().controllerTelemetryEnabled();
   }
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsAnnotationsInstrumentationModule.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/JaxrsAnnotationsInstrumentationModule.java
@@ -42,6 +42,6 @@ public class JaxrsAnnotationsInstrumentationModule extends InstrumentationModule
     // This instrumentation produces controller telemetry and sets http route. Http route is set by
     // this instrumentation only when it was not already set by a jax-rs framework instrumentation.
     // This instrumentation uses complex type matcher, disabling it can improve startup performance.
-    return ExperimentalConfig.get().controllerTelemetryEnabled();
+    return super.defaultEnabled(config) && ExperimentalConfig.get().controllerTelemetryEnabled();
   }
 }

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/JaxrsAnnotationsInstrumentationModule.java
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/JaxrsAnnotationsInstrumentationModule.java
@@ -42,6 +42,6 @@ public class JaxrsAnnotationsInstrumentationModule extends InstrumentationModule
     // This instrumentation produces controller telemetry and sets http route. Http route is set by
     // this instrumentation only when it was not already set by a jax-rs framework instrumentation.
     // This instrumentation uses complex type matcher, disabling it can improve startup performance.
-    return ExperimentalConfig.get().controllerTelemetryEnabled();
+    return super.defaultEnabled(config) && ExperimentalConfig.get().controllerTelemetryEnabled();
   }
 }

--- a/instrumentation/jaxws/jaxws-jws-api-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/jws/v1_1/JwsInstrumentationModule.java
+++ b/instrumentation/jaxws/jaxws-jws-api-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxws/jws/v1_1/JwsInstrumentationModule.java
@@ -28,6 +28,6 @@ public class JwsInstrumentationModule extends InstrumentationModule {
   @Override
   public boolean defaultEnabled(ConfigProperties config) {
     // this instrumentation only produces controller telemetry
-    return ExperimentalConfig.get().controllerTelemetryEnabled();
+    return super.defaultEnabled(config) && ExperimentalConfig.get().controllerTelemetryEnabled();
   }
 }

--- a/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/v2_0/SpringWsInstrumentationModule.java
+++ b/instrumentation/spring/spring-ws-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/ws/v2_0/SpringWsInstrumentationModule.java
@@ -27,6 +27,6 @@ public class SpringWsInstrumentationModule extends InstrumentationModule {
   @Override
   public boolean defaultEnabled(ConfigProperties config) {
     // this instrumentation only produces controller telemetry
-    return ExperimentalConfig.get().controllerTelemetryEnabled();
+    return super.defaultEnabled(config) && ExperimentalConfig.get().controllerTelemetryEnabled();
   }
 }


### PR DESCRIPTION
Call `super.defaultEnabled(config)` so that `otel.instrumentation.common.default-enabled` flag would also be used.