### PR TITLE
Undertow: restore attached context only when it is for different trace

### DIFF
--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/HandlerInstrumentation.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/HandlerInstrumentation.java
@@ -53,7 +53,7 @@ public class HandlerInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelScope") Scope scope) {
       Context attachedContext = helper().getServerContext(exchange);
       if (attachedContext != null) {
-        if (!Java8BytecodeBridge.currentContext().equals(attachedContext)) {
+        if (!helper().sameTrace(Java8BytecodeBridge.currentContext(), attachedContext)) {
           // request processing is dispatched to another thread
           scope = attachedContext.makeCurrent();
           context = attachedContext;

--- a/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHelper.java
+++ b/instrumentation/undertow-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/undertow/UndertowHelper.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.undertow;
 
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.bootstrap.servlet.AppServerBridge;
@@ -84,5 +85,13 @@ public class UndertowHelper {
             KeyHolder.contextKeys.computeIfAbsent(
                 AttachmentKey.class, key -> AttachmentKey.create(Context.class));
     exchange.putAttachment(contextKey, context);
+  }
+
+  public boolean sameTrace(Context currentContext, Context attachedContext) {
+    return sameTrace(Span.fromContext(currentContext), Span.fromContext(attachedContext));
+  }
+
+  private static boolean sameTrace(Span oneSpan, Span otherSpan) {
+    return oneSpan.getSpanContext().getTraceId().equals(otherSpan.getSpanContext().getTraceId());
   }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10323
Undertow tests pass even without restoring the context. I'm not sure whether it is needed at all, perhaps executor instrumentation has improved since this was originally written and can now propagate the context? Just in case it is needed I changed it so that the context that is attached to the request is restored only when the current context and the attached context have different traces.