### PR TITLE
Fix Calling shutdown() multiple times warning in spring starter

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
@@ -76,7 +76,7 @@ public class OpenTelemetryAutoConfiguration {
       return new MapConverter();
     }
 
-    @Bean(destroyMethod = "")
+    @Bean(destroyMethod = "") // SDK components are shutdown from the OpenTelemetry instance
     @ConditionalOnMissingBean
     public SdkTracerProvider sdkTracerProvider(
         SamplerProperties samplerProperties,
@@ -94,7 +94,7 @@ public class OpenTelemetryAutoConfiguration {
           .build();
     }
 
-    @Bean(destroyMethod = "")
+    @Bean(destroyMethod = "") // SDK components are shutdown from the OpenTelemetry instance
     @ConditionalOnMissingBean
     public SdkLoggerProvider sdkLoggerProvider(
         ObjectProvider<List<LogRecordExporter>> loggerExportersProvider, Resource otelResource) {
@@ -112,7 +112,7 @@ public class OpenTelemetryAutoConfiguration {
       return loggerProviderBuilder.build();
     }
 
-    @Bean(destroyMethod = "")
+    @Bean(destroyMethod = "") // SDK components are shutdown from the OpenTelemetry instance
     @ConditionalOnMissingBean
     public SdkMeterProvider sdkMeterProvider(
         MetricExportProperties properties,

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
@@ -76,7 +76,7 @@ public class OpenTelemetryAutoConfiguration {
       return new MapConverter();
     }
 
-    @Bean
+    @Bean(destroyMethod = "")
     @ConditionalOnMissingBean
     public SdkTracerProvider sdkTracerProvider(
         SamplerProperties samplerProperties,
@@ -94,7 +94,7 @@ public class OpenTelemetryAutoConfiguration {
           .build();
     }
 
-    @Bean
+    @Bean(destroyMethod = "")
     @ConditionalOnMissingBean
     public SdkLoggerProvider sdkLoggerProvider(
         ObjectProvider<List<LogRecordExporter>> loggerExportersProvider, Resource otelResource) {
@@ -112,7 +112,7 @@ public class OpenTelemetryAutoConfiguration {
       return loggerProviderBuilder.build();
     }
 
-    @Bean
+    @Bean(destroyMethod = "")
     @ConditionalOnMissingBean
     public SdkMeterProvider sdkMeterProvider(
         MetricExportProperties properties,

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingMetricExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingMetricExporterAutoConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(LoggingMetricExporter.class)
 public class LoggingMetricExporterAutoConfiguration {
 
-  @Bean(destroyMethod = "")
+  @Bean(destroyMethod = "") // SDK components are shutdown from the OpenTelemetry instance
   public LoggingMetricExporter otelLoggingMetricExporter() {
     return LoggingMetricExporter.create();
   }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingMetricExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingMetricExporterAutoConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(LoggingMetricExporter.class)
 public class LoggingMetricExporterAutoConfiguration {
 
-  @Bean
+  @Bean(destroyMethod = "")
   public LoggingMetricExporter otelLoggingMetricExporter() {
     return LoggingMetricExporter.create();
   }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(LoggingSpanExporter.class)
 public class LoggingSpanExporterAutoConfiguration {
 
-  @Bean(destroyMethod = "")
+  @Bean(destroyMethod = "") // SDK components are shutdown from the OpenTelemetry instance
   @ConditionalOnMissingBean
   public LoggingSpanExporter otelLoggingSpanExporter() {
     return LoggingSpanExporter.create();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/logging/LoggingSpanExporterAutoConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(LoggingSpanExporter.class)
 public class LoggingSpanExporterAutoConfiguration {
 
-  @Bean
+  @Bean(destroyMethod = "")
   @ConditionalOnMissingBean
   public LoggingSpanExporter otelLoggingSpanExporter() {
     return LoggingSpanExporter.create();

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpLoggerExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpLoggerExporterAutoConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Conditional;
 @ConditionalOnClass(OtlpGrpcLogRecordExporter.class)
 public class OtlpLoggerExporterAutoConfiguration {
 
-  @Bean
+  @Bean(destroyMethod = "")
   @ConditionalOnMissingBean({OtlpGrpcLogRecordExporter.class, OtlpHttpLogRecordExporter.class})
   public LogRecordExporter otelOtlpLogRecordExporter(OtlpExporterProperties properties) {
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpLoggerExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpLoggerExporterAutoConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Conditional;
 @ConditionalOnClass(OtlpGrpcLogRecordExporter.class)
 public class OtlpLoggerExporterAutoConfiguration {
 
-  @Bean(destroyMethod = "")
+  @Bean(destroyMethod = "") // SDK components are shutdown from the OpenTelemetry instance
   @ConditionalOnMissingBean({OtlpGrpcLogRecordExporter.class, OtlpHttpLogRecordExporter.class})
   public LogRecordExporter otelOtlpLogRecordExporter(OtlpExporterProperties properties) {
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpMetricExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpMetricExporterAutoConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(OtlpGrpcMetricExporter.class)
 public class OtlpMetricExporterAutoConfiguration {
 
-  @Bean(destroyMethod = "")
+  @Bean(destroyMethod = "") // SDK components are shutdown from the OpenTelemetry instance
   @ConditionalOnMissingBean({OtlpGrpcMetricExporter.class, OtlpHttpMetricExporter.class})
   public MetricExporter otelOtlpMetricExporter(OtlpExporterProperties properties) {
     return OtlpExporterUtil.applySignalProperties(

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpMetricExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpMetricExporterAutoConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(OtlpGrpcMetricExporter.class)
 public class OtlpMetricExporterAutoConfiguration {
 
-  @Bean
+  @Bean(destroyMethod = "")
   @ConditionalOnMissingBean({OtlpGrpcMetricExporter.class, OtlpHttpMetricExporter.class})
   public MetricExporter otelOtlpMetricExporter(OtlpExporterProperties properties) {
     return OtlpExporterUtil.applySignalProperties(

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpSpanExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpSpanExporterAutoConfiguration.java
@@ -41,7 +41,7 @@ public class OtlpSpanExporterAutoConfiguration {
     return OtlpHttpSpanExporter.builder();
   }
 
-  @Bean
+  @Bean(destroyMethod = "")
   @ConditionalOnMissingBean({OtlpGrpcSpanExporter.class, OtlpHttpSpanExporter.class})
   public SpanExporter otelOtlpSpanExporter(
       OtlpExporterProperties properties, OtlpHttpSpanExporterBuilder otlpHttpSpanExporterBuilder) {

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpSpanExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpSpanExporterAutoConfiguration.java
@@ -41,7 +41,7 @@ public class OtlpSpanExporterAutoConfiguration {
     return OtlpHttpSpanExporter.builder();
   }
 
-  @Bean(destroyMethod = "")
+  @Bean(destroyMethod = "") // SDK components are shutdown from the OpenTelemetry instance
   @ConditionalOnMissingBean({OtlpGrpcSpanExporter.class, OtlpHttpSpanExporter.class})
   public SpanExporter otelOtlpSpanExporter(
       OtlpExporterProperties properties, OtlpHttpSpanExporterBuilder otlpHttpSpanExporterBuilder) {

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(ZipkinSpanExporter.class)
 public class ZipkinSpanExporterAutoConfiguration {
 
-  @Bean(destroyMethod = "")
+  @Bean(destroyMethod = "") // SDK components are shutdown from the OpenTelemetry instance
   @ConditionalOnMissingBean
   public ZipkinSpanExporter otelZipkinSpanExporter(ZipkinSpanExporterProperties properties) {
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/zipkin/ZipkinSpanExporterAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(ZipkinSpanExporter.class)
 public class ZipkinSpanExporterAutoConfiguration {
 
-  @Bean
+  @Bean(destroyMethod = "")
   @ConditionalOnMissingBean
   public ZipkinSpanExporter otelZipkinSpanExporter(ZipkinSpanExporterProperties properties) {
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfigurationTest.java
@@ -75,13 +75,18 @@ class OpenTelemetryAutoConfigurationTest {
         .withBean(
             "customTracerProvider",
             SdkTracerProvider.class,
-            () -> SdkTracerProvider.builder().build())
+            () -> SdkTracerProvider.builder().build(),
+            bd -> bd.setDestroyMethodName(""))
         .withBean(
-            "customMeterProvider", SdkMeterProvider.class, () -> SdkMeterProvider.builder().build())
+            "customMeterProvider",
+            SdkMeterProvider.class,
+            () -> SdkMeterProvider.builder().build(),
+            bd -> bd.setDestroyMethodName(""))
         .withBean(
             "customLoggerProvider",
             SdkLoggerProvider.class,
-            () -> SdkLoggerProvider.builder().build())
+            () -> SdkLoggerProvider.builder().build(),
+            bd -> bd.setDestroyMethodName(""))
         .withConfiguration(AutoConfigurations.of(OpenTelemetryAutoConfiguration.class))
         .run(
             context ->

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpSpanExporterAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/exporters/otlp/OtlpSpanExporterAutoConfigurationTest.java
@@ -155,7 +155,10 @@ class OtlpSpanExporterAutoConfigurationTest {
   @DisplayName("logging exporter can still be configured")
   void loggingExporter() {
     this.contextRunner
-        .withBean(LoggingSpanExporter.class, LoggingSpanExporter::create)
+        .withBean(
+            LoggingSpanExporter.class,
+            LoggingSpanExporter::create,
+            bd -> bd.setDestroyMethodName(""))
         .run(
             context ->
                 assertThat(


### PR DESCRIPTION
While running tests I noticed the following warnings
```
Jan 12, 2024 9:56:04 AM io.opentelemetry.sdk.metrics.SdkMeterProvider shutdown
INFO: Multiple close calls
Jan 12, 2024 9:56:04 AM io.opentelemetry.sdk.logs.SdkLoggerProvider shutdown
INFO: Calling shutdown() multiple times.
Jan 12, 2024 9:56:04 AM io.opentelemetry.sdk.trace.SdkTracerProvider shutdown
INFO: Calling shutdown() multiple times.
```
these happen because all these providers are closed when `OpenTelemetrySdk` is close and as these providers implement `AutoCloseable` spring calls close for each of them once more. This pr prevents spring's `AutoCloseable` handling on the beans that are shut down along with the `OpenTelemetrySdk`.