### PR TITLE
update JDK to 21 and test latest versions of web servers

### DIFF
--- a/.github/workflows/pr-smoke-test-play-images.yml
+++ b/.github/workflows/pr-smoke-test-play-images.yml
@@ -15,4 +15,4 @@ jobs:
       # Play doesn't support Java 16+ yet
       # https://github.com/playframework/playframework/pull/10819
       skip-java-17: true
-      skip-java-19: true
+      skip-java-21: true

--- a/.github/workflows/publish-smoke-test-play-images.yml
+++ b/.github/workflows/publish-smoke-test-play-images.yml
@@ -18,7 +18,7 @@ jobs:
       # Play doesn't support Java 16+ yet
       # https://github.com/playframework/playframework/pull/10819
       skip-java-17: true
-      skip-java-19: true
+      skip-java-21: true
 
   workflow-notification:
     needs:

--- a/.github/workflows/reusable-smoke-test-images.yml
+++ b/.github/workflows/reusable-smoke-test-images.yml
@@ -18,7 +18,7 @@ on:
       skip-java-17:
         type: boolean
         required: false
-      skip-java-19:
+      skip-java-21:
         type: boolean
         required: false
 
@@ -64,6 +64,6 @@ jobs:
         if: "!inputs.skip-java-17"
         run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -Ptag=${{ env.TAG }} -PtargetJDK=17 -Djib.httpTimeout=120000 -Djib.console=plain
 
-      - name: Build Java 19 Docker image
-        if: "!inputs.skip-java-19"
-        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -Ptag=${{ env.TAG }} -PtargetJDK=19 -Djib.httpTimeout=120000 -Djib.console=plain
+      - name: Build Java 21 Docker image
+        if: "!inputs.skip-java-21"
+        run: ./gradlew ${{ inputs.project }}:${{ inputs.publish && 'jib' || 'jibDockerBuild' }} -Ptag=${{ env.TAG }} -PtargetJDK=21 -Djib.httpTimeout=120000 -Djib.console=plain

