### PR TITLE
Add context propagation for rector schedulers

### DIFF
--- a/instrumentation/reactor/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/v3_1/ContextPropagationOperator.java
+++ b/instrumentation/reactor/reactor-3.1/library/src/main/java/io/opentelemetry/instrumentation/reactor/v3_1/ContextPropagationOperator.java
@@ -31,6 +31,8 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
@@ -40,9 +42,11 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
+import reactor.core.scheduler.Schedulers;
 
 /** Based on Spring Sleuth's Reactor instrumentation. */
 public final class ContextPropagationOperator {
+  private static final Logger logger = Logger.getLogger(ContextPropagationOperator.class.getName());
 
   private static final Object VALUE = new Object();
 
@@ -51,6 +55,8 @@ public final class ContextPropagationOperator {
 
   @Nullable
   private static final MethodHandle FLUX_CONTEXT_WRITE_METHOD = getContextWriteMethod(Flux.class);
+
+  @Nullable private static final MethodHandle SCHEDULERS_HOOK_METHOD = getSchedulersHookMethod();
 
   @Nullable
   private static MethodHandle getContextWriteMethod(Class<?> type) {
@@ -62,6 +68,18 @@ public final class ContextPropagationOperator {
     }
     try {
       return lookup.findVirtual(type, "subscriberContext", methodType(type, Function.class));
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      // ignore
+    }
+    return null;
+  }
+
+  @Nullable
+  private static MethodHandle getSchedulersHookMethod() {
+    MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+    try {
+      return lookup.findStatic(
+          Schedulers.class, "onScheduleHook", methodType(void.class, String.class, Function.class));
     } catch (NoSuchMethodException | IllegalAccessException e) {
       // ignore
     }
@@ -137,7 +155,19 @@ public final class ContextPropagationOperator {
       Hooks.onEachOperator(
           TracingSubscriber.class.getName(), tracingLift(asyncOperationEndStrategy));
       AsyncOperationEndStrategies.instance().registerStrategy(asyncOperationEndStrategy);
+      registerScheduleHook(RunnableWrapper.class.getName(), RunnableWrapper::new);
       enabled = true;
+    }
+  }
+
+  private static void registerScheduleHook(String key, Function<Runnable, Runnable> function) {
+    if (SCHEDULERS_HOOK_METHOD == null) {
+      return;
+    }
+    try {
+      SCHEDULERS_HOOK_METHOD.invoke(key, function);
+    } catch (Throwable throwable) {
+      logger.log(Level.WARNING, "Failed to install scheduler hook", throwable);
     }
   }
 
@@ -310,6 +340,23 @@ public final class ContextPropagationOperator {
         return source;
       }
       return null;
+    }
+  }
+
+  private static class RunnableWrapper implements Runnable {
+    private final Runnable delegate;
+    private final Context context;
+
+    RunnableWrapper(Runnable delegate) {
+      this.delegate = delegate;
+      context = Context.current();
+    }
+
+    @Override
+    public void run() {
+      try (Scope ignore = context.makeCurrent()) {
+        delegate.run();
+      }
     }
   }
 }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/SpringWebfluxTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/SpringWebfluxTest.java
@@ -206,7 +206,15 @@ public class SpringWebfluxTest {
                     "/foo-delayed",
                     "/foo-delayed",
                     "getFooDelayed",
-                    new FooModel(3L, "delayed").toString()))));
+                    new FooModel(3L, "delayed").toString()))),
+        Arguments.of(
+            named(
+                "annotation API without parameters no mono",
+                new Parameter(
+                    "/foo-no-mono",
+                    "/foo-no-mono",
+                    "getFooModelNoMono",
+                    new FooModel(0L, "DEFAULT").toString()))));
   }
 
   @ParameterizedTest(name = "{index}: {0}")

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/server/TestController.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/test/java/server/TestController.java
@@ -63,6 +63,11 @@ public class TestController {
     return Mono.just(id).delayElement(Duration.ofMillis(100)).map(TestController::tracedMethod);
   }
 
+  @GetMapping("/foo-no-mono")
+  FooModel getFooModelNoMono() {
+    return new FooModel(0L, "DEFAULT");
+  }
+
   private static FooModel tracedMethod(long id) {
     tracer.spanBuilder("tracedMethod").startSpan().end();
     return new FooModel(id, "tracedMethod");

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxServerInstrumentationTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxServerInstrumentationTest.java
@@ -5,11 +5,17 @@
 
 package io.opentelemetry.instrumentation.spring.webflux.v5_3;
 
+import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
+import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest;
+import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.context.ConfigurableApplicationContext;
 
@@ -46,5 +52,18 @@ public final class SpringWebfluxServerInstrumentationTest
         });
 
     options.disableTestNonStandardHttpMethod();
+  }
+
+  @Test
+  void noMono() {
+    ServerEndpoint endpoint = new ServerEndpoint("NO_MONO", "no-mono", 200, "success");
+    String method = "GET";
+    AggregatedHttpRequest request = request(endpoint, method);
+    AggregatedHttpResponse response = client.execute(request).aggregate().join();
+
+    assertThat(response.status().code()).isEqualTo(SUCCESS.getStatus());
+    assertThat(response.contentUtf8()).isEqualTo(SUCCESS.getBody());
+
+    assertTheTraces(1, null, null, null, method, endpoint);
   }
 }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/TestWebfluxSpringBootApp.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/TestWebfluxSpringBootApp.java
@@ -57,7 +57,7 @@ class TestWebfluxSpringBootApp {
         .setCapturedServerResponseHeaders(
             singletonList(AbstractHttpServerTest.TEST_RESPONSE_HEADER))
         .build()
-        .createWebFilter();
+        .createWebFilterAndRegisterReactorHook();
   }
 
   @Controller
@@ -67,6 +67,12 @@ class TestWebfluxSpringBootApp {
     @ResponseBody
     Flux<String> success() {
       return Flux.defer(() -> Flux.just(controller(SUCCESS, SUCCESS::getBody)));
+    }
+
+    @RequestMapping("/no-mono")
+    @ResponseBody
+    String noMono() {
+      return controller(SUCCESS, SUCCESS::getBody);
     }
 
     @RequestMapping("/query")


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10304
In later versions of webflux when controller method returns `String` instead of `Mono<String>` it gets dispatched to new thread with the scheduler which causes the context to be lost when using library instrumentation.
