### PR TITLE
Fix shading aws propagator

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
@@ -35,7 +35,7 @@ tasks.withType<ShadowJar>().configureEach {
   // relocate(the OpenTelemetry extensions that are used by instrumentation modules)
   // these extensions live in the AgentClassLoader, and are injected into the user's class loader
   // by the instrumentation modules that use them
-  relocate("io.opentelemetry.extension.aws", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.aws")
+  relocate("io.opentelemetry.contrib.awsxray", "io.opentelemetry.javaagent.shaded.io.opentelemetry.contrib.awsxray")
   relocate("io.opentelemetry.extension.kotlin", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.kotlin")
 
   // this is for instrumentation of opentelemetry-api and opentelemetry-instrumentation-api

--- a/examples/distro/gradle/shadow.gradle
+++ b/examples/distro/gradle/shadow.gradle
@@ -18,6 +18,6 @@ ext.relocatePackages = { shadowJar ->
   // relocate the OpenTelemetry extensions that are used by instrumentation modules
   // these extensions live in the AgentClassLoader, and are injected into the user's class loader
   // by the instrumentation modules that use them
-  shadowJar.relocate("io.opentelemetry.extension.aws", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.aws")
+  shadowJar.relocate("io.opentelemetry.contrib.awsxray", "io.opentelemetry.javaagent.shaded.io.opentelemetry.contrib.awsxray")
   shadowJar.relocate("io.opentelemetry.extension.kotlin", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.kotlin")
 }

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -103,7 +103,7 @@ tasks.withType<ShadowJar>().configureEach {
   // relocate(the OpenTelemetry extensions that are used by instrumentation modules)
   // these extensions live in the AgentClassLoader, and are injected into the user's class loader
   // by the instrumentation modules that use them
-  relocate("io.opentelemetry.extension.aws", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.aws")
+  relocate("io.opentelemetry.contrib.awsxray", "io.opentelemetry.javaagent.shaded.io.opentelemetry.contrib.awsxray")
   relocate("io.opentelemetry.extension.kotlin", "io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.kotlin")
 
   // this is for instrumentation of opentelemetry-api and opentelemetry-instrumentation-api

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -71,6 +71,8 @@ dependencies {
   library("software.amazon.awssdk:sqs:2.2.0")
 
   testImplementation(project(":instrumentation:aws-sdk:aws-sdk-2.2:testing"))
+  testImplementation("io.opentelemetry.contrib:opentelemetry-aws-xray-propagator")
+
   // Make sure these don't add HTTP headers
   testInstrumentation(project(":instrumentation:apache-httpclient:apache-httpclient-4.0:javaagent"))
   testInstrumentation(project(":instrumentation:apache-httpclient:apache-httpclient-5.0:javaagent"))

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/s3PresignerTest/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/S3PresignerTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/s3PresignerTest/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/S3PresignerTest.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.Span;

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/Aws2ClientRecordHttpErrorTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/Aws2ClientRecordHttpErrorTest.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
+
 import io.opentelemetry.instrumentation.awssdk.v2_2.AbstractAws2ClientRecordHttpErrorTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsXrayPropagatorTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/AwsXrayPropagatorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.contrib.awsxray.propagator.AwsXrayPropagator;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+class AwsXrayPropagatorTest {
+  private static final StaticCredentialsProvider CREDENTIALS_PROVIDER =
+      StaticCredentialsProvider.create(
+          AwsBasicCredentials.create("my-access-key", "my-secret-key"));
+
+  @Test
+  void testAgentShadesAwsXrayPropagator() {
+    // first build a SqsClient to trigger instrumentation
+    SqsClient.builder()
+        .region(Region.AP_NORTHEAST_1)
+        .credentialsProvider(CREDENTIALS_PROVIDER)
+        .build();
+    // verify that AwsXrayPropagator is usable, if agent has not shaded AwsXrayPropagator this will
+    // fail with NoSuchMethodError
+    AwsXrayPropagator.getInstance()
+        .extract(
+            Context.root(),
+            Collections.singletonMap(
+                "X-Amzn-Trace-Id",
+                "Root=1-35a77be2-beae321878f706079d392ac3;Parent=df79f9d51134dc0b;Sampled=1"),
+            StringMapGetter.INSTANCE);
+  }
+
+  private enum StringMapGetter implements TextMapGetter<Map<String, String>> {
+    INSTANCE;
+
+    @Override
+    public Iterable<String> keys(Map<String, String> map) {
+      return map.keySet();
+    }
+
+    @Override
+    public String get(Map<String, String> map, String s) {
+      return map.get(s);
+    }
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/QueryProtocolModelTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/QueryProtocolModelTest.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
+
 import io.opentelemetry.instrumentation.awssdk.v2_2.AbstractQueryProtocolModelTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlConnection.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlConnection.java
@@ -36,8 +36,14 @@ public class RemappingUrlConnection extends URLConnection {
               "#io.opentelemetry.semconv",
               "#io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv"),
           rule(
-              "#io.opentelemetry.extension.aws",
-              "#io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.aws"),
+              "#io.opentelemetry.extension.incubator",
+              "#io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.incubator"),
+          rule(
+              "#io.opentelemetry.contrib.awsxray",
+              "#io.opentelemetry.javaagent.shaded.io.opentelemetry.contrib.awsxray"),
+          rule(
+              "#io.opentelemetry.extension.kotlin",
+              "#io.opentelemetry.javaagent.shaded.io.opentelemetry.extension.kotlin"),
           rule("#application.io.opentelemetry", "#io.opentelemetry"),
           rule("#java.util.logging.Logger", "#io.opentelemetry.javaagent.bootstrap.PatchLogger"));
 


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10659
We have to shade aws propagator to avoid conflict with the propagator in the application. Our shading configuration still uses to the old package name of the propagator.