### PR TITLE
AWS Lambda Runtime internal handlers need to be ignored from being instrumented and so traced.

### DIFF
--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaRequestHandlerInstrumentation.java
@@ -10,7 +10,9 @@ import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.
 import static io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0.AwsLambdaInstrumentationHelper.functionInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -35,7 +37,8 @@ public class AwsLambdaRequestHandlerInstrumentation implements TypeInstrumentati
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return implementsInterface(named("com.amazonaws.services.lambda.runtime.RequestHandler"));
+    return implementsInterface(named("com.amazonaws.services.lambda.runtime.RequestHandler"))
+        .and(not(nameStartsWith("com.amazonaws.services.lambda.runtime.api.client")));
   }
 
   @Override

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/com/amazonaws/services/lambda/runtime/api/client/AwsLambdaInternalRequestHandler.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/com/amazonaws/services/lambda/runtime/api/client/AwsLambdaInternalRequestHandler.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.lambda.runtime.api.client;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class AwsLambdaInternalRequestHandler implements RequestHandler<String, String> {
+
+  private final RequestHandler<String, String> requestHandler;
+
+  public AwsLambdaInternalRequestHandler(RequestHandler<String, String> requestHandler) {
+    this.requestHandler = requestHandler;
+  }
+
+  @Override
+  public String handleRequest(String input, Context context) {
+    return requestHandler.handleRequest(input, context);
+  }
+}

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdacore/v1_0/AwsLambdaTest.java
@@ -5,14 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.awslambdacore.v1_0;
 
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.api.client.AwsLambdaInternalRequestHandler;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.AbstractAwsLambdaTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class AwsLambdaTest extends AbstractAwsLambdaTest {
@@ -33,6 +38,23 @@ public class AwsLambdaTest extends AbstractAwsLambdaTest {
   @AfterEach
   void tearDown() {
     assertThat(testing.forceFlushCalled()).isTrue();
+  }
+
+  @Test
+  void awsLambdaInternalHandlerIgnoredAndUserHandlerTraced() {
+    RequestHandler<String, String> handler = new AwsLambdaInternalRequestHandler(handler());
+    String result = handler.handleRequest("hello", context());
+    assertThat(result).isEqualTo("world");
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("my_function")
+                            .hasKind(SpanKind.SERVER)
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(SemanticAttributes.FAAS_INVOCATION_ID, "1-22-333"))));
   }
 
   private static final class TestRequestHandler implements RequestHandler<String, String> {

--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/testing/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/AbstractAwsLambdaTest.java
@@ -53,6 +53,10 @@ public abstract class AbstractAwsLambdaTest {
     assertThat(testing().forceFlushCalled()).isTrue();
   }
 
+  protected Context context() {
+    return context;
+  }
+
   @Test
   void handlerTraced() {
     String result = handler().handleRequest("hello", context);


### PR DESCRIPTION
… Otherwise, there might be double root spans.

Fixes #7808 