### PR TITLE
fix trigger condition for smoketest images

### DIFF
--- a/.github/workflows/pr-smoke-test-grpc-images.yml
+++ b/.github/workflows/pr-smoke-test-grpc-images.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "smoke-tests/images/grpc/**"
       - ".github/workflows/pr-smoke-test-grpc-images.yml"
+      - ".github/workflows/reusable-smoke-test-images.yml"
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/pr-smoke-test-play-images.yml
+++ b/.github/workflows/pr-smoke-test-play-images.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "smoke-tests/images/play/**"
       - ".github/workflows/pr-smoke-test-play-images.yml"
+      - ".github/workflows/reusable-smoke-test-images.yml"
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/pr-smoke-test-quarkus-images.yml
+++ b/.github/workflows/pr-smoke-test-quarkus-images.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "smoke-tests/images/quarkus/**"
       - ".github/workflows/pr-smoke-test-quarkus-images.yml"
+      - ".github/workflows/reusable-smoke-test-images.yml"
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/pr-smoke-test-security-manager-images.yml
+++ b/.github/workflows/pr-smoke-test-security-manager-images.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "smoke-tests/images/security-manager/**"
       - ".github/workflows/pr-smoke-test-security-manager-images.yml"
+      - ".github/workflows/reusable-smoke-test-images.yml"
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/pr-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/pr-smoke-test-spring-boot-images.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "smoke-tests/images/spring-boot/**"
       - ".github/workflows/pr-smoke-test-spring-boot-images.yml"
+      - ".github/workflows/reusable-smoke-test-images.yml"
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/publish-smoke-test-grpc-images.yml
+++ b/.github/workflows/publish-smoke-test-grpc-images.yml
@@ -5,9 +5,9 @@ on:
     paths:
       - "smoke-tests/images/grpc/**"
       - ".github/workflows/publish-smoke-test-grpc-images.yml"
+      - ".github/workflows/reusable-smoke-test-images.yml"
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-smoke-test-play-images.yml
+++ b/.github/workflows/publish-smoke-test-play-images.yml
@@ -5,9 +5,9 @@ on:
     paths:
       - "smoke-tests/images/play/**"
       - ".github/workflows/publish-smoke-test-play-images.yml"
+      - ".github/workflows/reusable-smoke-test-images.yml"
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-smoke-test-quarkus-images.yml
+++ b/.github/workflows/publish-smoke-test-quarkus-images.yml
@@ -5,9 +5,9 @@ on:
     paths:
       - "smoke-tests/images/quarkus/**"
       - ".github/workflows/publish-smoke-test-quarkus-images.yml"
+      - ".github/workflows/reusable-smoke-test-images.yml"
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-smoke-test-security-manager-images.yml
+++ b/.github/workflows/publish-smoke-test-security-manager-images.yml
@@ -5,9 +5,9 @@ on:
     paths:
       - "smoke-tests/images/security-manager/**"
       - ".github/workflows/publish-smoke-test-security-manager-images.yml"
+      - ".github/workflows/reusable-smoke-test-images.yml"
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-smoke-test-spring-boot-images.yml
+++ b/.github/workflows/publish-smoke-test-spring-boot-images.yml
@@ -5,9 +5,9 @@ on:
     paths:
       - "smoke-tests/images/spring-boot/**"
       - ".github/workflows/publish-smoke-test-spring-boot-images.yml"
+      - ".github/workflows/reusable-smoke-test-images.yml"
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/reusable-smoke-test-images.yml
+++ b/.github/workflows/reusable-smoke-test-images.yml
@@ -1,3 +1,10 @@
+# Every workflow that includes this must also include the following to make sure that it
+# is triggered when a new JDK is added to the matrix:
+#on:
+#  push:
+#    paths:
+#      - ".github/workflows/reusable-smoke-test-images.yml"
+
 name: PR build fake backend images for smoke tests
 
 on:


### PR DESCRIPTION
Every workflow that includes this must also include the following to make sure that it
is triggered when a new JDK is added to the matrix:

```yaml
on:
  push:
    paths:
      - ".github/workflows/reusable-smoke-test-images.yml"
```