### PR TITLE
Don't set 1.x releases as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,7 @@ jobs:
           gh release create --target $GITHUB_REF_NAME \
                             --title "Version $VERSION" \
                             --notes-file /tmp/release-notes.txt \
+                            --latest=false \
                             v$VERSION \
                             opentelemetry-javaagent.jar
 


### PR DESCRIPTION
hopefully this will avoid the version update PRs in the website repo