### PR TITLE
change jar resource detector priority

### DIFF
--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetector.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetector.java
@@ -129,7 +129,8 @@ public final class JarServiceNameDetector implements ConditionalResourceProvider
 
   @Override
   public int order() {
-    // make it run later than the SpringBootServiceNameDetector
-    return 1000;
+    // make it run earlier than the SpringBootServiceNameDetector
+    // because jar files often get renamed in production
+    return -1000;
   }
 }


### PR DESCRIPTION
change jar resource detector priority, because jar files often get renamed in production

Depends on https://github.com/open-telemetry/opentelemetry-java/pull/6222