### PR TITLE
Remove tomcat-jdbc latest test dep pinning

### DIFF
--- a/instrumentation/jdbc/javaagent/build.gradle.kts
+++ b/instrumentation/jdbc/javaagent/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
   testImplementation("org.scala-lang:scala-library:2.11.12")
   testImplementation("com.typesafe.slick:slick_2.11:3.2.0")
   testImplementation("com.h2database:h2:1.4.197")
-  latestDepTestLibrary("org.apache.tomcat:tomcat-jdbc:10.1.13")
 }
 
 sourceSets {


### PR DESCRIPTION
Resolves #9644 based on #9643.

There have been [several releases since then](https://mvnrepository.com/artifact/org.apache.tomcat/tomcat-jdbc). I assume keeping the null guard in is fine/desirable.

cc: @laurit 