### PR TITLE
update instrumenter api on contributing doc

### DIFF
--- a/docs/contributing/using-instrumenter-api.md
+++ b/docs/contributing/using-instrumenter-api.md
@@ -418,16 +418,16 @@ method for that: passing `false` will turn the newly created `Instrumenter` into
 The `Instrumenter` creation process ends with calling one of the following `InstrumenterBuilder`
 methods:
 
-- `newInstrumenter()`: the returned `Instrumenter` will always start spans with kind `INTERNAL`.
-- `newInstrumenter(SpanKindExtractor)`: the returned `Instrumenter` will always start spans with
+- `buildInstrumenter()`: the returned `Instrumenter` will always start spans with kind `INTERNAL`.
+- `buildInstrumenter(SpanKindExtractor)`: the returned `Instrumenter` will always start spans with
   kind determined by the passed `SpanKindExtractor`.
-- `newClientInstrumenter(TextMapSetter)`: the returned `Instrumenter` will always start `CLIENT`
+- `buildClientInstrumenter(TextMapSetter)`: the returned `Instrumenter` will always start `CLIENT`
   spans and will propagate operation context into the outgoing request.
-- `newServerInstrumenter(TextMapGetter)`: the returned `Instrumenter` will always start `SERVER`
+- `buildServerInstrumenter(TextMapGetter)`: the returned `Instrumenter` will always start `SERVER`
   spans and will extract the parent span context from the incoming request.
-- `newProducerInstrumenter(TextMapSetter)`: the returned `Instrumenter` will always start `PRODUCER`
+- `buildProducerInstrumenter(TextMapSetter)`: the returned `Instrumenter` will always start `PRODUCER`
   spans and will propagate operation context into the outgoing request.
-- `newConsumerInstrumenter(TextMapGetter)`: the returned `Instrumenter` will always start `SERVER`
+- `buildConsumerInstrumenter(TextMapGetter)`: the returned `Instrumenter` will always start `SERVER`
   spans and will extract the parent span context from the incoming request.
 
 The last four variants that create non-`INTERNAL` spans accept either `TextMapSetter`

--- a/docs/contributing/using-instrumenter-api.md
+++ b/docs/contributing/using-instrumenter-api.md
@@ -427,7 +427,7 @@ methods:
   spans and will extract the parent span context from the incoming request.
 - `buildProducerInstrumenter(TextMapSetter)`: the returned `Instrumenter` will always start `PRODUCER`
   spans and will propagate operation context into the outgoing request.
-- `buildConsumerInstrumenter(TextMapGetter)`: the returned `Instrumenter` will always start `SERVER`
+- `buildConsumerInstrumenter(TextMapGetter)`: the returned `Instrumenter` will always start `CONSUMER`
   spans and will extract the parent span context from the incoming request.
 
 The last four variants that create non-`INTERNAL` spans accept either `TextMapSetter`


### PR DESCRIPTION
These APIs changed after #6393, but the contributed documentation didn't update yet.