### PR TITLE
Reactor kafka wrapper delegates to wrong method

### DIFF
--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/InstrumentedKafkaReceiver.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/InstrumentedKafkaReceiver.java
@@ -59,7 +59,7 @@ public final class InstrumentedKafkaReceiver<K, V> implements KafkaReceiver<K, V
   @Override
   public Flux<Flux<ConsumerRecord<K, V>>> receiveExactlyOnce(
       TransactionManager transactionManager) {
-    return actual.receiveAutoAck().map(InstrumentedKafkaReceiver::wrap);
+    return actual.receiveExactlyOnce(transactionManager).map(InstrumentedKafkaReceiver::wrap);
   }
 
   // added in 1.3.3


### PR DESCRIPTION
Hopefully resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10330
Calling `receiveExactlyOnce` should delegate to `receiveExactlyOnce`. My guess is that calling `receiveAutoAck` is a copy-paste mistake.