### PR TITLE
Disable another flaky test

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -18,12 +18,14 @@ import org.elasticsearch.node.Node
 import org.elasticsearch.search.aggregations.bucket.nested.InternalNested
 import org.elasticsearch.search.aggregations.bucket.terms.Terms
 import org.elasticsearch.transport.Netty3Plugin
+import org.junit.jupiter.api.Assumptions
 import org.springframework.data.elasticsearch.core.ElasticsearchTemplate
 import org.springframework.data.elasticsearch.core.ResultsExtractor
 import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder
 import spock.lang.Shared
+import spock.util.environment.Jvm
 
 import java.util.concurrent.atomic.AtomicLong
 
@@ -45,7 +47,6 @@ class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecificatio
   ElasticsearchTemplate template
 
   def setupSpec() {
-
     esWorkingDir = File.createTempDir("test-es-working-dir-", "")
     esWorkingDir.deleteOnExit()
     println "ES work dir: $esWorkingDir"
@@ -79,6 +80,11 @@ class Elasticsearch53SpringTemplateTest extends AgentInstrumentationSpecificatio
       FileSystemUtils.deleteSubDirectories(esWorkingDir.toPath())
       esWorkingDir.delete()
     }
+  }
+
+  def setup() {
+    // when running on jdk 21 this test occasionally fails with timeout
+    Assumptions.assumeTrue(Boolean.getBoolean("testLatestDeps") || !Jvm.getCurrent().isJava21Compatible())
   }
 
   def "test elasticsearch error"() {


### PR DESCRIPTION
https://ge.opentelemetry.io/s/yfupdfz27uohm/tests/task/:instrumentation:elasticsearch:elasticsearch-transport-5.3:javaagent:test/details/springdata.Elasticsearch53SpringTemplateTest/test%20elasticsearch%20get%20%5BindexName:%20test-index%2C%20indexType:%20test-type%2C%20id:%201%2C%20%230%5D?expanded-stacktrace=WyIwIl0&top-execution=1
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10360