### PR TITLE
Make Netty Instrumentation HttpServerRequestTracingHandler propagate "Channel Inactive" event to downstream according to parent contract

### DIFF
--- a/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/library/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/internal/server/HttpServerRequestTracingHandler.java
@@ -73,12 +73,13 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
   }
 
   @Override
-  public void channelInactive(ChannelHandlerContext ctx) {
+  public void channelInactive(ChannelHandlerContext ctx) throws Exception {
     // connection was closed, close all remaining requests
     Attribute<Deque<ServerContext>> contextAttr = ctx.channel().attr(AttributeKeys.SERVER_CONTEXT);
     Deque<ServerContext> serverContexts = contextAttr.get();
 
     if (serverContexts == null) {
+      super.channelInactive(ctx);
       return;
     }
 
@@ -86,6 +87,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     while ((serverContext = serverContexts.pollFirst()) != null) {
       instrumenter.end(serverContext.context(), serverContext.request(), null, null);
     }
+    super.channelInactive(ctx);
   }
 
   private static <T> Deque<T> getOrCreate(Channel channel, AttributeKey<Deque<T>> key) {


### PR DESCRIPTION
# Motivation
Current Netty instrumentation of ChannelHandlerAdapter violates parent contract of ChannelHandler. It does not propagate Channel Inactive event to downstream handlers, which may lead to bad side effects(In my case there was a memory leak, because connection-close channel handler was not called with Channel Inactive event). 
That PR calls super.channelInactive(ctx) on each execution path of HttpServerRequestTracingHandler channelInactive method to avoid that situation.

# Additional considerations
I suggest backporting that fix to 1.32.x, as that issue can break a lot of custom Netty-based code.