### PR TITLE
Improve rediscala instrumentation

### DIFF
--- a/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
+++ b/instrumentation/rediscala-1.8/javaagent/build.gradle.kts
@@ -44,12 +44,19 @@ muzzle {
     versions.set("[1.9.0,)")
     assertInverse.set(true)
   }
+
+  pass {
+    group.set("io.github.rediscala")
+    module.set("rediscala_2.13")
+    versions.set("[1.10.0,)")
+    assertInverse.set(true)
+  }
 }
 
 dependencies {
   library("com.github.etaty:rediscala_2.11:1.8.0")
 
-  latestDepTestLibrary("com.github.etaty:rediscala_2.13:+")
+  latestDepTestLibrary("io.github.rediscala:rediscala_2.13:+")
 }
 
 tasks {


### PR DESCRIPTION
Update maven coordinates for rediscala to test the latest version.
Rework instrumentation to use `executionContext` method instead of the field. This instrumentation also applies to interfaces that have the method but don't have the field. This change should resolve the failure in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10287 It seems to produce instrumentation failures event without that pr, but these happen so early in the test that `AgentTestRunner` resets the failure counter to get rid of the failures that might have leaked from previous test.