### PR TITLE
Instrumenter SpanOmitter

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
@@ -1,2 +1,9 @@
 Comparing source compatibility of  against 
-No changes.
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	GENERIC TEMPLATES: === REQUEST:java.lang.Object, === RESPONSE:java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder<REQUEST,RESPONSE> addSpanOmitter(io.opentelemetry.instrumentation.api.instrumenter.SpanOmitter)
++++  NEW INTERFACE: PUBLIC(+) ABSTRACT(+) io.opentelemetry.instrumentation.api.instrumenter.SpanOmitter  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) ABSTRACT(+) boolean shouldOmit(io.opentelemetry.context.Context)

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/MultiSpanSuppressor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/MultiSpanSuppressor.java
@@ -1,0 +1,37 @@
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import java.util.Arrays;
+import java.util.List;
+
+class MultiSpanSuppressor implements SpanSuppressor {
+  private final List<SpanSuppressor> suppressors;
+
+  static SpanSuppressor create(SpanSuppressor... suppressors) {
+    return new MultiSpanSuppressor(Arrays.asList(suppressors));
+  }
+
+  private MultiSpanSuppressor(List<SpanSuppressor> suppressors) {
+    this.suppressors = suppressors;
+  }
+
+  @Override
+  public Context storeInContext(Context context, SpanKind spanKind, Span span) {
+    for (SpanSuppressor suppressor : suppressors) {
+      context = suppressor.storeInContext(context, spanKind, span);
+    }
+    return context;
+  }
+
+  @Override
+  public boolean shouldSuppress(Context parentContext, SpanKind spanKind) {
+    for (SpanSuppressor suppressor : suppressors) {
+      if(suppressor.shouldSuppress(parentContext, spanKind)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/MultiSpanSuppressor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/MultiSpanSuppressor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.api.instrumenter;
 
 import io.opentelemetry.api.trace.Span;
@@ -28,7 +33,7 @@ class MultiSpanSuppressor implements SpanSuppressor {
   @Override
   public boolean shouldSuppress(Context parentContext, SpanKind spanKind) {
     for (SpanSuppressor suppressor : suppressors) {
-      if(suppressor.shouldSuppress(parentContext, spanKind)) {
+      if (suppressor.shouldSuppress(parentContext, spanKind)) {
         return true;
       }
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitter.java
@@ -1,0 +1,16 @@
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+
+/**
+ * Allows providing custom filters for the creation of {@link Span}s in an {@link Instrumenter}.
+ */
+public interface SpanOmitter {
+  /**
+   * Called right before creating a {@link Span}.
+   * @param context The parent context of the {@link Span} that's about to get created.
+   * @return TRUE to avoid creating a {@link Span}, FALSE to proceed with the {@link Span} creation.
+   */
+  boolean shouldOmit(Context context);
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitter.java
@@ -1,14 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.api.instrumenter;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 
-/**
- * Allows providing custom filters for the creation of {@link Span}s in an {@link Instrumenter}.
- */
+/** Allows providing custom filters for the creation of {@link Span}s in an {@link Instrumenter}. */
 public interface SpanOmitter {
   /**
    * Called right before creating a {@link Span}.
+   *
    * @param context The parent context of the {@link Span} that's about to get created.
    * @return TRUE to avoid creating a {@link Span}, FALSE to proceed with the {@link Span} creation.
    */

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitterDelegator.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitterDelegator.java
@@ -1,0 +1,36 @@
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import java.util.Collections;
+import java.util.List;
+
+class SpanOmitterDelegator implements SpanSuppressor {
+  private final List<SpanOmitter> spanOmitters;
+
+  SpanOmitterDelegator(List<SpanOmitter> spanOmitters) {
+    this.spanOmitters = spanOmitters;
+  }
+
+  static SpanSuppressor create(List<SpanOmitter> spanOmitters) {
+    return new SpanOmitterDelegator(Collections.unmodifiableList(spanOmitters));
+  }
+
+  @CanIgnoreReturnValue
+  @Override
+  public Context storeInContext(Context context, SpanKind spanKind, Span span) {
+    return context;
+  }
+
+  @Override
+  public boolean shouldSuppress(Context parentContext, SpanKind spanKind) {
+    for (SpanOmitter spanOmitter : spanOmitters) {
+      if(spanOmitter.shouldOmit(parentContext)){
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitterDelegator.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitterDelegator.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.api.instrumenter;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -27,7 +32,7 @@ class SpanOmitterDelegator implements SpanSuppressor {
   @Override
   public boolean shouldSuppress(Context parentContext, SpanKind spanKind) {
     for (SpanOmitter spanOmitter : spanOmitters) {
-      if(spanOmitter.shouldOmit(parentContext)){
+      if (spanOmitter.shouldOmit(parentContext)) {
         return true;
       }
     }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/MultiSpanSuppressorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/MultiSpanSuppressorTest.java
@@ -1,0 +1,95 @@
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class MultiSpanSuppressorTest {
+
+  @Test
+  void delegateToSuppressorsInOrder() {
+    Context context = Context.current();
+    SpanKind spanKind = SpanKind.CLIENT;
+    Span span = Span.getInvalid();
+    SpanSuppressor suppressor1 = getSpanSuppressor(context, false);
+    SpanSuppressor suppressor2 = getSpanSuppressor(context, false);
+
+    SpanSuppressor suppressor = MultiSpanSuppressor.create(suppressor1, suppressor2);
+
+    suppressor.shouldSuppress(context, spanKind);
+    suppressor.storeInContext(context, spanKind, span);
+
+    InOrder inOrder = inOrder(suppressor1, suppressor2);
+    inOrder.verify(suppressor1).shouldSuppress(context, spanKind);
+    inOrder.verify(suppressor2).shouldSuppress(context, spanKind);
+    inOrder.verify(suppressor1).storeInContext(context, spanKind, span);
+    inOrder.verify(suppressor2).storeInContext(context, spanKind, span);
+  }
+
+  @Test
+  void shouldSuppressTrueWhenAtLeastOneReturnsTrue() {
+    Context context = Context.current();
+    SpanKind spanKind = SpanKind.CLIENT;
+    SpanSuppressor suppressor1 = getSpanSuppressor(context, false);
+    SpanSuppressor suppressor2 = getSpanSuppressor(context, true);
+    SpanSuppressor suppressor3 = getSpanSuppressor(context, false);
+
+    SpanSuppressor suppressor = MultiSpanSuppressor.create(suppressor1, suppressor2, suppressor3);
+
+    Assertions.assertThat(suppressor.shouldSuppress(context,spanKind)).isTrue();
+    verify(suppressor1).shouldSuppress(context, spanKind);
+    verify(suppressor2).shouldSuppress(context, spanKind);
+    verify(suppressor3, never()).shouldSuppress(any(), any());
+  }
+
+  @Test
+  void shouldSuppressFalseWhenNoneReturnsTrue() {
+    Context context = Context.current();
+    SpanKind spanKind = SpanKind.CLIENT;
+    SpanSuppressor suppressor1 = getSpanSuppressor(context, false);
+    SpanSuppressor suppressor2 = getSpanSuppressor(context, false);
+    SpanSuppressor suppressor3 = getSpanSuppressor(context, false);
+
+    SpanSuppressor suppressor = MultiSpanSuppressor.create(suppressor1, suppressor2, suppressor3);
+
+    Assertions.assertThat(suppressor.shouldSuppress(context,spanKind)).isFalse();
+    verify(suppressor1).shouldSuppress(context, spanKind);
+    verify(suppressor2).shouldSuppress(context, spanKind);
+    verify(suppressor3).shouldSuppress(context, spanKind);
+  }
+
+  @Test
+  void returnCompositeContext(){
+    SpanKind spanKind = SpanKind.CLIENT;
+    Span span = Span.getInvalid();
+    Context original = mock(Context.class);
+    Context fromSuppressor1 = mock(Context.class);
+    Context fromSuppressor2 = mock(Context.class);
+    SpanSuppressor suppressor1 = getSpanSuppressor(fromSuppressor1, false);
+    SpanSuppressor suppressor2 = getSpanSuppressor(fromSuppressor2, false);
+
+    SpanSuppressor suppressor = MultiSpanSuppressor.create(suppressor1, suppressor2);
+
+    Assertions.assertThat(suppressor.storeInContext(original, spanKind, span)).isEqualTo(fromSuppressor2);
+    verify(suppressor1).storeInContext(original, spanKind, span);
+    verify(suppressor2).storeInContext(fromSuppressor1, spanKind, span);
+  }
+
+  private static SpanSuppressor getSpanSuppressor(Context contextToReturn, boolean shouldSuppress) {
+    SpanSuppressor suppressor = mock(SpanSuppressor.class);
+    doReturn(contextToReturn).when(suppressor).storeInContext(any(), any(), any());
+    doReturn(shouldSuppress).when(suppressor).shouldSuppress(any(), any());
+
+    return suppressor;
+  }
+}

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/MultiSpanSuppressorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/MultiSpanSuppressorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.api.instrumenter;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -46,7 +51,7 @@ class MultiSpanSuppressorTest {
 
     SpanSuppressor suppressor = MultiSpanSuppressor.create(suppressor1, suppressor2, suppressor3);
 
-    Assertions.assertThat(suppressor.shouldSuppress(context,spanKind)).isTrue();
+    Assertions.assertThat(suppressor.shouldSuppress(context, spanKind)).isTrue();
     verify(suppressor1).shouldSuppress(context, spanKind);
     verify(suppressor2).shouldSuppress(context, spanKind);
     verify(suppressor3, never()).shouldSuppress(any(), any());
@@ -62,14 +67,14 @@ class MultiSpanSuppressorTest {
 
     SpanSuppressor suppressor = MultiSpanSuppressor.create(suppressor1, suppressor2, suppressor3);
 
-    Assertions.assertThat(suppressor.shouldSuppress(context,spanKind)).isFalse();
+    Assertions.assertThat(suppressor.shouldSuppress(context, spanKind)).isFalse();
     verify(suppressor1).shouldSuppress(context, spanKind);
     verify(suppressor2).shouldSuppress(context, spanKind);
     verify(suppressor3).shouldSuppress(context, spanKind);
   }
 
   @Test
-  void returnCompositeContext(){
+  void returnCompositeContext() {
     SpanKind spanKind = SpanKind.CLIENT;
     Span span = Span.getInvalid();
     Context original = mock(Context.class);
@@ -80,7 +85,8 @@ class MultiSpanSuppressorTest {
 
     SpanSuppressor suppressor = MultiSpanSuppressor.create(suppressor1, suppressor2);
 
-    Assertions.assertThat(suppressor.storeInContext(original, spanKind, span)).isEqualTo(fromSuppressor2);
+    Assertions.assertThat(suppressor.storeInContext(original, spanKind, span))
+        .isEqualTo(fromSuppressor2);
     verify(suppressor1).storeInContext(original, spanKind, span);
     verify(suppressor2).storeInContext(fromSuppressor1, spanKind, span);
   }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitterDelegatorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitterDelegatorTest.java
@@ -1,0 +1,74 @@
+package io.opentelemetry.instrumentation.api.instrumenter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+class SpanOmitterDelegatorTest {
+  @Test
+  void returnContextAsReceived() {
+    Context context = mock(Context.class);
+
+    SpanSuppressor suppressor = SpanOmitterDelegator.create(Collections.emptyList());
+
+    assertThat(suppressor.storeInContext(context, SpanKind.CLIENT, Span.getInvalid())).isEqualTo(context);
+  }
+
+  @Test
+  void suppressSpanWhenAtLeastOneOmitterOmitsIt(){
+    Context context = mock(Context.class);
+    List<SpanOmitter> omitters = new ArrayList<>();
+    SpanOmitter omitter1 = createOmitter(false);
+    SpanOmitter omitter2 = createOmitter(true);
+    SpanOmitter omitter3 = createOmitter(false);
+    omitters.add(omitter1);
+    omitters.add(omitter2);
+    omitters.add(omitter3);
+
+    SpanSuppressor suppressor = SpanOmitterDelegator.create(omitters);
+
+    assertThat(suppressor.shouldSuppress(context, SpanKind.CLIENT)).isTrue();
+    verify(omitter1).shouldOmit(context);
+    verify(omitter2).shouldOmit(context);
+    verify(omitter3, never()).shouldOmit(context);
+  }
+
+  @Test
+  void shouldNotSuppressWhenNoOmitterOmitsIt(){
+    Context context = mock(Context.class);
+    List<SpanOmitter> omitters = new ArrayList<>();
+    SpanOmitter omitter1 = createOmitter(false);
+    SpanOmitter omitter2 = createOmitter(false);
+    SpanOmitter omitter3 = createOmitter(false);
+    omitters.add(omitter1);
+    omitters.add(omitter2);
+    omitters.add(omitter3);
+
+    SpanSuppressor suppressor = SpanOmitterDelegator.create(omitters);
+
+    assertThat(suppressor.shouldSuppress(context, SpanKind.CLIENT)).isFalse();
+    InOrder inOrder = Mockito.inOrder(omitter1, omitter2, omitter3);
+    inOrder.verify(omitter1).shouldOmit(context);
+    inOrder.verify(omitter2).shouldOmit(context);
+    inOrder.verify(omitter3).shouldOmit(context);
+  }
+
+  private static SpanOmitter createOmitter(boolean shouldOmit) {
+    SpanOmitter omitter = mock(SpanOmitter.class);
+    doReturn(shouldOmit).when(omitter).shouldOmit(any());
+    return omitter;
+  }
+}

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitterDelegatorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/SpanOmitterDelegatorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.api.instrumenter;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,11 +29,12 @@ class SpanOmitterDelegatorTest {
 
     SpanSuppressor suppressor = SpanOmitterDelegator.create(Collections.emptyList());
 
-    assertThat(suppressor.storeInContext(context, SpanKind.CLIENT, Span.getInvalid())).isEqualTo(context);
+    assertThat(suppressor.storeInContext(context, SpanKind.CLIENT, Span.getInvalid()))
+        .isEqualTo(context);
   }
 
   @Test
-  void suppressSpanWhenAtLeastOneOmitterOmitsIt(){
+  void suppressSpanWhenAtLeastOneOmitterOmitsIt() {
     Context context = mock(Context.class);
     List<SpanOmitter> omitters = new ArrayList<>();
     SpanOmitter omitter1 = createOmitter(false);
@@ -47,7 +53,7 @@ class SpanOmitterDelegatorTest {
   }
 
   @Test
-  void shouldNotSuppressWhenNoOmitterOmitsIt(){
+  void shouldNotSuppressWhenNoOmitterOmitsIt() {
     Context context = mock(Context.class);
     List<SpanOmitter> omitters = new ArrayList<>();
     SpanOmitter omitter1 = createOmitter(false);


### PR DESCRIPTION
An approach to allow suppressing Spans for an Instrumenter instance.

Example usage:

```java
SpanOmitter omitter = ...

Instrumenter.<String, String>builder(OpenTelemetry, "test", request -> "test span")
  .addSpanOmitter(omitter)
  .buildInstrumenter();
```

The provided `SpanOmitter`s allow to either continue with the Span creation or not, and their decision can be changed at any point at runtime. This is useful to allow for remote config instrumentation filtering for example.

By the way, I think `SpanSuppressor` could have been a better name but it was already taken.