### PR TITLE
Correctly fix NPE in servlet AsyncListener

### DIFF
--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Accessor.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/Servlet3Accessor.java
@@ -101,7 +101,9 @@ public class Servlet3Accessor extends JavaxServletAccessor<HttpServletResponse>
 
     @Override
     public void onStartAsync(AsyncEvent event) {
-      event.getAsyncContext().addListener(this);
+      event
+          .getAsyncContext()
+          .addListener(this, event.getSuppliedRequest(), event.getSuppliedResponse());
     }
   }
 }

--- a/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
+++ b/instrumentation/servlet/servlet-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v5_0/Servlet5Accessor.java
@@ -194,7 +194,9 @@ public class Servlet5Accessor
 
     @Override
     public void onStartAsync(AsyncEvent event) {
-      event.getAsyncContext().addListener(this);
+      event
+          .getAsyncContext()
+          .addListener(this, event.getSuppliedRequest(), event.getSuppliedResponse());
     }
   }
 }


### PR DESCRIPTION
This is the correct fix for #7449 as the spec says the following on [AsyncEvent.getSuppliedResponse()](https://jakarta.ee/specifications/platform/9/apidocs/jakarta/servlet/asyncevent#getSuppliedResponse--):
> If the AsyncListener to which this AsyncEvent is being delivered was added using AsyncContext.addListener(AsyncListener, ServletRequest, ServletResponse), the returned ServletResponse will be the same as the one supplied to the above method. If the AsyncListener was added via AsyncContext.addListener(AsyncListener), this method must return null.