### PR TITLE
Resolve memory leak in redisson instrumentation

### DIFF
--- a/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
@@ -213,14 +213,14 @@ public abstract class AbstractRedissonAsyncClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("DB Query")
+                    span.hasName("BATCH EXECUTE")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(SemanticAttributes.NETWORK_TYPE, "ipv4"),
                             equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
                             equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
                             equalTo(SemanticAttributes.DB_SYSTEM, "redis"),
-                            equalTo(SemanticAttributes.DB_STATEMENT, "MULTI;SET batch1 ?"))
+                            equalTo(SemanticAttributes.DB_OPERATION, "BATCH EXECUTE"))
                         .hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("SET")

--- a/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -147,15 +147,14 @@ public abstract class AbstractRedissonClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("DB Query")
+                    span.hasName("BATCH EXECUTE")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(SemanticAttributes.NETWORK_TYPE, "ipv4"),
                             equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
                             equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
                             equalTo(SemanticAttributes.DB_SYSTEM, "redis"),
-                            equalTo(
-                                SemanticAttributes.DB_STATEMENT, "SET batch1 ?;SET batch2 ?"))));
+                            equalTo(SemanticAttributes.DB_OPERATION, "BATCH EXECUTE"))));
   }
 
   private static void invokeExecute(RBatch batch)
@@ -188,14 +187,14 @@ public abstract class AbstractRedissonClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent().hasKind(INTERNAL),
                 span ->
-                    span.hasName("DB Query")
+                    span.hasName("BATCH EXECUTE")
                         .hasKind(CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(SemanticAttributes.NETWORK_TYPE, "ipv4"),
                             equalTo(NetworkAttributes.NETWORK_PEER_ADDRESS, "127.0.0.1"),
                             equalTo(NetworkAttributes.NETWORK_PEER_PORT, (long) port),
                             equalTo(SemanticAttributes.DB_SYSTEM, "redis"),
-                            equalTo(SemanticAttributes.DB_STATEMENT, "MULTI;SET batch1 ?"))
+                            equalTo(SemanticAttributes.DB_OPERATION, "BATCH EXECUTE"))
                         .hasParent(trace.getSpan(0)),
                 span ->
                     span.hasName("SET")


### PR DESCRIPTION
resolve [issue](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9952)
When a large number of commands are sent to the Redis server at once using the `RedisConnection.send(CommandsData data)` method, a significant number of `normalizeSingleCommand` operations are executed. This can result in a long statement that takes up a large amount of memory or causes an Out-of-Memory (OOM) error. When users use batch execute, they usually do not pay attention to the specific content of each statement.