### PR TITLE
Add http.route to HTTP client requests and extract from Spring WebClient

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpClientAttributesGetter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpClientAttributesGetter.java
@@ -32,6 +32,16 @@ public interface HttpClientAttributesGetter<REQUEST, RESPONSE>
   @Nullable
   String getUrlFull(REQUEST request);
 
+  /**
+   * Returns the path template in the format used by the respective client framework.
+   *
+   * <p>Examples: {@code /foo/{bar}</p>
+   */
+  @Nullable
+  default String getHttpRoute(REQUEST request) {
+    return null;
+  }
+
   /** {@inheritDoc} */
   @Nullable
   @Override

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpMetricsAdvice.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpMetricsAdvice.java
@@ -26,6 +26,7 @@ final class HttpMetricsAdvice {
     ((ExtendedDoubleHistogramBuilder) builder)
         .setAttributesAdvice(
             asList(
+                SemanticAttributes.HTTP_ROUTE,
                 SemanticAttributes.HTTP_REQUEST_METHOD,
                 SemanticAttributes.HTTP_RESPONSE_STATUS_CODE,
                 SemanticAttributes.ERROR_TYPE,


### PR DESCRIPTION
Adds the semantic attribute `http.route` to the list of attributes supported by HTTP client requests, indicating a templated URI used when making the HTTP request as supported by the client framework.

Adds support for extracting that templated URI from the `ClientRequest` attributes when using Spring WebClient.  This is based on the Spring actuator implementation for Spring Boot 2.x that extracts the URI template and formats it for the purposes of reporting to Micrometer:

https://github.com/spring-projects/spring-boot/blob/2.7.x/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/reactive/client/WebClientExchangeTags.java#L68

This implementation returns `null` if the attribute is not found to avoid reporting raw URIs.