### PR TITLE
Remove disabling spring-boot-autoconfigure tests on openj9 18

### DIFF
--- a/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
@@ -127,13 +127,5 @@ tasks {
     // required on jdk17
     jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
     jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
-
-    // disable tests on openj9 18 because they often crash JIT compiler
-    val testJavaVersion = gradle.startParameter.projectProperties["testJavaVersion"]?.let(JavaVersion::toVersion)
-    val testOnOpenJ9 = gradle.startParameter.projectProperties["testJavaVM"]?.run { this == "openj9" }
-      ?: false
-    if (testOnOpenJ9 && testJavaVersion?.majorVersion == "18") {
-      enabled = false
-    }
   }
 }


### PR DESCRIPTION
We don't test on openj9 18 any more