### PR TITLE
Fix OTel Spring starter native test

### DIFF
--- a/smoke-tests-otel-starter/src/main/java/io/opentelemetry/spring/smoketest/RuntimeHints.java
+++ b/smoke-tests-otel-starter/src/main/java/io/opentelemetry/spring/smoketest/RuntimeHints.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.spring.smoketest;
 
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.data.web.config.SpringDataJacksonConfiguration;
 
 // Necessary for GraalVM native test
 public class RuntimeHints implements RuntimeHintsRegistrar {
@@ -14,5 +16,15 @@ public class RuntimeHints implements RuntimeHintsRegistrar {
   public void registerHints(
       org.springframework.aot.hint.RuntimeHints hints, ClassLoader classLoader) {
     hints.resources().registerResourceBundle("org.apache.commons.dbcp2.LocalStrings");
+
+    // To remove from Spring Boot 3.2.3 release:
+    // https://github.com/spring-projects/spring-data-commons/issues/3025
+    hints
+        .reflection()
+        .registerType(
+            TypeReference.of("org.springframework.data.domain.Unpaged"),
+            hint -> {
+              hint.onReachableType(SpringDataJacksonConfiguration.PageModule.class);
+            });
   }
 }


### PR DESCRIPTION
A regression in Spring Data 3.2.2 (https://github.com/spring-projects/spring-data-commons/issues/3025) is causing the failure of GraalVM native tests (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10297).

The problem has just been fixed on the Spring side. The next Spring release is supposed to happen in about 3 weeks. This PR adds a workaround to make the failing GraalVM native tests work, waiting for the next Spring release.