### PR TITLE
Disable minor updates for logback

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -137,7 +137,7 @@
       // intentionally using logback 1.3 in dependency management (for Java 8 support)
       "matchFileNames": ["dependencyManagement/build.gradle.kts"],
       "matchPackagePrefixes": ["ch.qos.logback:"],
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Reverts part of #10451 I really wanted to enable updates to patch version which for some reason are not happening :(