### PR TITLE
Wrap request to avoid modifying attributes of the original request

### DIFF
--- a/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/javaagent/src/main/java/org/springframework/web/servlet/v3_1/OpenTelemetryHandlerMappingFilter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/javaagent/src/main/java/org/springframework/web/servlet/v3_1/OpenTelemetryHandlerMappingFilter.java
@@ -50,9 +50,6 @@ public class OpenTelemetryHandlerMappingFilter implements Filter, Ordered {
           // Let the parent span resource name be set with the attribute set in findMapping.
           return SpringWebMvcServerSpanNaming.SERVER_SPAN_NAME.get(context, request);
         }
-        // we are calling this method with a HttpServletRequestWrapper that does not delegate
-        // setting attributes to the original request, so we can skip restoring the attributes to
-        // their original values
 
         return null;
       };

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/javaagent/src/main/java/org/springframework/web/servlet/v3_1/OpenTelemetryHandlerMappingFilter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/javaagent/src/main/java/org/springframework/web/servlet/v3_1/OpenTelemetryHandlerMappingFilter.java
@@ -16,7 +16,9 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.servlet.Filter;
@@ -26,6 +28,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.core.Ordered;
 import org.springframework.web.servlet.HandlerExecutionChain;
@@ -33,34 +36,24 @@ import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 public class OpenTelemetryHandlerMappingFilter implements Filter, Ordered {
-  private static final String PATH_ATTRIBUTE = getRequestPathAttribute();
   private static final MethodHandle usesPathPatternsMh = getUsesPathPatternsMh();
   private static final MethodHandle parseAndCacheMh = parseAndCacheMh();
 
   private final HttpServerRouteGetter<HttpServletRequest> serverSpanName =
       (context, request) -> {
-        Object previousValue = null;
-        if (this.parseRequestPath && PATH_ATTRIBUTE != null) {
-          previousValue = request.getAttribute(PATH_ATTRIBUTE);
+        if (this.parseRequestPath) {
           // sets new value for PATH_ATTRIBUTE of request
           parseAndCache(request);
         }
-        try {
-          if (findMapping(request)) {
-            // Name the parent span based on the matching pattern
-            // Let the parent span resource name be set with the attribute set in findMapping.
-            return SpringWebMvcServerSpanNaming.SERVER_SPAN_NAME.get(context, request);
-          }
-        } finally {
-          // mimic spring DispatcherServlet and restore the previous value of PATH_ATTRIBUTE
-          if (this.parseRequestPath && PATH_ATTRIBUTE != null) {
-            if (previousValue == null) {
-              request.removeAttribute(PATH_ATTRIBUTE);
-            } else {
-              request.setAttribute(PATH_ATTRIBUTE, previousValue);
-            }
-          }
+        if (findMapping(request)) {
+          // Name the parent span based on the matching pattern
+          // Let the parent span resource name be set with the attribute set in findMapping.
+          return SpringWebMvcServerSpanNaming.SERVER_SPAN_NAME.get(context, request);
         }
+        // we are calling this method with a HttpServletRequestWrapper that does not delegate
+        // setting attributes to the original request, so we can skip restoring the attributes to
+        // their original values
+
         return null;
       };
 
@@ -84,13 +77,38 @@ public class OpenTelemetryHandlerMappingFilter implements Filter, Ordered {
     } finally {
       if (handlerMappings != null) {
         Context context = Context.current();
-        HttpServerRoute.update(context, CONTROLLER, serverSpanName, (HttpServletRequest) request);
+        HttpServerRoute.update(context, CONTROLLER, serverSpanName, prepareRequest(request));
       }
     }
   }
 
   @Override
   public void destroy() {}
+
+  private static HttpServletRequest prepareRequest(ServletRequest request) {
+    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10379
+    // Finding the request handler modifies request attributes. We are wrapping the request to avoid
+    // this.
+    return new HttpServletRequestWrapper((HttpServletRequest) request) {
+      private final Map<String, Object> attributes = new HashMap<>();
+
+      @Override
+      public void setAttribute(String name, Object o) {
+        attributes.put(name, o);
+      }
+
+      @Override
+      public Object getAttribute(String name) {
+        Object value = attributes.get(name);
+        return value != null ? value : super.getAttribute(name);
+      }
+
+      @Override
+      public void removeAttribute(String name) {
+        attributes.remove(name);
+      }
+    };
+  }
 
   /**
    * When a HandlerMapping matches a request, it sets HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE
@@ -182,21 +200,6 @@ public class OpenTelemetryHandlerMappingFilter implements Filter, Ordered {
     }
     try {
       parseAndCacheMh.invoke(request);
-    } catch (Throwable throwable) {
-      throw new IllegalStateException(throwable);
-    }
-  }
-
-  private static String getRequestPathAttribute() {
-    try {
-      Class<?> pathUtilsClass =
-          Class.forName("org.springframework.web.util.ServletRequestPathUtils");
-      return (String)
-          MethodHandles.lookup()
-              .findStaticGetter(pathUtilsClass, "PATH_ATTRIBUTE", String.class)
-              .invoke();
-    } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException exception) {
-      return null;
     } catch (Throwable throwable) {
       throw new IllegalStateException(throwable);
     }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/main/java/org/springframework/web/servlet/v6_0/OpenTelemetryHandlerMappingFilter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/main/java/org/springframework/web/servlet/v6_0/OpenTelemetryHandlerMappingFilter.java
@@ -18,14 +18,16 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.springframework.core.Ordered;
-import org.springframework.http.server.RequestPath;
 import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -35,25 +37,19 @@ public class OpenTelemetryHandlerMappingFilter implements Filter, Ordered {
 
   private final HttpServerRouteGetter<HttpServletRequest> serverSpanName =
       (context, request) -> {
-        RequestPath previousValue = null;
         if (this.parseRequestPath) {
-          previousValue =
-              (RequestPath) request.getAttribute(ServletRequestPathUtils.PATH_ATTRIBUTE);
           // sets new value for PATH_ATTRIBUTE of request
           ServletRequestPathUtils.parseAndCache(request);
         }
-        try {
-          if (findMapping(request)) {
-            // Name the parent span based on the matching pattern
-            // Let the parent span resource name be set with the attribute set in findMapping.
-            return SpringWebMvcServerSpanNaming.SERVER_SPAN_NAME.get(context, request);
-          }
-        } finally {
-          // mimic spring DispatcherServlet and restore the previous value of PATH_ATTRIBUTE
-          if (this.parseRequestPath) {
-            ServletRequestPathUtils.setParsedRequestPath(previousValue, request);
-          }
+        if (findMapping(request)) {
+          // Name the parent span based on the matching pattern
+          // Let the parent span resource name be set with the attribute set in findMapping.
+          return SpringWebMvcServerSpanNaming.SERVER_SPAN_NAME.get(context, request);
         }
+        // we are calling this method with a HttpServletRequestWrapper that does not delegate
+        // setting attributes to the original request, so we can skip restoring the attributes to
+        // their original values
+
         return null;
       };
 
@@ -77,13 +73,38 @@ public class OpenTelemetryHandlerMappingFilter implements Filter, Ordered {
     } finally {
       if (handlerMappings != null) {
         Context context = Context.current();
-        HttpServerRoute.update(context, CONTROLLER, serverSpanName, (HttpServletRequest) request);
+        HttpServerRoute.update(context, CONTROLLER, serverSpanName, prepareRequest(request));
       }
     }
   }
 
   @Override
   public void destroy() {}
+
+  private static HttpServletRequest prepareRequest(ServletRequest request) {
+    // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10379
+    // Finding the request handler modifies request attributes. We are wrapping the request to avoid
+    // this.
+    return new HttpServletRequestWrapper((HttpServletRequest) request) {
+      private final Map<String, Object> attributes = new HashMap<>();
+
+      @Override
+      public void setAttribute(String name, Object o) {
+        attributes.put(name, o);
+      }
+
+      @Override
+      public Object getAttribute(String name) {
+        Object value = attributes.get(name);
+        return value != null ? value : super.getAttribute(name);
+      }
+
+      @Override
+      public void removeAttribute(String name) {
+        attributes.remove(name);
+      }
+    };
+  }
 
   /**
    * When a HandlerMapping matches a request, it sets HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/main/java/org/springframework/web/servlet/v6_0/OpenTelemetryHandlerMappingFilter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/javaagent/src/main/java/org/springframework/web/servlet/v6_0/OpenTelemetryHandlerMappingFilter.java
@@ -46,9 +46,6 @@ public class OpenTelemetryHandlerMappingFilter implements Filter, Ordered {
           // Let the parent span resource name be set with the attribute set in findMapping.
           return SpringWebMvcServerSpanNaming.SERVER_SPAN_NAME.get(context, request);
         }
-        // we are calling this method with a HttpServletRequestWrapper that does not delegate
-        // setting attributes to the original request, so we can skip restoring the attributes to
-        // their original values
 
         return null;
       };


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10379
Or spring mvc instrumentation tries to update the root span name/set route at the end of the request if it wasn't already set earlier. This usually happens when the request is rejected for some reason and request processing does not reach the part where request handler is determined and where we usually do the name update. If that is the case we try to find the handler that matches current request and use the patter it matches as the route. This process alters request attributes which is not desired. This PR wraps the original request so that its attributes could be preserved.