### PR TITLE
Disable flaky test

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/build.gradle.kts
@@ -59,6 +59,8 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
+  systemProperty("testLatestDeps", findProperty("testLatestDeps") as Boolean)
+
   // TODO run tests both with and without experimental span attributes
   jvmArgs("-Dotel.instrumentation.elasticsearch.experimental-span-attributes=true")
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -7,8 +7,10 @@ package springdata
 
 import io.opentelemetry.instrumentation.test.AgentInstrumentationSpecification
 import io.opentelemetry.semconv.SemanticAttributes
+import org.junit.jupiter.api.Assumptions
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Shared
+import spock.util.environment.Jvm
 
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
@@ -48,7 +50,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
     }
 
     void close() {
-      applicationContext.close()
+      applicationContext?.close()
     }
 
     @Override
@@ -58,6 +60,9 @@ class Elasticsearch53SpringRepositoryTest extends AgentInstrumentationSpecificat
   }
 
   def setup() {
+    // when running on jdk 21 this test occasionally fails with timeout
+    Assumptions.assumeTrue(Boolean.getBoolean("testLatestDeps") || !Jvm.getCurrent().isJava21Compatible())
+
     repo.refresh()
     clearExportedData()
     runWithSpan("delete") {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10359
https://ge.opentelemetry.io/s/hxzeni6hksmja/tests/task/:instrumentation:elasticsearch:elasticsearch-transport-5.3:javaagent:test/details/springdata.Elasticsearch53SpringRepositoryTest/test%20empty%20repo%20%5BindexName:%20test-index%2C%20%230%5D?top-execution=1
There have been multiple failures in the last couple of days.