### PR TITLE
Downgrade native build tools version

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
     id("org.jetbrains.kotlin.jvm") version "1.9.22"
     id("org.xbib.gradle.plugin.jflex") version "3.0.2"
     id("org.unbroken-dome.xjc") version "2.0.0"
-    id("org.graalvm.buildtools.native") version "0.10.0"
+    id("org.graalvm.buildtools.native") version "0.9.28"
   }
 }
 


### PR DESCRIPTION
Fix #10398

See https://github.com/graalvm/native-build-tools/issues/572

There is a workaround by disabling the metadata repository, but it would require to do it at different places.