--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -24,10 +24,10 @@ val extraTag = findProperty("extraTag")
 // Dockerfile name, args key passes raw arguments to docker build
 val targets = mapOf(
   "jetty" to listOf(
-    ImageTarget(listOf("9.4.53"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21"), mapOf("sourceVersion" to "9.4.51.v20230217")),
-    ImageTarget(listOf("10.0.19"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), mapOf("sourceVersion" to "10.0.7")),
-    ImageTarget(listOf("11.0.19"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), mapOf("sourceVersion" to "11.0.7"), "servlet-5.0"),
-    ImageTarget(listOf("12.0.5"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), mapOf("sourceVersion" to "12.0.5")),
+    ImageTarget(listOf("9.4.53"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21"), mapOf("sourceVersion" to "9.4.53.v20231009")),
+    ImageTarget(listOf("10.0.19"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), mapOf("sourceVersion" to "10.0.19")),
+    ImageTarget(listOf("11.0.19"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), mapOf("sourceVersion" to "11.0.19"), "servlet-5.0"),
+//    ImageTarget(listOf("12.0.5"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), mapOf("sourceVersion" to "12.0.5")), //enable once Jetty 12 is supported
   ),
   "liberty" to listOf(
     ImageTarget(listOf("20.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11"), mapOf("release" to "2020-11-11_0736")),
@@ -35,11 +35,11 @@ val targets = mapOf(
     // Java 19 is not supported until 22.0.0.10
     ImageTarget(listOf("22.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17"), mapOf("release" to "22.0.0.12")),
     // Java 21 is not supported until 23.0.0.3
-    ImageTarget(listOf("23.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21"), mapOf("release" to "23.0.0.3")),
+    ImageTarget(listOf("23.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21"), mapOf("release" to "23.0.0.12")),
   ),
   "payara" to listOf(
     ImageTarget(listOf("5.2020.6", "5.2021.8"), listOf("hotspot", "openj9"), listOf("8", "11")),
-    ImageTarget(listOf("6.2024.1"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), war = "servlet-5.0")
+    ImageTarget(listOf("6.2023.12"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), war = "servlet-5.0")
   ),
   "tomcat" to listOf(
     ImageTarget(listOf("7.0.109"), listOf("hotspot", "openj9"), listOf("8"), mapOf("majorVersion" to "7")),
@@ -158,7 +158,13 @@ fun configureImage(
       // ibm-semeru-runtimes doesn't publish windows images
       throw GradleException("Unexpected vm: $vm")
     } else {
-      "ibm-semeru-runtimes:open-$jdk-jdk"
+      // looks like 21 is coming soon https://github.com/ibmruntimes/semeru-containers/commit/03eeaa90a3e9ae742bbdeeb9bf893b8d506f9e32#diff-e91d84b927d0b95d9682c441b44a7ed83afc726e8a31840955cc4a0fd97de17c
+      // remove this workaround once it's published
+      if (jdk == "21") {
+        "ibm-semeru-runtimes:open-20-jdk"
+      } else {
+        "ibm-semeru-runtimes:open-$jdk-jdk"
+      }
     }
   } else {
     throw GradleException("Unexpected vm: $vm")

--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -35,7 +35,7 @@ val targets = mapOf(
     // Java 19 is not supported until 22.0.0.10
     ImageTarget(listOf("22.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17"), mapOf("release" to "22.0.0.12")),
     // Java 21 is not supported until 23.0.0.3
-    ImageTarget(listOf("23.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21"), mapOf("release" to "23.0.0.12")),
+    ImageTarget(listOf("23.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "20"), mapOf("release" to "23.0.0.12")),
   ),
   "payara" to listOf(
     ImageTarget(listOf("5.2020.6", "5.2021.8"), listOf("hotspot", "openj9"), listOf("8", "11")),

--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -24,54 +24,43 @@ val extraTag = findProperty("extraTag")
 // Dockerfile name, args key passes raw arguments to docker build
 val targets = mapOf(
   "jetty" to listOf(
-    ImageTarget(listOf("9.4.51"), listOf("hotspot"), listOf("8", "11", "17", "20", "21"), mapOf("sourceVersion" to "9.4.51.v20230217")),
-    ImageTarget(listOf("9.4.51"), listOf("openj9"), listOf("8", "11", "17", "18"), mapOf("sourceVersion" to "9.4.51.v20230217")),
-    ImageTarget(listOf("10.0.15"), listOf("hotspot"), listOf("11", "17", "20", "21"), mapOf("sourceVersion" to "10.0.7")),
-    ImageTarget(listOf("10.0.15"), listOf("openj9"), listOf("11", "17", "18"), mapOf("sourceVersion" to "10.0.7")),
-    ImageTarget(listOf("11.0.15"), listOf("hotspot"), listOf("11", "17", "20", "21"), mapOf("sourceVersion" to "11.0.7"), "servlet-5.0"),
-    ImageTarget(listOf("11.0.15"), listOf("openj9"), listOf("11", "17", "18"), mapOf("sourceVersion" to "11.0.7"), "servlet-5.0"),
+    ImageTarget(listOf("9.4.53"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21"), mapOf("sourceVersion" to "9.4.51.v20230217")),
+    ImageTarget(listOf("10.0.19"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), mapOf("sourceVersion" to "10.0.7")),
+    ImageTarget(listOf("11.0.19"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), mapOf("sourceVersion" to "11.0.7"), "servlet-5.0"),
+    ImageTarget(listOf("12.0.5"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), mapOf("sourceVersion" to "12.0.5")),
   ),
   "liberty" to listOf(
     ImageTarget(listOf("20.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11"), mapOf("release" to "2020-11-11_0736")),
-    ImageTarget(listOf("21.0.0.12"), listOf("hotspot"), listOf("8", "11", "17"), mapOf("release" to "2021-11-17_1256")),
-    ImageTarget(listOf("21.0.0.12"), listOf("openj9"), listOf("8", "11", "17"), mapOf("release" to "2021-11-17_1256")),
+    ImageTarget(listOf("21.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17"), mapOf("release" to "2021-11-17_1256")),
     // Java 19 is not supported until 22.0.0.10
-    ImageTarget(listOf("22.0.0.12"), listOf("hotspot"), listOf("8", "11", "17", "20"), mapOf("release" to "22.0.0.12")),
-    ImageTarget(listOf("22.0.0.12"), listOf("openj9"), listOf("8", "11", "17"), mapOf("release" to "22.0.0.12")),
-    ImageTarget(listOf("23.0.0.3"), listOf("hotspot"), listOf("8", "11", "17", "20"), mapOf("release" to "23.0.0.3")),
-    ImageTarget(listOf("23.0.0.3"), listOf("openj9"), listOf("8", "11", "17"), mapOf("release" to "23.0.0.3")),
+    ImageTarget(listOf("22.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17"), mapOf("release" to "22.0.0.12")),
+    // Java 21 is not supported until 23.0.0.3
+    ImageTarget(listOf("23.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21"), mapOf("release" to "23.0.0.3")),
   ),
   "payara" to listOf(
-    ImageTarget(listOf("5.2020.6"), listOf("hotspot", "openj9"), listOf("8", "11")),
-    ImageTarget(listOf("5.2021.8"), listOf("hotspot", "openj9"), listOf("8", "11")),
-    ImageTarget(listOf("6.2023.4"), listOf("hotspot", "openj9"), listOf("11", "17"), war = "servlet-5.0")
+    ImageTarget(listOf("5.2020.6", "5.2021.8"), listOf("hotspot", "openj9"), listOf("8", "11")),
+    ImageTarget(listOf("6.2024.1"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), war = "servlet-5.0")
   ),
   "tomcat" to listOf(
     ImageTarget(listOf("7.0.109"), listOf("hotspot", "openj9"), listOf("8"), mapOf("majorVersion" to "7")),
-    ImageTarget(listOf("8.5.88"), listOf("hotspot"), listOf("8", "11", "17", "20", "21"), mapOf("majorVersion" to "8")),
-    ImageTarget(listOf("8.5.88"), listOf("openj9"), listOf("8", "11", "17", "18"), mapOf("majorVersion" to "8")),
-    ImageTarget(listOf("9.0.74"), listOf("hotspot"), listOf("8", "11", "17", "20", "21"), mapOf("majorVersion" to "9")),
-    ImageTarget(listOf("9.0.74"), listOf("openj9"), listOf("8", "11", "17", "18"), mapOf("majorVersion" to "9")),
-    ImageTarget(listOf("10.1.8"), listOf("hotspot"), listOf("11", "17", "20", "21"), mapOf("majorVersion" to "10"), "servlet-5.0"),
-    ImageTarget(listOf("10.1.8"), listOf("openj9"), listOf("11", "17", "18"), mapOf("majorVersion" to "10"), "servlet-5.0"),
+    ImageTarget(listOf("8.5.98"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21"), mapOf("majorVersion" to "8")),
+    ImageTarget(listOf("9.0.85"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21"), mapOf("majorVersion" to "9")),
+    ImageTarget(listOf("10.1.18"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), mapOf("majorVersion" to "10"), "servlet-5.0"),
   ),
   "tomee" to listOf(
-    ImageTarget(listOf("7.0.9"), listOf("hotspot", "openj9"), listOf("8")),
-    ImageTarget(listOf("7.1.4"), listOf("hotspot", "openj9"), listOf("8")),
-    ImageTarget(listOf("8.0.14"), listOf("hotspot"), listOf("8", "11", "17", "20", "21")),
-    ImageTarget(listOf("8.0.14"), listOf("openj9"), listOf("8", "11", "17", "18")),
-    ImageTarget(listOf("9.0.0"), listOf("hotspot"), listOf("11", "17", "20", "21"), war = "servlet-5.0"),
-    ImageTarget(listOf("9.0.0"), listOf("openj9"), listOf("11", "17", "18"), war = "servlet-5.0"),
+    ImageTarget(listOf("7.0.9", "7.1.4"), listOf("hotspot", "openj9"), listOf("8")),
+    ImageTarget(listOf("8.0.16"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21")),
+    ImageTarget(listOf("9.1.2"), listOf("hotspot", "openj9"), listOf("11", "17", "21"), war = "servlet-5.0"),
   ),
   "websphere" to listOf(
     ImageTarget(listOf("8.5.5.22", "9.0.5.14"), listOf("openj9"), listOf("8"), windows = false),
   ),
   "wildfly" to listOf(
     ImageTarget(listOf("13.0.0.Final"), listOf("hotspot", "openj9"), listOf("8")),
-    ImageTarget(listOf("17.0.1.Final", "21.0.0.Final"), listOf("hotspot"), listOf("8", "11", "17", "20", "21")),
-    ImageTarget(listOf("17.0.1.Final", "21.0.0.Final"), listOf("openj9"), listOf("8", "11", "17", "18")),
-    ImageTarget(listOf("28.0.0.Final"), listOf("hotspot"), listOf("11", "17", "20", "21"), war = "servlet-5.0"),
-    ImageTarget(listOf("28.0.0.Final"), listOf("openj9"), listOf("11", "17", "18"), war = "servlet-5.0"),
+    ImageTarget(
+      listOf("17.0.1.Final", "21.0.0.Final", "28.0.1.Final", "29.0.1.Final", "30.0.1.Final"),
+      listOf("hotspot", "openj9"),
+      listOf("11", "17", "21"), war = "servlet-5.0"),
   ),
 )
 

--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -34,7 +34,7 @@ val targets = mapOf(
     ImageTarget(listOf("21.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17"), mapOf("release" to "2021-11-17_1256")),
     // Java 19 is not supported until 22.0.0.10
     ImageTarget(listOf("22.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17"), mapOf("release" to "22.0.0.12")),
-    // Java 21 is not supported until 23.0.0.3
+    // Java 21 is not supported until 23.0.0.3 - despite that only 20 seems to work
     ImageTarget(listOf("23.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "20"), mapOf("release" to "23.0.0.12")),
   ),
   "payara" to listOf(

--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -60,7 +60,9 @@ val targets = mapOf(
     ImageTarget(
       listOf("17.0.1.Final", "21.0.0.Final", "28.0.1.Final", "29.0.1.Final", "30.0.1.Final"),
       listOf("hotspot", "openj9"),
-      listOf("11", "17", "21"), war = "servlet-5.0"),
+      listOf("11", "17", "21"),
+      war = "servlet-5.0"
+    ),
   ),
 )
 
@@ -158,13 +160,7 @@ fun configureImage(
       // ibm-semeru-runtimes doesn't publish windows images
       throw GradleException("Unexpected vm: $vm")
     } else {
-      // looks like 21 is coming soon https://github.com/ibmruntimes/semeru-containers/commit/03eeaa90a3e9ae742bbdeeb9bf893b8d506f9e32#diff-e91d84b927d0b95d9682c441b44a7ed83afc726e8a31840955cc4a0fd97de17c
-      // remove this workaround once it's published
-      if (jdk == "21") {
-        "ibm-semeru-runtimes:open-20-jdk"
-      } else {
-        "ibm-semeru-runtimes:open-$jdk-jdk"
-      }
+      "ibm-semeru-runtimes:open-$jdk-jdk"
     }
   } else {
     throw GradleException("Unexpected vm: $vm")

--- a/smoke-tests/images/servlet/build.gradle.kts
+++ b/smoke-tests/images/servlet/build.gradle.kts
@@ -35,7 +35,7 @@ val targets = mapOf(
     // Java 19 is not supported until 22.0.0.10
     ImageTarget(listOf("22.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17"), mapOf("release" to "22.0.0.12")),
     // Java 21 is not supported until 23.0.0.3
-    ImageTarget(listOf("23.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "20"), mapOf("release" to "23.0.0.12")),
+    ImageTarget(listOf("23.0.0.12"), listOf("hotspot", "openj9"), listOf("8", "11", "17", "21"), mapOf("release" to "23.0.0.12")),
   ),
   "payara" to listOf(
     ImageTarget(listOf("5.2020.6", "5.2021.8"), listOf("hotspot", "openj9"), listOf("8", "11")),


### PR DESCRIPTION
~~JDK 21 for OpenJ9 has not been released yet - so there's a workaround in the PR to set it to JDK 20 instead.~~
~~Either we keep that workaround or wait for JDK 21.~~

[OpenJ9 JDK 21](https://hub.docker.com/layers/library/ibm-semeru-runtimes/open-21-jdk/images/sha256-23077f479904f173852ba2ae73ec711ae471958e822b70c78451cacaf5b419b9?context=explore) has just been pushed.