### PR TITLE
Spring starter should support otel.propagators

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
@@ -56,7 +56,11 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  * <p>Updates the sampler probability for the configured {@link TracerProvider}.
  */
 @Configuration
-@EnableConfigurationProperties({MetricExportProperties.class,SamplerProperties.class, OtlpExporterProperties.class})
+@EnableConfigurationProperties({
+  MetricExportProperties.class,
+  SamplerProperties.class,
+  OtlpExporterProperties.class
+})
 public class OpenTelemetryAutoConfiguration {
 
   public OpenTelemetryAutoConfiguration() {}

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java
@@ -56,11 +56,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  * <p>Updates the sampler probability for the configured {@link TracerProvider}.
  */
 @Configuration
-@EnableConfigurationProperties({
-  MetricExportProperties.class,
-  SamplerProperties.class,
-  OtlpExporterProperties.class
-})
+@EnableConfigurationProperties({MetricExportProperties.class,SamplerProperties.class, OtlpExporterProperties.class})
 public class OpenTelemetryAutoConfiguration {
 
   public OpenTelemetryAutoConfiguration() {}

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/PropagationAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/PropagationAutoConfiguration.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.propagators;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.BeanFactory;
@@ -24,6 +25,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(PropagationProperties.class)
 @AutoConfigureBefore(OpenTelemetryAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "otel.propagation", name = "enabled", matchIfMissing = true)
+@SuppressWarnings("deprecation")
 public class PropagationAutoConfiguration {
 
   @Bean
@@ -41,9 +43,11 @@ public class PropagationAutoConfiguration {
 
     @Bean
     TextMapPropagator compositeTextMapPropagator(
-        BeanFactory beanFactory, PropagationProperties properties) {
+        BeanFactory beanFactory,
+        PropagationProperties properties,
+        ConfigProperties configProperties) {
       return CompositeTextMapPropagatorFactory.getCompositeTextMapPropagator(
-          beanFactory, properties.getType());
+          beanFactory, configProperties.getList("otel.propagators", properties.getType()));
     }
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/PropagationProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/PropagationProperties.java
@@ -11,6 +11,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Configuration for propagators. */
 @ConfigurationProperties(prefix = "otel.propagation")
+@Deprecated // use otel.propagators instead
 public final class PropagationProperties {
 
   private List<String> type = Arrays.asList("tracecontext", "baggage");

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/resources/SpringConfigProperties.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/resources/SpringConfigProperties.java
@@ -71,7 +71,8 @@ public class SpringConfigProperties implements ConfigProperties {
   @SuppressWarnings("unchecked")
   @Override
   public List<String> getList(String name) {
-    return (List<String>) environment.getProperty(name, List.class);
+    List<String> value = environment.getProperty(name, List.class);
+    return value == null ? Collections.emptyList() : value;
   }
 
   @Nullable

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -311,6 +311,12 @@
       "defaultValue": false
     },
     {
+      "name": "otel.springboot.resource.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the resource auto-configuration.",
+      "defaultValue": true
+    },
+    {
       "name": "otel.traces.exporter",
       "type": "java.util.List<java.lang.String>",
       "description": "List of exporters to be used for tracing.",

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -305,6 +305,11 @@
       "defaultValue": "tracecontext,baggage"
     },
     {
+      "name": "otel.resource.attributes",
+      "type": "java.util.Map<java.lang.String, java.lang.String>",
+      "description": "Resource attributes to be added to all spans. In addition to these attributes, the resource will also include attributes discovered from the runtime, such as <code>host.name</code> and <code>process.id</code>."
+    },
+    {
       "name": "otel.sdk.disabled",
       "type": "java.lang.Boolean",
       "description": "Disable the OpenTelemetry Spring Starter.",
@@ -405,6 +410,10 @@
     {
       "name": "otel.logs.exporter",
       "values": [
+        {
+          "value": "logging",
+          "description": "The logging exporter prints exported logs to stdout. It's mainly used for testing and debugging."
+        },
         {
           "value": "none",
           "description": "No autoconfigured exporter."

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -229,13 +229,13 @@
     },
     {
       "name": "otel.instrumentation.logback-appender.experimental.capture-mdc-attributes",
-      "type": "java.lang.String",
-      "description": "Comma separated list of MDC attributes to capture. Use the wildcard character <code>*</code> to capture all attributes."
+      "type": "java.util.List<java.lang.String>",
+      "description": "MDC attributes to capture. Use the wildcard character <code>*</code> to capture all attributes."
     },
     {
       "name": "otel.logs.exporter",
-      "type": "java.lang.String",
-      "description": "List of exporters to be used for logs, separated by commas.",
+      "type": "java.util.List<java.lang.String>",
+      "description": "List of exporters to be used for logs.",
       "defaultValue": "otlp"
     },
     {
@@ -246,14 +246,20 @@
     },
     {
       "name": "otel.metrics.exporter",
-      "type": "java.lang.String",
-      "description": "List of exporters to be used for metrics, separated by commas.",
+      "type": "java.util.List<java.lang.String>",
+      "description": "List of exporters to be used for metrics.",
       "defaultValue": "otlp"
     },
     {
+      "name": "otel.propagators",
+      "type": "java.util.List<java.lang.String>",
+      "description": "List of propagators to be used for context propagation.",
+      "defaultValue": "tracecontext,baggage"
+    },
+    {
       "name": "otel.traces.exporter",
-      "type": "java.lang.String",
-      "description": "List of exporters to be used for tracing, separated by commas.",
+      "type": "java.util.List<java.lang.String>",
+      "description": "List of exporters to be used for tracing.",
       "defaultValue": "otlp"
     },
     {
@@ -363,6 +369,39 @@
         {
           "value": "otlp",
           "description": "OpenTelemetry Protocol (OTLP) exporter."
+        }
+      ]
+    },
+    {
+      "name": "otel.propagators",
+      "values": [
+        {
+          "value": "baggage",
+          "description": "The Baggage propagator propagates baggage using the W3C Baggage format. See https://www.w3.org/TR/baggage/."
+        },
+        {
+          "value": "b3",
+          "description": "The B3 propagator propagates trace context using the B3 single-header format: See https://github.com/openzipkin/b3-propagation#single-header."
+        },
+        {
+          "value": "b3multi",
+          "description": "The B3 propagator propagates trace context using the B3 multi-header format: See https://github.com/openzipkin/b3-propagation#multiple-headers."
+        },
+        {
+          "value": "jaeger",
+          "description": "The Jaeger propagator propagates trace context using the Jaeger format. See https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format."
+        },
+        {
+          "value": "ottrace",
+          "description": "The OpenTelemetry Trace Context propagator propagates trace context using the OpenTelemetry format. See https://github.com/opentracing/specification/blob/master/rfc/trace_identifiers.md."
+        },
+        {
+          "value": "tracecontext",
+          "description": "The Trace Context propagator propagates trace context using the W3C Trace Context format (add `baggage` as well to include W3C baggage). See https://www.w3.org/TR/trace-context/."
+        },
+        {
+          "value": "xray",
+          "description": "The AWS X-Ray propagator propagates trace context using the AWS X-Ray format. See https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader."
         }
       ]
     },

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -198,6 +198,30 @@
       "defaultValue": "http://localhost:9411/api/v2/spans"
     },
     {
+      "name": "otel.instrumentation.annotations.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the <code>@WithSpan</code> annotation.",
+      "defaultValue": true
+    },
+    {
+      "name": "otel.instrumentation.kafka.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the Kafka instrumentation.",
+      "defaultValue": true
+    },
+    {
+      "name": "otel.instrumentation.log4j-appender.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the Log4J2 appender instrumentation.",
+      "defaultValue": true
+    },
+    {
+      "name": "otel.instrumentation.logback-appender.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the Logback appender instrumentation.",
+      "defaultValue": true
+    },
+    {
       "name": "otel.instrumentation.logback-appender.experimental.capture-code-attributes",
       "type": "java.lang.Boolean",
       "description": "Enable the capture of source code attributes. Note that capturing source code attributes at logging sites might add a performance overhead.",
@@ -233,6 +257,30 @@
       "description": "MDC attributes to capture. Use the wildcard character <code>*</code> to capture all attributes."
     },
     {
+      "name": "otel.instrumentation.micrometer.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the Micrometer instrumentation.",
+      "defaultValue": false
+    },
+    {
+      "name": "otel.instrumentation.spring-web.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the RestTemplate instrumentation.",
+      "defaultValue": true
+    },
+    {
+      "name": "otel.instrumentation.spring-webflux.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the WebClient instrumentation.",
+      "defaultValue": true
+    },
+    {
+      "name": "otel.instrumentation.spring-webmvc.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the Servlet instrumentation.",
+      "defaultValue": true
+    },
+    {
       "name": "otel.logs.exporter",
       "type": "java.util.List<java.lang.String>",
       "description": "List of exporters to be used for logs.",
@@ -255,6 +303,12 @@
       "type": "java.util.List<java.lang.String>",
       "description": "List of propagators to be used for context propagation.",
       "defaultValue": "tracecontext,baggage"
+    },
+    {
+      "name": "otel.sdk.disabled",
+      "type": "java.lang.Boolean",
+      "description": "Disable the OpenTelemetry Spring Starter.",
+      "defaultValue": false
     },
     {
       "name": "otel.traces.exporter",

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/PropagationAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/PropagationAutoConfigurationTest.java
@@ -92,10 +92,25 @@ class PropagationAutoConfigurationTest {
   }
 
   @Test
+  @DisplayName(
+      "when propagation is set to some values should contain only supported values - deprecated")
+  void shouldContainOnlySupportedDeprecated() {
+    this.contextRunner
+        .withPropertyValues("otel.propagation.type=invalid,b3")
+        .run(
+            context -> {
+              TextMapPropagator compositePropagator =
+                  context.getBean("compositeTextMapPropagator", TextMapPropagator.class);
+
+              assertThat(compositePropagator.fields()).containsExactly("b3");
+            });
+  }
+
+  @Test
   @DisplayName("when propagation is set to some values should contain only supported values")
   void shouldContainOnlySupported() {
     this.contextRunner
-        .withPropertyValues("otel.propagation.type=invalid,b3")
+        .withPropertyValues("otel.propagators=invalid,b3")
         .run(
             context -> {
               TextMapPropagator compositePropagator =

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/PropagationPropertiesTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/propagators/PropagationPropertiesTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
+@SuppressWarnings("deprecation") // test for deprecated code
 public class PropagationPropertiesTest {
 
   private final ApplicationContextRunner contextRunner =


### PR DESCRIPTION
Follow up to #10292 

- respect otel.propagators as specified [spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration)

Split off:

- use duration parser of config properties for `otel.metric.export.interval` for consistency - moved to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10512
- deprecate deprecate otel.springboot.resource.attributes - moved to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10511