### PR TITLE
Don't append signal path to signal specific endpoint

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpExporterUtil.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpExporterUtil.java
@@ -44,15 +44,15 @@ class OtlpExporterUtil {
     String endpoint = signalProperties.getEndpoint();
     if (endpoint == null) {
       endpoint = properties.getEndpoint();
-    }
-    if (endpoint != null) {
-      if (isHttpProtobuf) {
+      if (endpoint != null && isHttpProtobuf) {
         if (!endpoint.endsWith("/")) {
           endpoint += "/";
         }
         endpoint += signalPath(dataType);
       }
+    }
 
+    if (endpoint != null) {
       if (isHttpProtobuf) {
         setHttpEndpoint.accept(httpBuilder, endpoint);
       } else {


### PR DESCRIPTION
Having user specify the full endpoint when specifying a signal specific endpoint is more in line with what sdk autoconfigure does and allows signal specific endpoints to have non standard paths.