### PR TITLE
Fix documentation link to graphql semantic conventions

### DIFF
--- a/docs/supported-libraries.md
+++ b/docs/supported-libraries.md
@@ -166,7 +166,7 @@ These are the supported libraries and frameworks:
 [Database Pool Metrics]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-metrics.md
 [JVM Runtime Metrics]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/runtime/jvm-metrics.md
 [System Metrics]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/system/system-metrics.md
-[GraphQL Server Spans]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/graphql.md
+[GraphQL Server Spans]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/graphql/graphql-spans.md
 [FaaS Server Spans]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/faas-spans.md
 
 ## Application Servers


### PR DESCRIPTION
Fixes the CI pipeline after the linked file was moved in https://github.com/open-telemetry/semantic-conventions/commit/5d7e48746a1f01059b86bc59f62c4daa09f86903