### PR TITLE
Cherry pick #10041 into 1.32.x

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -8,7 +8,7 @@ val dependencyVersions = hashMapOf<String, String>()
 rootProject.extra["versions"] = dependencyVersions
 
 // this line is managed by .github/scripts/update-sdk-version.sh
-val otelSdkVersion = "1.32.0"
+val otelSdkVersion = "1.33.0"
 val otelSdkAlphaVersion = otelSdkVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
 
 // Need both BOM and groovy jars

--- a/examples/distro/build.gradle
+++ b/examples/distro/build.gradle
@@ -27,7 +27,7 @@ subprojects {
   ext {
     versions = [
       // this line is managed by .github/scripts/update-sdk-version.sh
-      opentelemetrySdk           : "1.32.0",
+      opentelemetrySdk           : "1.33.0",
 
       // these lines are managed by .github/scripts/update-version.sh
       opentelemetryJavaagent     : "1.32.0",

--- a/examples/extension/build.gradle
+++ b/examples/extension/build.gradle
@@ -23,7 +23,7 @@ version '1.0'
 ext {
   versions = [
     // this line is managed by .github/scripts/update-sdk-version.sh
-    opentelemetrySdk           : "1.32.0",
+    opentelemetrySdk           : "1.33.0",
 
     // these lines are managed by .github/scripts/update-version.sh
     opentelemetryJavaagent     : "1.32.0",

--- a/opentelemetry-api-shaded-for-instrumenting/build.gradle.kts
+++ b/opentelemetry-api-shaded-for-instrumenting/build.gradle.kts
@@ -43,6 +43,7 @@ val v1_32Deps by configurations.creating {
   isCanBeConsumed = false
   // exclude the bom added by dependencyManagement
   exclude("io.opentelemetry", "opentelemetry-bom")
+  exclude("io.opentelemetry", "opentelemetry-bom-alpha")
 }
 
 // configuration for publishing the shadowed artifact


### PR DESCRIPTION
Does not include license updates. Replaces #10286.

Will be followed with picks from 1.34.0 (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10180) and then 1.34.1 (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10217).