### PR TITLE
Fix log4j appender latest dep test

### DIFF
--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/build.gradle.kts
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 
   if (testLatestDeps) {
     // this dependency is needed for the slf4j->log4j test
-    testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:+")
+    testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.+")
     testCompileOnly("biz.aQute.bnd:biz.aQute.bnd.annotation:7.0.0")
   } else {
     // log4j 2.17 doesn't have an slf4j2 bridge


### PR DESCRIPTION
Latest version for log4j is `3.0.0-beta2`. `library` ignore versions that contain `-beta`, but `testImplementation ` doesn't so we need to pin the version.