### PR TITLE
Correct labeler version

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,6 +10,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # 5.0.0
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Renovate complains https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9098 `Could not determine new digest for update (github-tags package actions/labeler)`