### PR TITLE
Disable sporadically failing test

### DIFF
--- a/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
+++ b/instrumentation/cassandra/cassandra-4.4/testing/src/main/java/io/opentelemetry/testing/cassandra/v4_4/AbstractCassandra44Test.java
@@ -25,12 +25,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Named.named;
 
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.CqlSessionBuilder;
-import com.datastax.oss.driver.internal.core.metadata.SniEndPoint;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.cassandra.v4.common.AbstractCassandraTest;
 import io.opentelemetry.instrumentation.api.semconv.network.internal.NetworkAttributes;
-import java.net.InetSocketAddress;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -154,10 +151,11 @@ public abstract class AbstractCassandra44Test extends AbstractCassandraTest {
                     "users"))));
   }
 
-  @Override
-  protected CqlSessionBuilder addContactPoint(CqlSessionBuilder sessionBuilder) {
-    InetSocketAddress address = new InetSocketAddress("localhost", cassandraPort);
-    sessionBuilder.addContactEndPoint(new SniEndPoint(address, "localhost"));
-    return sessionBuilder;
-  }
+  // TODO (trask) this is causing sporadic test failures
+  // @Override
+  // protected CqlSessionBuilder addContactPoint(CqlSessionBuilder sessionBuilder) {
+  //   InetSocketAddress address = new InetSocketAddress("localhost", cassandraPort);
+  //   sessionBuilder.addContactEndPoint(new SniEndPoint(address, "localhost"));
+  //   return sessionBuilder;
+  // }
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10562

cc @heyams 

I think it's ok not to test SniEndpoint since that wasn't really the purpose of #10357 anyways