### PR TITLE
use duration parser in jmx metrics

### DIFF
--- a/instrumentation/jmx-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/jmx/JmxMetricInsightInstaller.java
+++ b/instrumentation/jmx-metrics/javaagent/src/main/java/io/opentelemetry/instrumentation/javaagent/jmx/JmxMetricInsightInstaller.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.List;
 
 /** An {@link AgentListener} that enables JMX metrics during agent startup. */
@@ -46,8 +47,9 @@ public class JmxMetricInsightInstaller implements AgentListener {
 
     // If discovery delay has not been configured, have a peek at the metric export interval.
     // It makes sense for both of these values to be similar.
-    long exportInterval = configProperties.getLong("otel.metric.export.interval", 60000);
-    return exportInterval;
+    return configProperties
+        .getDuration("otel.metric.export.interval", Duration.ofMinutes(1))
+        .toMillis();
   }
 
   private static String resourceFor(String platform) {


### PR DESCRIPTION
- use duration parser (to support e.g. "5s")
- SDK treats `otel.metric.export.interval` as duration, so we have to, too