### PR TITLE
 Fix Netty addListener instrumentation 

### DIFF
--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/FutureListenerWrappers.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/FutureListenerWrappers.java
@@ -43,7 +43,7 @@ public final class FutureListenerWrappers {
       };
 
   public static boolean shouldWrap(GenericFutureListener<? extends Future<?>> listener) {
-    return shouldWrap.get(listener.getClass());
+    return listener != null && shouldWrap.get(listener.getClass());
   }
 
   @SuppressWarnings("unchecked")

--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/NettyFutureInstrumentation.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/NettyFutureInstrumentation.java
@@ -82,6 +82,8 @@ public class NettyFutureInstrumentation implements TypeInstrumentation {
       for (int i = 0; i < listeners.length; ++i) {
         if (FutureListenerWrappers.shouldWrap(listeners[i])) {
           wrappedListeners[i] = FutureListenerWrappers.wrap(context, listeners[i]);
+        } else {
+          wrappedListeners[i] = listeners[i];
         }
       }
       listeners = wrappedListeners;


### PR DESCRIPTION
# Motivation
PR aims to address two issues with the Netty instrumentation.

1. The instrumentation of Netty's "addListeners" methods violates the method's contract, failing to check for null values in listeners. In contrast, the original Netty addListeners method omits the processing of listeners that are null. As the advice is executed before Netty addListener, a null pointer exception (NPE) may be encountered.

2. In cases where the listeners do not require wrapping, the addListeners advice may lose them. To address this issue, the pull request wraps all listeners that require wrapping and leaves those that do not (i.e., already wrapped listeners or Netty-provided listeners) as is.

# Additional suggestions

It would be great to backport it to 1.32.x, as this issue breaks a lot of custom Netty-based code.