### PR TITLE
Add note about draft PRs to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,3 +88,11 @@ https://gradle.com/s/ila4qwp5lcf5s
 
 Opening the build scan link can sometimes take several seconds (it's a large build), but it
 typically makes it a lot clearer what's failing.
+
+### Draft PRs
+
+Draft PRs are welcome, especially when exploring new ideas or experimenting with a hypothesis.
+However, draft PRs may not receive the same degree of attention, feedback, or scrutiny unless
+requested directly. In order to help keep the PR backlog maintainable, drafts older than 6 months
+will be closed by the project maintainers. This should not be interpreted as a rejection. Closed
+PRs may be reopened by the author when time or interest allows.


### PR DESCRIPTION
In the SIG meeting yesterday we decided to add a section to CONTRIBUTING.md that explains why we may close draft PRs, and we said we'd try and close old drafts after 6 generous months. Hopefully this captures what we discussed.

same change in core: https://github.com/open-telemetry/opentelemetry-java/pull/6247