### PR TITLE
Priority resource detector

### DIFF
--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarResourceDetector.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarResourceDetector.java
@@ -44,6 +44,11 @@ public abstract class JarResourceDetector
   }
 
   @Override
+  protected final String cacheKey() {
+    return JarResourceDetector.class.getName();
+  }
+
+  @Override
   protected Optional<NameAndVersion> readData() {
     return getJarPath()
         .flatMap(

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarResourceDetector.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarResourceDetector.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.resources;
+
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ConditionalResourceProvider;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+public abstract class JarResourceDetector implements ConditionalResourceProvider {
+  protected static final Logger logger = Logger.getLogger(JarServiceNameDetector.class.getName());
+  private static final Pattern JAR_FILE_VERSION_PATTERN = Pattern.compile("[-_]v?\\d.*");
+  private static final Pattern ANY_DIGIT = Pattern.compile("\\d");
+  protected final Supplier<String[]> getProcessHandleArguments;
+  protected final Function<String, String> getSystemProperty;
+  protected final Predicate<Path> fileExists;
+
+  public JarResourceDetector(
+      Supplier<String[]> getProcessHandleArguments,
+      Function<String, String> getSystemProperty,
+      Predicate<Path> fileExists) {
+    this.getProcessHandleArguments = getProcessHandleArguments;
+    this.getSystemProperty = getSystemProperty;
+    this.fileExists = fileExists;
+  }
+
+  protected Optional<NameAndVersion> getServiceNameAndVersion() {
+    Path jarPath = getJarPathFromProcessHandle();
+    if (jarPath == null) {
+      jarPath = getJarPathFromSunCommandLine();
+    }
+    if (jarPath == null) {
+      return Optional.empty();
+    }
+
+    String jarName = jarPath.getFileName().toString();
+    int dotIndex = jarName.lastIndexOf(".");
+    if (dotIndex == -1 || ANY_DIGIT.matcher(jarName.substring(dotIndex)).find()) {
+      // don't change if digit it extension, it's probably a version
+      return Optional.of(new NameAndVersion(jarName, Optional.empty()));
+    }
+
+    return Optional.of(JarResourceDetector.getNameAndVersion(jarName.substring(0, dotIndex)));
+  }
+
+  private static NameAndVersion getNameAndVersion(String jarNameWithoutExtension) {
+    Matcher matcher = JAR_FILE_VERSION_PATTERN.matcher(jarNameWithoutExtension);
+    if (matcher.find()) {
+      int start = matcher.start();
+      String name = jarNameWithoutExtension.substring(0, start);
+      String version = jarNameWithoutExtension.substring(start + 1);
+      return new NameAndVersion(name, Optional.of(version));
+    }
+
+    return new NameAndVersion(jarNameWithoutExtension, Optional.empty());
+  }
+
+  @Nullable
+  private Path getJarPathFromProcessHandle() {
+    String[] javaArgs = getProcessHandleArguments.get();
+    for (int i = 0; i < javaArgs.length; ++i) {
+      if ("-jar".equals(javaArgs[i]) && (i < javaArgs.length - 1)) {
+        return Paths.get(javaArgs[i + 1]);
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private Path getJarPathFromSunCommandLine() {
+    // the jar file is the first argument in the command line string
+    String programArguments = getSystemProperty.apply("sun.java.command");
+    if (programArguments == null) {
+      return null;
+    }
+
+    // Take the path until the first space. If the path doesn't exist extend it up to the next
+    // space. Repeat until a path that exists is found or input runs out.
+    int next = 0;
+    while (true) {
+      int nextSpace = programArguments.indexOf(' ', next);
+      if (nextSpace == -1) {
+        return pathIfExists(programArguments);
+      }
+      Path path = pathIfExists(programArguments.substring(0, nextSpace));
+      next = nextSpace + 1;
+      if (path != null) {
+        return path;
+      }
+    }
+  }
+
+  @Nullable
+  private Path pathIfExists(String programArguments) {
+    Path candidate;
+    try {
+      candidate = Paths.get(programArguments);
+    } catch (InvalidPathException e) {
+      return null;
+    }
+    return fileExists.test(candidate) ? candidate : null;
+  }
+
+  @Override
+  public int order() {
+    // make it run later than the SpringBootServiceNameDetector
+    return 1000;
+  }
+
+  protected static class NameAndVersion {
+    final String name;
+    final Optional<String> version;
+
+    NameAndVersion(String name, Optional<String> version) {
+      this.name = name;
+      this.version = version;
+    }
+
+    @Override
+    public String toString() {
+      return version
+          .map(v -> String.format("name: %s, version: %s", name, v))
+          .orElse(String.format("name: %s", name));
+    }
+  }
+}

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetector.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetector.java
@@ -16,6 +16,7 @@ import io.opentelemetry.semconv.ResourceAttributes;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -28,15 +29,20 @@ public final class JarServiceNameDetector extends JarResourceDetector {
 
   @SuppressWarnings("unused") // SPI
   public JarServiceNameDetector() {
-    this(ProcessArguments::getProcessArguments, System::getProperty, Files::isRegularFile);
+    this(
+        ProcessArguments::getProcessArguments,
+        System::getProperty,
+        Files::isRegularFile,
+        CACHE_LOOKUP);
   }
 
   // visible for tests
   JarServiceNameDetector(
       Supplier<String[]> getProcessHandleArguments,
       Function<String, String> getSystemProperty,
-      Predicate<Path> fileExists) {
-    super(getProcessHandleArguments, getSystemProperty, fileExists);
+      Predicate<Path> fileExists,
+      Function<Supplier<Optional<String>>, Optional<String>> jarNameCacheLookup) {
+    super(getProcessHandleArguments, getSystemProperty, fileExists, jarNameCacheLookup);
   }
 
   @Override

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetector.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceNameDetector.java
@@ -8,14 +8,10 @@ package io.opentelemetry.instrumentation.resources;
 import static java.util.logging.Level.FINE;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.ResourceAttributes;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -29,42 +25,25 @@ public final class JarServiceNameDetector extends JarResourceDetector {
 
   @SuppressWarnings("unused") // SPI
   public JarServiceNameDetector() {
-    this(
-        ProcessArguments::getProcessArguments,
-        System::getProperty,
-        Files::isRegularFile,
-        CACHE_LOOKUP);
+    this(ProcessArguments::getProcessArguments, System::getProperty, Files::isRegularFile);
   }
 
   // visible for tests
   JarServiceNameDetector(
       Supplier<String[]> getProcessHandleArguments,
       Function<String, String> getSystemProperty,
-      Predicate<Path> fileExists,
-      Function<Supplier<Optional<String>>, Optional<String>> jarNameCacheLookup) {
-    super(getProcessHandleArguments, getSystemProperty, fileExists, jarNameCacheLookup);
+      Predicate<Path> fileExists) {
+    super(getProcessHandleArguments, getSystemProperty, fileExists);
   }
 
   @Override
-  public Resource createResource(ConfigProperties config) {
-    return getServiceNameAndVersion()
-        .map(
-            nameAndVersion -> {
-              logger.log(
-                  FINE, "Auto-detected service.name from the jar file: {0}", nameAndVersion.name);
-
-              return Resource.create(
-                  Attributes.of(ResourceAttributes.SERVICE_NAME, nameAndVersion.name));
-            })
-        .orElse(Resource.empty());
-  }
-
-  @Override
-  public boolean shouldApply(ConfigProperties config, Resource existing) {
-    String serviceName = config.getString("otel.service.name");
-    Map<String, String> resourceAttributes = config.getMap("otel.resource.attributes");
-    return serviceName == null
-        && !resourceAttributes.containsKey(ResourceAttributes.SERVICE_NAME.getKey())
-        && "unknown_service:java".equals(existing.getAttribute(ResourceAttributes.SERVICE_NAME));
+  protected void registerAttributes(
+      PriorityResourceProvider<NameAndVersion>.AttributeBuilder attributeBuilder) {
+    attributeBuilder.add(
+        ResourceAttributes.SERVICE_NAME,
+        d -> {
+          logger.log(FINE, "Auto-detected service.name from the jar file: {0}", d.name);
+          return Optional.of(d.name);
+        });
   }
 }

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceVersionDetector.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceVersionDetector.java
@@ -15,6 +15,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.ResourceAttributes;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -27,15 +28,20 @@ public final class JarServiceVersionDetector extends JarResourceDetector {
 
   @SuppressWarnings("unused") // SPI
   public JarServiceVersionDetector() {
-    this(ProcessArguments::getProcessArguments, System::getProperty, Files::isRegularFile);
+    this(
+        ProcessArguments::getProcessArguments,
+        System::getProperty,
+        Files::isRegularFile,
+        CACHE_LOOKUP);
   }
 
   // visible for tests
   JarServiceVersionDetector(
       Supplier<String[]> getProcessHandleArguments,
       Function<String, String> getSystemProperty,
-      Predicate<Path> fileExists) {
-    super(getProcessHandleArguments, getSystemProperty, fileExists);
+      Predicate<Path> fileExists,
+      Function<Supplier<Optional<String>>, Optional<String>> jarNameCacheLookup) {
+    super(getProcessHandleArguments, getSystemProperty, fileExists, jarNameCacheLookup);
   }
 
   @Override

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceVersionDetector.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceVersionDetector.java
@@ -8,14 +8,10 @@ package io.opentelemetry.instrumentation.resources;
 import static java.util.logging.Level.FINE;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
-import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.ResourceAttributes;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -28,39 +24,26 @@ public final class JarServiceVersionDetector extends JarResourceDetector {
 
   @SuppressWarnings("unused") // SPI
   public JarServiceVersionDetector() {
-    this(
-        ProcessArguments::getProcessArguments,
-        System::getProperty,
-        Files::isRegularFile,
-        CACHE_LOOKUP);
+    this(ProcessArguments::getProcessArguments, System::getProperty, Files::isRegularFile);
   }
 
   // visible for tests
   JarServiceVersionDetector(
       Supplier<String[]> getProcessHandleArguments,
       Function<String, String> getSystemProperty,
-      Predicate<Path> fileExists,
-      Function<Supplier<Optional<String>>, Optional<String>> jarNameCacheLookup) {
-    super(getProcessHandleArguments, getSystemProperty, fileExists, jarNameCacheLookup);
+      Predicate<Path> fileExists) {
+    super(getProcessHandleArguments, getSystemProperty, fileExists);
   }
 
   @Override
-  public Resource createResource(ConfigProperties config) {
-    return getServiceNameAndVersion()
-        .flatMap(n -> n.version)
-        .map(
-            version -> {
-              logger.log(FINE, "Auto-detected service.version from the jar file: {0}", version);
+  protected void registerAttributes(
+      PriorityResourceProvider<NameAndVersion>.AttributeBuilder attributeBuilder) {
 
-              return Resource.create(Attributes.of(ResourceAttributes.SERVICE_VERSION, version));
-            })
-        .orElse(Resource.empty());
-  }
-
-  @Override
-  public boolean shouldApply(ConfigProperties config, Resource existing) {
-    return !config
-        .getMap("otel.resource.attributes")
-        .containsKey(ResourceAttributes.SERVICE_VERSION.getKey());
+    attributeBuilder.add(
+        ResourceAttributes.SERVICE_VERSION,
+        d -> {
+          logger.log(FINE, "Auto-detected service.version from the jar file: {0}", d.version);
+          return d.version;
+        });
   }
 }

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/PriorityResourceProvider.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/PriorityResourceProvider.java
@@ -90,6 +90,7 @@ public abstract class PriorityResourceProvider<D> implements ConditionalResource
               // the thread local is a hack to work around this
               Resource existing =
                   Objects.requireNonNull(existingResource.get(), "call shouldApply first");
+              existingResource.remove();
               Map<String, String> resourceAttributes = getResourceAttributes(config);
               AttributesBuilder builder = Attributes.builder();
               attributeGetters.entrySet().stream()

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/PriorityResourceProvider.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/PriorityResourceProvider.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.resources;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ConditionalResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.ResourceAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+public abstract class PriorityResourceProvider<D> implements ConditionalResourceProvider {
+
+  // API
+
+  protected abstract int priority();
+
+  protected abstract Optional<D> readData();
+
+  protected abstract void registerAttributes(AttributeBuilder attributeBuilder);
+
+  protected String cacheKey() {
+    return getClass().getName();
+  }
+
+  // visible for tests
+  public static void resetForTest() {
+    cache.clear();
+  }
+
+  // implementation
+
+  public class AttributeBuilder {
+
+    private AttributeBuilder() {}
+
+    @CanIgnoreReturnValue
+    public <T> AttributeBuilder add(AttributeKey<T> key, Function<D, Optional<T>> getter) {
+      attributeGetters.put((AttributeKey) key, Objects.requireNonNull((Function) getter));
+      return this;
+    }
+  }
+
+  private static final ConcurrentHashMap<String, Object> cache = new ConcurrentHashMap<>();
+
+  private static final ThreadLocal<Resource> existingResource = new ThreadLocal<>();
+
+  private final Map<AttributeKey<Object>, Function<D, Optional<?>>> attributeGetters =
+      new HashMap<>();
+
+  public PriorityResourceProvider() {
+    registerAttributes(new AttributeBuilder());
+  }
+
+  @Override
+  public final int order() {
+    return -priority();
+  }
+
+  @Override
+  public final boolean shouldApply(ConfigProperties config, Resource existing) {
+    existingResource.set(existing);
+
+    Map<String, String> resourceAttributes = getResourceAttributes(config);
+    return attributeGetters.keySet().stream()
+        .allMatch(key -> shouldUpdate(config, existing, key, resourceAttributes));
+  }
+
+  @Override
+  public final Resource createResource(ConfigProperties config) {
+    return getData()
+        .map(
+            data -> {
+              // what should we do here?
+              // we don't have access to the existing resource
+              // if the resource provider produces a single key, we can rely on shouldApply
+              // i.e. this method won't be called if the key is already present
+              // the thread local is a hack to work around this
+              Resource existing =
+                  Objects.requireNonNull(existingResource.get(), "call shouldApply first");
+              Map<String, String> resourceAttributes = getResourceAttributes(config);
+              AttributesBuilder builder = Attributes.builder();
+              attributeGetters.entrySet().stream()
+                  .filter(e -> shouldUpdate(config, existing, e.getKey(), resourceAttributes))
+                  .forEach(
+                      e ->
+                          e.getValue()
+                              .apply(data)
+                              .ifPresent(value -> putAttribute(builder, e.getKey(), value)));
+              return Resource.create(builder.build());
+            })
+        .orElse(Resource.empty());
+  }
+
+  private Optional<D> getData() {
+    return (Optional<D>) cache.computeIfAbsent(cacheKey(), k -> readData());
+  }
+
+  private static <T> void putAttribute(AttributesBuilder builder, AttributeKey<T> key, T value) {
+    builder.put(key, value);
+  }
+
+  private static Map<String, String> getResourceAttributes(ConfigProperties config) {
+    return config.getMap("otel.resource.attributes");
+  }
+
+  private static boolean shouldUpdate(
+      ConfigProperties config,
+      Resource existing,
+      AttributeKey<?> key,
+      Map<String, String> resourceAttributes) {
+    if (resourceAttributes.containsKey(key.getKey())) {
+      return false;
+    }
+
+    Object value = existing.getAttribute(key);
+
+    if (key.equals(ResourceAttributes.SERVICE_NAME)) {
+      return config.getString("otel.service.name") == null && "unknown_service:java".equals(value);
+    }
+
+    return value == null;
+  }
+}

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarResourceDetectorsTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/JarResourceDetectorsTest.java
@@ -30,7 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class JarServiceNameDetectorTest {
+class JarResourceDetectorsTest {
 
   @Mock ConfigProperties config;
 
@@ -38,7 +38,7 @@ class JarServiceNameDetectorTest {
   void createResource_empty() {
     JarServiceNameDetector serviceNameProvider =
         new JarServiceNameDetector(
-            () -> new String[0], prop -> null, JarServiceNameDetectorTest::failPath);
+            () -> new String[0], prop -> null, JarResourceDetectorsTest::failPath);
 
     Resource resource = serviceNameProvider.createResource(config);
 
@@ -49,7 +49,7 @@ class JarServiceNameDetectorTest {
   void createResource_noJarFileInArgs() {
     String[] args = new String[] {"-Dtest=42", "-Xmx666m", "-jar"};
     JarServiceNameDetector serviceNameProvider =
-        new JarServiceNameDetector(() -> args, prop -> null, JarServiceNameDetectorTest::failPath);
+        new JarServiceNameDetector(() -> args, prop -> null, JarResourceDetectorsTest::failPath);
 
     Resource resource = serviceNameProvider.createResource(config);
 
@@ -76,9 +76,14 @@ class JarServiceNameDetectorTest {
     String path = Paths.get("path", "to", "app", jar).toString();
     String[] args = new String[] {"-Dtest=42", "-Xmx666m", "-jar", path, "abc", "def"};
     JarServiceNameDetector serviceNameProvider =
-        new JarServiceNameDetector(() -> args, prop -> null, JarServiceNameDetectorTest::failPath);
+        new JarServiceNameDetector(() -> args, prop -> null, JarResourceDetectorsTest::failPath);
+    JarServiceVersionDetector serviceVersionProvider =
+        new JarServiceVersionDetector(() -> args, prop -> null, JarResourceDetectorsTest::failPath);
 
-    Resource resource = serviceNameProvider.createResource(config);
+    Resource resource =
+        serviceNameProvider
+            .createResource(config)
+            .merge(serviceVersionProvider.createResource(config));
 
     AttributesAssert attributesAssert = assertThat(resource.getAttributes());
     attributesAssert.containsEntry(ResourceAttributes.SERVICE_NAME, expectedServiceName);


### PR DESCRIPTION
Attempt to fix subtle bugs when writing resource providers.

- This PR is build on top of https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10514 - which is [getting it wrong](https://github.com/zeitlinger/opentelemetry-java-instrumentation/blob/jar-version-detector/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/JarServiceVersionDetector.java#L61-L65) (not checking for the `existing` resource in `shouldApply`.
- It also makes the priority of resource providers explicit, which [can be confusing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10523)
- A perhaps cleaner solution would be in the SDK, which is proposed [here](https://github.com/open-telemetry/opentelemetry-java/pull/6222)

The crust of this PR is the [PriorityResourceProvider API](https://github.com/zeitlinger/opentelemetry-java-instrumentation/blob/2d1753f0bb0efaa90509feefb5ab2dac0fa2e5c0/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/PriorityResourceProvider.java#L28-L41)

