### PR TITLE
Netty: don't expose tracing handler in handlers map

### DIFF
--- a/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/AbstractNettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v4/common/AbstractNettyChannelPipelineInstrumentation.java
@@ -18,6 +18,8 @@ import io.netty.channel.ChannelPipeline;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.util.Iterator;
+import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -59,6 +61,9 @@ public abstract class AbstractNettyChannelPipelineInstrumentation implements Typ
             .and(takesArgument(1, String.class))
             .and(takesArguments(4)),
         AbstractNettyChannelPipelineInstrumentation.class.getName() + "$AddAfterAdvice");
+    transformer.applyAdviceToMethod(
+        isMethod().and(named("toMap")).and(takesArguments(0)).and(returns(Map.class)),
+        AbstractNettyChannelPipelineInstrumentation.class.getName() + "$ToMapAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -190,6 +195,24 @@ public abstract class AbstractNettyChannelPipelineInstrumentation implements Typ
         ChannelHandler ourHandler = virtualField.get(handler);
         if (ourHandler != null) {
           name = ourHandler.getClass().getName();
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class ToMapAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void wrapIterator(@Advice.Return Map<String, ChannelHandler> map) {
+      VirtualField<ChannelHandler, ChannelHandler> virtualField =
+          VirtualField.find(ChannelHandler.class, ChannelHandler.class);
+      for (Iterator<ChannelHandler> iterator = map.values().iterator(); iterator.hasNext(); ) {
+        ChannelHandler handler = iterator.next();
+        String handlerClassName = handler.getClass().getName();
+        if (handlerClassName.startsWith("io.opentelemetry.javaagent.instrumentation.netty.")
+            || handlerClassName.startsWith("io.opentelemetry.instrumentation.netty.")) {
+          iterator.remove();
         }
       }
     }

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/ChannelPipelineTest.groovy
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/groovy/ChannelPipelineTest.groovy
@@ -70,7 +70,7 @@ class ChannelPipelineTest extends AgentInstrumentationSpecification {
     replaceMethod(channelPipeline, "test", noopHandler, "http", httpHandler)
 
     then: "noop handler was removed; http and instrumentation handlers were added"
-    channelPipeline.size() == 2
+    channelPipeline.size() == 1
     channelPipeline.first() == httpHandler
     channelPipeline.last().getClass().getSimpleName() == "HttpClientTracingHandler"
 
@@ -103,7 +103,7 @@ class ChannelPipelineTest extends AgentInstrumentationSpecification {
     channelPipeline.addLast("http", httpHandler)
 
     then: "add http and instrumentation handlers"
-    channelPipeline.size() == 2
+    channelPipeline.size() == 1
     channelPipeline.first() == httpHandler
     channelPipeline.last().getClass().getSimpleName() == "HttpClientTracingHandler"
 
@@ -112,7 +112,7 @@ class ChannelPipelineTest extends AgentInstrumentationSpecification {
     channelPipeline.addAfter("http", "noop", noopHandler)
 
     then: "instrumentation handler is between with http and noop"
-    channelPipeline.size() == 3
+    channelPipeline.size() == 2
     channelPipeline.first() == httpHandler
     channelPipeline.last() == noopHandler
 
@@ -120,7 +120,7 @@ class ChannelPipelineTest extends AgentInstrumentationSpecification {
     channelPipeline.removeLast()
 
     then: "http and instrumentation handlers will be remained"
-    channelPipeline.size() == 2
+    channelPipeline.size() == 1
     channelPipeline.first() == httpHandler
     channelPipeline.last().getClass().getSimpleName() == "HttpClientTracingHandler"
 
@@ -131,6 +131,33 @@ class ChannelPipelineTest extends AgentInstrumentationSpecification {
     channelPipeline.size() == 0
     // removing tracing handler also removes the http handler and returns it
     removed == httpHandler
+  }
+
+  // regression test for https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10377
+  def "our handler not in handlers map"() {
+    setup:
+    def channel = new EmbeddedChannel(new NoopChannelHandler())
+    def channelPipeline = new DefaultChannelPipeline(channel)
+    def handler = new HttpClientCodec()
+
+    when:
+    // no handlers
+    channelPipeline.first() == null
+
+    then:
+    // add handler
+    channelPipeline.addLast("http", handler)
+    channelPipeline.first() == handler
+    // our handler was also added
+    channelPipeline.last().getClass().simpleName == "HttpClientTracingHandler"
+    // our handler not counted
+    channelPipeline.size() == 1
+    // our handler is not in handlers map
+    channelPipeline.toMap().size() == 1
+    // our handler is not in handlers iterator
+    def list = []
+    channelPipeline.iterator().forEachRemaining {list.add(it) }
+    list.size() == 1
   }
 
   private static class NoopChannelHandler extends ChannelHandlerAdapter {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10377
Handlers map is used to build handlers iterator. In https://github.com/eclipse-vertx/vert.x/blob/244b91045bb166625b2645bfdc95ede825c133a3/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java#L139 vert.x iterates over handlers and removes them. As we remove our handler together with the traced handler calling `pipeline.remove()` for our handler fails because it was already removed.